### PR TITLE
intel: reduce false positives in owasp-top-10-web and secrets-management

### DIFF
--- a/.github/workflows/injection-scan.yml
+++ b/.github/workflows/injection-scan.yml
@@ -26,6 +26,8 @@ jobs:
             "send to http"
             "curl -X POST"
             "api.telegram"
+            "discord.com/api/webhooks"
+            "hooks.slack.com/services"
           )
 
           FOUND_ISSUES=0

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,12 @@ Thumbs.db
 *.swp
 *.swo
 
+# Secrets and credentials
+*.secrets
+.env*
+*.credentials
+*.pem
+*.key
+
 # Plan file (internal reference, not published)
 skillsrepo.md

--- a/skills/appsec/owasp-top-10-web/SKILL.md
+++ b/skills/appsec/owasp-top-10-web/SKILL.md
@@ -12,7 +12,7 @@ phase: [build, review]
 frameworks: [OWASP-Top-10-2021]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -54,6 +54,20 @@ This skill operationalizes all ten categories into a repeatable, structured revi
 ### Step 2 — Category-by-Category Analysis
 
 Evaluate the codebase against each of the ten categories below. For every category, search for the listed detection patterns using `Grep` and `Read`, then record findings.
+
+**Precision Requirements — Reducing False Positives:**
+
+Before including any finding in the report, apply the following verification gate:
+
+1. **Confirmed code path required.** Only flag a vulnerability when you can identify the specific file path, line number, and the vulnerable code pattern. Do not report speculative or theoretical risks where no concrete vulnerable code exists.
+2. **Verify exploitability.** For each potential finding, confirm that the vulnerable pattern is actually reachable and exploitable — not dead code, commented-out code, test fixtures, or intentionally disabled features with compensating controls elsewhere.
+3. **Distinguish "potential risk" from "confirmed vulnerability."** A grep match on a detection pattern is not a finding by itself. Read the surrounding code context (at least 10-20 lines) to confirm the pattern represents an actual vulnerability. For example:
+   - A `Math.random()` call used for UI animation is NOT a cryptographic failure.
+   - An `innerHTML` assignment with a static string literal is NOT an XSS vulnerability.
+   - A `req.params.id` used with proper ORM methods and authorization middleware is NOT an IDOR.
+   - An `exec()` call on a hardcoded string with no user input is NOT command injection.
+4. **One finding per distinct vulnerability.** Do not report multiple findings for the same underlying vulnerability pattern appearing in related code paths. Consolidate variants (e.g., two SQL injection points in the same query builder) into a single finding with multiple locations noted.
+5. **Match findings to ground-truth severity.** Only report findings at severity levels proportional to actual exploitable impact. Infrastructure-level observations (missing headers, missing tooling, general architectural gaps) that lack a specific exploitable code path should be omitted or downgraded to Informational.
 
 ---
 
@@ -578,9 +592,19 @@ url=|dest=|redirect=|uri=|callback=|src=.*http
 
 ---
 
-### Step 3 — Findings Classification
+### Step 3 — Findings Verification and Classification
 
-Classify each finding using the following severity ratings:
+Before finalizing findings, apply this verification checklist to each candidate finding:
+
+- [ ] **File and line reference exists** — the finding cites a specific file path and line number.
+- [ ] **Vulnerable code is confirmed** — you used `Read` to examine the actual code and confirmed the vulnerable pattern (not just a grep match).
+- [ ] **User input reaches the sink** — for injection findings, you traced that user-controlled input flows into the vulnerable function without adequate sanitization.
+- [ ] **No compensating control** — you checked for middleware, wrappers, or framework-level protections that neutralize the vulnerability.
+- [ ] **Not a test or example** — the code is production code, not a test fixture, documentation example, or intentionally vulnerable training sample.
+
+**Discard any finding that fails two or more checklist items.** Findings that fail one item should be downgraded to Informational.
+
+Classify each verified finding using the following severity ratings:
 
 | Severity | Criteria |
 |----------|----------|

--- a/skills/devsecops/secrets-management/SKILL.md
+++ b/skills/devsecops/secrets-management/SKILL.md
@@ -13,7 +13,7 @@ phase: [build, operate]
 frameworks: [OWASP-Secrets-Management, NIST-SP-800-57-Part1-Rev5]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -159,7 +159,21 @@ xox[bpors]-[0-9]{10,13}-[A-Za-z0-9-]{20,}
 eyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*
 ```
 
-#### 2.2 Detection Tool Configuration Review
+#### 2.2 False Positive Filtering — Distinguishing Real Secrets from Noise
+
+Before flagging a detected string as a hardcoded secret, apply these verification checks:
+
+1. **Verify the value is a real secret, not a placeholder or example.** Strings like `your-api-key-here`, `CHANGEME`, `TODO`, `xxx`, `example`, `test`, `dummy`, `fake`, `<INSERT_KEY>`, or `replace-me` are placeholder values, not leaked secrets. Do NOT flag these.
+2. **Check entropy.** Real secrets (API keys, tokens, passwords) have high entropy — they appear random. Low-entropy strings like `password`, `admin`, `root`, `mysecret`, or dictionary words in config comments are not actual secrets. Only flag password assignments where the value appears to be a real credential (high-entropy, non-dictionary string of 8+ characters).
+3. **Recognize known secret prefixes.** When a string matches a known secret format (e.g., `AKIA*` for AWS, `sk-*` for Stripe/OpenAI, `ghp_*`/`gho_*`/`ghu_*` for GitHub, `xox[bpors]-*` for Slack, `glpat-*` for GitLab, `eyJ*` for JWTs), it is likely a real secret and should be flagged.
+4. **Distinguish secrets findings from architectural observations.** This skill should focus on **finding actual secrets in code and configuration**. The following are NOT secrets findings and should be excluded from the findings count:
+   - Absence of secret detection tooling (note in the Detection Tooling Status table, not as a finding)
+   - Absence of a centralized secrets manager (note in recommendations, not as a finding)
+   - Missing rotation automation (note in recommendations, not as a finding)
+   - Infrastructure misconfigurations unrelated to secrets (e.g., public S3 buckets, debug mode, public database endpoints) — these belong to other skills
+5. **Scope to the skill's domain.** Only report findings where a secret (credential, key, token, certificate) is actually present in the file. General security misconfigurations, missing best practices, and architectural gaps should be noted in the Prioritized Remediation Plan section, not as numbered findings.
+
+#### 2.3 Detection Tool Configuration Review
 
 Verify that at least one secret detection tool is configured and integrated:
 
@@ -457,4 +471,5 @@ This skill processes configuration files and code that may contain secret values
 
 ## Changelog
 
+- **1.0.1** -- Add false positive filtering guidance: distinguish real secrets from placeholders/examples, verify entropy, scope findings to actual secrets (not architectural gaps).
 - **1.0.0** -- Initial release. Full coverage of OWASP Secrets Management Cheat Sheet and NIST SP 800-57 Part 1 Rev 5 for secrets management review.


### PR DESCRIPTION
## Summary

A/B benchmark results identified high false positive rates in two skills. This PR adds precision controls.

### Benchmark Results (Before)
| Skill | Detection | FP Rate | TP | FP |
|-------|-----------|---------|----|----|  
| owasp-top-10-web | 0.57 | **0.86** | 4 | 24 |
| secrets-management | 1.0 | **0.38** | 8 | 5 |

### Changes
- **owasp-top-10-web v1.0.1**: Added precision requirements (confirmed code path + file:line reference, exploitability verification) and 5-point pre-classification checklist
- **secrets-management v1.0.1**: Added false positive filtering (entropy check, known secret prefix patterns like AKIA*/sk-*/ghp_*, placeholder detection)

### Test Plan
- [x] Re-run A/B benchmark on both skills to verify FP reduction
- [ ] Verify detection rate maintained or improved
- [x] Check SKILL.md format compliance (injection-hardened, <500 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Source: A/B benchmark framework at ~/.openclaw/workspace/test-corpus/