### PR TITLE
Improve llm-top-10 data-flow evidence review

### DIFF
--- a/skills/ai-security/llm-top-10/SKILL.md
+++ b/skills/ai-security/llm-top-10/SKILL.md
@@ -53,12 +53,41 @@ Before beginning the review, collect the following:
 - [ ] **Rate limiting and quota configuration** — per-user and per-session limits on model invocations.
 - [ ] **Data classification** — what sensitivity level of data flows into or out of the model (PII, PHI, financial, credentials).
 - [ ] **Deployment topology** — self-hosted vs. third-party API, data residency, network boundaries.
+- [ ] **Evidence confidence** — classify each claim as source-code, config, runtime export, test evidence, docs-only, unknown, or not evaluable.
 
 ---
 
 ## 3. Process
 
-Review the application against each of the ten OWASP LLM risk categories below. For each category, examine the codebase for the specified patterns, apply the detection methods, and recommend the listed mitigations where gaps are found.
+Before reviewing the ten OWASP LLM risk categories, complete the source-to-sink evidence matrix below. Do not assign final severity until the matrix identifies the data source, trust boundary, transformation, model/runtime configuration, sink, enforcing control, and evidence confidence for the affected flow.
+
+### Mandatory Data-Flow Evidence Matrix
+
+Use one row per distinct LLM flow. Split flows when the same model output reaches different sinks, because escaped UI text, sanitized Markdown, JSON tool calls, SQL, shell, file writes, and external API calls have different risk profiles.
+
+| Field | What to Record | Strong Evidence | Weak Evidence |
+|-------|----------------|-----------------|---------------|
+| Source | User prompt, retrieved chunk, tool output, memory, cache, fine-tuning data, file upload, OCR/audio transcript, or external API response. | Code path, schema, ingestion handler, retrieval query, or test fixture. | Architecture diagram or README claim only. |
+| Trust boundary | Where data crosses between user, tenant, model, tool, service, database, or third party. | Auth middleware, tenant filter, ACL check, policy decision, or network boundary config. | Statement that "the user is authenticated" without the actual enforcement point. |
+| Transformation/parser | Prompt assembly, chunking, Markdown rendering, JSON parsing, function-call schema validation, sanitizer, redactor, or output parser. | Source-code call site with validation/sanitization configuration. | Parser/sanitizer listed in dependencies but not tied to the flow. |
+| Model/runtime config | Provider, model ID, temperature, max tokens, tool/function list, rate/cost limits, streaming mode, and moderation/filter settings. | SDK call, gateway config, deployed config export, or test assertion. | Documentation saying limits are enabled. |
+| RAG authorization | Document ACL, chunk ACL, tenant filter, source-document permission, and stale-metadata handling. | Query filter plus tests proving unauthorized chunks are excluded. | Tenant ID filter without proof chunk ACLs are inherited and current. |
+| Output sink | UI text, sanitized Markdown/HTML, SQL, shell, code eval, filesystem, database write, tool call, email/send flow, publish flow, or external API call. | Code-level sink and calling function. | Generic statement that output is "shown to the user." |
+| Enforcing layer | Deterministic code, schema validator, sanitizer, IAM policy, broker policy, approval gate, quota middleware, or human review workflow. | Enforcement at the execution layer that cannot be bypassed by alternate code paths. | Prompt-only instruction or UI copy. |
+| Evidence confidence | source-code, config, runtime export, test evidence, docs-only, unknown, or not evaluable. | Direct artifact inspected during review. | Assumption or undocumented maintainer statement. |
+| Related OWASP categories | LLM01-LLM10 categories implicated by this flow. | Categories mapped to concrete source, sink, and control evidence. | Category selected only because the application uses an LLM. |
+
+If a field cannot be verified, mark the related category **Not Evaluable** instead of downgrading it to Low or Informational. Use these reason codes:
+
+- `NE-MODEL-CONFIG`: Provider, model ID, temperature, max token, streaming, or tool configuration is missing.
+- `NE-PROMPT-FLOW`: Prompt assembly or message-role separation cannot be traced.
+- `NE-RAG-ACL`: Retrieval authorization is not proven at both document and chunk scope.
+- `NE-SINK-MAP`: Model output sink cannot be identified or is described only generically.
+- `NE-TOOL-POLICY`: Tool/function permissions or execution gate cannot be tied to deterministic enforcement.
+- `NE-OUTPUT-FILTER`: Sanitization, redaction, or moderation is described but not tied to the output flow.
+- `NE-RUNTIME-EVIDENCE`: The claim depends only on documentation or intended configuration with no code, config, runtime export, or test evidence.
+
+Then review the application against each of the ten OWASP LLM risk categories below. For each category, examine the codebase for the specified patterns, apply the detection methods, tie findings back to the matrix row, and recommend the listed mitigations where gaps are found.
 
 ---
 
@@ -413,6 +442,18 @@ Structure the findings report as follows:
 
 [2-3 sentences: overall risk posture, critical findings count, top recommendation]
 
+## Data-Flow Evidence Matrix
+
+| Flow ID | Source | Trust Boundary | Transformation / Parser | Model / Runtime Config | RAG Authorization | Output Sink | Enforcing Layer | Evidence Confidence | OWASP Categories |
+|---------|--------|----------------|--------------------------|------------------------|-------------------|-------------|-----------------|---------------------|------------------|
+| FLOW-001 | [user prompt / retrieved chunk / tool output / memory / upload] | [user -> app -> model -> tool / tenant boundary] | [prompt assembly / parser / sanitizer] | [provider, model, temperature, max tokens, tools, streaming] | [document ACL, chunk ACL, tenant filter, or N/A] | [UI / Markdown / SQL / shell / filesystem / tool / API] | [deterministic validator / policy / approval / quota] | [source-code / config / runtime export / test evidence / docs-only / unknown] | [LLM0X list] |
+
+## Not Evaluable Items
+
+| Area | Reason Code | Missing Evidence | Risk if Assumed |
+|------|-------------|------------------|-----------------|
+| [Prompt flow / RAG ACL / sink map / tool policy / runtime config] | [NE-*] | [specific artifact not available] | [how severity could be understated or overstated] |
+
 ## Findings
 
 ### [FINDING-001] [Title]
@@ -420,6 +461,8 @@ Structure the findings report as follows:
 - **OWASP Category:** LLM0X:2025 — [Category Name]
 - **Severity:** Critical | High | Medium | Low | Informational
 - **CWE:** CWE-XXX
+- **Flow ID:** FLOW-XXX
+- **Evidence Confidence:** source-code | config | runtime export | test evidence | docs-only | unknown
 - **Location:** [file path, function, configuration]
 - **Description:** [What was found]
 - **Evidence:** [Code snippet, configuration excerpt, or architectural observation]
@@ -475,6 +518,12 @@ These are the five most frequent mistakes agents make when performing LLM securi
 4. **Failing to enumerate tool permissions.** When function-calling or tool-use is configured, every tool must be enumerated with its permissions documented. Agents frequently overlook that a "search" tool also has write access, or that a "database" tool allows arbitrary SQL. This is the core of LLM06.
 
 5. **Scoping the review to the application layer only.** LLM security includes supply chain (LLM03) — model provenance, dependency versions, serialization formats — and infrastructure — vector database authentication, API key management, cost controls (LLM10). These are outside the application code but within scope of this review.
+
+6. **Treating docs-only controls as implemented controls.** README statements such as "temperature is low," "tenant filtering is enabled," or "output is sanitized" are weak evidence until tied to SDK calls, gateway configuration, runtime exports, source-code enforcement, or tests.
+
+7. **Missing output paths that re-enter the model or bypass final filters.** Tool output, retrieved snippets, cached prompts, conversation memory, streaming chunks, OCR text, PDF text, and audio transcripts can all become new untrusted inputs. If streaming moderation or redaction only runs after completion, chunks may reach the user before the final filter executes.
+
+8. **Assuming tenant filters prove RAG authorization.** A tenant filter is not enough if source documents and chunks have mixed, stale, or missing ACL metadata. Verify document-level and chunk-level access decisions, and record `NE-RAG-ACL` when either layer is not inspectable.
 
 ---
 

--- a/skills/ai-security/llm-top-10/tests/data-flow-evidence-matrix.md
+++ b/skills/ai-security/llm-top-10/tests/data-flow-evidence-matrix.md
@@ -1,0 +1,77 @@
+# LLM Top 10 Data-Flow Evidence Matrix Test Cases
+
+These fixtures validate the issue #45 improvement: the skill must require source-to-sink flow evidence, evidence confidence, and Not Evaluable reason codes before category severity is finalized.
+
+## Test Case 1: Sanitized Markdown Is Not the Same as Raw HTML
+
+### Input Scenario
+
+```typescript
+const response = await llm.complete({ messages, max_tokens: 500 });
+return markdownToHtml(response.text, { sanitize: true });
+```
+
+### Expected Review Behavior
+
+- Create a flow row with source `model output`, transformation `markdownToHtml sanitize=true`, sink `HTML response`, and evidence confidence `source-code`.
+- Treat the flow as lower risk than raw `innerHTML` rendering because the sink has source-code evidence of sanitization.
+- Do not file a raw-HTML LLM05 finding unless sanitization is missing, misconfigured, or bypassable.
+
+### Failure Mode Caught
+
+Without the matrix, a reviewer can overstate severity by treating all Markdown rendering as equivalent to raw HTML injection.
+
+## Test Case 2: JSON Tool Action Must Be Classified by Sink and Gate
+
+### Input Scenario
+
+```typescript
+const action = JSON.parse(modelOutput);
+await toolExecutor.run(action);
+```
+
+### Expected Review Behavior
+
+- Create a flow row with source `model output`, transformation `JSON.parse`, sink `tool call`, and related categories `LLM05` and `LLM06`.
+- Require evidence for the tool schema, allowed action list, execution-layer policy gate, audit log, and confirmation requirements.
+- If the execution gate cannot be inspected, add `NE-TOOL-POLICY` and do not downgrade the issue to Low based on prompt text.
+
+### Failure Mode Caught
+
+Without the matrix, a reviewer can understate risk by saying output is "structured JSON" while missing that the JSON drives a real tool action.
+
+## Test Case 3: Docs-Only Runtime Limits Are Weak Evidence
+
+### Input Scenario
+
+```text
+README: "The application uses low temperature, max token limits, and per-user quotas."
+```
+
+### Expected Review Behavior
+
+- Create a flow row for the model invocation, but mark model/runtime config as `docs-only` unless SDK calls, gateway config, runtime export, or tests prove the limits.
+- Add `NE-MODEL-CONFIG` or `NE-RUNTIME-EVIDENCE` when the implementation cannot be inspected.
+- Avoid treating the README claim as proof that LLM09 or LLM10 controls are implemented.
+
+### Failure Mode Caught
+
+Without evidence confidence levels, a reviewer can incorrectly accept intended configuration as deployed configuration.
+
+## Test Case 4: RAG Tenant Filter Needs Chunk-Level ACL Evidence
+
+### Input Scenario
+
+```text
+Retriever filters by tenant_id, but source documents and chunks have mixed ACL metadata.
+```
+
+### Expected Review Behavior
+
+- Create a flow row with source `retrieved chunks`, trust boundary `tenant/document ACL`, RAG authorization `tenant filter plus chunk ACL unknown`, and related categories `LLM02`, `LLM04`, and `LLM08`.
+- Require evidence that source document permissions are inherited by every chunk and are current at query time.
+- Add `NE-RAG-ACL` if chunk-level ACL evidence is unavailable.
+
+### Failure Mode Caught
+
+Without the matrix, a reviewer can over-trust a tenant filter and miss cross-document or stale-metadata authorization failures.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `llm-top-10`
**Skill path:** `skills/ai-security/llm-top-10/`

Addresses #45.

### What Was Wrong
The skill covered OWASP LLM01-LLM10, but it did not require reviewers to build a concrete source-to-sink data-flow and trust-boundary inventory before assigning category findings. That made it easy to overstate or understate severity when model output moved through different sinks, when RAG ACL evidence was incomplete, or when runtime controls were only documented rather than proven.

### What This PR Fixes
- Adds a mandatory data-flow evidence matrix before category scoring.
- Adds evidence confidence levels: source-code, config, runtime export, test evidence, docs-only, unknown, and not evaluable.
- Adds Not Evaluable reason codes for missing model config, prompt flow, RAG ACLs, sink mapping, tool policy, output filters, and runtime evidence.
- Expands the report template so findings include Flow ID and Evidence Confidence.
- Adds common pitfalls for docs-only controls, tool-output re-entry, streaming filter bypass, and stale/missing RAG chunk ACL metadata.

### Evidence
**Before (skill can miss this / misclassify this):**
```typescript
const action = JSON.parse(modelOutput);
await toolExecutor.run(action);
```
A reviewer could treat this as generic output handling without documenting that the model output drives a real tool action and needs an execution-layer policy gate.

**After (now correctly handled):**
The reviewer must create a flow row with source `model output`, transformation `JSON.parse`, sink `tool call`, related categories `LLM05` and `LLM06`, and either provide policy-gate evidence or mark `NE-TOOL-POLICY`.

### Test Cases Added/Updated
- [x] Added markdown fixtures under `skills/ai-security/llm-top-10/tests/data-flow-evidence-matrix.md`
- [x] Covers sanitized Markdown, JSON tool execution, docs-only runtime limits, and RAG tenant/chunk ACL evidence
- [x] Existing frontmatter lint still passes locally
- [x] `git diff --check` passes locally

### Bounty Tier
- [ ] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Crypto or PayPal; can provide payout details privately after acceptance
