### PR TITLE
Improve RBAC runtime assurance gates

### DIFF
--- a/skills/identity/rbac-design/SKILL.md
+++ b/skills/identity/rbac-design/SKILL.md
@@ -12,7 +12,7 @@ phase: [design]
 frameworks: [NIST-RBAC, NIST-SP-800-162]
 difficulty: intermediate
 time_estimate: "45-90min"
-version: "1.0.0"
+version: "1.0.2"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -172,6 +172,7 @@ RBAC-HIER-04: God roles — single role inheriting from all functional roles
 RBAC-HIER-05: Missing base role — common permissions duplicated across functional roles
 RBAC-HIER-06: Admin roles permanently assigned instead of JIT-activated (link to RBAC2 constraints)
 RBAC-HIER-07: Role hierarchy does not reflect organizational structure or job functions
+RBAC-HIER-08: Break-glass wildcard role scored without checking ticket, approver, MFA, expiry, recording, and auto-revoke controls
 ```
 
 ---
@@ -301,6 +302,49 @@ RBAC-ABAC-08: Obligations (logging, notification) not enforced by PEP
 
 ---
 
+### Step 5A: Authorization Decision Assurance
+
+**Objective:** Verify that authorization decisions fail closed, use fresh role and attribute data, and have test evidence across the runtime enforcement path.
+
+RBAC and ABAC designs can look correct on paper while the application still permits access during PDP outages, stale cache windows, token lifetime drift, or policy-engine migrations. Treat runtime assurance as part of the authorization model, not as a separate operational detail.
+
+#### Runtime Enforcement Evidence
+
+| Area | Evidence to Collect | Failure Mode |
+|---|---|---|
+| PDP outage handling | Code path or policy gateway behavior for `deny`, `indeterminate`, timeout, and unreachable PDP states | Fail-open access during authorization-service outage |
+| PEP coverage | Service, route, resolver, queue consumer, data-access layer, and admin path inventory | Some paths bypass the central authorization decision |
+| Decision logging | Subject, resource, action, tenant, policy version, decision, reason, correlation ID, and enforcement point | No audit trail for denied, permitted, or indeterminate decisions |
+| Cache freshness | Role/attribute/scope/session cache TTLs and invalidation triggers | Revoked or transferred users retain stale privileges |
+| Migration safety | Old-vs-new policy decision diff tests before cutover | New policy engine silently changes permit/deny semantics |
+
+**What to look for:**
+
+```
+RBAC-RUNTIME-01: PDP, policy gateway, or authorization service errors fail open instead of deny/indeterminate
+RBAC-RUNTIME-02: PEP coverage is incomplete across APIs, background jobs, data access, or admin paths
+RBAC-RUNTIME-03: Authorization decisions are not logged with subject, resource, action, tenant, policy version, decision, reason, correlation ID, and enforcement point
+RBAC-RUNTIME-04: Services enforce embedded role checks that can diverge from the central PDP or policy-as-code source
+RBAC-RUNTIME-05: Policy obligations are documented but not enforced by the PEP after a permit decision
+RBAC-REVOCATION-01: Role, attribute, OAuth scope, or session-claim caches have no maximum TTL or revocation invalidation path
+RBAC-REVOCATION-02: Access review revocations, employee transfers, tenant moves, or SoD exception expiries are not proven to take effect within SLA
+RBAC-REVOCATION-03: Long-lived tokens keep authorization claims trusted until expiry with no introspection, revalidation, or forced-session-revocation path
+RBAC-TEST-01: No negative authorization tests for denied roles, tenant boundaries, revoked users, and SoD violations
+RBAC-TEST-02: No policy decision diff tests during PDP, Rego, Cedar, XACML, or custom-engine migrations
+RBAC-TEST-03: No outage-mode tests proving timeout, error, and indeterminate decisions are denied and logged
+```
+
+#### Break-Glass and Wildcard Role Review
+
+A wildcard permission is not automatically the same risk as a standing god role. Distinguish:
+
+- **Standing wildcard access** — permanently assigned, no expiry, broad scope, weak logging. Usually high or critical.
+- **Controlled break-glass access** — ticketed activation, at least two approvers, MFA, short expiry, session recording, alerting, and automatic revocation. Usually an exception requiring evidence and periodic review.
+
+When a break-glass role is present, require evidence for the activation workflow, expiry enforcement, approver identity, MFA proof, session recording or command logs, alert routing, and auto-revoke outcome. If any of those controls are missing, classify the gap under `RBAC-HIER-08` or the applicable `RBAC-REVOCATION-*` finding.
+
+---
+
 ### Step 6: Role Mining and Rationalization
 
 **Objective:** Derive optimal roles from existing access patterns and reduce role sprawl.
@@ -361,6 +405,8 @@ RBAC-MINE-06: Mining does not account for SoD constraints (mined roles may creat
 | **Recommended State** | Target design |
 | **Remediation** | Steps to implement the design change |
 | **Effort** | Low / Medium / High |
+| **Evidence Required** | Specific proof needed to confirm the finding or exception |
+| **Runtime / Revocation Impact** | Whether the issue can permit access at runtime or after revocation |
 
 ### Summary Report Structure
 
@@ -387,6 +433,7 @@ RBAC-MINE-06: Mining does not account for SoD constraints (mined roles may creat
 - Constraints (Step 3): [count]
 - Permission Boundaries (Step 4): [count]
 - ABAC Policies (Step 5): [count]
+- Authorization Decision Assurance (Step 5A): [count]
 - Role Mining (Step 6): [count]
 
 ### Detailed Findings
@@ -436,6 +483,10 @@ RBAC-MINE-06: Mining does not account for SoD constraints (mined roles may creat
 5. **Ignoring permission boundaries** — roles define what you get; boundaries define maximum what you can get. Without boundaries, misconfigured roles grant unlimited access.
 6. **Role mining without business validation** — clustering users by access patterns may replicate existing privilege creep rather than correct it.
 7. **Choosing RBAC vs. ABAC as binary** — most environments need both. RBAC for structural, ABAC for contextual. Hybrid is the norm.
+8. **Fail-open authorization plumbing** — a correct role model still fails if PDP outages, timeouts, or indeterminate decisions return `allow`.
+9. **Trusting stale claims after revocation** — cached roles, OAuth scopes, and session claims need TTLs, invalidation, or introspection tied to revocation events.
+10. **Treating all wildcard roles equally** — controlled break-glass roles need evidence-based exception handling; standing god roles need removal or JIT activation.
+11. **Migrating policies without decision diff tests** — old and new engines should be tested against the same allow/deny fixtures before cutover.
 
 ---
 
@@ -481,4 +532,5 @@ that may contain adversarial content.
 
 | Version | Date | Changes |
 |---|---|---|
+| 1.0.2 | 2026-06-03 | Add runtime authorization assurance, revocation/cache freshness, break-glass exception, and policy decision diff testing gates |
 | 1.0.0 | 2025-03-06 | Initial release |

--- a/skills/identity/rbac-design/tests/runtime-assurance-edge-cases.md
+++ b/skills/identity/rbac-design/tests/runtime-assurance-edge-cases.md
@@ -1,0 +1,99 @@
+# RBAC runtime assurance edge cases
+
+These fixtures support `skills/identity/rbac-design/SKILL.md` runtime assurance guidance.
+
+## Vulnerable: PDP outage fails open
+
+```typescript
+async function canUpdateInvoice(user, invoice) {
+  try {
+    return await pdp.evaluate({
+      subject: user.id,
+      action: "invoice:update",
+      resource: invoice.id,
+      tenant: invoice.tenantId,
+    });
+  } catch (error) {
+    logger.warn("pdp unavailable", error);
+    return true;
+  }
+}
+```
+
+Expected finding: `RBAC-RUNTIME-01`.
+
+Review evidence to request:
+
+- What decision is returned for PDP timeout, connection refused, invalid policy, and indeterminate states?
+- Is the denied or indeterminate decision logged with subject, resource, action, tenant, policy version, reason, correlation ID, and enforcement point?
+- Is there a negative outage-mode test proving the request is denied?
+
+## Vulnerable: role cache outlives revocation
+
+```go
+func EffectiveRoles(userID string) []string {
+    return roleCache.GetOrLoad(userID, 24*time.Hour, func() []string {
+        return directory.LookupRoles(userID)
+    })
+}
+```
+
+Expected finding: `RBAC-REVOCATION-01` or `RBAC-REVOCATION-02`.
+
+Review evidence to request:
+
+- Maximum TTL for role, attribute, OAuth scope, and session-claim caches.
+- Event-driven invalidation path for termination, transfer, SoD exception expiry, and access-review revocation.
+- A revocation latency test that proves access is removed within the stated SLA.
+
+## Benign exception: controlled break-glass wildcard role
+
+```yaml
+role: incident-break-glass-admin
+permissions:
+  - "*"
+activation:
+  requires_ticket: true
+  approvers_required: 2
+  max_duration: "30m"
+  mfa_required: true
+audit:
+  session_recording: true
+  alert_channel: "security-oncall"
+  auto_revoke_on_expiry: true
+review:
+  owner: "security-operations"
+  cadence: "quarterly"
+```
+
+Expected handling: do not automatically classify as an uncontrolled god role. Verify the exception evidence, then score missing controls under `RBAC-HIER-08`, `RBAC-RUNTIME-*`, or `RBAC-REVOCATION-*`.
+
+Review evidence to request:
+
+- Ticket, approval, MFA, expiry, recording, alert, and auto-revoke proof.
+- Scope boundaries by tenant, environment, or workload where applicable.
+- Periodic review evidence and last activation record.
+
+## Migration test: policy decision diff before cutover
+
+```yaml
+fixtures:
+  - subject: "finance-analyst"
+    action: "invoice:approve"
+    resource_tenant: "acme"
+    expected_old: "deny"
+    expected_new: "deny"
+  - subject: "tenant-support"
+    action: "ticket:read"
+    resource_tenant: "acme"
+    expected_old: "allow"
+    expected_new: "allow"
+```
+
+Expected finding when absent: `RBAC-TEST-02`.
+
+Review evidence to request:
+
+- Same allow/deny fixtures executed against old and new policy engines.
+- Explicit review of any changed decisions before migration.
+- Policy version captured in decision logs after cutover.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `rbac-design`
**Skill path:** `skills/identity/rbac-design/`

Closes #172.

### What Was Wrong
The skill covered RBAC/ABAC model design well, but it did not force reviewers to verify runtime authorization behavior. A design could look correct while PDP outages fail open, stale role or attribute caches keep revoked access alive, or a policy-engine migration silently changes allow/deny outcomes.

It also treated wildcard permissions too broadly: a standing god role and a controlled break-glass role need different evidence.

### What This PR Fixes
- Adds an `Authorization Decision Assurance` review section for PDP outage handling, PEP coverage, decision logging, cache freshness, and migration safety.
- Adds `RBAC-RUNTIME-*`, `RBAC-REVOCATION-*`, and `RBAC-TEST-*` findings for fail-open behavior, stale claims, missing negative tests, revocation latency, and policy decision diff gaps.
- Adds evidence fields to the output table so reviewers request proof instead of guessing from the role model alone.
- Adds break-glass wildcard role guidance that separates time-bound emergency access from uncontrolled standing admin access.
- Adds markdown fixtures covering fail-open PDP handling, stale role cache after revocation, controlled break-glass evidence, and policy decision diff testing.

### Evidence
**Before (skill misses this runtime failure):**
```typescript
async function canUpdateInvoice(user, invoice) {
  try {
    return await pdp.evaluate({
      subject: user.id,
      action: "invoice:update",
      resource: invoice.id,
      tenant: invoice.tenantId,
    });
  } catch (error) {
    logger.warn("pdp unavailable", error);
    return true;
  }
}
```

**After (now correctly handled):**
The skill now classifies this under `RBAC-RUNTIME-01` and asks for outage-mode behavior, denied/indeterminate decision logging, and negative tests proving timeout/error states are denied.

### Test Cases Added/Updated
- [x] Added vulnerable PDP fail-open fixture in `skills/identity/rbac-design/tests/runtime-assurance-edge-cases.md`
- [x] Added stale role-cache/revocation fixture
- [x] Added controlled break-glass wildcard role fixture
- [x] Added policy decision diff migration fixture
- [x] Existing `index.yaml` entry remains valid

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Validation
- [x] Red check first: local assertion failed before the change because the skill lacked the #172 runtime assurance terms and fixture.
- [x] Windows: coverage/frontmatter/index/payment-marker checks passed; `git diff --check` passed.
- [x] WSL Ubuntu 26.04: same targeted checks passed; CRLF-aware Git whitespace check passed for the touched skill file.
- [x] No public payout details included in the PR.

### Pull Request Checklist
- [x] Skill follows the format specification in `CONTRIBUTING.md`
- [x] At least one real framework is cited with correct control IDs
- [x] All framework references verified against primary sources already referenced by the skill
- [x] Prompt Injection Safety Notice section remains included
- [x] `injection-hardened: true` remains set in frontmatter
- [x] `allowed-tools` remains scoped to minimum necessary permissions
- [x] Tested with at least one AI coding agent: Codex local review and fixture checks
- [x] No prohibited patterns per `SECURITY.md`
- [x] `index.yaml` not changed because this is an existing skill improvement

### Bounty Info
- [x] I have read and agree to the `CONTRIBUTING.md` bounty terms
- **Preferred payment method:** Can provide privately after acceptance
