### PR TITLE
Improve container runtime admission evidence

### DIFF
--- a/skills/cloud/container-security/SKILL.md
+++ b/skills/cloud/container-security/SKILL.md
@@ -13,7 +13,7 @@ phase: [build, deploy, operate]
 frameworks: [CIS-Docker-v1.6.0, CIS-Kubernetes-v1.9.0, NIST-SP-800-190]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -60,7 +60,7 @@ NIST SP 800-190 identifies five risk categories: image risks, registry risks, or
 - Kubernetes manifests (YAML), Helm charts, or Kustomize overlays
 - RBAC configuration files (Roles, ClusterRoles, RoleBindings)
 - NetworkPolicy definitions
-- Pod Security Standard configurations or OPA/Gatekeeper policies
+- Pod Security Standard configurations, OPA/Gatekeeper constraints, Kyverno policies, or Kubernetes admission policy resources
 - Container registry configurations (if available)
 
 ---
@@ -115,6 +115,42 @@ For detailed CIS benchmark checklist items, NIST SP 800-190 countermeasure table
 
 ---
 
+### Step 6A: RuntimeClass and Admission Policy Evidence
+
+**Objective:** Verify sandbox runtime selection and admission-time enforcement before scoring a workload from static manifests alone.
+
+Runtime isolation and admission controls can materially change the risk of a Kubernetes workload. A manifest that looks hardened may be admitted through a broad exception, and a manifest that looks weak may be blocked or mutated before it reaches the cluster. Treat `RuntimeClass`, policy engine mode, selectors, and exception resources as evidence that must be collected, not as assumptions.
+
+#### RuntimeClass and Admission Policy Evidence
+
+| Area | Evidence to Collect | Failure Mode |
+|---|---|---|
+| RuntimeClass selection | Pod `runtimeClassName`, matching `RuntimeClass` object, handler/runtime implementation, namespace eligibility | High-risk workload claims sandboxing but falls back to the default runtime |
+| Workload risk tier | Multi-tenant runners, plugin execution, CI jobs, document/media processing, untrusted code paths | Workload that should use gVisor, Kata, or another sandboxed runtime runs with ordinary runc isolation |
+| Admission engine | Pod Security Admission labels, Kyverno `ClusterPolicy`, Gatekeeper `ConstraintTemplate`/constraints, `ValidatingAdmissionPolicy`, `MutatingAdmissionPolicy`, and bindings | Static manifest review misses controls that enforce, mutate, audit, or exempt workloads |
+| Policy mode | `Enforce`, `Audit`, dry-run, warning-only, validation failure action, background mode | Report counts audit-only or dry-run policy as active blocking protection |
+| Selection and exceptions | Namespace selectors, object selectors, service accounts, policy exceptions, excluded namespaces, emergency bypasses | Workload under review is not actually selected by the policy |
+| Container coverage | Main, init, sidecar, and ephemeral containers in the policy match path | Policy validates app containers but misses init or debug containers |
+
+**What to look for:**
+
+```
+CONT-RUNTIME-01: Pod sets `runtimeClassName` but no matching RuntimeClass object or handler evidence is reviewed
+CONT-RUNTIME-02: Multi-tenant, plugin, CI, or untrusted-code workload uses the default runtime without sandbox-runtime justification
+CONT-RUNTIME-03: RuntimeClass exists but namespace, node, or handler constraints are not proven for the workload under review
+CONT-ADMISSION-01: Admission policy is counted as protection without proving enforcement mode (`Enforce` vs `Audit`/dry-run/warn)
+CONT-ADMISSION-02: Kyverno, Gatekeeper, or CEL admission policy selectors do not actually match the workload namespace, labels, or service account
+CONT-ADMISSION-03: Policy exceptions, exclusions, or break-glass bypasses are broad, stale, or undocumented
+CONT-ADMISSION-04: Admission checks cover only app containers and omit init, sidecar, or ephemeral containers
+CONT-ADMISSION-05: Review ignores Kubernetes `ValidatingAdmissionPolicy`, `ValidatingAdmissionPolicyBinding`, `MutatingAdmissionPolicy`, or `MutatingAdmissionPolicyBinding` resources
+CONT-INIT-01: Root init container is scored without recording container type, duration, command, mounts, capabilities, privilege escalation, seccomp, and image pinning
+CONT-INIT-02: Root init container has hostPath, broad capabilities, writable root filesystem, or privilege escalation and is treated as a benign exception
+```
+
+Root-running init containers are not automatically equivalent to long-running root application containers. Score them from evidence: command scope, lifetime, target volume, host mounts, dropped capabilities, `allowPrivilegeEscalation`, read-only root filesystem, seccomp, image digest pinning, and whether admission policy covers init containers. Missing context is a finding (`CONT-INIT-01`); unsafe context remains High or Critical (`CONT-INIT-02`).
+
+---
+
 ### Step 7: Compile Assessment Report
 
 
@@ -127,8 +163,8 @@ Produce the final report using the structure defined in the Output Format sectio
 | Severity | Definition | Examples |
 |----------|-----------|----------|
 | **Critical** | Container escape, cluster compromise, or credential exposure | Privileged containers, Docker socket mounts, cluster-admin bound to application SA, secrets in plaintext manifests, `hostPID`/`hostNetwork` on app pods |
-| **High** | Significant security gap enabling lateral movement or privilege escalation | Running as root, missing network policies, wildcard RBAC, `allowPrivilegeEscalation: true`, host path mounts to sensitive directories |
-| **Medium** | Missing hardening that weakens defense-in-depth | No resource limits, mutable image tags, missing seccomp profile, read-write root filesystem, secrets as env vars |
+| **High** | Significant security gap enabling lateral movement or privilege escalation | Long-running root application containers, missing network policies, wildcard RBAC, `allowPrivilegeEscalation: true`, host path mounts to sensitive directories |
+| **Medium** | Missing hardening that weakens defense-in-depth or lacks exception evidence | No resource limits, mutable image tags, missing seccomp profile, read-write root filesystem, tightly scoped root init container without complete justification |
 | **Low** | Best-practice deviation with limited immediate risk | No HEALTHCHECK in Dockerfile, ADD instead of COPY, missing liveness/readiness probes, using default namespace |
 | **Informational** | Observation with no direct security impact | Image size optimization, multi-stage build suggestions, label recommendations |
 
@@ -151,6 +187,8 @@ Produce the final report using the structure defined in the Output Format sectio
 - Failed: <N>
 - Critical/High findings requiring immediate attention: <N>
 - Pod Security Standard compliance: Privileged / Baseline / Restricted
+- RuntimeClass coverage for high-risk workloads: <default / sandboxed / unknown>
+- Admission policy enforcement coverage: <enforce / audit-only / partial / unknown>
 
 ### Findings by Domain
 
@@ -174,9 +212,19 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Line(s):** <line numbers>
 - **Resource:** <Deployment/StatefulSet name>
 - **Container:** <container name>
+- **Container Role:** app / init / sidecar / ephemeral
+- **RuntimeClass:** <runtimeClassName, matching RuntimeClass object, handler evidence>
+- **Admission Evidence:** <policy engine, mode, selectors, exceptions, container coverage>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration>
 - **Remediation:** <fix with code example>
+
+### Runtime and Admission Evidence Matrix
+
+| Workload | Namespace | RuntimeClass | RuntimeClass object verified | Admission engine | Mode | Selected by policy? | Exceptions | Container coverage |
+|----------|-----------|--------------|------------------------------|------------------|------|---------------------|------------|--------------------|
+| deploy/plugin-runner | plugins | gvisor | yes | Kyverno | Enforce | yes | none | app/init/ephemeral |
+| deploy/app | default | default | n/a | PSA | Audit | partial | namespace excluded | app only |
 
 ### Pod Security Standards Compliance Matrix
 
@@ -257,6 +305,8 @@ Produce the final report using the structure defined in the Output Format sectio
 5. **`readOnlyRootFilesystem` breaks many applications.** When recommending this control, also recommend adding writable `emptyDir` volume mounts for directories the application needs to write to (e.g., `/tmp`, `/var/cache`).
 6. **Network policies are additive, not subtractive.** A default-deny policy must be explicitly created. Without it, all pod-to-pod traffic is allowed regardless of other NetworkPolicy resources.
 7. **Distroless images have no shell.** While this is excellent for security, note that debugging requires ephemeral containers (`kubectl debug`). Flag this as a consideration, not a problem.
+8. **RuntimeClass names are not proof of sandboxing.** A pod `runtimeClassName` must be matched to a `RuntimeClass` object and handler/runtime evidence.
+9. **Admission policy presence is not enforcement.** Kyverno, Gatekeeper, PSA, and CEL admission resources need mode, selector, binding, exception, and container-coverage evidence before they count as blocking controls.
 
 ---
 
@@ -293,4 +343,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Added RuntimeClass, admission-policy evidence, and root init-container exception guidance.
 - **1.0.0** -- Initial release. Full coverage of CIS Docker Benchmark v1.6.0 Section 4-5, CIS Kubernetes Benchmark v1.9.0 Sections 1-5, and NIST SP 800-190 countermeasures across all five risk categories.

--- a/skills/cloud/container-security/tests/runtime-admission-edge-cases.md
+++ b/skills/cloud/container-security/tests/runtime-admission-edge-cases.md
@@ -1,0 +1,165 @@
+# RuntimeClass and admission policy edge cases
+
+These fixtures support `skills/cloud/container-security/SKILL.md` runtime and admission evidence guidance.
+
+## Benign exception: constrained root init container
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: volume-permissions
+          image: busybox:1.36@sha256:4be8f0d59d41a3a494f1c350f064a9f1c8b3b7595510e164e47f2c6d3fda25a2
+          command: ["sh", "-c", "chown -R 65532:65532 /work"]
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: work
+              mountPath: /work
+      containers:
+        - name: app
+          image: ghcr.io/example/app@sha256:1111111111111111111111111111111111111111111111111111111111111111
+          securityContext:
+            runAsUser: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: work
+          emptyDir: {}
+```
+
+Expected handling: do not score as the same risk as a long-running root application container. Verify exception evidence and flag missing context under `CONT-INIT-01`.
+
+Review evidence to request:
+
+- Container role, command, duration, mounts, hostPath absence, dropped capabilities, seccomp, read-only root filesystem, and image digest pinning.
+- Whether admission policy validates init containers as well as app containers.
+- Whether the volume target is scoped to an `emptyDir` or similarly isolated volume.
+
+## Vulnerable: runtimeClassName without RuntimeClass object evidence
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: untrusted-plugin-runner
+spec:
+  template:
+    spec:
+      runtimeClassName: gvisor
+      containers:
+        - name: runner
+          image: ghcr.io/example/plugin-runner@sha256:2222222222222222222222222222222222222222222222222222222222222222
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+```
+
+Expected finding when the matching object is not reviewed: `CONT-RUNTIME-01`.
+
+Review evidence to request:
+
+- Matching `RuntimeClass` object and handler/runtime implementation.
+- Namespace or node eligibility for the sandbox runtime.
+- Justification if a high-risk plugin runner uses the default runtime.
+
+## Vulnerable: admission policy exists but is audit-only
+
+```yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-runtime-default-seccomp
+spec:
+  validationFailureAction: Audit
+  rules:
+    - name: require-runtime-default
+      match:
+        any:
+          - resources:
+              kinds: ["Pod"]
+      validate:
+        pattern:
+          spec:
+            securityContext:
+              seccompProfile:
+                type: RuntimeDefault
+```
+
+Expected finding: `CONT-ADMISSION-01`.
+
+Review evidence to request:
+
+- Whether the policy mode is `Enforce`, `Audit`, dry-run, or warn-only.
+- Namespace and object selectors for the workload under review.
+- Exception resources and excluded service accounts or namespaces.
+
+## Vulnerable: CEL admission resources not discovered
+
+```yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: require-non-root
+spec:
+  validations:
+    - expression: "object.spec.securityContext.runAsNonRoot == true"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: require-non-root-binding
+spec:
+  policyName: require-non-root
+  validationActions: ["Warn"]
+```
+
+Expected finding: `CONT-ADMISSION-05` or `CONT-ADMISSION-01` when the binding is warn-only.
+
+Review evidence to request:
+
+- `ValidatingAdmissionPolicy` and `ValidatingAdmissionPolicyBinding` resources.
+- `MutatingAdmissionPolicy` and `MutatingAdmissionPolicyBinding` resources when mutation is expected.
+- Binding validation actions, namespace selectors, and workload match evidence.
+
+## Vulnerable: policy omits init or ephemeral containers
+
+```yaml
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPAllowPrivilegeEscalationContainer
+metadata:
+  name: deny-privilege-escalation
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+  parameters:
+    exemptImages: ["registry.local/debug:*"]
+```
+
+Expected finding: `CONT-ADMISSION-04` when coverage is not proven for init and ephemeral containers, and `CONT-ADMISSION-03` when exceptions are broad.
+
+Review evidence to request:
+
+- Constraint template logic proving app, init, and ephemeral containers are checked.
+- Exception scope, owner, expiry, and review evidence.
+- Workload labels and namespace selectors proving the policy matches the assessed pod.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `container-security`
**Skill path:** `skills/cloud/container-security/`

Closes #168.

### What Was Wrong
The skill covered Pod Security Standards, CIS Kubernetes controls, and general OPA/Gatekeeper policy review, but it did not require evidence for sandbox runtime selection or admission-time enforcement.

That leaves two gaps: a workload can claim `runtimeClassName: gvisor` without a verified `RuntimeClass` object or handler, and a policy can exist in the repo while only running in audit/warn mode or excluding the workload under review. Root init containers also need evidence-based scoring instead of being treated like long-running root app containers.

### What This PR Fixes
- Adds `RuntimeClass and Admission Policy Evidence` as a dedicated review step.
- Adds `CONT-RUNTIME-*`, `CONT-ADMISSION-*`, and `CONT-INIT-*` checks.
- Requires evidence for `runtimeClassName`, matching `RuntimeClass` object, handler/runtime implementation, policy mode, selectors, bindings, exceptions, and container coverage.
- Adds CEL admission resources to discovery expectations: `ValidatingAdmissionPolicy`, `ValidatingAdmissionPolicyBinding`, `MutatingAdmissionPolicy`, and `MutatingAdmissionPolicyBinding`.
- Refines severity language so constrained root init containers are reviewed as scoped exceptions, while unsafe root init context remains High/Critical.
- Adds a runtime/admission evidence matrix to the output format.

### Evidence
**Before (runtime class claim is insufficient):**
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: untrusted-plugin-runner
spec:
  template:
    spec:
      runtimeClassName: gvisor
      containers:
        - name: runner
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop: ["ALL"]
```

**After (now correctly handled):**
The review must verify the matching `RuntimeClass` object, handler/runtime evidence, namespace or node eligibility, and whether the workload risk tier justifies sandbox runtime requirements. Missing evidence maps to `CONT-RUNTIME-01` or `CONT-RUNTIME-02`.

### Test Cases Added/Updated
- [x] Added constrained root init container exception fixture
- [x] Added `runtimeClassName` without matching object evidence fixture
- [x] Added audit-only Kyverno policy fixture
- [x] Added Kubernetes CEL admission resource fixture
- [x] Added Gatekeeper policy coverage/exception fixture for init and ephemeral containers

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Validation
- [x] Red check first: local assertion failed on upstream `main` because RuntimeClass/admission finding IDs, output evidence, and fixture coverage were absent.
- [x] Windows: coverage/frontmatter/index/payment-marker checks passed; `git diff --check` passed.
- [x] WSL Ubuntu 26.04: same targeted checks passed; worktree-aware Git diff check passed with CRLF handling.
- [x] Duplicate check: no open PR found for `#168`, `CONT-RUNTIME`, `CONT-ADMISSION`, RuntimeClass, or CEL admission gates before submission.
- [x] No public payout details included in the PR.

### Pull Request Checklist
- [x] Skill follows the format specification in `CONTRIBUTING.md`
- [x] At least one real framework is cited with correct control IDs
- [x] All framework references verified against primary sources already referenced by the skill
- [x] Prompt Injection Safety Notice section remains included
- [x] `injection-hardened: true` remains set in frontmatter
- [x] `allowed-tools` remains scoped to minimum necessary permissions
- [x] Tested with at least one AI coding agent: Codex local review and fixture checks
- [x] No prohibited patterns per `SECURITY.md`
- [x] `index.yaml` not changed because this is an existing skill improvement

### Bounty Info
- [x] I have read and agree to the `CONTRIBUTING.md` bounty terms
- **Preferred payment method:** Can provide privately after acceptance
