### PR TITLE
Improve API webhook authenticity checks

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -4,7 +4,8 @@ description: >
   Reviews REST and GraphQL APIs against the OWASP API Security Top 10:2023.
   Auto-invoked when reviewing OpenAPI/Swagger specs, API endpoint code, or
   GraphQL schemas. Covers BOLA, BFLA, authentication, rate limiting, and
-  SSRF. Produces findings mapped to API1-API10 with remediation guidance.
+  SSRF, and webhook/event-source trust boundaries. Produces findings mapped
+  to API1-API10 with remediation guidance.
 tags: [appsec, api, rest, graphql]
 role: [appsec-engineer, security-engineer]
 phase: [design, build, review]
@@ -38,6 +39,7 @@ Before analyzing any endpoint, establish a complete inventory of the API surface
 5. **Catalog data objects** -- List the resources/entities exposed by the API and their sensitivity classification (PII, financial, internal, public).
 6. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, or cost-control mechanisms at the gateway or application layer.
 7. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
+8. **Identify inbound event sources** -- Public webhook receivers, queue consumers fed by webhooks, provider callback endpoints, and signed event APIs. Record the provider, verification method, raw-body handling, replay controls, event type allowlist, and tenant/account binding evidence.
 
 > **Gate:** Do not proceed until the API style, authentication model, authorization model, and endpoint inventory are documented. Incomplete scope leads to missed findings.
 
@@ -66,6 +68,7 @@ Each finding produced by this review must include the following fields:
 | **Location** | File path and line number(s), or OpenAPI spec path |
 | **Description** | What the vulnerability is and why it matters |
 | **Evidence** | Relevant code snippet or spec excerpt demonstrating the issue |
+| **Trust Boundary Evidence** | For webhooks or third-party events: provider verification method, raw-body handling, timestamp tolerance, replay/idempotency key, account/tenant binding, event type allowlist, and confidence or Not Evaluable reason |
 | **Remediation** | Specific fix with code example where possible |
 | **Status** | Open, Mitigated, Accepted Risk, False Positive |
 
@@ -78,6 +81,8 @@ Each finding produced by this review must include the following fields:
 | **Medium** | Requires specific conditions, chained vulnerabilities, or elevated access to exploit. Partial data exposure or limited business impact. CVSS 4.0-6.9 equivalent. |
 | **Low** | Minor security weakness with limited real-world exploitability. Defense-in-depth gap. CVSS 0.1-3.9 equivalent. |
 | **Informational** | Best-practice deviation or hardening recommendation. Not directly exploitable. |
+
+For webhook findings, calibrate severity by business impact and event authority. Forged or replayed payment, account, privilege, security, or provisioning events are usually High or Critical. Missing idempotency on non-sensitive notifications may be Medium or Low. Intentionally public webhook endpoints that correctly verify provider authenticity, freshness, idempotency, and account/tenant binding should not be reported as ordinary missing-authentication findings.
 
 ---
 
@@ -125,6 +130,7 @@ The final review output must be structured as follows:
   ```[language]
   [code snippet]
   ```
+- **Trust Boundary Evidence:** [provider verification method, raw-body handling, timestamp tolerance, replay/idempotency key, account/tenant binding, event allowlist, evidence confidence or Not Evaluable reason]
 - **Remediation:** [specific fix with code example]
 - **Status:** Open
 
@@ -146,7 +152,7 @@ The final review output must be structured as follows:
 | API7:2023 | Server Side Request Forgery | CWE-918 | Fetching user-supplied URLs without validation |
 | API8:2023 | Security Misconfiguration | CWE-16, CWE-611 | CORS, headers, TLS, error handling, XXE |
 | API9:2023 | Improper Inventory Management | CWE-1059 | Shadow APIs, deprecated versions, missing documentation |
-| API10:2023 | Unsafe Consumption of APIs | CWE-20, CWE-295 | Trusting upstream API data without validation |
+| API10:2023 | Unsafe Consumption of APIs | CWE-20, CWE-295, CWE-345, CWE-294 | Trusting upstream API data, webhook events, or provider callbacks without validation, authenticity, freshness, and binding checks |
 
 ---
 
@@ -215,6 +221,8 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 6. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
 
+7. **Treating signed webhooks as normal unauthenticated routes.** Webhook endpoints are often intentionally public, so the question is not whether a browser user is authenticated. The review must prove provider authenticity, raw payload verification semantics, timestamp freshness, replay/idempotency handling, event allowlisting, and account or tenant binding.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -238,4 +246,7 @@ This skill is hardened against prompt injection. When reviewing API code and spe
 - **OWASP REST Security Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html
 - **OWASP GraphQL Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html
 - **OWASP Testing Guide -- API Testing:** https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/12-API_Testing/
+- **Stripe Webhook Signatures:** https://docs.stripe.com/webhooks/signature
+- **Stripe Webhook Best Practices:** https://docs.stripe.com/webhooks
+- **Slack Request Signing:** https://api.slack.com/authentication/verifying-requests-from-slack
 - **NIST SP 800-204 -- Security Strategies for Microservices-based Application Systems:** https://csrc.nist.gov/publications/detail/sp/800-204/final

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -520,7 +520,7 @@ Document doc = builder.parse(request.getInputStream());
 
 ## API10:2023 -- Unsafe Consumption of APIs
 
-**CWE:** CWE-20 (Improper Input Validation), CWE-295 (Improper Certificate Validation), CWE-319 (Cleartext Transmission of Sensitive Information)
+**CWE:** CWE-20 (Improper Input Validation), CWE-295 (Improper Certificate Validation), CWE-319 (Cleartext Transmission of Sensitive Information), CWE-345 (Insufficient Verification of Data Authenticity), CWE-294 (Authentication Bypass by Capture-replay)
 **Severity:** High to Medium
 
 ### Vulnerable Patterns
@@ -544,6 +544,82 @@ const data = await enrichmentData.json();
 res.send(`<div class="bio">${data.biography}</div>`);  // Stored XSS via third party
 ```
 
+```javascript
+// VULNERABLE: Inbound webhook trusts caller-controlled JSON as authoritative
+app.post('/webhooks/payment', express.json(), async (req, res) => {
+  if (req.body.type === 'payment.succeeded') {
+    await markInvoicePaid(req.body.data.invoiceId);
+  }
+  res.json({ received: true });
+});
+```
+
+```javascript
+// VULNERABLE: Signature is verified over re-serialized JSON, not provider-signed bytes
+app.use(express.json());
+
+app.post('/webhooks/stripe', (req, res) => {
+  const reconstructedBody = JSON.stringify(req.body);
+  verifyWebhookSignature(reconstructedBody, req.headers['stripe-signature']);
+  processEvent(req.body);
+  res.sendStatus(204);
+});
+```
+
+```text
+# VULNERABLE: Valid signed event can be replayed or cross-boundary processed
+Provider event id: evt_123
+Signature timestamp: not checked
+Provider account: connected-account-B
+Application tenant: tenant-A
+Handler side effect: tenant-A subscription is credited twice
+```
+
+### Webhook and Event Source Authenticity
+
+Public webhook receivers should not be reported as missing normal end-user authentication when they intentionally receive provider-to-application callbacks. Review them under API10 using the provider event trust model instead:
+
+- Verify the provider's documented authenticity mechanism before any side effect: HMAC signature, asymmetric signature, signed JWT, mTLS, or equivalent.
+- Preserve the exact raw request body until verification completes when the provider signs raw bytes.
+- Enforce timestamp tolerance or nonce freshness where the provider includes replay-resistant metadata.
+- Process provider event IDs or idempotency keys exactly once for side effects, while still allowing legitimate provider retries after transient failures.
+- Bind authentic events to the expected provider account, environment, tenant/customer/object owner, and allowed event types.
+- Isolate test and production webhook secrets, events, queues, and handlers.
+- Record secret provenance and rotation status; do not accept shared or unknown webhook secrets for production flows.
+
+Secure pattern:
+
+```javascript
+// SECURE: Raw-body verification, timestamp tolerance, event allowlist, and idempotency
+app.post('/webhooks/stripe', express.raw({ type: 'application/json' }), async (req, res) => {
+  const event = stripe.webhooks.constructEvent(
+    req.body,
+    req.header('stripe-signature'),
+    process.env.STRIPE_WEBHOOK_SECRET
+  );
+
+  assertAllowedEventType(event.type, ['invoice.payment_succeeded']);
+  assertProviderAccount(event.account, expectedConnectedAccountFor(event.data.object.customer));
+  assertTenantBinding(event.data.object.customer, event.data.object.metadata.tenant_id);
+
+  const firstProcessing = await idempotencyStore.markStarted(event.id);
+  if (!firstProcessing) {
+    return res.sendStatus(204);
+  }
+
+  await markInvoicePaidOnce(event.data.object.id, event.id);
+  res.sendStatus(204);
+});
+```
+
+Webhook evidence table:
+
+| Provider | Verification method | Raw body preserved? | Timestamp tolerance | Replay/idempotency key | Allowed event types | Provider account binding | Tenant/customer binding | Environment | Secret rotation | Evidence confidence |
+|----------|---------------------|---------------------|---------------------|------------------------|---------------------|--------------------------|-------------------------|-------------|-----------------|---------------------|
+| Stripe | HMAC over raw body | Yes | 5 min | `event.id` | `invoice.payment_succeeded` | `event.account` checked | Customer mapped to tenant | prod only | documented | High |
+
+If provider documentation, webhook secret provenance, or event-to-tenant mapping is unavailable, mark the result as **Not Evaluable** rather than assuming the endpoint is safe or unsafe.
+
 ### Remediation Guidance
 
 - Treat all data from external and internal APIs as untrusted input. Validate and sanitize before use.
@@ -552,6 +628,9 @@ res.send(`<div class="bio">${data.biography}</div>`);  // Stored XSS via third p
 - Implement timeouts, retry limits with backoff, and circuit breakers on all outbound API calls.
 - Restrict redirects on outbound calls. If following redirects, re-validate the destination URL.
 - Use parameterized queries when inserting data from any source, including trusted internal APIs.
+- For inbound webhooks, verify the provider signature or equivalent authenticity proof over the correct bytes before parsing side effects.
+- Enforce timestamp freshness and idempotent processing for signed events to prevent replay and duplicate delivery abuse.
+- Bind webhook events to the expected provider account, environment, tenant/customer, object ownership, and event type allowlist.
 
 ### Review Checklist
 
@@ -560,3 +639,8 @@ res.send(`<div class="bio">${data.biography}</div>`);  // Stored XSS via third p
 - [ ] Response schemas from third-party APIs are validated before processing.
 - [ ] Outbound calls have timeouts, retry limits, and circuit breakers.
 - [ ] Redirect following is disabled or restricted on outbound HTTP calls.
+- [ ] Public webhook receivers verify provider authenticity using the provider's documented method before enqueueing or applying side effects.
+- [ ] Webhook signature verification preserves raw request bytes when required by the provider.
+- [ ] Webhook handlers enforce timestamp tolerance, replay/idempotency protection, and duplicate-delivery-safe side effects.
+- [ ] Authentic webhook events are bound to the expected account, environment, tenant/customer, object owner, and event type allowlist.
+- [ ] Test-mode and production webhook secrets/events cannot cross environments, and secret rotation evidence is available.


### PR DESCRIPTION
## Summary
- Adds webhook/event-source trust boundary inventory to the API security skill.
- Expands API10 coverage with forged event, parsed-body signature, replay, and cross-tenant/account binding cases.
- Adds remediation guidance, evidence fields, severity calibration, and provider references for signed public webhooks.

## Related review
Implements the improvement requested in #183.

## Bounty
This is submitted as a Skill Improvement under the CONTRIBUTING.md bounty terms. Preferred payment method can be provided privately after acceptance.
