### PR TITLE
Improve IaC plan/state evidence checks

### DIFF
--- a/skills/cloud/iac-security/SKILL.md
+++ b/skills/cloud/iac-security/SKILL.md
@@ -57,6 +57,7 @@ The OWASP IaC Security Cheat Sheet categorizes common IaC vulnerabilities. SLSA 
 - Variable definition files and environment-specific overrides
 - State file references (for understanding current deployment, if available)
 - Terraform plan JSON, saved plan files, remote backend metadata, CI artifact rules, and live-state or drift evidence when reviewing effective Terraform security posture
+- Equivalent deploy-time evidence for other IaC frameworks when available, such as CloudFormation change sets and stack exports, Pulumi preview JSON and stack exports, or Bicep/ARM what-if output
 
 ---
 
@@ -99,7 +100,7 @@ For detailed tool-specific rule sets, detection patterns, vulnerable code exampl
 
 ---
 
-### Step 10: Terraform Plan, State, and Drift Evidence
+### Step 10: IaC Plan, State, and Drift Evidence
 
 When reviewing Terraform, separate source-code evidence from resolved plan, state, and deployed-state evidence. Do not claim that an effective control passes when source files alone cannot prove the deployed value after variables, workspace settings, provider defaults, imported resources, ignored attributes, data sources, or generated modules are resolved.
 
@@ -112,9 +113,19 @@ Record whether the review had access to each of the following:
 - Drift or live-cloud evidence for resources that may be changed outside the reviewed module
 - Scanner suppression directives and their owner, reason, expiry, ticket or risk acceptance, environment scope, and compensating controls
 
+For non-Terraform IaC, collect the closest equivalent evidence instead of skipping this step:
+
+| Framework | Effective Evidence to Request |
+|-----------|-------------------------------|
+| CloudFormation / SAM | Change sets, processed templates, `get-template`, `describe-stacks`, StackSet deployment status, drift detection, and stack events |
+| Pulumi | `pulumi preview --json`, `pulumi stack export`, policy pack results, stack configuration, and drift evidence |
+| Bicep / ARM | `what-if` output, compiled ARM template JSON, deployment operation logs, and live-resource state |
+
 Treat Terraform state, saved plan files, `terraform show -json` output, and CI plan artifacts as sensitive unless the review proves they are redacted, encrypted, access-controlled, and retained safely. Values marked `sensitive = true` can still persist in state and plan artifacts.
 
 When Terraform JSON plan evidence is available, inspect `resource_changes[].change.actions`, `before`, `after`, and `after_unknown` for destructive changes, privilege expansion, public exposure, replacements, and unknown-at-apply security values. If plan/state/live evidence is unavailable for a control that depends on resolved values or deployed state, mark the result as `Not Evaluable from Source Only` instead of passing or failing it from source alone.
+
+Use `Fail` when the reviewed source or available plan/state/live evidence directly proves a violation, such as hardcoded secrets, public ingress, missing encryption, or unbounded IAM in the reviewed artifact. Use `Not Evaluable from Source Only` when the result depends on resolved values, imported resources, provider defaults, deployment account context, runtime drift, or policy-as-code results that were not available. Record the missing evidence rather than downgrading a source-proven finding.
 
 ---
 
@@ -206,6 +217,11 @@ Produce the final report using the structure defined in the Output Format sectio
 |-------------|-------------|------|-------|--------|--------|-------|--------------------------|----------------------|--------|
 | <checkov:skip / tfsec:ignore / kics ignore> | <path:line> | <rule id> | <owner> | <reason> | <date> | <env/resource> | <link/id> | <control> | Accepted / Expired / Missing Evidence |
 
+Suppression status values:
+- **Accepted:** owner, reason, scope, approval or risk acceptance, compensating control, and unexpired review date are present.
+- **Expired:** expiry or review date has passed, or the linked ticket/risk acceptance is no longer valid.
+- **Missing Evidence:** the suppression may be technically scoped, but one or more lifecycle fields are absent.
+
 ### Supply Chain Assessment (SLSA Alignment)
 - Module pinning: <pinned / partially pinned / unpinned>
 - Provider pinning: <pinned / unpinned>
@@ -276,7 +292,8 @@ This skill applies checks equivalent to the following high-impact rules:
 7. **Source-only overconfidence.** Source files do not prove effective deployed security when variables, workspace settings, provider defaults, imported resources, ignored attributes, or manual drift are involved. Use `Not Evaluable from Source Only` when plan/state/live evidence is required but unavailable.
 8. **Plan JSON blind spots.** Terraform JSON plans expose `resource_changes[].change.actions`, `before`, `after`, and `after_unknown`. Review those fields for destructive changes, privilege expansion, replacements, public exposure, and unknown-at-apply security values.
 9. **Suppression comments without lifecycle evidence.** `checkov:skip`, `tfsec:ignore`, and KICS ignore directives need owner, reason, expiry, environment scope, ticket or risk acceptance, and compensating-control evidence. Missing lifecycle evidence should be reported.
-10. **Provider-specific encryption defaults.** Some providers encrypt by default (e.g., AWS S3 since January 2023). Know the defaults before flagging missing explicit encryption configuration.
+10. **Ignoring policy-as-code plan checks.** OPA, Sentinel, and `terraform-compliance` can evaluate plan output before apply. If those policy results are part of the pipeline, include pass/fail evidence and policy exceptions in the evidence-origin summary.
+11. **Provider-specific encryption defaults.** Some providers encrypt by default (e.g., AWS S3 since January 2023). Know the defaults before flagging missing explicit encryption configuration.
 
 ---
 
@@ -318,5 +335,5 @@ This skill applies checks equivalent to the following high-impact rules:
 
 ## Changelog
 
-- **1.1.0** -- Added Terraform plan/state evidence gates, evidence-origin reporting, source-only not-evaluable outcomes, and suppression lifecycle tracking.
+- **1.1.0** -- Added Terraform and equivalent IaC plan/state evidence gates, evidence-origin reporting, source-only not-evaluable outcomes, and suppression lifecycle tracking.
 - **1.0.0** -- Initial release. Coverage of eight security domains across Terraform, CloudFormation, Pulumi, and Bicep with Checkov/tfsec/KICS rule equivalents.

--- a/skills/cloud/iac-security/SKILL.md
+++ b/skills/cloud/iac-security/SKILL.md
@@ -13,7 +13,7 @@ phase: [build, review]
 frameworks: [OWASP-IaC-Security, SLSA-v1.0, CIS-Benchmarks]
 difficulty: intermediate
 time_estimate: "45-90min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -56,6 +56,7 @@ The OWASP IaC Security Cheat Sheet categorizes common IaC vulnerabilities. SLSA 
 - Access to module registries or module source references
 - Variable definition files and environment-specific overrides
 - State file references (for understanding current deployment, if available)
+- Terraform plan JSON, saved plan files, remote backend metadata, CI artifact rules, and live-state or drift evidence when reviewing effective Terraform security posture
 
 ---
 
@@ -98,10 +99,26 @@ For detailed tool-specific rule sets, detection patterns, vulnerable code exampl
 
 ---
 
+### Step 10: Terraform Plan, State, and Drift Evidence
+
+When reviewing Terraform, separate source-code evidence from resolved plan, state, and deployed-state evidence. Do not claim that an effective control passes when source files alone cannot prove the deployed value after variables, workspace settings, provider defaults, imported resources, ignored attributes, data sources, or generated modules are resolved.
+
+Record whether the review had access to each of the following:
+
+- Backend type, encryption configuration, locking, access scope, and local fallback behavior
+- Saved binary plan files, `terraform show -json` output, Terraform Cloud/HCP plan JSON, and CI plan logs
+- CI artifact upload rules, retention period, redaction behavior, and who can download plan/state artifacts
+- Terraform state location, encryption, retention, backup handling, and least-privilege access controls
+- Drift or live-cloud evidence for resources that may be changed outside the reviewed module
+- Scanner suppression directives and their owner, reason, expiry, ticket or risk acceptance, environment scope, and compensating controls
+
+Treat Terraform state, saved plan files, `terraform show -json` output, and CI plan artifacts as sensitive unless the review proves they are redacted, encrypted, access-controlled, and retained safely. Values marked `sensitive = true` can still persist in state and plan artifacts.
+
+When Terraform JSON plan evidence is available, inspect `resource_changes[].change.actions`, `before`, `after`, and `after_unknown` for destructive changes, privilege expansion, public exposure, replacements, and unknown-at-apply security values. If plan/state/live evidence is unavailable for a control that depends on resolved values or deployed state, mark the result as `Not Evaluable from Source Only` instead of passing or failing it from source alone.
 
 ---
 
-### Step 10: Compile Assessment Report
+### Step 11: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
 
@@ -136,32 +153,58 @@ Produce the final report using the structure defined in the Output Format sectio
 - Total checks evaluated: <N>
 - Passed: <N>
 - Failed: <N>
+- Not evaluable from source only: <N>
 - Critical/High findings requiring immediate attention: <N>
 
 ### Findings by Domain
 
-| Domain | Critical | High | Medium | Low | Pass |
-|--------|----------|------|--------|-----|------|
-| Secrets Management | X | X | X | X | X |
-| Public Exposure | X | X | X | X | X |
-| Encryption | X | X | X | X | X |
-| IAM & Access Control | X | X | X | X | X |
-| Logging & Monitoring | X | X | X | X | X |
-| Network Security | X | X | X | X | X |
-| Supply Chain Integrity | X | X | X | X | X |
-| Resource Hardening | X | X | X | X | X |
+| Domain | Critical | High | Medium | Low | Pass | Not Evaluable |
+|--------|----------|------|--------|-----|------|---------------|
+| Secrets Management | X | X | X | X | X | X |
+| Public Exposure | X | X | X | X | X | X |
+| Encryption | X | X | X | X | X | X |
+| IAM & Access Control | X | X | X | X | X | X |
+| Logging & Monitoring | X | X | X | X | X | X |
+| Network Security | X | X | X | X | X | X |
+| Supply Chain Integrity | X | X | X | X | X | X |
+| Resource Hardening | X | X | X | X | X | X |
 
 ### Detailed Findings
 
 #### [DOMAIN-N] <Finding Title>
-- **Status:** Fail
+- **Status:** Fail / Pass / Not Evaluable from Source Only
 - **Severity:** Critical / High / Medium / Low
 - **Equivalent Rule:** Checkov CKV_XXX_NN / tfsec xxx-xxx / KICS xxxxxxxx
+- **Evidence Origin:** Source / Plan / State / Live / Not Evaluable from Source Only
 - **File:** <path>
 - **Line(s):** <line numbers>
 - **Description:** <what was found>
 - **Evidence:** <specific code>
 - **Remediation:** <fix with code example>
+
+### Terraform Plan and State Evidence
+
+| Evidence Gate | Status | Evidence | Risk if Missing |
+|---------------|--------|----------|-----------------|
+| Backend type identified | Present / Missing / Not applicable | <S3 / GCS / AzureRM / Terraform Cloud / local> | Cannot judge state protection or shared state behavior |
+| State encryption and locking | Present / Missing / Not applicable | <configuration or backend policy> | State may expose secrets or allow concurrent unsafe applies |
+| State and plan artifact access scope | Present / Missing / Not applicable | <IAM / workspace / artifact ACLs> | Sensitive state or plan data may be broadly readable |
+| CI artifact retention and redaction | Present / Missing / Not applicable | <workflow or CI settings> | Saved plans or JSON output may persist beyond review need |
+| Plan JSON reviewed | Present / Missing / Not applicable | <source and timestamp> | Effective changes may be hidden by variables or provider defaults |
+| Drift/live-state evidence reviewed | Present / Missing / Not applicable | <cloud/state/drift tool evidence> | Source may not match deployed security posture |
+| Local fallback and backups checked | Present / Missing / Not applicable | <local state, backups, crash logs> | Secrets may remain on developer or CI hosts |
+
+### Evidence Origin Summary
+
+| Control / Finding | Source | Plan | State | Live | Outcome |
+|-------------------|--------|------|-------|------|---------|
+| <control name> | Reviewed / Missing | Reviewed / Missing | Reviewed / Missing | Reviewed / Missing | Pass / Fail / Not Evaluable from Source Only |
+
+### Suppression Register
+
+| Suppression | File / Line | Rule | Owner | Reason | Expiry | Scope | Ticket / Risk Acceptance | Compensating Control | Status |
+|-------------|-------------|------|-------|--------|--------|-------|--------------------------|----------------------|--------|
+| <checkov:skip / tfsec:ignore / kics ignore> | <path:line> | <rule id> | <owner> | <reason> | <date> | <env/resource> | <link/id> | <control> | Accepted / Expired / Missing Evidence |
 
 ### Supply Chain Assessment (SLSA Alignment)
 - Module pinning: <pinned / partially pinned / unpinned>
@@ -169,6 +212,7 @@ Produce the final report using the structure defined in the Output Format sectio
 - State encryption: <encrypted / unencrypted>
 - State locking: <enabled / disabled>
 - Lock file committed: <yes / no>
+- Plan/state evidence confidence: <High / Medium / Low / Not Evaluable from Source Only>
 
 ### Prioritized Remediation Plan
 
@@ -228,8 +272,11 @@ This skill applies checks equivalent to the following high-impact rules:
 3. **Module abstraction hiding misconfigurations.** A module call may look clean, but the module source may contain insecure defaults. When possible, trace into module source code.
 4. **CloudFormation parameters with NoEcho.** Parameters marked `NoEcho: true` are not necessarily secure -- the default value is still in plaintext in the template.
 5. **Confusing `aws_s3_bucket_acl` with `aws_s3_bucket_public_access_block`.** The public access block overrides ACLs. Check both, but the access block is the stronger control.
-6. **Terraform state file secrets.** Even when variables are marked `sensitive`, they may appear in plaintext in the state file. Verify state encryption and access controls.
-7. **Provider-specific encryption defaults.** Some providers encrypt by default (e.g., AWS S3 since January 2023). Know the defaults before flagging missing explicit encryption configuration.
+6. **Terraform state and plan artifact secrets.** Even when variables are marked `sensitive`, values may appear in state files, saved binary plans, `terraform show -json` output, CI logs, or artifact uploads. Verify encryption, locking, access scope, redaction, and retention controls before claiming the artifacts are protected.
+7. **Source-only overconfidence.** Source files do not prove effective deployed security when variables, workspace settings, provider defaults, imported resources, ignored attributes, or manual drift are involved. Use `Not Evaluable from Source Only` when plan/state/live evidence is required but unavailable.
+8. **Plan JSON blind spots.** Terraform JSON plans expose `resource_changes[].change.actions`, `before`, `after`, and `after_unknown`. Review those fields for destructive changes, privilege expansion, replacements, public exposure, and unknown-at-apply security values.
+9. **Suppression comments without lifecycle evidence.** `checkov:skip`, `tfsec:ignore`, and KICS ignore directives need owner, reason, expiry, environment scope, ticket or risk acceptance, and compensating-control evidence. Missing lifecycle evidence should be reported.
+10. **Provider-specific encryption defaults.** Some providers encrypt by default (e.g., AWS S3 since January 2023). Know the defaults before flagging missing explicit encryption configuration.
 
 ---
 
@@ -259,10 +306,17 @@ This skill applies checks equivalent to the following high-impact rules:
 - KICS (Keeping Infrastructure as Code Secure): https://docs.kics.io/
 - cfn-nag Rules: https://github.com/stelligent/cfn_nag
 - Terraform Security Best Practices: https://developer.hashicorp.com/terraform/cloud-docs/recommended-practices
+- Terraform sensitive values: https://developer.hashicorp.com/terraform/tutorials/configuration-language/sensitive-variables
+- Terraform state documentation: https://docs.hashicorp.com/terraform/language/state
+- Terraform backend state storage and locking: https://docs.hashicorp.com/terraform/language/state/backends
+- Terraform JSON output format: https://developer.hashicorp.com/terraform/internals/json-format
+- Checkov suppressing and skipping policies: https://www.checkov.io/2.Basics/Suppressing%20and%20Skipping%20Policies.html
+- tfsec ignore configuration: https://aquasecurity.github.io/tfsec/v1.27.2/guides/configuration/ignores/
 - AWS Security Best Practices in IAM: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 
 ---
 
 ## Changelog
 
+- **1.1.0** -- Added Terraform plan/state evidence gates, evidence-origin reporting, source-only not-evaluable outcomes, and suppression lifecycle tracking.
 - **1.0.0** -- Initial release. Coverage of eight security domains across Terraform, CloudFormation, Pulumi, and Bicep with Checkov/tfsec/KICS rule equivalents.

--- a/skills/cloud/iac-security/tool-rules.md
+++ b/skills/cloud/iac-security/tool-rules.md
@@ -488,6 +488,8 @@ State and saved plan artifacts can contain secrets and effective configuration t
 - drift or live-cloud evidence for imported or manually changed resources
 ```
 
+Equivalent evidence for non-Terraform IaC should be captured when available: CloudFormation change sets, StackSet deployment status, drift detection, processed templates, Pulumi preview JSON, Pulumi stack exports, policy pack results, Bicep/ARM what-if output, compiled ARM JSON, and deployment operation logs.
+
 When plan JSON is available, review these fields before claiming effective security posture:
 
 ```json
@@ -521,6 +523,16 @@ resource "aws_s3_bucket_acl" "legacy" {
 ```
 
 Require owner, reason, expiry, environment scope, ticket or risk acceptance, and compensating-control evidence. Missing lifecycle evidence should be reported even if the suppression is technically valid.
+
+Use these status rules in the suppression register:
+
+| Status | Criteria |
+|--------|----------|
+| Accepted | Owner, reason, scoped resource/environment, approval or risk acceptance, compensating control, and unexpired review date are present |
+| Expired | Expiry/review date has passed, or the linked ticket/risk acceptance is closed or invalid |
+| Missing Evidence | One or more lifecycle fields are absent, even if the skip syntax is valid |
+
+If OPA, Sentinel, `terraform-compliance`, Checkov, tfsec, or KICS policy-as-code results are generated from plan output, record the policy result, exception owner, and evidence artifact alongside the raw plan JSON review.
 
 ### Lock File Presence
 

--- a/skills/cloud/iac-security/tool-rules.md
+++ b/skills/cloud/iac-security/tool-rules.md
@@ -474,6 +474,54 @@ terraform {
 
 **Checkov:** CKV_AWS_145 (S3 backend encryption)
 
+### Terraform Plan and State Artifact Evidence
+
+State and saved plan artifacts can contain secrets and effective configuration that is not visible in source files. Treat the following as sensitive inputs and report `Not Evaluable from Source Only` when a control depends on them but they are unavailable:
+
+```text
+# Evidence to request or inspect
+- terraform show -json <saved-plan>
+- Terraform Cloud/HCP run plan JSON and workspace variables
+- CI logs and uploaded plan artifacts
+- remote backend IAM policy, encryption settings, lock table, and retention
+- local terraform.tfstate, *.tfstate.backup, crash logs, and saved tfplan files
+- drift or live-cloud evidence for imported or manually changed resources
+```
+
+When plan JSON is available, review these fields before claiming effective security posture:
+
+```json
+{
+  "resource_changes": [
+    {
+      "address": "aws_iam_policy.admin",
+      "change": {
+        "actions": ["update"],
+        "before": {"policy": "...limited..."},
+        "after": {"policy": "{\"Statement\":[{\"Action\":\"*\",\"Resource\":\"*\"}]}"},
+        "after_unknown": {}
+      }
+    }
+  ]
+}
+```
+
+Flag risky transitions such as `create`, `delete`, `replace`, privilege expansion, public exposure, encryption disablement, or security-relevant `after_unknown` values. Do not treat `sensitive = true` as proof that secrets are absent from state, saved plans, `terraform show -json`, CI logs, or downloadable artifacts.
+
+### Scanner Suppression Evidence
+
+Suppression directives should be inventoried and validated rather than trusted:
+
+```hcl
+#checkov:skip=CKV_AWS_20:temporary public access for migration
+#tfsec:ignore:aws-s3-no-public-access-with-acl
+resource "aws_s3_bucket_acl" "legacy" {
+  acl = "public-read"
+}
+```
+
+Require owner, reason, expiry, environment scope, ticket or risk acceptance, and compensating-control evidence. Missing lifecycle evidence should be reported even if the suppression is technically valid.
+
 ### Lock File Presence
 
 Verify `.terraform.lock.hcl` exists and is committed:


### PR DESCRIPTION
## Summary
- Adds Terraform plan/state/drift evidence gates to the iac-security skill.
- Updates the report template with evidence-origin fields, Not Evaluable from Source Only outcomes, plan/state evidence tables, and a suppression register.
- Extends tool rules with plan JSON review guidance, sensitive artifact handling, and suppression lifecycle evidence.

## Validation
- git diff --check
- Verified updated skill and tool-rules files exist

## Related review
Implements the improvement requested in #188.

## Bounty
This is submitted as a Skill Improvement under the CONTRIBUTING.md bounty terms. Preferred payment method can be provided privately after acceptance.
