### PR TITLE
Add AWS organization evidence scope

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -55,7 +55,7 @@ The CIS Amazon Web Services Foundations Benchmark v3.0.0 is a consensus-driven s
 - S3 bucket policies and ACL configurations
 - VPC, security group, and NACL definitions
 - CloudTrail and CloudWatch configuration files
-- AWS Organizations metadata, delegated administrator configuration, account/OU inventory, Region scope, Security Hub central configuration, AWS Config aggregators, and SCPs when making organization-wide conclusions
+- AWS Organizations metadata, delegated administrator configuration, account/OU inventory, Region scope, Security Hub central configuration, AWS Config aggregators, SCPs, CloudFormation StackSets, AWS RAM shares, and Control Tower guardrails when making organization-wide conclusions
 
 ---
 
@@ -90,6 +90,9 @@ Also locate supporting configuration:
 **/scp/**
 **/service-control-policies/**
 **/access-analyzer/**
+**/stacksets/**
+**/ram/**
+**/controltower/**
 ```
 
 Record all discovered files. If no AWS configurations are found, report that finding and halt.
@@ -102,16 +105,20 @@ Before scoring CIS controls, record the scope of each evidence source. Distingui
 
 Capture:
 
-- AWS Organization ID, management account, delegated administrator accounts, and evidence export date
-- Accounts and OUs reviewed, excluded accounts/OUs, suspended accounts, newly created accounts, and the coverage denominator
-- Regions reviewed, opt-in Regions, Security Hub home Region, linked Regions, and Regions excluded from central configuration
-- Whether each evidence source is account-local, delegated-admin scoped, organization-wide, sampled, or IaC-only
-- Whether CloudTrail trails are account trails or organization trails, including owning account and covered accounts/OUs
-- Whether IAM Access Analyzer is `ACCOUNT` or `ORGANIZATION` scoped, and whether delegated administrator configuration is present
-- Security Hub CSPM central configuration status, policy associations, centrally managed targets, self-managed targets, and exceptions
-- AWS Config aggregator scope and SCP/permission-boundary/session-policy evidence that constrains effective access
+- [ ] AWS Organization ID, management account, delegated administrator accounts, and evidence export date
+- [ ] Accounts and OUs reviewed, excluded accounts/OUs, suspended accounts, newly created accounts, and the coverage denominator
+- [ ] Regions reviewed, opt-in Regions, Security Hub home Region, linked Regions, and Regions excluded from central configuration
+- [ ] Whether each evidence source is account-local, delegated-admin scoped, organization-wide, sampled, or IaC-only
+- [ ] Whether CloudTrail trails are account trails or organization trails, including owning account and covered accounts/OUs
+- [ ] Whether IAM Access Analyzer is `ACCOUNT` or `ORGANIZATION` scoped, and whether delegated administrator configuration is present
+- [ ] Security Hub CSPM central configuration status, policy associations, centrally managed targets, self-managed targets, and exceptions
+- [ ] AWS Config aggregator scope and SCP/permission-boundary/session-policy evidence that constrains effective access
+- [ ] CloudFormation StackSets and AWS RAM shares that deploy or share security controls across accounts
+- [ ] AWS Control Tower guardrails, account factory configuration, and landing-zone managed controls if Control Tower resources or account-factory files are detected
 
 Use `Not Evaluable from Single Account` when the evidence cannot prove organization-wide posture, and `Not Evaluable from IaC Only` when runtime, delegated-admin, Region, or account coverage evidence is required but unavailable.
+
+If more than half of the applicable CIS controls are Not Evaluable, flag a data-gap warning in the Executive Summary and do not rely on the compliance percentage without organization-wide evidence collection.
 
 ---
 
@@ -167,6 +174,7 @@ Produce the final report using the structure defined in the Output Format sectio
 - Not Evaluable (insufficient data): <N>
 - Not Evaluable from Single Account: <N>
 - Not Evaluable from IaC Only: <N>
+- Data-gap warning: <required when more than 50% of applicable controls are not evaluable>
 - Overall compliance: <percentage>
 
 ### Section Scores
@@ -185,12 +193,10 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Status:** Pass / Fail / Not Evaluable / Not Evaluable from Single Account / Not Evaluable from IaC Only
 - **Severity:** Critical / High / Medium / Low
 - **CIS Profile:** Level 1 / Level 2
-- **Evidence scope:** Single account / Account+Region / OU / Organization-wide / Delegated admin / IaC only / Sampled
+- **Evidence scope:** single account / account+region / ou / organization-wide / delegated admin / iac only / sampled, with delegate or coverage detail inline when applicable
 - **Account/OU/Region:** <account id, OU, Region list, or coverage denominator>
-- **Delegated admin?:** <yes/no/service/account id>
-- **Organization-wide?:** <yes/no/unknown>
 - **Effective-access qualifiers:** <SCPs / permission boundaries / session policies / resource policies / none reviewed>
-- **Not Evaluable reason:** <single account only / IaC only / missing delegated admin / missing Region denominator / missing account inventory / sampled export>
+- **Not Evaluable reason:** <single account only / iac only / missing delegated admin / missing Region denominator / missing account inventory / sampled export>
 - **File:** <path to relevant config>
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
@@ -205,7 +211,9 @@ Produce the final report using the structure defined in the Output Format sectio
 | IAM Access Analyzer | ACCOUNT / ORGANIZATION / Not reviewed | <account> | <accounts/OUs/denominator> | <Regions> | <account or n/a> | Yes / No / Unknown | <missing Regions/account analyzers> |
 | Security Hub CSPM | Central / Self-managed / Not reviewed | <home Region/account> | <policy target associations> | <home + linked Regions> | <account or n/a> | Yes / No / Unknown | <self-managed targets/exceptions> |
 | AWS Config Aggregator | Organization / Account / Not reviewed | <account> | <accounts/OUs/denominator> | <Regions> | <account or n/a> | Yes / No / Unknown | <excluded accounts/Regions> |
-| SCP / effective access | Reviewed / Missing / Not applicable | <management account> | <accounts/OUs> | <n/a> | <n/a> | Yes / No / Unknown | <policy boundary gaps> |
+| SCP / effective access | Reviewed / Missing / Not applicable | <management account> | <accounts/OUs> | <n/a> | <management account> | Yes / No / Unknown | <policy boundary gaps> |
+| CloudFormation StackSets / AWS RAM | Reviewed / Missing / Not applicable | <management or delegated account> | <stack instances / shared principals> | <Regions> | <account or n/a> | Yes / No / Unknown | <deployment/share gaps> |
+| AWS Control Tower | Reviewed / Missing / Not applicable | <management account> | <landing zone accounts/OUs> | <governed Regions> | <account or n/a> | Yes / No / Unknown | <guardrail/account-factory gaps> |
 
 ### Prioritized Remediation Plan
 
@@ -252,6 +260,7 @@ Produce the final report using the structure defined in the Output Format sectio
 7. **Overclaiming organization coverage from one account.** A member-account CloudTrail, Security Hub export, Access Analyzer, or Config result is useful local evidence, but it does not prove organization-wide coverage unless accounts, OUs, delegated admin, Regions, and exclusions are recorded.
 8. **Over-reporting local gaps when central controls exist.** Organization trails, Security Hub central configuration, AWS Config aggregators, SCPs, and delegated-admin services may cover accounts where local IaC appears incomplete. Record central evidence before escalating the finding.
 9. **Treating SCPs as grants.** SCPs set maximum permissions; they do not grant access and do not make a broad local IAM allow safe without underlying IAM/resource-policy evidence. Use SCPs to calibrate blast radius only when the boundary is verified.
+10. **Missing landing-zone controls.** CloudFormation StackSets, AWS RAM shares, and AWS Control Tower guardrails can deploy or enforce controls outside the local account's IaC. Record these before concluding an organization-wide control is absent.
 
 ---
 

--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-AWS-v3.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -55,6 +55,7 @@ The CIS Amazon Web Services Foundations Benchmark v3.0.0 is a consensus-driven s
 - S3 bucket policies and ACL configurations
 - VPC, security group, and NACL definitions
 - CloudTrail and CloudWatch configuration files
+- AWS Organizations metadata, delegated administrator configuration, account/OU inventory, Region scope, Security Hub central configuration, AWS Config aggregators, and SCPs when making organization-wide conclusions
 
 ---
 
@@ -85,13 +86,36 @@ Also locate supporting configuration:
 **/.aws/credentials
 **/aws-config-rules/**
 **/security-hub/**
+**/organizations/**
+**/scp/**
+**/service-control-policies/**
+**/access-analyzer/**
 ```
 
 Record all discovered files. If no AWS configurations are found, report that finding and halt.
 
 ---
 
-### Step 2 through Step 6: CIS Benchmark Evaluation (Sections 1-5)
+### Step 2: Establish Evidence Scope
+
+Before scoring CIS controls, record the scope of each evidence source. Distinguish member-account evidence from organization-wide evidence so a single account export is not over-reported as an AWS Organizations failure or overclaimed as full coverage.
+
+Capture:
+
+- AWS Organization ID, management account, delegated administrator accounts, and evidence export date
+- Accounts and OUs reviewed, excluded accounts/OUs, suspended accounts, newly created accounts, and the coverage denominator
+- Regions reviewed, opt-in Regions, Security Hub home Region, linked Regions, and Regions excluded from central configuration
+- Whether each evidence source is account-local, delegated-admin scoped, organization-wide, sampled, or IaC-only
+- Whether CloudTrail trails are account trails or organization trails, including owning account and covered accounts/OUs
+- Whether IAM Access Analyzer is `ACCOUNT` or `ORGANIZATION` scoped, and whether delegated administrator configuration is present
+- Security Hub CSPM central configuration status, policy associations, centrally managed targets, self-managed targets, and exceptions
+- AWS Config aggregator scope and SCP/permission-boundary/session-policy evidence that constrains effective access
+
+Use `Not Evaluable from Single Account` when the evidence cannot prove organization-wide posture, and `Not Evaluable from IaC Only` when runtime, delegated-admin, Region, or account coverage evidence is required but unavailable.
+
+---
+
+### Step 3 through Step 7: CIS Benchmark Evaluation (Sections 1-5)
 
 Evaluate all AWS configurations against CIS AWS v3.0.0 Sections 1 through 5, covering Identity and Access Management, Storage, Logging, Monitoring, and Networking.
 
@@ -99,7 +123,7 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
-### Step 7: Compile Assessment Report
+### Step 8: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
 
@@ -127,6 +151,13 @@ Produce the final report using the structure defined in the Output Format sectio
 - Date: <assessment date>
 - Framework: CIS Amazon Web Services Foundations Benchmark v3.0.0
 - Files reviewed: <list of IaC files>
+- Evidence scope: <single account / delegated admin / organization-wide / IaC only / sampled>
+- Organization ID: <org id or not available>
+- Management account: <account id or not available>
+- Delegated administrators: <service -> account id>
+- Accounts/OUs reviewed: <list and denominator>
+- Regions reviewed: <list and excluded/opt-in Regions>
+- Evidence export date: <timestamp>
 
 ### Executive Summary
 - Total CIS recommendations evaluated: <N>/62
@@ -134,29 +165,47 @@ Produce the final report using the structure defined in the Output Format sectio
 - Failed: <N>
 - Not Applicable: <N>
 - Not Evaluable (insufficient data): <N>
+- Not Evaluable from Single Account: <N>
+- Not Evaluable from IaC Only: <N>
 - Overall compliance: <percentage>
 
 ### Section Scores
 
-| Section | Description | Passed | Failed | N/A | Compliance |
-|---------|-------------|--------|--------|-----|------------|
-| 1 | Identity and Access Management | X/22 | Y | Z | nn% |
-| 2 | Storage | X/10 | Y | Z | nn% |
-| 3 | Logging | X/11 | Y | Z | nn% |
-| 4 | Monitoring | X/16 | Y | Z | nn% |
-| 5 | Networking | X/6 | Y | Z | nn% |
+| Section | Description | Passed | Failed | N/A | Not Evaluable | Compliance |
+|---------|-------------|--------|--------|-----|---------------|------------|
+| 1 | Identity and Access Management | X/22 | Y | Z | NE | nn% |
+| 2 | Storage | X/10 | Y | Z | NE | nn% |
+| 3 | Logging | X/11 | Y | Z | NE | nn% |
+| 4 | Monitoring | X/16 | Y | Z | NE | nn% |
+| 5 | Networking | X/6 | Y | Z | NE | nn% |
 
 ### Detailed Findings
 
 #### [CIS X.Y] <Recommendation Title>
-- **Status:** Pass / Fail / Not Evaluable
+- **Status:** Pass / Fail / Not Evaluable / Not Evaluable from Single Account / Not Evaluable from IaC Only
 - **Severity:** Critical / High / Medium / Low
 - **CIS Profile:** Level 1 / Level 2
+- **Evidence scope:** Single account / Account+Region / OU / Organization-wide / Delegated admin / IaC only / Sampled
+- **Account/OU/Region:** <account id, OU, Region list, or coverage denominator>
+- **Delegated admin?:** <yes/no/service/account id>
+- **Organization-wide?:** <yes/no/unknown>
+- **Effective-access qualifiers:** <SCPs / permission boundaries / session policies / resource policies / none reviewed>
+- **Not Evaluable reason:** <single account only / IaC only / missing delegated admin / missing Region denominator / missing account inventory / sampled export>
 - **File:** <path to relevant config>
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration or code snippet>
 - **Remediation:** <specific fix with code example>
+
+### AWS Organization Coverage
+
+| Evidence Source | Scope | Owning Account | Covered Accounts/OUs | Regions | Delegated Admin | Organization-wide? | Gaps / Exceptions |
+|-----------------|-------|----------------|----------------------|---------|-----------------|--------------------|-------------------|
+| CloudTrail | Account trail / Organization trail / Not reviewed | <account> | <accounts/OUs/denominator> | <Regions> | <account or n/a> | Yes / No / Unknown | <excluded/suspended/new accounts> |
+| IAM Access Analyzer | ACCOUNT / ORGANIZATION / Not reviewed | <account> | <accounts/OUs/denominator> | <Regions> | <account or n/a> | Yes / No / Unknown | <missing Regions/account analyzers> |
+| Security Hub CSPM | Central / Self-managed / Not reviewed | <home Region/account> | <policy target associations> | <home + linked Regions> | <account or n/a> | Yes / No / Unknown | <self-managed targets/exceptions> |
+| AWS Config Aggregator | Organization / Account / Not reviewed | <account> | <accounts/OUs/denominator> | <Regions> | <account or n/a> | Yes / No / Unknown | <excluded accounts/Regions> |
+| SCP / effective access | Reviewed / Missing / Not applicable | <management account> | <accounts/OUs> | <n/a> | <n/a> | Yes / No / Unknown | <policy boundary gaps> |
 
 ### Prioritized Remediation Plan
 
@@ -200,6 +249,9 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
 5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
 6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
+7. **Overclaiming organization coverage from one account.** A member-account CloudTrail, Security Hub export, Access Analyzer, or Config result is useful local evidence, but it does not prove organization-wide coverage unless accounts, OUs, delegated admin, Regions, and exclusions are recorded.
+8. **Over-reporting local gaps when central controls exist.** Organization trails, Security Hub central configuration, AWS Config aggregators, SCPs, and delegated-admin services may cover accounts where local IaC appears incomplete. Record central evidence before escalating the finding.
+9. **Treating SCPs as grants.** SCPs set maximum permissions; they do not grant access and do not make a broad local IAM allow safe without underlying IAM/resource-policy evidence. Use SCPs to calibrate blast radius only when the boundary is verified.
 
 ---
 
@@ -224,6 +276,11 @@ Produce the final report using the structure defined in the Output Format sectio
 - AWS IAM Best Practices: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 - AWS CloudTrail Documentation: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/
 - AWS Security Hub: https://docs.aws.amazon.com/securityhub/latest/userguide/
+- AWS CloudTrail organization trails: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-trail-organization.html
+- IAM Access Analyzer delegated administrator: https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-delegated-administrator.html
+- AWS Security Hub central configuration: https://docs.aws.amazon.com/securityhub/latest/userguide/start-central-configuration.html
+- Security Hub central configuration management type: https://docs.aws.amazon.com/securityhub/latest/userguide/central-configuration-management-type.html
+- AWS Organizations and CloudTrail integration: https://docs.aws.amazon.com/organizations/latest/userguide/services-that-can-integrate-cloudtrail.html
 - AWS VPC Security: https://docs.aws.amazon.com/vpc/latest/userguide/security.html
 - Terraform AWS Provider Documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 
@@ -231,4 +288,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.1.0** -- Added AWS Organizations evidence scope, delegated-admin coverage fields, organization-wide service checks, and single-account/IaC-only not-evaluable outcomes.
 - **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 (62 recommendations).

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -45,6 +45,18 @@ resource "aws_organizations_policy" {
 }
 ```
 
+Record the SCP scope before using it to calibrate severity:
+
+```text
+- policy id/name
+- attached root, OU, or account targets
+- excluded or suspended accounts
+- management account evidence source
+- whether permission boundaries, session policies, and resource policies were also reviewed
+```
+
+SCPs set maximum permissions; they do not grant access and do not make a broad IAM allow safe without the underlying IAM and resource-policy evidence.
+
 ### CIS 1.8 -- Ensure IAM password policy requires minimum length of 14 or greater
 
 **What to look for in Terraform:**
@@ -144,7 +156,29 @@ Check for certificate management configurations.
 ```
 aws_accessanalyzer_analyzer
 type = "ACCOUNT"
+type = "ORGANIZATION"
 ```
+
+For multi-account reviews, record whether each analyzer is account-scoped or organization-scoped:
+
+```hcl
+resource "aws_accessanalyzer_analyzer" "org" {
+  analyzer_name = "organization-zone"
+  type          = "ORGANIZATION"
+}
+```
+
+Evidence fields:
+
+```text
+- analyzer type: ACCOUNT / ORGANIZATION
+- owning account and delegated administrator account
+- Regions with analyzers enabled
+- covered accounts/OUs and excluded accounts
+- external-access and unused-access coverage if available
+```
+
+If only a single account analyzer is available, mark organization-wide Access Analyzer posture as `Not Evaluable from Single Account`.
 
 ### CIS 1.21 -- Ensure IAM users are managed centrally via identity federation or AWS Organizations for multi-account environments
 
@@ -274,7 +308,18 @@ Evaluate logging configurations against Section 3 recommendations.
 resource "aws_cloudtrail" {
   is_multi_region_trail = true
   enable_logging        = true
+  is_organization_trail = true
 }
+```
+
+Separate account trails from organization trails. A member-account trail can satisfy local logging evidence, but organization-wide conclusions require:
+
+```text
+- is_organization_trail = true or equivalent CLI/API evidence
+- trail owning account: management or delegated administrator
+- covered accounts/OUs and excluded or suspended accounts
+- home Region, multi-Region setting, and opt-in Region coverage
+- delivery status and log file validation status
 ```
 
 ### CIS 3.2 -- Ensure CloudTrail log file validation is enabled
@@ -403,7 +448,23 @@ resource "aws_cloudwatch_metric_alarm" {
 ```
 aws_securityhub_account
 aws_securityhub_standards_subscription
+aws_securityhub_organization_admin_account
+aws_securityhub_configuration_policy
+aws_securityhub_configuration_policy_association
 ```
+
+For organization reviews, Security Hub evidence should identify central configuration scope:
+
+```text
+- delegated administrator account
+- home Region and linked Regions
+- centrally managed accounts/OUs
+- self-managed targets and exceptions
+- standards/control policy associations
+- finding aggregation or configuration policy export timestamp
+```
+
+A delegated administrator export is not automatically full-organization evidence unless policy associations, linked Regions, and self-managed exceptions are recorded.
 
 ---
 

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -188,7 +188,12 @@ Check for SSO/Identity Center configuration:
 aws_ssoadmin_managed_policy_attachment
 aws_identitystore
 aws_organizations_organization
+aws_cloudformation_stack_set
+aws_ram_resource_share
+aws_controltower_control
 ```
+
+For organization-wide identity or guardrail conclusions, record whether CloudFormation StackSets deploy controls across accounts, whether AWS RAM shares security-relevant resources with member accounts, and whether AWS Control Tower guardrails or account-factory configuration enforce CIS-equivalent controls at the landing-zone level.
 
 ### CIS 1.22 -- Ensure access to AWSCloudShellFullAccess is restricted
 


### PR DESCRIPTION
## Summary
- Adds an AWS evidence-scope step for organization ID, management/delegated admin accounts, accounts/OUs, Regions, and export timing.
- Updates the report template with organization coverage fields, per-finding scope qualifiers, Not Evaluable from Single Account, and Not Evaluable from IaC Only outcomes.
- Expands checklist guidance for CloudTrail organization trails, IAM Access Analyzer organization analyzers, Security Hub central configuration, and SCP/effective-access boundaries.

## Validation
- git diff --check
- Verified updated skill and benchmark checklist files exist

## Related review
Implements the improvement requested in #190.

## Bounty
This is submitted as a Skill Improvement under the CONTRIBUTING.md bounty terms. Preferred payment method can be provided privately after acceptance.
