### PR TITLE
Add .NET ReDoS timeout evidence

### DIFF
--- a/skills/appsec/secure-code-review/SKILL.md
+++ b/skills/appsec/secure-code-review/SKILL.md
@@ -109,7 +109,7 @@ Remediation: Canonicalize the resolved path and verify it remains within the exp
 - [ ] HTML output is encoded contextually (HTML body, attribute, JavaScript, URL).
 - [ ] OS commands, if unavoidable, use allowlisted arguments and avoid shell interpretation.
 - [ ] File path operations validate and canonicalize against a base directory.
-- [ ] Regular expressions used for validation are anchored (`^...$`) and tested for ReDoS.
+- [ ] Regular expressions used for validation are anchored (`^...$`), length-bounded, timeout-protected, and reviewed for ReDoS; `Regex.InfiniteMatchTimeout` or equivalent infinite timeouts are not accepted on untrusted input.
 
 ---
 

--- a/skills/appsec/secure-code-review/csharp-dotnet.md
+++ b/skills/appsec/secure-code-review/csharp-dotnet.md
@@ -324,6 +324,33 @@ App-wide defaults can be valid supporting evidence, but reviewers must prove the
 }
 ```
 
+Timeout handling must fail closed for validation decisions:
+
+```csharp
+// VULNERABLE: timeout becomes a validation bypass
+try
+{
+    return ValidationRegex.IsMatch(userInput);
+}
+catch (RegexMatchTimeoutException)
+{
+    return true;
+}
+```
+
+```csharp
+// SECURE: reject on timeout and avoid logging the full attacker-controlled payload
+try
+{
+    return ValidationRegex.IsMatch(userInput);
+}
+catch (RegexMatchTimeoutException ex)
+{
+    _logger.LogWarning(ex, "Regex timeout for input length {Length}", userInput.Length);
+    return false;
+}
+```
+
 Regex/ReDoS evidence should include:
 
 | Evidence | Required review question |

--- a/skills/appsec/secure-code-review/csharp-dotnet.md
+++ b/skills/appsec/secure-code-review/csharp-dotnet.md
@@ -263,16 +263,58 @@ public bool ValidateInput(string input)
 }
 ```
 
-Remediation: Set a timeout on the `Regex` instance and simplify the pattern.
+Remediation: Set a timeout on regex execution, simplify the pattern, and document whether non-backtracking mode is applicable.
 
 ```csharp
-// SECURE: timeout prevents catastrophic backtracking
+// SECURE: timeout and simple pattern prevent catastrophic backtracking
 public bool ValidateInput(string input)
 {
-    var regex = new Regex(@"^a+$", RegexOptions.None, TimeSpan.FromSeconds(1));
+    var regex = new Regex(
+        @"^a+$",
+        RegexOptions.NonBacktracking,
+        TimeSpan.FromMilliseconds(250));
     return regex.IsMatch(input);
 }
 ```
+
+Static regex calls and source-generated regexes need the same evidence. Do not mark a call site safe only because no local `new Regex(...)` constructor is present.
+
+```csharp
+// SECURE: static calls rely on a default timeout configured at startup
+AppDomain.CurrentDomain.SetData(
+    "REGEX_DEFAULT_MATCH_TIMEOUT",
+    TimeSpan.FromMilliseconds(250));
+
+public static bool IsKnownCode(string value)
+{
+    return Regex.IsMatch(value, @"^[A-Z]{3}-\d{4}$");
+}
+```
+
+```csharp
+// SECURE: generated regex records timeout and options in the attribute
+[GeneratedRegex(
+    @"^[A-Z]{3}-\d{4}$",
+    RegexOptions.NonBacktracking,
+    matchTimeoutMilliseconds: 250)]
+private static partial Regex KnownCodeRegex();
+```
+
+Regex/ReDoS evidence should include:
+
+| Evidence | Required review question |
+|---|---|
+| Input source | Is the regex applied to attacker-controlled, tenant-controlled, uploaded, or otherwise unbounded data? |
+| Input bound | Is length bounded before matching, and is the bound enforced on every path that reaches the regex? |
+| Pattern risk | Does the pattern contain nested quantifiers, ambiguous alternation, backreferences, lookarounds, or other backtracking-heavy constructs? |
+| Call style | Is the match executed through static `Regex` methods, `new Regex(...)`, cached instances, `[GeneratedRegex]`, `Replace`, `Split`, or validation framework adapters? |
+| Timeout evidence | Is a local timeout supplied, or is `REGEX_DEFAULT_MATCH_TIMEOUT` configured early enough for static calls? |
+| Generated regex evidence | If `[GeneratedRegex]` is used, does the attribute specify `matchTimeoutMilliseconds` and appropriate `RegexOptions`? |
+| NonBacktracking review | Was `RegexOptions.NonBacktracking` evaluated and either applied or rejected with a compatibility reason? |
+| Exception handling | Does `RegexMatchTimeoutException` fail closed for validation and avoid unbounded retries or sensitive payload logging? |
+| Test evidence | Are bounded adversarial fixtures used to prove timeout behavior without running production load tests? |
+
+Severity guidance: untrusted unbounded input plus a catastrophic pattern and no timeout is High. A simple anchored pattern over bounded enum-like input can be Low or Not Applicable when the input bound and timeout/default-timeout evidence are present. Fail-open timeout handling should be reviewed as a validation bypass in addition to an availability issue.
 
 ---
 
@@ -931,6 +973,10 @@ Use these regex patterns to locate potential vulnerabilities in C# source files.
 | XXE (DTD) | `DtdProcessing\s*=\s*DtdProcessing\.Parse` |
 | LDAP Injection | `DirectorySearcher.*Filter\s*=.*[\+\$]` |
 | ReDoS | `new\s+Regex\s*\([^)]*\)\s*[^,]` (missing timeout parameter) |
+| ReDoS (static calls) | `Regex\.(IsMatch|Match|Matches|Replace|Split)\s*\(` |
+| ReDoS (generated regex) | `\[GeneratedRegex\s*\(` |
+| ReDoS (non-backtracking) | `RegexOptions\.NonBacktracking` (verify compatibility, not just presence) |
+| ReDoS timeout handling | `catch\s*\(\s*RegexMatchTimeoutException` |
 | Hard-coded credentials | `(Password\|Secret\|Key)\s*=\s*"[^"]{8,}"` |
 | BinaryFormatter | `BinaryFormatter` |
 | NetDataContractSerializer | `NetDataContractSerializer` |

--- a/skills/appsec/secure-code-review/csharp-dotnet.md
+++ b/skills/appsec/secure-code-review/csharp-dotnet.md
@@ -277,6 +277,18 @@ public bool ValidateInput(string input)
 }
 ```
 
+```csharp
+// SECURE: .NET 7+ static overload with explicit timeout
+public static bool IsKnownCode(string value)
+{
+    return Regex.IsMatch(
+        value,
+        @"^[A-Z]{3}-\d{4}$",
+        RegexOptions.NonBacktracking,
+        TimeSpan.FromMilliseconds(250));
+}
+```
+
 Static regex calls and source-generated regexes need the same evidence. Do not mark a call site safe only because no local `new Regex(...)` constructor is present.
 
 ```csharp
@@ -300,6 +312,18 @@ public static bool IsKnownCode(string value)
 private static partial Regex KnownCodeRegex();
 ```
 
+`Regex.InfiniteMatchTimeout`, `TimeSpan.FromMilliseconds(-1)`, or other infinite timeout aliases are red flags when the regex processes untrusted input. They disable the timeout control and should not be treated as equivalent to a bounded timeout.
+
+App-wide defaults can be valid supporting evidence, but reviewers must prove they are configured early and are not overridden locally:
+
+```json
+{
+  "configProperties": {
+    "System.Text.RegularExpressions.DefaultMatchTimeout": "00:00:00.250"
+  }
+}
+```
+
 Regex/ReDoS evidence should include:
 
 | Evidence | Required review question |
@@ -308,7 +332,8 @@ Regex/ReDoS evidence should include:
 | Input bound | Is length bounded before matching, and is the bound enforced on every path that reaches the regex? |
 | Pattern risk | Does the pattern contain nested quantifiers, ambiguous alternation, backreferences, lookarounds, or other backtracking-heavy constructs? |
 | Call style | Is the match executed through static `Regex` methods, `new Regex(...)`, cached instances, `[GeneratedRegex]`, `Replace`, `Split`, or validation framework adapters? |
-| Timeout evidence | Is a local timeout supplied, or is `REGEX_DEFAULT_MATCH_TIMEOUT` configured early enough for static calls? |
+| Timeout evidence | Is a local timeout supplied, or is `REGEX_DEFAULT_MATCH_TIMEOUT` / `System.Text.RegularExpressions.DefaultMatchTimeout` configured early enough for static calls? |
+| Infinite timeout check | Is `Regex.InfiniteMatchTimeout`, `TimeSpan.FromMilliseconds(-1)`, or an equivalent infinite timeout absent on untrusted input paths? |
 | Generated regex evidence | If `[GeneratedRegex]` is used, does the attribute specify `matchTimeoutMilliseconds` and appropriate `RegexOptions`? |
 | NonBacktracking review | Was `RegexOptions.NonBacktracking` evaluated and either applied or rejected with a compatibility reason? |
 | Exception handling | Does `RegexMatchTimeoutException` fail closed for validation and avoid unbounded retries or sensitive payload logging? |
@@ -972,8 +997,9 @@ Use these regex patterns to locate potential vulnerabilities in C# source files.
 | XXE | `XmlResolver\s*=\s*new\s+XmlUrlResolver` |
 | XXE (DTD) | `DtdProcessing\s*=\s*DtdProcessing\.Parse` |
 | LDAP Injection | `DirectorySearcher.*Filter\s*=.*[\+\$]` |
-| ReDoS | `new\s+Regex\s*\([^)]*\)\s*[^,]` (missing timeout parameter) |
-| ReDoS (static calls) | `Regex\.(IsMatch|Match|Matches|Replace|Split)\s*\(` |
+| ReDoS call sites | `(?:new\s+Regex|Regex\.(IsMatch|Match|Matches|Replace|Split))\s*\(` (inspect for input trust, pattern risk, and timeout) |
+| ReDoS infinite timeout | `Regex\.InfiniteMatchTimeout|TimeSpan\.FromMilliseconds\s*\(\s*-1\s*\)` |
+| ReDoS default timeout config | `REGEX_DEFAULT_MATCH_TIMEOUT|System\.Text\.RegularExpressions\.DefaultMatchTimeout` |
 | ReDoS (generated regex) | `\[GeneratedRegex\s*\(` |
 | ReDoS (non-backtracking) | `RegexOptions\.NonBacktracking` (verify compatibility, not just presence) |
 | ReDoS timeout handling | `catch\s*\(\s*RegexMatchTimeoutException` |


### PR DESCRIPTION
## Summary
- Expands the .NET ReDoS guidance beyond instance Regex constructors to cover static calls, global default timeout, source-generated regexes, NonBacktracking compatibility, and timeout exception handling.
- Adds a Regex/ReDoS evidence table for input trust, bounds, pattern risk, call style, timeout source, generated regex attributes, NonBacktracking review, exception handling, and bounded test evidence.
- Adds grep patterns for static regex calls, GeneratedRegex attributes, NonBacktracking usage, and RegexMatchTimeoutException catch paths.

## Validation
- git diff --check
- Verified ReDoS default timeout, GeneratedRegex, NonBacktracking, exception handling, and detection-pattern updates are present

## Related review
Implements the improvement requested in #228.

## Bounty
This is submitted as a Skill Improvement under the CONTRIBUTING.md bounty terms. Preferred payment method can be provided privately after acceptance.