### PR TITLE
Add rendered manifest and CronJob evidence gates

### DIFF
--- a/skills/cloud/container-security/SKILL.md
+++ b/skills/cloud/container-security/SKILL.md
@@ -3,8 +3,8 @@ name: container-security
 description: >
   Performs a container and Kubernetes security review against the CIS Docker
   Benchmark v1.6.0, CIS Kubernetes Benchmark v1.9.0, and NIST SP 800-190.
-  Auto-invoked when reviewing Dockerfiles, Kubernetes manifests, Helm charts,
-  or container orchestration configurations. Evaluates image security, runtime
+  Auto-invoked when reviewing Dockerfiles, Kubernetes manifests, rendered Helm
+  charts, Kustomize overlays, or container orchestration configurations. Evaluates image security, runtime
   hardening, RBAC, Pod Security Standards, network policies, and secrets
   management. Produces a prioritized findings report with remediation guidance.
 tags: [cloud, containers, kubernetes, docker]
@@ -13,7 +13,7 @@ phase: [build, deploy, operate]
 frameworks: [CIS-Docker-v1.6.0, CIS-Kubernetes-v1.9.0, NIST-SP-800-190]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -58,6 +58,8 @@ NIST SP 800-190 identifies five risk categories: image risks, registry risks, or
 
 - Access to Dockerfiles and container build configurations
 - Kubernetes manifests (YAML), Helm charts, or Kustomize overlays
+- Rendered manifests for the environment under review, or enough local context to
+  run `helm template`, `helm get manifest`, `kubectl kustomize`, or `kustomize build`
 - RBAC configuration files (Roles, ClusterRoles, RoleBindings)
 - NetworkPolicy definitions
 - Pod Security Standard configurations or OPA/Gatekeeper policies
@@ -99,15 +101,97 @@ Use Glob to locate all relevant configuration files.
 **/*-ingress.yaml
 **/*-networkpolicy.yaml
 **/*-rbac.yaml
+**/*-job*.yaml
+**/*-cronjob*.yaml
 **/*-psp.yaml
 **/*-podsecuritypolicy.yaml
 ```
 
-Classify findings by type: Dockerfiles, Kubernetes manifests, Helm charts, Kustomize overlays, and supporting configs. Record all discovered files.
+Also search manifest contents for workload kinds that hide pod specs below nested paths:
+
+```
+kind: Pod
+kind: Deployment
+kind: StatefulSet
+kind: DaemonSet
+kind: ReplicaSet
+kind: ReplicationController
+kind: Job
+kind: CronJob
+```
+
+Classify findings by type: Dockerfiles, Kubernetes manifests, Helm charts, Kustomize overlays, rendered manifests, and supporting configs. Record all discovered files.
 
 ---
 
-### Step 2 through Step 6: CIS Benchmark and NIST SP 800-190 Evaluation
+### Step 2: Render Final Manifests for Helm and Kustomize
+
+**Objective:** Base Kubernetes findings on the final manifest for the reviewed environment, not only on raw templates, base manifests, or default values.
+
+If Helm or Kustomize inputs are present, run or request the rendered output before scoring Pod Security, RBAC, NetworkPolicy, and secret findings.
+
+| Source Type | Render Command or Evidence | Required Evidence |
+|-------------|----------------------------|-------------------|
+| Helm chart, not deployed | `helm template <release> <chart> --values <values-file>` | Chart path, release name, values files, rendered manifest path/hash |
+| Deployed Helm release | `helm get manifest <release>` and `helm get values <release>` | Release name, namespace, deployed manifest, active values |
+| Kustomize overlay | `kubectl kustomize <overlay-dir>` or `kustomize build <overlay-dir>` | Overlay path, base path, patches used, rendered manifest path/hash |
+| Plain manifest | No render step needed | Manifest path and environment mapping |
+
+**Finding rule:** The rendered manifest is the evidence of what Kubernetes will receive. If a source template looks safe but selected values or overlays render it as privileged, flag the rendered unsafe workload and trace it back to the source template, values file, or patch that introduced the field.
+
+**What to look for:**
+
+```
+CS-RENDER-01: Helm/Kustomize input reviewed without rendered manifest evidence
+CS-RENDER-02: Finding based only on base manifest while environment overlay changes security controls
+CS-RENDER-03: Helm values file used for the target environment not identified
+CS-RENDER-04: Rendered manifest finding lacks source template/values/patch provenance
+CS-RENDER-05: Deployed Helm release reviewed without `helm get manifest` or equivalent deployed-state export
+```
+
+---
+
+### Step 3: Normalize Workload Pod Specs
+
+**Objective:** Apply pod and container checks consistently across every Kubernetes workload kind.
+
+Pod Security Standards apply to the pod spec that will create containers. Different resources store that pod spec at different YAML paths:
+
+| Kind | API Group | Pod Spec Path |
+|------|-----------|---------------|
+| Pod | `v1` | `spec` |
+| Deployment | `apps/v1` | `spec.template.spec` |
+| StatefulSet | `apps/v1` | `spec.template.spec` |
+| DaemonSet | `apps/v1` | `spec.template.spec` |
+| ReplicaSet | `apps/v1` | `spec.template.spec` |
+| ReplicationController | `v1` | `spec.template.spec` |
+| Job | `batch/v1` | `spec.template.spec` |
+| CronJob | `batch/v1` | `spec.jobTemplate.spec.template.spec` |
+
+For each normalized pod spec, inspect `containers[]`, `initContainers[]`, and `ephemeralContainers[]` where present. A CronJob pod template with `privileged: true`, `hostPath`, Docker socket mounts, default service account, or broad service account token mounting carries the same runtime risk as a Deployment that creates equivalent pods.
+
+For CronJobs, also record:
+
+- `spec.schedule`
+- `spec.suspend`
+- `spec.concurrencyPolicy`
+- `spec.successfulJobsHistoryLimit` and `spec.failedJobsHistoryLimit` when present
+
+Treat `spec.suspend: true` as a severity modifier, not as a pass. The unsafe pod template remains a finding because the CronJob may be resumed.
+
+**What to look for:**
+
+```
+CS-WORKLOAD-01: CronJob or Job pod template not included in Pod Security evaluation
+CS-WORKLOAD-02: Only top-level `spec.containers[]` searched, missing nested pod specs
+CS-WORKLOAD-03: Init or ephemeral containers omitted from security-context review
+CS-WORKLOAD-04: Suspended CronJob with unsafe pod template marked as pass instead of reduced-severity finding
+CS-WORKLOAD-05: Finding lacks workload kind and pod spec path, making remediation ambiguous
+```
+
+---
+
+### Step 4 through Step 8: CIS Benchmark and NIST SP 800-190 Evaluation
 
 Evaluate all container and Kubernetes configurations against CIS Docker Benchmark v1.6.0, CIS Kubernetes Benchmark v1.9.0, and NIST SP 800-190 countermeasures. This covers Dockerfile security, Pod Security Standards, RBAC, Network Policies, Secrets Management, Control Plane configuration, and Container Runtime Hardening.
 
@@ -115,7 +199,7 @@ For detailed CIS benchmark checklist items, NIST SP 800-190 countermeasure table
 
 ---
 
-### Step 7: Compile Assessment Report
+### Step 9: Compile Assessment Report
 
 
 Produce the final report using the structure defined in the Output Format section.
@@ -144,6 +228,8 @@ Produce the final report using the structure defined in the Output Format sectio
 - Date: <assessment date>
 - Frameworks: CIS Docker Benchmark v1.6.0, CIS Kubernetes Benchmark v1.9.0, NIST SP 800-190
 - Files reviewed: <N Dockerfiles, N K8s manifests, N Helm charts>
+- Rendered manifests reviewed: <none / Helm release / Helm template output / Kustomize overlay output>
+- Render inputs: <values files, overlay directories, deployed release exports>
 
 ### Executive Summary
 - Total checks evaluated: <N>
@@ -161,6 +247,8 @@ Produce the final report using the structure defined in the Output Format sectio
 | RBAC | CIS K8s 5.1.x | X | X | X | X | X |
 | Network Policies | CIS K8s 5.3.x | X | X | X | X | X |
 | Secrets Management | CIS K8s 5.4.x | X | X | X | X | X |
+| Rendered Manifest Provenance | CS-RENDER | X | X | X | X | X |
+| Workload Pod-Spec Coverage | CS-WORKLOAD | X | X | X | X | X |
 | Runtime Hardening | NIST 800-190 | X | X | X | X | X |
 | Control Plane | CIS K8s 1.x-4.x | X | X | X | X | X |
 
@@ -172,7 +260,13 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Pod Security Standard Impact:** Violates Restricted / Violates Baseline / Compliant
 - **File:** <path>
 - **Line(s):** <line numbers>
-- **Resource:** <Deployment/StatefulSet name>
+- **Rendered Source:** <plain manifest / Helm template / Helm release / Kustomize overlay>
+- **Rendered File:** <path or artifact hash, if generated>
+- **Source Template:** <template path:line, if applicable>
+- **Source Values/Patch:** <values file or Kustomize patch path:line, if applicable>
+- **Workload Kind:** <Pod/Deployment/StatefulSet/DaemonSet/ReplicaSet/ReplicationController/Job/CronJob>
+- **Resource:** <resource name>
+- **Pod Spec Path:** <spec / spec.template.spec / spec.jobTemplate.spec.template.spec>
 - **Container:** <container name>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration>
@@ -232,6 +326,16 @@ Produce the final report using the structure defined in the Output Format sectio
 | Container Risks | Runtime privilege escalation, unbounded resources, writable filesystems | Non-root, capabilities, resource limits, read-only FS |
 | Host OS Risks | Shared kernel, large attack surface, unpatched hosts | Minimal host OS, regular patching, immutable infrastructure |
 
+### Workload Pod Spec Paths
+
+| Kind | Pod Spec Path | Review Notes |
+|------|---------------|--------------|
+| Pod | `spec` | Direct pod spec; check all container arrays |
+| Deployment / StatefulSet / DaemonSet / ReplicaSet | `spec.template.spec` | Controller creates pods from the template |
+| ReplicationController | `spec.template.spec` | Legacy controller; still creates pods from a template |
+| Job | `spec.template.spec` | Batch workload pod template |
+| CronJob | `spec.jobTemplate.spec.template.spec` | CronJob creates Jobs, which create pods from this nested template |
+
 ### Pod Security Standards Quick Reference
 
 | Control | Baseline | Restricted |
@@ -257,6 +361,9 @@ Produce the final report using the structure defined in the Output Format sectio
 5. **`readOnlyRootFilesystem` breaks many applications.** When recommending this control, also recommend adding writable `emptyDir` volume mounts for directories the application needs to write to (e.g., `/tmp`, `/var/cache`).
 6. **Network policies are additive, not subtractive.** A default-deny policy must be explicitly created. Without it, all pod-to-pod traffic is allowed regardless of other NetworkPolicy resources.
 7. **Distroless images have no shell.** While this is excellent for security, note that debugging requires ephemeral containers (`kubectl debug`). Flag this as a consideration, not a problem.
+8. **Rendered output beats template intent.** Helm and Kustomize templates can add or remove security fields after the source file is read. Require rendered manifest evidence before marking production workloads pass or fail.
+9. **CronJobs hide pods one level deeper.** Security checks that only inspect `spec.template.spec` miss CronJob pod templates under `spec.jobTemplate.spec.template.spec`.
+10. **Kustomize patches can remove controls.** Strategic merge or JSON6902 patches can delete `runAsNonRoot`, seccomp, dropped capabilities, or NetworkPolicy resources. Inspect the built overlay, not just the base and patch files.
 
 ---
 
@@ -285,6 +392,12 @@ Produce the final report using the structure defined in the Output Format sectio
 - Kubernetes Pod Security Admission: https://kubernetes.io/docs/concepts/security/pod-security-admission/
 - Kubernetes Network Policies: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 - Kubernetes RBAC: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Kubernetes CronJobs: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/
+- Kubernetes Pods and Pod templates: https://kubernetes.io/docs/concepts/workloads/pods/
+- Helm template command: https://helm.sh/docs/helm/helm_template/
+- Helm get manifest command: https://helm.sh/docs/helm/helm_get_manifest/
+- Kubernetes Kustomize task: https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/
+- kubectl kustomize command: https://kubernetes.io/docs/reference/kubectl/generated/kubectl_kustomize/
 - Docker Security Best Practices: https://docs.docker.com/develop/security-best-practices/
 - Dockerfile Best Practices: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
 - NSA/CISA Kubernetes Hardening Guide: https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF
@@ -293,4 +406,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Adds rendered Helm/Kustomize manifest evidence gates, workload pod-spec normalization, CronJob/Job pod-template coverage, and report provenance fields.
 - **1.0.0** -- Initial release. Full coverage of CIS Docker Benchmark v1.6.0 Section 4-5, CIS Kubernetes Benchmark v1.9.0 Sections 1-5, and NIST SP 800-190 countermeasures across all five risk categories.

--- a/skills/cloud/container-security/cis-benchmarks.md
+++ b/skills/cloud/container-security/cis-benchmarks.md
@@ -193,6 +193,28 @@ ENTRYPOINT ["/server"]
 
 Evaluate Kubernetes workload definitions against CIS Kubernetes Benchmark Section 5 (Policies) and Pod Security Standards.
 
+### Rendered Manifest and Workload Traversal Gate
+
+Before applying the pod-security checks below, identify the environment artifact being reviewed:
+
+| Input Type | Evidence Needed Before Scoring |
+|------------|--------------------------------|
+| Plain Kubernetes YAML | Manifest path and environment mapping |
+| Helm chart | `helm template` output with selected values, or `helm get manifest` output for a deployed release |
+| Kustomize overlay | `kubectl kustomize` or `kustomize build` output for the reviewed overlay |
+
+Then normalize each workload to the pod spec that creates containers:
+
+| Kind | Pod Spec Path | Container Arrays to Inspect |
+|------|---------------|-----------------------------|
+| Pod | `spec` | `containers[]`, `initContainers[]`, `ephemeralContainers[]` |
+| Deployment / StatefulSet / DaemonSet / ReplicaSet | `spec.template.spec` | `containers[]`, `initContainers[]`, `ephemeralContainers[]` |
+| ReplicationController | `spec.template.spec` | `containers[]`, `initContainers[]`, `ephemeralContainers[]` |
+| Job | `spec.template.spec` | `containers[]`, `initContainers[]`, `ephemeralContainers[]` |
+| CronJob | `spec.jobTemplate.spec.template.spec` | `containers[]`, `initContainers[]`, `ephemeralContainers[]` |
+
+Do not mark a Helm or Kustomize workload as pass or fail from the source template alone when the reviewed environment has selected values or overlays. The rendered manifest is the evidence; source templates, values, and patches are provenance for remediation.
+
 ### CIS 5.1 -- RBAC and Service Accounts
 
 #### CIS 5.1.1 -- Ensure that the cluster-admin role is only used where required

--- a/skills/cloud/container-security/tests/benign/rendered-kustomize-overlay.md
+++ b/skills/cloud/container-security/tests/benign/rendered-kustomize-overlay.md
@@ -1,0 +1,52 @@
+# Benign: Kustomize overlay supplies the final pod security context
+
+This fixture calibrates `CS-RENDER-*` behavior. A reviewer who inspects only the
+base manifest may report missing pod hardening, but the production overlay adds
+the controls that appear in the rendered manifest.
+
+## Base manifest
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  template:
+    spec:
+      containers:
+        - name: api
+          image: ghcr.io/example/api@sha256:1111111111111111111111111111111111111111111111111111111111111111
+```
+
+## Production overlay patch
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: api
+          securityContext:
+            runAsUser: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+```
+
+## Expected review result
+
+- Do not mark the production workload as failing only from the base file.
+- Require the rendered Kustomize output or an equivalent merged manifest.
+- Record `Rendered Source: Kustomize overlay` and the overlay patch provenance.

--- a/skills/cloud/container-security/tests/vulnerable/cronjob-rendered-privileged.md
+++ b/skills/cloud/container-security/tests/vulnerable/cronjob-rendered-privileged.md
@@ -1,0 +1,43 @@
+# Vulnerable: CronJob renders a privileged pod template
+
+This fixture calibrates `CS-WORKLOAD-*` behavior. The unsafe pod spec is nested
+under `spec.jobTemplate.spec.template.spec`, so checks that only inspect
+Deployment-style `spec.template.spec` paths miss it.
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: nightly-export
+spec:
+  schedule: "0 2 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: default
+          containers:
+            - name: exporter
+              image: ghcr.io/example/exporter:latest
+              securityContext:
+                privileged: true
+                allowPrivilegeEscalation: true
+                capabilities:
+                  add: ["SYS_ADMIN"]
+              volumeMounts:
+                - name: docker-sock
+                  mountPath: /var/run/docker.sock
+          volumes:
+            - name: docker-sock
+              hostPath:
+                path: /var/run/docker.sock
+          restartPolicy: OnFailure
+```
+
+## Expected findings
+
+- Critical: privileged CronJob pod template.
+- Critical: Docker socket hostPath mount.
+- High: default service account used by the CronJob-created pods.
+- Evidence must include `Workload Kind: CronJob` and
+  `Pod Spec Path: spec.jobTemplate.spec.template.spec`.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified

Skill name: container-security
Skill path: `skills/cloud/container-security/`

Closes #204.

### What Was Wrong

The skill warned that Helm values and Kustomize overlays can change security settings, and the detailed benchmark file mentioned Jobs/CronJobs, but the main workflow did not force reviewers to inspect the rendered manifest for the reviewed environment. It also did not normalize workload pod-spec paths, so CronJob pod templates under `spec.jobTemplate.spec.template.spec` could be missed by Deployment-focused checks.

### What This PR Fixes

- Adds explicit discovery patterns for Job and CronJob manifests.
- Adds a rendered-manifest step for Helm charts, deployed Helm releases, Kustomize overlays, and plain manifests.
- Adds `CS-RENDER-*` findings for missing rendered output, missing values/overlay evidence, and missing source provenance.
- Adds workload pod-spec normalization for Pod, Deployment, StatefulSet, DaemonSet, ReplicaSet, ReplicationController, Job, and CronJob.
- Adds `CS-WORKLOAD-*` findings for skipped CronJob/Job pod templates, missed nested paths, missed init/ephemeral containers, and ambiguous evidence.
- Extends report output with rendered source, rendered file, source template, source values/patch, workload kind, resource, and pod spec path fields.
- Adds detailed benchmark guidance and two calibration fixtures: one benign Kustomize overlay case and one vulnerable privileged CronJob case.

### Evidence

Before:
A reviewer could inspect a Kustomize base or Helm template only, then score the workload as pass/fail without knowing the production overlay or selected values. A CronJob with a privileged Docker socket pod template could also be missed if the review only searched `spec.template.spec`.

After:
The review requires rendered manifest evidence, source provenance, and normalized pod-spec traversal before scoring Kubernetes workload security.

### Framework References

- CIS Docker Benchmark v1.6.0 and CIS Kubernetes Benchmark v1.9.0 references already used by the skill.
- NIST SP 800-190 references already used by the skill.
- Kubernetes CronJobs and Pods documentation.
- Helm `template` and `get manifest` command documentation.
- Kubernetes Kustomize and `kubectl kustomize` documentation.

### Testing

- `git diff --cached --check`
- Markdown fence balance check for touched Markdown files and new fixtures
- SKILL.md frontmatter check
- Link checks for added Kubernetes and Helm references returned HTTP 200
- Reviewed with OpenAI Codex

### Bounty Tier

- Minor ($50) - Doc update, small logic tweak, typo fix
- Moderate ($100) - New edge case coverage, FP reduction with evidence
- Substantial ($150) - Rewritten detection logic, major coverage expansion

Suggested tier: Moderate ($100), because this adds new edge-case coverage and false-positive/false-negative reduction with fixtures.

### Bounty Info

- I have read and agree to the CONTRIBUTING.md bounty terms
- Preferred payment method: Crypto, EVM wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`
