### PR TITLE
Refresh SAST ASVS and CWE mapping evidence

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -548,7 +548,7 @@ skills:
     role: [security-engineer, appsec-engineer]
     phase: [build]
     activity: [configure, review]
-    frameworks: [OWASP-ASVS-4.0.3, CWE-Top-25]
+    frameworks: [OWASP-ASVS-5.0.0, CWE-Top-25-2025]
     difficulty: intermediate
     time_estimate: "30-60min"
     file: skills/devsecops/sast-config/SKILL.md

--- a/skills/devsecops/sast-config/SKILL.md
+++ b/skills/devsecops/sast-config/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: sast-config
 description: >
-  Reviews and tunes SAST tool configurations against OWASP ASVS 4.0.3 and
-  CWE Top 25. Auto-invoked when reviewing Semgrep rules, CodeQL queries, SAST
+  Reviews and tunes SAST tool configurations against OWASP ASVS 5.0.0 and
+  CWE Top 25 2025. Auto-invoked when reviewing Semgrep rules, CodeQL queries, SAST
   CI integration, or false positive triage workflows. Produces a SAST maturity
   assessment covering rule authoring, severity tuning, custom rule development,
   and CI integration patterns.
 tags: [devsecops, sast, semgrep, codeql]
 role: [security-engineer, appsec-engineer]
 phase: [build]
-frameworks: [OWASP-ASVS-4.0.3, CWE-Top-25]
+frameworks: [OWASP-ASVS-5.0.0, CWE-Top-25-2025]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -22,7 +22,7 @@ argument-hint: "[target-file-or-directory]"
 
 # SAST Tool Configuration and Tuning
 
-A structured, repeatable process for reviewing and tuning Static Application Security Testing (SAST) tool configurations against OWASP ASVS 4.0.3 verification requirements and the CWE Top 25 Most Dangerous Software Weaknesses. This skill covers Semgrep rule authoring, CodeQL query patterns, severity tuning, false positive management, custom rule development, and CI integration. All findings map to ASVS controls and CWE identifiers.
+A structured, repeatable process for reviewing and tuning Static Application Security Testing (SAST) tool configurations against OWASP ASVS 5.0.0 verification requirements and the CWE Top 25 2025 Most Dangerous Software Weaknesses. This skill covers Semgrep rule authoring, CodeQL query patterns, severity tuning, false positive management, custom rule development, and CI integration. All findings map to ASVS controls and CWE identifiers with the framework version and source date recorded.
 
 ---
 
@@ -41,7 +41,7 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 
 ## Context
 
-SAST tools are only as effective as their configuration. Default rule sets produce high false positive rates that erode developer trust, while overly aggressive tuning creates dangerous blind spots. OWASP ASVS 4.0.3 provides 286 verification requirements across 14 chapters -- a subset of these are automatable via SAST. The CWE Top 25 (2024 edition) identifies the most prevalent and impactful weakness types. Effective SAST tuning maps rules to these frameworks, tunes severity to organizational risk context, and integrates into CI with clear pass/fail criteria that developers can act on.
+SAST tools are only as effective as their configuration. Default rule sets produce high false positive rates that erode developer trust, while overly aggressive tuning creates dangerous blind spots. OWASP ASVS 5.0.0 reorganizes the verification standard into 17 chapters; only a subset of these controls are automatable via SAST. The CWE Top 25 2025 identifies the current ranked set of prevalent and impactful weakness types. Effective SAST tuning maps rules to these frameworks, records the source version used, tunes severity to organizational risk context, and integrates into CI with clear pass/fail criteria that developers can act on.
 
 ---
 
@@ -93,31 +93,69 @@ Categorize by:
 
 ---
 
-### Step 2: Rule Coverage Analysis Against CWE Top 25
+### Step 1.5: Framework and Rule-Pack Freshness Preflight
 
-Map the active SAST rule set against CWE Top 25 (2024) to identify coverage gaps.
+Before scoring coverage, record the exact framework and rule-pack sources. Do not assume that a registry alias such as `p/cwe-top-25` proves current CWE Top 25 2025 coverage.
+
+**Evidence to capture:**
+
+| Evidence Field | Required Value |
+|----------------|----------------|
+| ASVS baseline | `OWASP ASVS 5.0.0` unless the engagement explicitly requests legacy ASVS 4.0.3 |
+| ASVS source | Release URL or downloaded CSV/PDF name, plus retrieval date |
+| CWE Top 25 edition | `2025` |
+| CWE source | MITRE 2025 Top 25 URL, plus retrieval date |
+| SAST tool version | Scanner version, action/container tag, and local CLI version when available |
+| Rule-pack source | Registry alias, release tag, commit SHA, or date pulled |
+| Active languages | Languages actually scanned in the target repository |
+| Mapping confidence | `High`, `Medium`, `Low`, or `Not Evaluable` with a reason |
+
+**Finding classification:** A report created after ASVS 5.0.0 that treats ASVS 4.0.3 as current without a scoped legacy exception is **High**. A CWE Top 25 report without year and source date is **Medium**. A CI gate that blocks or allows merges using stale framework mappings is **High**.
+
+---
+
+### Step 2: Rule Coverage Analysis Against CWE Top 25 2025
+
+Map the active SAST rule set against CWE Top 25 2025 to identify coverage gaps. If the engagement requires an older CWE list, record it as a legacy baseline and explain why the current 2025 list was not used.
 
 #### 2.1 CWE Top 25 Coverage Matrix
 
 | Rank | CWE ID | Weakness | SAST Detectable | Semgrep Registry | CodeQL Coverage |
 |------|--------|----------|-----------------|-----------------|-----------------|
-| 1 | CWE-787 | Out-of-bounds Write | Partial (C/C++) | Limited | `cpp/overflow-buffer` |
-| 2 | CWE-79 | Cross-site Scripting (XSS) | Yes | `javascript.browser.security.*.xss` | `js/xss`, `js/reflected-xss` |
-| 3 | CWE-89 | SQL Injection | Yes | `python.django.security.injection.sql.*`, `java.lang.security.audit.sqli.*` | `java/sql-injection`, `python/sql-injection` |
-| 4 | CWE-416 | Use After Free | Partial (C/C++) | Limited | `cpp/use-after-free` |
-| 5 | CWE-78 | OS Command Injection | Yes | `python.lang.security.audit.dangerous-subprocess-use.*` | `python/command-injection`, `java/command-injection` |
-| 6 | CWE-20 | Improper Input Validation | Partial | Pattern-dependent | Pattern-dependent |
-| 7 | CWE-125 | Out-of-bounds Read | Partial (C/C++) | Limited | `cpp/out-of-bounds-read` |
-| 8 | CWE-22 | Path Traversal | Yes | `python.lang.security.audit.path-traversal.*` | `python/path-injection`, `java/path-injection` |
-| 9 | CWE-352 | CSRF | Partial | Framework-specific | `java/csrf`, `python/csrf` |
-| 10 | CWE-434 | Unrestricted Upload | Partial | Framework-specific | Pattern-dependent |
+| 1 | CWE-79 | Cross-site Scripting (XSS) | Yes | `javascript.browser.security.*.xss` | `js/xss`, `js/reflected-xss` |
+| 2 | CWE-89 | SQL Injection | Yes | `python.django.security.injection.sql.*`, `java.lang.security.audit.sqli.*` | `java/sql-injection`, `python/sql-injection` |
+| 3 | CWE-352 | CSRF | Partial | Framework-specific | `java/csrf`, `python/csrf` |
+| 4 | CWE-862 | Missing Authorization | Partial | Custom rules needed | Custom query needed |
+| 5 | CWE-787 | Out-of-bounds Write | Partial (C/C++) | Limited | `cpp/overflow-buffer` |
+| 6 | CWE-22 | Path Traversal | Yes | `python.lang.security.audit.path-traversal.*` | `python/path-injection`, `java/path-injection` |
+| 7 | CWE-416 | Use After Free | Partial (C/C++) | Limited | `cpp/use-after-free` |
+| 8 | CWE-125 | Out-of-bounds Read | Partial (C/C++) | Limited | `cpp/out-of-bounds-read` |
+| 9 | CWE-78 | OS Command Injection | Yes | `python.lang.security.audit.dangerous-subprocess-use.*` | `python/command-injection`, `java/command-injection` |
+| 10 | CWE-94 | Code Injection | Yes | `python.lang.security.audit.code-injection.*` | `python/code-injection`, language-specific injection queries |
+| 11 | CWE-120 | Classic Buffer Overflow | Yes (C/C++) | Limited | `cpp/buffer-overflow` |
+| 12 | CWE-434 | Unrestricted Upload | Partial | Framework-specific | Pattern-dependent |
+| 13 | CWE-476 | NULL Pointer Dereference | Yes (C/C++/Java) | Limited | `cpp/null-dereference` |
+| 14 | CWE-121 | Stack-based Buffer Overflow | Yes (C/C++) | Limited | `cpp/stack-buffer-overflow` |
+| 15 | CWE-502 | Deserialization of Untrusted Data | Partial | `java.lang.security.audit.unsafe-deserialization.*` | `java/unsafe-deserialization` |
+| 16 | CWE-122 | Heap-based Buffer Overflow | Yes (C/C++) | Limited | `cpp/heap-buffer-overflow` |
+| 17 | CWE-863 | Incorrect Authorization | Partial | Custom rules needed | Custom query needed |
+| 18 | CWE-20 | Improper Input Validation | Partial | Pattern-dependent | Pattern-dependent |
+| 19 | CWE-284 | Improper Access Control | Partial | Custom rules needed | Custom query needed |
+| 20 | CWE-200 | Sensitive Information Exposure | Partial | Language/framework-specific | Language/framework-specific |
+| 21 | CWE-306 | Missing Authentication | Partial | Custom rules needed | Custom query needed |
+| 22 | CWE-918 | Server-Side Request Forgery (SSRF) | Yes | `python.lang.security.audit.request-ssrf.*` | `java/ssrf`, `python/ssrf` |
+| 23 | CWE-77 | Command Injection | Yes | Same family as CWE-78 rules | Same family as CWE-78 queries |
+| 24 | CWE-639 | Authorization Bypass Through User-Controlled Key | Partial | Custom rules needed | Custom query needed |
+| 25 | CWE-770 | Allocation of Resources Without Limits or Throttling | Partial | Pattern-dependent | Pattern-dependent |
 
 For each CWE, verify:
 - At least one active rule covers the weakness for each language in the codebase.
 - Rule is enabled (not suppressed in configuration).
-- Rule severity matches the CWE's risk (Top 10 CWEs should not be INFO level).
+- Rule severity matches the CWE's 2025 rank and local risk context (Top 10 CWEs should not be INFO level).
+- Rule-pack version/date is recorded when the rule comes from a managed registry alias.
+- Mapping confidence is stated. Use `Not Evaluable` when SAST cannot prove the control without manual, DAST, IAST, or runtime evidence.
 
-**Finding classification:** CWE Top 10 weakness with zero SAST coverage for a language in use is **High**. CWE 11-25 with no coverage is **Medium**.
+**Finding classification:** CWE Top 10 2025 weakness with zero SAST coverage for a language in use is **High**. CWE 11-25 2025 with no coverage is **Medium**. Missing authorization or authentication coverage for internet-facing code is **High** even when the exact rule cannot be fully automated by SAST.
 
 ---
 
@@ -176,7 +214,7 @@ rules:
       owasp:
         - "A02:2021 - Cryptographic Failures"
       asvs:
-        - "V6.2.1"
+        - "V9.1.2"
       confidence: HIGH
       impact: HIGH
       references:
@@ -195,7 +233,7 @@ rules:
       cwe:
         - "CWE-798: Use of Hard-coded Credentials"
       asvs:
-        - "V2.10.1"
+        - "V8.2.1"
       confidence: HIGH
 
   - id: custom.crypto.weak-random
@@ -216,7 +254,7 @@ rules:
       cwe:
         - "CWE-330: Use of Insufficiently Random Values"
       asvs:
-        - "V6.3.1"
+        - "V11.5.1"
 ```
 
 **Rule quality checklist:**
@@ -311,7 +349,7 @@ select sink.getNode(), source, sink, "SQL injection from $@.", source.getNode(),
 
 ### Step 5: Severity Tuning and False Positive Management
 
-#### 5.1 Severity Mapping to OWASP ASVS
+#### 5.1 Severity Mapping to OWASP ASVS 5.0.0
 
 Map tool-native severity levels to a consistent organizational severity:
 
@@ -456,15 +494,27 @@ jobs:
 - SAST tool(s): <Semgrep, CodeQL, SonarQube, etc.>
 - Configuration files analyzed: <list of file paths>
 - Date: <assessment date>
-- Frameworks applied: OWASP ASVS 4.0.3, CWE Top 25
+- Frameworks applied: OWASP ASVS 5.0.0, CWE Top 25 2025
+- ASVS source URL and retrieval date: <url>, <date>
+- CWE source URL and retrieval date: <url>, <date>
+- SAST rule-pack source/version/date: <registry alias, release tag, commit SHA, or date pulled>
+- Legacy framework exception: <None, or explicit ASVS 4.0.3/CWE year scope>
 
 ### CWE Top 25 Coverage
 
-| CWE ID | Weakness | Language(s) | Rule(s) Active | Severity | Gap |
-|--------|----------|-------------|----------------|----------|-----|
-| CWE-79 | XSS | JS, Python | 3 rules | ERROR | None |
-| CWE-89 | SQLi | Python | 2 rules | ERROR | None |
-| CWE-78 | Cmd Injection | Python | 0 rules | N/A | GAP |
+| CWE Rank | CWE ID | Weakness | Language(s) | Rule(s) Active | Mapping Confidence | Severity | Gap |
+|----------|--------|----------|-------------|----------------|--------------------|----------|-----|
+| 1 | CWE-79 | XSS | JS, Python | 3 rules | High | ERROR | None |
+| 2 | CWE-89 | SQLi | Python | 2 rules | High | ERROR | None |
+| 9 | CWE-78 | Cmd Injection | Python | 0 rules | Not Evaluable | N/A | GAP |
+
+### ASVS 5.0.0 SAST Mapping
+
+| ASVS Control/Chapter | Coverage Status | Evidence | Manual Evidence Required |
+|----------------------|-----------------|----------|--------------------------|
+| V1.2.4 | Covered by SAST | <SQLi rule IDs> | No |
+| V8.2.1 | Partial | <authorization rule IDs> | Yes - business logic review |
+| V13 | Not Evaluable by SAST | <config files unavailable> | Yes - deployment/config review |
 
 ### CI Integration Status
 
@@ -481,6 +531,8 @@ jobs:
 - **Severity:** Critical / High / Medium / Low
 - **Control Reference:** ASVS V.X.X / CWE-XXX
 - **File:** <path to config file>
+- **Framework Version:** OWASP ASVS 5.0.0 / CWE Top 25 2025
+- **Mapping Confidence:** High / Medium / Low / Not Evaluable
 - **Description:** <what was found>
 - **Remediation:** <concrete fix with example>
 
@@ -494,33 +546,66 @@ jobs:
 
 ## Framework Reference
 
-### OWASP ASVS 4.0.3 (SAST-Relevant Chapters)
+### OWASP ASVS 5.0.0 (SAST-Relevant Chapters)
 
-| Chapter | Title | SAST Coverage |
-|---------|-------|---------------|
-| V2 | Authentication | Partial -- hardcoded credentials, weak password checks |
-| V3 | Session Management | Limited -- configuration review only |
-| V4 | Access Control | Partial -- missing authorization checks |
-| V5 | Validation, Sanitization, Encoding | Strong -- injection, XSS, path traversal |
-| V6 | Stored Cryptography | Moderate -- weak algorithms, hardcoded keys |
-| V8 | Data Protection | Partial -- sensitive data in logs |
-| V12 | File and Resources | Moderate -- upload validation, path traversal |
-| V13 | API and Web Service | Partial -- mass assignment, SSRF patterns |
+| Chapter | Title | SAST Coverage | Legacy ASVS 4.0.3 Area |
+|---------|-------|---------------|------------------------|
+| V1 | Encoding and Sanitization | Strong -- injection, XSS, path traversal, SSRF sanitization patterns | V5 split |
+| V2 | Validation and Business Logic | Partial -- input validation and business rule patterns | V5 split |
+| V3 | Web Frontend Security | Strong -- DOM XSS, CSP/header configuration, CSRF patterns | New/emphasized |
+| V4 | API and Web Service | Partial -- mass assignment, SSRF, API authorization hints | V13 |
+| V5 | File Handling | Moderate -- upload validation, path traversal, file type checks | V12 |
+| V6 | Authentication | Partial -- weak checks, credential handling, brute-force controls | V2 |
+| V7 | Session Management | Limited -- token handling and configuration review | V3 |
+| V8 | Authorization | Partial -- missing function/data/object authorization patterns | V4 |
+| V9 | Self-contained Tokens | Moderate -- JWT algorithm allowlists, signature validation, audience checks | New/split |
+| V10 | OAuth and OIDC | Partial -- OAuth/OIDC flow and claim validation patterns | New |
+| V11 | Cryptography | Moderate -- weak algorithms, hardcoded keys, insecure randomness | V6 |
+| V12 | Secure Communication | Limited -- TLS and transport configuration review | New |
+| V13 | Configuration | Limited -- security headers and deployment configuration | New |
+| V14 | Data Protection | Partial -- sensitive data in logs and storage misuse | V8 |
+| V15 | Secure Coding and Architecture | Limited -- coding standard and architecture evidence | New |
+| V16 | Security Logging and Error Handling | Partial -- log injection, sensitive error leakage | New |
+| V17 | WebRTC | Minimal -- WebRTC configuration and signaling patterns | New |
 
-### CWE Top 25 (2024)
+### Coverage Status Codes
+
+| Status | Meaning |
+|--------|---------|
+| Covered by SAST | Active rules can directly detect the weakness pattern in the repository language(s). |
+| Partially Covered | SAST can detect some variants, but manual, DAST, IAST, or runtime evidence is still needed. |
+| Manual Evidence Required | The control is security-relevant, but proof depends on design, business logic, deployment, or runtime behavior. |
+| Not Evaluable by SAST | Static source/config analysis cannot make a reliable claim from the available evidence. |
+
+### CWE Top 25 (2025)
 
 | Rank | CWE | Name |
 |------|-----|------|
-| 1 | 787 | Out-of-bounds Write |
-| 2 | 79 | Improper Neutralization of Input During Web Page Generation (XSS) |
-| 3 | 89 | Improper Neutralization of Special Elements in SQL Command (SQLi) |
-| 4 | 416 | Use After Free |
-| 5 | 78 | Improper Neutralization of Special Elements in OS Command |
-| 6 | 20 | Improper Input Validation |
-| 7 | 125 | Out-of-bounds Read |
-| 8 | 22 | Improper Limitation of a Pathname to a Restricted Directory |
-| 9 | 352 | Cross-Site Request Forgery |
-| 10 | 434 | Unrestricted Upload of File with Dangerous Type |
+| 1 | 79 | Improper Neutralization of Input During Web Page Generation (XSS) |
+| 2 | 89 | Improper Neutralization of Special Elements used in an SQL Command (SQL Injection) |
+| 3 | 352 | Cross-Site Request Forgery |
+| 4 | 862 | Missing Authorization |
+| 5 | 787 | Out-of-bounds Write |
+| 6 | 22 | Improper Limitation of a Pathname to a Restricted Directory (Path Traversal) |
+| 7 | 416 | Use After Free |
+| 8 | 125 | Out-of-bounds Read |
+| 9 | 78 | Improper Neutralization of Special Elements used in an OS Command |
+| 10 | 94 | Improper Control of Generation of Code (Code Injection) |
+| 11 | 120 | Buffer Copy without Checking Size of Input |
+| 12 | 434 | Unrestricted Upload of File with Dangerous Type |
+| 13 | 476 | NULL Pointer Dereference |
+| 14 | 121 | Stack-based Buffer Overflow |
+| 15 | 502 | Deserialization of Untrusted Data |
+| 16 | 122 | Heap-based Buffer Overflow |
+| 17 | 863 | Incorrect Authorization |
+| 18 | 20 | Improper Input Validation |
+| 19 | 284 | Improper Access Control |
+| 20 | 200 | Exposure of Sensitive Information to an Unauthorized Actor |
+| 21 | 306 | Missing Authentication for Critical Function |
+| 22 | 918 | Server-Side Request Forgery |
+| 23 | 77 | Improper Neutralization of Special Elements used in a Command |
+| 24 | 639 | Authorization Bypass Through User-Controlled Key |
+| 25 | 770 | Allocation of Resources Without Limits or Throttling |
 
 ---
 
@@ -535,6 +620,8 @@ jobs:
 4. **Not testing custom rules against both vulnerable and safe code.** A custom rule that fires on vulnerable patterns but also fires on safe patterns is worse than no rule (it trains developers to suppress). Maintain a test corpus with expected true positives and expected true negatives for every custom rule.
 
 5. **Ignoring SAST scan performance.** If SAST takes 30 minutes on a PR check, developers will find ways to bypass it. Target under 10 minutes for PR scans. Use diff-aware scanning for PRs and reserve full analysis for scheduled scans.
+
+6. **Treating stale framework mappings as current.** ASVS and CWE Top 25 versions change. A report that says only "CWE Top 25" or "ASVS" without a version, source URL, and retrieval date cannot support a reliable pass/fail gate.
 
 ---
 
@@ -551,8 +638,9 @@ This skill processes SAST configuration files, custom rules, and code patterns t
 
 ## References
 
-- OWASP ASVS 4.0.3: https://owasp.org/www-project-application-security-verification-standard/
-- CWE Top 25 (2024): https://cwe.mitre.org/top25/archive/2024/2024_cwe_top25.html
+- OWASP ASVS 5.0.0 release: https://github.com/OWASP/ASVS/releases/tag/v5.0.0_release
+- OWASP ASVS 5.0.0 CSV: https://github.com/OWASP/ASVS/releases/download/v5.0.0_release/OWASP_Application_Security_Verification_Standard_5.0.0_en.csv
+- CWE Top 25 (2025): https://cwe.mitre.org/top25/archive/2025/2025_cwe_top25.html
 - Semgrep Documentation: https://semgrep.dev/docs/
 - Semgrep Rule Syntax: https://semgrep.dev/docs/writing-rules/rule-syntax/
 - Semgrep Registry: https://semgrep.dev/r
@@ -564,4 +652,5 @@ This skill processes SAST configuration files, custom rules, and code patterns t
 
 ## Changelog
 
+- **1.0.1** -- Refresh default framework baseline to OWASP ASVS 5.0.0 and CWE Top 25 2025. Add framework source/version preflight, rule-pack freshness fields, mapping confidence, full CWE 2025 matrix, ASVS 5 chapter mapping, and SAST coverage status codes.
 - **1.0.0** -- Initial release. Full coverage of SAST configuration review against OWASP ASVS 4.0.3 and CWE Top 25, with Semgrep and CodeQL patterns.

--- a/skills/devsecops/sast-config/tests/benign/current-framework-mapping-report.md
+++ b/skills/devsecops/sast-config/tests/benign/current-framework-mapping-report.md
@@ -1,0 +1,24 @@
+# Benign Fixture: Current SAST Framework Mapping
+
+## SAST Configuration Assessment Report
+
+### Scope
+
+- Repository: example-service
+- SAST tool(s): Semgrep, CodeQL
+- Configuration files analyzed: `.semgrep.yml`, `.github/codeql/codeql-config.yml`
+- Date: 2026-06-03
+- Frameworks applied: OWASP ASVS 5.0.0, CWE Top 25 2025
+- ASVS source URL and retrieval date: https://github.com/OWASP/ASVS/releases/tag/v5.0.0_release, 2026-06-03
+- CWE source URL and retrieval date: https://cwe.mitre.org/top25/archive/2025/2025_cwe_top25.html, 2026-06-03
+- SAST rule-pack source/version/date: `p/cwe-top-25`, retrieved 2026-06-03
+- Legacy framework exception: None
+
+### Coverage Sample
+
+| CWE Rank | CWE ID | Weakness | Language(s) | Rule(s) Active | Mapping Confidence | Severity | Gap |
+|----------|--------|----------|-------------|----------------|--------------------|----------|-----|
+| 1 | CWE-79 | XSS | JavaScript | 2 rules | High | ERROR | None |
+| 4 | CWE-862 | Missing Authorization | JavaScript | 1 custom rule | Medium | WARNING | Partial - manual business logic review required |
+| 22 | CWE-918 | SSRF | Python | 1 rule | High | WARNING | None |
+

--- a/skills/devsecops/sast-config/tests/vulnerable/stale-framework-mapping-report.md
+++ b/skills/devsecops/sast-config/tests/vulnerable/stale-framework-mapping-report.md
@@ -1,0 +1,18 @@
+# Vulnerable Fixture: Stale SAST Framework Mapping
+
+## SAST Configuration Assessment Report
+
+### Scope
+
+- Repository: example-service
+- SAST tool(s): Semgrep
+- Configuration files analyzed: `.semgrep.yml`
+- Date: 2026-06-03
+- Frameworks applied: OWASP ASVS 4.0.3, CWE Top 25
+
+### Finding
+
+- Control Reference: ASVS V6.3.1 / CWE-20
+- Description: The report treats ASVS 4.0.3 and an unspecified CWE Top 25 list as the current baseline.
+- Expected skill behavior: flag this as stale unless the report records an explicit legacy assessment scope.
+


### PR DESCRIPTION
## Summary
- Refreshes `skills/devsecops/sast-config/SKILL.md` from OWASP ASVS 4.0.3 / CWE Top 25 2024 defaults to OWASP ASVS 5.0.0 / CWE Top 25 2025.
- Adds framework source/version preflight evidence, rule-pack freshness fields, mapping confidence, SAST coverage status codes, and a full CWE Top 25 2025 matrix.
- Adds benign and vulnerable fixtures showing current versus stale framework mapping reports.

## Bounty
- Closes #205
- Category: Skill Improvement
- Suggested tier: Moderate ($100) because this updates the framework baseline, output evidence model, matrix, references, and fixtures.
- Preferred payment method: crypto to `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`

## Verification
- `git diff --check`
- Markdown fence balance check for touched markdown files
- Frontmatter delimiter check for `skills/devsecops/sast-config/SKILL.md`
- Link checks returned HTTP 200 for OWASP ASVS 5.0.0 release, OWASP ASVS 5.0.0 CSV, and MITRE CWE Top 25 2025

## Bounty Terms
- [x] I have read and agree to the CONTRIBUTING.md bounty terms.