### PR TITLE
Refresh alert triage NIST Rev 3 mapping

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -462,7 +462,7 @@ skills:
     role: [soc-analyst]
     phase: [operate, respond]
     activity: [triage, investigate]
-    frameworks: [MITRE-ATT&CK-v16, NIST-SP-800-61r2]
+    frameworks: [MITRE-ATT&CK-current, NIST-SP-800-61-Rev3, NIST-CSF-2.0, NIST-SP-800-61-Rev2-legacy]
     difficulty: beginner
     time_estimate: "10-20min per alert"
     file: skills/secops/alert-triage/SKILL.md

--- a/skills/secops/alert-triage/SKILL.md
+++ b/skills/secops/alert-triage/SKILL.md
@@ -2,18 +2,18 @@
 name: alert-triage
 description: >
   Guides structured triage of security alerts using a four-phase methodology
-  (collect, correlate, classify, escalate) mapped to MITRE ATT&CK v16 and
-  aligned with NIST SP 800-61 Rev 2 incident handling guidelines. Auto-invoked
+  (collect, correlate, classify, escalate) mapped to MITRE ATT&CK and aligned
+  with NIST SP 800-61 Rev. 3 and NIST CSF 2.0 incident response guidance. Auto-invoked
   when the user discusses alert investigation, asks "is this a true positive?",
   or shares alert data requiring disposition. Produces a triage decision with
   priority assignment, disposition category, and escalation recommendation.
 tags: [secops, triage, soc]
 role: [soc-analyst]
 phase: [operate, respond]
-frameworks: [MITRE-ATT&CK-v16, NIST-SP-800-61-Rev2]
+frameworks: [MITRE-ATT&CK-current, NIST-SP-800-61-Rev3, NIST-CSF-2.0, NIST-SP-800-61-Rev2-legacy]
 difficulty: beginner
 time_estimate: "10-20min per alert"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -23,7 +23,7 @@ argument-hint: "[CVE-ID-or-alert-ID]"
 
 # Alert Triage Playbook
 
-> **Frameworks:** MITRE ATT&CK v16, NIST SP 800-61 Rev 2
+> **Frameworks:** MITRE ATT&CK, NIST SP 800-61 Rev. 3, NIST CSF 2.0
 > **Role:** SOC Analyst
 > **Time:** 10-20 min per alert
 > **Output:** Alert disposition (TP/BTP/FP), priority assignment (P1-P4), escalation decision
@@ -50,6 +50,7 @@ Invoke this skill when any of the following conditions are met:
 
 Before beginning triage, gather or confirm:
 
+- [ ] **NIST source version:** NIST SP 800-61 Rev. 3 by default; if Rev. 2 is required, record the legacy-mode reason and source date.
 - [ ] **Alert details:** Rule name, severity, timestamp, source system (SIEM, EDR, IDS, cloud security).
 - [ ] **Alert data:** The raw event(s) that triggered the alert -- including all available fields (source IP, destination IP, username, hostname, process name, command line, file hash, URL).
 - [ ] **ATT&CK mapping:** If the alert rule maps to a MITRE ATT&CK technique, note the technique ID.
@@ -57,8 +58,22 @@ Before beginning triage, gather or confirm:
 - [ ] **User context:** Who is the associated user? (Role, department, normal working hours, recent activity patterns.)
 - [ ] **Historical context:** Has this alert fired before? What was the previous disposition? Has this user or host generated related alerts recently?
 - [ ] **Threat intelligence:** Do any indicators in the alert (IPs, domains, hashes) appear in threat intelligence feeds?
+- [ ] **Incident declaration criteria:** The organization's threshold for converting an alert into an incident.
+- [ ] **Communication and recovery triggers:** Stakeholder notification criteria and recovery initiation criteria for confirmed impact.
 
 If some context is unavailable, proceed with available information and note gaps as assumptions.
+
+### NIST Rev. 3 / CSF 2.0 Triage Frame
+
+NIST SP 800-61 Rev. 3 supersedes Rev. 2 and is structured as a CSF 2.0 Community Profile. Alert triage primarily produces evidence for Detect and Respond outcomes, with Recover triggers recorded when impact is confirmed.
+
+| CSF 2.0 Area | Triage Evidence to Record | Why It Matters |
+|---|---|---|
+| **DE.AE -- Adverse Event Analysis** | Alert payload, correlated events, evidence confidence, and missing data | Proves the alert was analyzed, not only acknowledged |
+| **RS.MA -- Incident Management** | Incident declaration criteria and whether the alert meets them | Separates alert disposition from incident declaration |
+| **RS.AN -- Incident Analysis** | Scope, likely cause, affected entities, and uncertainty | Supports escalation and follow-on investigation |
+| **RS.CO -- Incident Response Communication** | Internal/external notification trigger and recipient | Prevents delayed communication for high-impact alerts |
+| **RC.RP -- Recovery Plan Execution** | Recovery trigger, impacted service, and recovery owner if impact is confirmed | Ensures triage hands off to recovery when needed |
 
 ---
 
@@ -80,7 +95,7 @@ Gather all data associated with the alert. Do not make a disposition decision un
 | **Threat intelligence** | IOC lookups for IPs, domains, hashes, URLs | VirusTotal, OTX, MISP, TI platform |
 | **Previous alerts** | Historical alerts for same user, host, or IOC | SIEM, case management |
 
-**NIST SP 800-61 alignment:** This phase corresponds to Section 3.2 "Detection and Analysis" -- specifically the initial analysis and validation of the alert before classification.
+**NIST SP 800-61 Rev. 3 / CSF 2.0 alignment:** This phase supports Detect outcomes by collecting source-dated alert evidence, not just the SIEM-generated summary.
 
 ### Phase 2: Correlate
 
@@ -103,6 +118,18 @@ Connect the alert data with surrounding context to build a picture of what happe
 | Credential Access (TA0006) | Lateral Movement (TA0008) -- were stolen credentials used to move? |
 | Lateral Movement (TA0008) | Collection (TA0009), Exfiltration (TA0010) -- what was the objective? |
 | Command and Control (TA0011) | All tactics -- C2 implies an active intrusion; look for the full chain |
+
+**CSF 2.0 correlation evidence:**
+
+```
+Triage Evidence Gate:
+- DE.AE evidence:       [raw alert + correlated events + confidence]
+- RS.MA criteria:       [incident declaration threshold met? yes/no/unclear]
+- RS.AN scope:          [known affected entities and unknowns]
+- RS.CO trigger:        [notification required? yes/no/unclear]
+- RC.RP trigger:        [recovery required? yes/no/unclear]
+- Not Evaluable Reason: [missing sensor data | missing asset context | missing policy threshold | stale source | none]
+```
 
 ### Phase 3: Classify
 
@@ -138,6 +165,18 @@ Assign a priority level based on the combination of asset criticality, threat se
 | Confidence level | Multiple corroborating signals | Single low-fidelity signal |
 | Business context | During M&A, audit, or incident response | Normal operations |
 
+#### Incident Declaration and Confidence
+
+Do not treat alert disposition, incident declaration, and recovery trigger as the same decision.
+
+| Decision | Values | Required Evidence |
+|---|---|---|
+| **Alert disposition** | TP / BTP / FP / Not Evaluable | Collected and correlated alert evidence |
+| **Incident declaration** | Declared / Not Declared / Pending | Organization criteria, affected asset, impact or credible threat path |
+| **Communication trigger** | Internal / External / Legal/Privacy / None / Pending | Stakeholder criteria, regulated data, critical service, or management threshold |
+| **Recovery trigger** | Required / Not Required / Pending | Confirmed impact to service, data integrity, or availability |
+| **Evidence confidence** | High / Medium / Low / Not Evaluable | Sensor health, data completeness, source freshness, correlation quality |
+
 ### Phase 4: Escalate
 
 Determine whether the alert requires escalation and to whom.
@@ -154,7 +193,7 @@ Determine whether the alert requires escalation and to whom.
 | Alert matches a known active threat campaign | Threat intelligence team + IR team |
 | Multiple correlated alerts suggest a coordinated attack | IR team lead for incident declaration |
 
-**NIST SP 800-61 alignment:** This phase corresponds to Section 3.2.6 "Incident Notification" and Section 3.2.7 "Escalation." NIST recommends predefined escalation procedures with clear criteria and contact information.
+**NIST SP 800-61 Rev. 3 / CSF 2.0 alignment:** This phase records Respond communication and incident-management handoff evidence. If impact is confirmed, also record the Recover trigger and owner.
 
 **Escalation documentation (minimum required):**
 
@@ -194,9 +233,17 @@ Produce the triage decision as a structured report:
 ```markdown
 ## Alert Triage Report
 **Date:** [YYYY-MM-DD HH:MM UTC]
-**Skill:** alert-triage v1.0.0
-**Frameworks:** MITRE ATT&CK v16, NIST SP 800-61 Rev 2
+**Skill:** alert-triage v1.0.1
+**Frameworks:** MITRE ATT&CK, NIST SP 800-61 Rev. 3, NIST CSF 2.0
 **Analyst:** [Name or AI-assisted]
+
+### Source and Scope
+| Field | Value |
+|-------|-------|
+| NIST Source Version | [SP 800-61 Rev. 3 / Rev. 2 legacy] |
+| NIST Source Date | [publication/review date] |
+| Legacy Mode Reason | [N/A or reason Rev. 2 is required] |
+| Triage Scope | [single alert / alert cluster / campaign] |
 
 ### Alert Summary
 | Field | Value |
@@ -221,7 +268,11 @@ Produce the triage decision as a structured report:
 | **Disposition** | **[True Positive / Benign True Positive / False Positive]** |
 | **Priority** | **[P1 Critical / P2 High / P3 Medium / P4 Low]** |
 | **Confidence** | [High / Medium / Low] |
+| **Incident Declaration** | [Declared / Not Declared / Pending / Not Evaluable] |
 | **Escalation Required** | [Yes -- to IR team / Yes -- to Tier 2 / No] |
+| **Communication Trigger** | [Internal / External / Legal-Privacy / None / Pending] |
+| **Recovery Trigger** | [Required / Not Required / Pending] |
+| **Not Evaluable Reason** | [missing sensor data / missing asset context / missing policy threshold / stale source / none] |
 
 ### Evidence Summary
 1. [Key finding 1 -- what was observed]
@@ -233,6 +284,15 @@ Produce the triage decision as a structured report:
 - **Lateral:** [Related alerts on other hosts/users]
 - **Threat Intel:** [IOC match results]
 - **Kill Chain Position:** [Where this falls in the attack lifecycle]
+
+### CSF 2.0 Triage Mapping
+| CSF Area | Evidence | Status |
+|---|---|---|
+| DE.AE -- Adverse Event Analysis | [alert evidence and correlated context] | [Complete / Partial / Missing] |
+| RS.MA -- Incident Management | [declaration criteria and decision] | [Declared / Not Declared / Pending] |
+| RS.AN -- Incident Analysis | [scope, cause, affected entities] | [Complete / Partial / Missing] |
+| RS.CO -- Communication | [notification trigger and recipient] | [Required / Not Required / Pending] |
+| RC.RP -- Recovery | [recovery trigger and owner] | [Required / Not Required / Pending] |
 
 ### Recommended Actions
 - [ ] [Action 1 -- e.g., isolate host, disable account, block IP]
@@ -249,9 +309,9 @@ exclude known-good IP range, adjust threshold.]
 
 ## 6. Framework Reference
 
-### MITRE ATT&CK v16
+### MITRE ATT&CK
 
-For alert triage, ATT&CK provides the shared vocabulary for understanding what adversary behavior the alert represents and what to look for next. Key uses during triage:
+For alert triage, ATT&CK provides the shared vocabulary for understanding what adversary behavior the alert represents and what to look for next. Record the ATT&CK version or release date used when producing a client-facing report.
 
 - **Technique identification:** Map the alert to a specific ATT&CK technique to understand the adversary's objective.
 - **Kill chain positioning:** Determine where the detected activity falls in the attack lifecycle to assess urgency and look for related activity.
@@ -267,27 +327,22 @@ Discovery -> Lateral Movement -> Collection -> Exfiltration -> Impact
 
 Alerts that map to later-stage tactics (Lateral Movement, Collection, Exfiltration, Impact) generally warrant higher priority because they indicate deeper compromise.
 
-### NIST SP 800-61 Rev 2 -- Computer Security Incident Handling Guide
+### NIST SP 800-61 Rev. 3 -- Incident Response Recommendations
 
-NIST SP 800-61 Revision 2 (published August 2012) provides the foundational framework for incident handling in organizations. The alert triage process maps to the "Detection and Analysis" phase of the NIST incident response lifecycle:
+NIST SP 800-61 Rev. 3, published in April 2025, supersedes Rev. 2 and is organized as a NIST CSF 2.0 Community Profile. For alert triage, use Rev. 3 by default and map evidence to Detect, Respond, and Recover outcomes.
 
-**NIST Incident Response Lifecycle:**
+**Rev. 3 triage implications:**
 
-| Phase | Description | Triage Relevance |
+| Area | Triage Relevance |
 |-------|-------------|------------------|
-| 1. Preparation | Establishing IR capability, tools, procedures | Defines triage playbooks and escalation paths |
-| 2. Detection and Analysis | Identifying and validating potential incidents | **Primary triage phase** -- collect, correlate, classify |
-| 3. Containment, Eradication, and Recovery | Limiting damage, removing threat, restoring operations | Post-triage for confirmed TPs |
-| 4. Post-Incident Activity | Lessons learned, metric collection, process improvement | Feeds back into triage process improvement |
+| Detect | Analyze adverse events and collect evidence before disposition |
+| Respond | Declare incidents, communicate, escalate, and coordinate response |
+| Recover | Start recovery when service, availability, or integrity impact is confirmed |
+| Govern/Identify/Protect | Provide policy thresholds, asset context, critical services, and stakeholder expectations |
 
-**Key NIST 800-61 Rev 2 recommendations for triage:**
+### NIST SP 800-61 Rev. 2 -- Legacy Mode
 
-- **Section 3.2.4 -- Incident Analysis:** Use multiple data sources for correlation. Do not rely on a single alert in isolation.
-- **Section 3.2.5 -- Incident Documentation:** Document all triage decisions, evidence, and rationale. Maintain an incident log from the first alert.
-- **Section 3.2.6 -- Incident Prioritization:** Prioritize based on the functional impact, information impact, and recoverability of the incident.
-- **Section 3.2.7 -- Incident Notification:** Notify designated personnel based on predefined criteria. Over-communication is preferred to under-communication during active incidents.
-
-**NIST prioritization factors (SP 800-61 Rev 2, Section 3.2.6):**
+Use Rev. 2 only when an organization explicitly requires an older playbook mapping. If Rev. 2 is used, label the report as legacy and record the reason. The Rev. 2 prioritization factors remain useful as legacy supporting context:
 
 | Factor | Rating Levels |
 |--------|---------------|
@@ -317,7 +372,15 @@ Investigating an alert in isolation without checking for activity before and aft
 
 ### Pitfall 5: Delaying Escalation While Seeking Perfect Information
 
-Waiting for complete certainty before escalating a high-priority alert costs response time. NIST SP 800-61 recommends erring on the side of over-notification. If 20 minutes of investigation has not resolved the disposition and the alert involves a critical asset or privileged account, escalate to Tier 2 or the IR team with your current findings and continue investigation in parallel.
+Waiting for complete certainty before escalating a high-priority alert costs response time. If 20 minutes of investigation has not resolved the disposition and the alert involves a critical asset or privileged account, escalate to Tier 2 or the IR team with your current findings and continue investigation in parallel.
+
+### Pitfall 6: Treating Rev. 2 Alignment as Current by Default
+
+NIST SP 800-61 Rev. 3 supersedes Rev. 2. If a report uses Rev. 2, label it as legacy and record the business or contractual reason. Do not present Rev. 2 section mappings as current NIST guidance.
+
+### Pitfall 7: Conflating Alert Disposition with Incident Declaration
+
+A true positive alert is not automatically a declared incident, and a benign true positive may still require detection tuning or communication. Record disposition, incident declaration, communication trigger, and recovery trigger as separate decisions.
 
 ---
 
@@ -335,12 +398,23 @@ This skill processes user-supplied content that may include alert payloads, log 
 
 ## 9. References
 
-1. **NIST SP 800-61 Rev 2 -- Computer Security Incident Handling Guide** -- https://csrc.nist.gov/publications/detail/sp/800-61/rev-2/final
-2. **MITRE ATT&CK Enterprise Matrix v16** -- https://attack.mitre.org/matrices/enterprise/
-3. **MITRE ATT&CK Tactics** -- https://attack.mitre.org/tactics/enterprise/
-4. **FIRST CSIRT Services Framework** -- https://www.first.org/standards/frameworks/csirts/csirt_services_framework_v2.1
-5. **SANS Incident Handler's Handbook** -- https://www.sans.org/white-papers/33901/
-6. **SOC Analyst Triage Best Practices (SANS)** -- https://www.sans.org/reading-room/
-7. **Microsoft Sentinel Incident Triage** -- https://learn.microsoft.com/en-us/azure/sentinel/investigate-incidents
-8. **Splunk Enterprise Security Notable Event Triage** -- https://docs.splunk.com/Documentation/ES/latest/User/TriageNotableEvents
-9. **NIST Cybersecurity Framework (CSF) 2.0 -- Detect Function** -- https://www.nist.gov/cyberframework
+1. **NIST SP 800-61 Rev. 3 -- Incident Response Recommendations and Considerations for Cybersecurity Risk Management: A CSF 2.0 Community Profile** -- https://csrc.nist.gov/pubs/sp/800/61/r3/final
+2. **NIST Incident Response project page** -- https://csrc.nist.gov/projects/incident-response
+3. **NIST Cybersecurity Framework 2.0** -- https://www.nist.gov/cyberframework
+4. **NIST SP 800-61 Rev. 2 -- legacy Computer Security Incident Handling Guide** -- https://csrc.nist.gov/publications/detail/sp/800-61/rev-2/final
+5. **MITRE ATT&CK Enterprise Matrix** -- https://attack.mitre.org/matrices/enterprise/
+6. **MITRE ATT&CK Tactics** -- https://attack.mitre.org/tactics/enterprise/
+7. **FIRST CSIRT Services Framework** -- https://www.first.org/standards/frameworks/csirts/csirt_services_framework_v2.1
+8. **SANS Incident Handler's Handbook** -- https://www.sans.org/white-papers/33901/
+9. **SOC Analyst Triage Best Practices (SANS)** -- https://www.sans.org/reading-room/
+10. **Microsoft Sentinel Incident Triage** -- https://learn.microsoft.com/en-us/azure/sentinel/investigate-incidents
+11. **Splunk Enterprise Security Notable Event Triage** -- https://docs.splunk.com/Documentation/ES/latest/User/TriageNotableEvents
+
+---
+
+## Version History
+
+| Version | Date | Changes |
+|---|---|---|
+| 1.0.1 | 2026-06-03 | Refreshed default NIST alignment to SP 800-61 Rev. 3 and added CSF 2.0 triage evidence fields |
+| 1.0.0 | 2025-03-06 | Initial release |

--- a/skills/secops/alert-triage/tests/benign/current-rev3-csf-triage-report.md
+++ b/skills/secops/alert-triage/tests/benign/current-rev3-csf-triage-report.md
@@ -1,0 +1,36 @@
+# Alert Triage Fixture: Current Rev. 3 / CSF 2.0 Evidence
+
+## Alert Triage Report
+**Date:** 2026-06-03 10:00 UTC
+**Skill:** alert-triage v1.0.1
+**Frameworks:** MITRE ATT&CK, NIST SP 800-61 Rev. 3, NIST CSF 2.0
+**Analyst:** AI-assisted
+
+### Source and Scope
+| Field | Value |
+|-------|-------|
+| NIST Source Version | SP 800-61 Rev. 3 |
+| NIST Source Date | April 2025; reviewed 2026-06-03 |
+| Legacy Mode Reason | N/A |
+| Triage Scope | single alert |
+
+### Triage Decision
+| Field | Value |
+|-------|-------|
+| Disposition | Benign True Positive |
+| Priority | P4 Low |
+| Confidence | High |
+| Incident Declaration | Not Declared |
+| Escalation Required | No |
+| Communication Trigger | None |
+| Recovery Trigger | Not Required |
+| Not Evaluable Reason | none |
+
+### CSF 2.0 Triage Mapping
+| CSF Area | Evidence | Status |
+|---|---|---|
+| DE.AE -- Adverse Event Analysis | alert payload plus EDR process context reviewed | Complete |
+| RS.MA -- Incident Management | incident criteria not met because activity matched approved admin job | Not Declared |
+| RS.AN -- Incident Analysis | host, user, parent process, and change ticket matched | Complete |
+| RS.CO -- Communication | no regulated data or critical service trigger | Not Required |
+| RC.RP -- Recovery | no service, integrity, or availability impact | Not Required |

--- a/skills/secops/alert-triage/tests/vulnerable/stale-rev2-only-triage-report.md
+++ b/skills/secops/alert-triage/tests/vulnerable/stale-rev2-only-triage-report.md
@@ -1,0 +1,29 @@
+# Alert Triage Fixture: Stale Rev. 2-Only Report
+
+## Alert Triage Report
+**Date:** 2026-06-03 10:00 UTC
+**Skill:** alert-triage v1.0.0
+**Frameworks:** MITRE ATT&CK v16, NIST SP 800-61 Rev 2
+**Analyst:** AI-assisted
+
+### Alert Summary
+| Field | Value |
+|-------|-------|
+| Alert ID | SIEM-123 |
+| Rule Name | Suspicious PowerShell |
+| Source System | SIEM |
+| Timestamp | 2026-06-03 09:45:00 UTC |
+| ATT&CK Technique | T1059.001 -- PowerShell |
+| ATT&CK Tactic | Execution |
+
+### Triage Decision
+| Field | Value |
+|-------|-------|
+| Disposition | True Positive |
+| Priority | P2 High |
+| Confidence | Medium |
+| Escalation Required | Yes -- to IR team |
+
+### Why This Fixture Should Be Flagged
+
+The report uses only NIST SP 800-61 Rev. 2 without a legacy-mode reason, NIST source date, CSF 2.0 mapping, incident declaration criteria, communication trigger, recovery trigger, evidence confidence basis, or not-evaluable reason.


### PR DESCRIPTION
## Summary
- refresh `alert-triage` from default NIST SP 800-61 Rev. 2 alignment to NIST SP 800-61 Rev. 3 and NIST CSF 2.0 triage evidence
- keep Rev. 2 as explicit legacy mode with a required reason/source date
- separate alert disposition from incident declaration, communication trigger, recovery trigger, evidence confidence, and not-evaluable reasons
- add benign and vulnerable fixtures for current Rev. 3/CSF evidence vs stale Rev. 2-only triage reporting

## Problem
NIST finalized SP 800-61 Rev. 3 in April 2025 and states that Rev. 3 supersedes Rev. 2. The existing `alert-triage` skill still presents Rev. 2 as the default NIST alignment, so reports can look current while using superseded section mappings and missing CSF 2.0 triage evidence.

Closes #324.

## Validation
- `git diff --check`
- local frontmatter check matching `.github/workflows/lint-skills.yml`
- markdown fence and table-row checks for alert-triage files
- official link check returned HTTP 200 for NIST Rev. 3, NIST incident response, NIST CSF 2.0, NIST Rev. 2 legacy, MITRE ATT&CK, FIRST CSIRT, and Microsoft Sentinel references

## Bounty Info
- Type: Skill Improvement
- Suggested tier: Moderate ($100)
- Preferred payment method: Crypto
- Wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099
