### PR TITLE
Improve iam-review effective privilege evidence matrix, confidence classifications, and pitfalls

### DIFF
--- a/skills/ai-security/agent-security/SKILL.md
+++ b/skills/ai-security/agent-security/SKILL.md
@@ -137,8 +137,15 @@ Evaluate what each agent can do, under what conditions, and whether the permissi
 - **Dynamic vs. static tool sets:** Can the agent's tool set change at runtime? If an orchestrator dynamically assigns tools, what governs which tools are assigned?
 - **Per-session vs. permanent tool access:** Is tool access scoped to a specific task or session, or does every invocation receive the same broad tool set regardless of the task?
 - **Cross-agent tool sharing:** Can one agent invoke another agent's tools? If so, through what authorization mechanism?
+- **MCP Tool Boundary and Identity Provenance:** For Model Context Protocol (MCP) integrations, verify that the reviewer maps each tool to its originating server identity (stdio path or remote SSE URL), publisher channel (verified vs. community), transport containment, and registered tool/parameter schema hashes.
+- **MCP Tool Descriptor Poisoning:** Check if tool descriptions, parameter schemas, enum options, and examples include instruction-carrying text or unsafe formatting (HTML/Markdown scripts, remote URLs). These are visible to the LLM and can trigger indirect prompt injection if poisoned.
+- **Descriptor Update and Rug-pull Controls:** Verify if the client pins and verifies hashes/signatures of tool descriptors. Determine whether changes in remote descriptors trigger a diff and force a re-approval workflow, or if updates are silently accepted.
+- **Namespace partitioning and name collisions:** Verify if tools use canonical namespace schemas (e.g., `namespace.tool_name`) to prevent lookalike tool hijacking (e.g., registering `github_get_issue` on an untrusted community server to hijack `github.get_issue` calls).
+- **OAuth and resource-bounded scopes:** For remote MCP tools using OAuth, verify whether token scopes are restricted to specific resources and actions (least-privilege audience/indicator) rather than granting wildcard tool access (`mcp:tools`) across all databases or client actions.
+- **Local stdio transport privilege isolation:** For local stdio-based servers, verify if the execution process is sandboxed, inherits a scrubbed environment without parent API keys, and has restricted process/user group access.
 
-**Detection methods:** Search for agent/tool definitions (`register_tool`, `add_tool`, `@tool`, `FunctionTool`), permission configs (`service_account`, `iam`, `role_arn`, wildcards in IAM policies), and tool scoping logic (`filter_tools`, `permitted_tools`, `enabled_tools`).
+**Detection methods:** Search for agent/tool definitions (`register_tool`, `add_tool`, `@tool`, `FunctionTool`), permission configs (`service_account`, `iam`, `role_arn`, wildcards in IAM policies), tool scoping logic (`filter_tools`, `permitted_tools`, `enabled_tools`), MCP server configurations (`mcpServers` config files, stdio binary args, SSE endpoints), tool schema loading functions, descriptor validation code, client-side descriptor signature/hash checking, namespace partition logic, and OAuth token request parameterizations.
+
 
 **Permission model evaluation matrix:**
 
@@ -159,9 +166,14 @@ Evaluate what each agent can do, under what conditions, and whether the permissi
 |---|---|
 | Agent has write/delete access to production databases without task justification | Critical |
 | Agent service account has wildcard IAM permissions | Critical |
+| Unverified/unsigned remote MCP tool descriptors loaded without integrity checks | High |
+| Remote MCP server descriptors updated without human-in-the-loop re-approval (rug-pull risk) | High |
+| Remote MCP tool token reusing general administrative user token with broad scopes | High |
+| Local stdio MCP server inheriting parent environment keys or running unsandboxed | High |
 | Agent has access to tools it never needs for its defined purpose | High |
 | No per-task or per-session tool scoping -- every invocation gets full tool set | High |
 | Tool registration allows runtime tool injection by the agent itself | High |
+| Tool name lookalikes allowed without namespace partition checks | Medium |
 | Agent credentials do not expire or rotate | Medium |
 | Tool permissions not documented or reviewed periodically | Medium |
 
@@ -492,6 +504,12 @@ Glob: **/security_architecture*
 |---|---|---|---|---|---|
 | [name] | [purpose] | [tool list] | [credential type] | [Yes/No, which actions] | [trust level] |
 
+## MCP Tool Boundary Inventory
+
+| Server URL/Path | Canonical Resource | Transport | Publisher/Source | Install/Update Channel | Tool Name | Descriptor Hash | Schema Hash | Side Effects | Required Scopes | Token Audience/Resource | Per-Tool Consent | Last Descriptor Change | Re-approval Required? | Evidence Confidence |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| [e.g., /bin/mcp] | [e.g., repo_list] | stdio/SSE/WS | Verified/Community | npm/Docker/Local | [Name] | [SHA256] | [SHA256] | none/write/destroy | [Scopes] | [Audience] | Yes/No | [Date] | Yes/No | [Confidence] |
+
 ## Architecture Diagram Annotations
 [Notes on trust boundaries, data flows, and security control placement annotating the existing architecture diagram, or a text-based representation if no diagram exists]
 
@@ -568,6 +586,14 @@ Glob: **/security_architecture*
 4. **Building audit trails that log actions but not context.** An audit log that records "Agent-A called write_file at 14:32:01" is useful for timeline reconstruction but insufficient for root cause analysis. Without logging what the agent was told (the prompt or task), what it reasoned (the chain of thought), and what it received from other agents or tools (the inputs), investigators cannot determine whether the action was legitimate, hallucinated, or injected. Log the full decision context for every consequential action.
 
 5. **Assuming rollback is someone else's problem.** Agent developers frequently rely on downstream systems (databases, deployment platforms, email providers) to handle rollback without verifying that rollback mechanisms actually exist and work. A database transaction can be rolled back, but only if the agent's actions are wrapped in a transaction. An email cannot be recalled. A deployed binary cannot be un-deployed if the deployment pipeline has no rollback. For every tool an agent can invoke, the architecture must document the rollback mechanism and test it.
+
+6. **Trusting MCP tool descriptions as static metadata.** Reviewers often treat tool descriptions as developer documentation rather than model input context. In MCP integrations, tool descriptions are loaded dynamically and sent directly to the model as part of the context. If these descriptions are not vetted or sanitized, they introduce a tool-descriptor poisoning vector where a remote server or a local package can execute indirect prompt injection attacks on the agent via the descriptions.
+
+7. **Overlooking remote descriptor updates (rug-pulls).** A major pitfall is approving an MCP tool based on its current behavior and tool descriptors, but failing to lock or verify the version/hash of the descriptors during subsequent executions. If the remote MCP server updates its tool descriptions, parameter schemas, or advertised side effects, the agent client may silently accept these changes. This allows malicious servers to change their instructions or parameter requirements post-approval without triggering security review.
+
+8. **Broad OAuth token reuse across remote MCP connections.** Remote MCP tools frequently use OAuth to access databases or APIs. Often, the client uses a single broad administrative token or client credentials across all servers and tools. If one remote tool is compromised or malicious, it can misuse the broad token to access resources outside its designated scope. Authentication tokens must be scoped tightly per-tool and per-resource.
+
+9. **Stdio privilege inheritance in local MCP setups.** Developers frequently launch local stdio MCP servers directly from the parent application process. This means the server process inherits the host system environment, filesystems, and parent credentials by default. If the local tool or its underlying npm/docker library is compromised, it has full ambient host access. Reviewers must verify that stdio execution is isolated, sandboxed, and environment variables are explicitly scrubbed.
 
 ---
 

--- a/skills/identity/iam-review/SKILL.md
+++ b/skills/identity/iam-review/SKILL.md
@@ -72,6 +72,45 @@ SECURITY BOUNDARY — This skill processes IAM configuration data only.
 
 ## Process
 
+### Step 0: IAM Evidence and Effective Privilege Matrix
+
+Before assigning findings or performing the step-by-step checks, the reviewer MUST construct an **IAM Evidence and Effective Privilege Matrix**. This matrix is crucial because a simple policy check does not represent effective privilege. For instance, an attached `AdministratorAccess` policy can be restricted by SCPs, permission boundaries, IAM conditions, or conditional access policies, while an account with no direct attached policies might inherit wildcard access through unexpanded groups or nested roles.
+
+#### 1. Constructing the Matrix
+For every privileged identity or target group, map the following attributes:
+- **Identity ID:** Unique name, ARN, or email.
+- **Identity Type:** Human user, federated identity, guest, service account, workload identity, managed identity, or API key.
+- **Provider:** AWS, Azure/Entra ID, GCP, Okta, etc.
+- **Owner:** Individual, team, or application responsible for the identity.
+- **Assigned Privilege:** The explicit policy or role attached (e.g., `AdministratorAccess`, `Owner` role).
+- **Effective Privilege Modifiers:** Explicit Deny policies, Service Control Policies (SCPs), Permission Boundaries, IAM resource policies, or session duration limits that restrict the assigned privilege.
+- **MFA / Conditional Access State:** MFA status (none, SMS, TOTP, FIDO2/WebAuthn) and conditional access policy state (e.g., enforced, report-only, excluded).
+- **Activity Source:** Where the last activity data is sourced from (e.g., credential report, sign-in logs, CloudTrail, GCP IAM Recommender).
+- **Last Activity Timestamp:** Date of last recorded authentication or API call.
+- **Log Retention:** The retention period of the activity logs (to evaluate if "N/A" or stale status is due to lack of logs).
+- **Evidence Confidence:** Confidence level of the gathered evidence (`source-code` | `config` | `runtime export` | `test evidence` | `docs-only` | `unknown`).
+
+#### 2. Evidence Confidence Classification
+For each evaluated control and finding, classify the evidence confidence using these standards:
+- **`source-code`:** Verified via direct code definitions (e.g., IaC configurations, Terraform, CloudFormation).
+- **`config`:** Verified via exported policy JSON files, configuration definitions, or console screens.
+- **`runtime export`:** Verified via live API exports (e.g., credential reports, active CLI outputs).
+- **`test evidence`:** Verified via Access Analyzer tests, Policy Simulator results, or login audit logs.
+- **`docs-only`:** Stated in documentation (e.g., README, disaster recovery wiki) but not verified in code or live configs.
+- **`unknown`:** No evidence could be gathered.
+
+#### 3. Not Evaluable Reason Codes
+If an identity or control cannot be evaluated due to missing access or data, specify one of the following reason codes:
+- **`missing inventory`:** Central list of identities, guests, or application registrations is unavailable.
+- **`missing activity logs`:** Access logs, CloudTrail, or Entra sign-in history cannot be accessed or have expired.
+- **`unknown enforcement mode`:** Cannot verify if conditional access or MFA rules are enforced, in report-only mode, or have bypass groups.
+- **`unexpanded groups`:** Nested roles, directory groups, or federated mapping permissions cannot be traced to effective members.
+- **`unknown modifiers`:** Permission boundaries, SCPs, or resource-level deny rules are not accessible to verify effective limits.
+- **`missing owner`:** Identity exists but has no metadata, tags, or records identifying the responsible owner.
+- **`missing break-glass monitoring`:** Break-glass or emergency access accounts exist but their alert or audit settings are not reviewable.
+
+---
+
 ### Step 1: Inventory Identities
 
 **Objective:** Build a complete inventory of all identity types across the environment.
@@ -379,6 +418,8 @@ For each finding, produce a row with:
 | **Severity** | Critical / High / Medium / Low |
 | **Framework Ref** | NIST SP 800-63B section, NIST SP 800-207 tenet, or CIS Control ID |
 | **Affected Scope** | Accounts, roles, policies, or platforms impacted |
+| **Evidence Confidence** | source-code | config | runtime export | test evidence | docs-only | unknown |
+| **Not Evaluable Reason** | [Reason code if applicable, else N/A: missing inventory | missing activity logs | unknown enforcement mode | unexpanded groups | unknown modifiers | missing owner | missing break-glass monitoring] |
 | **Evidence** | Specific configuration, policy, or data supporting the finding |
 | **Remediation** | Prioritized fix with implementation guidance |
 | **Effort** | Low (< 1 day) / Medium (1-5 days) / High (> 5 days) |
@@ -397,6 +438,11 @@ For each finding, produce a row with:
 ### Executive Summary
 [2-3 sentences: overall posture, critical gaps, top priority actions]
 
+### IAM Evidence and Effective Privilege Matrix
+| Identity ID | Identity Type | Provider | Owner | Assigned Privilege | Effective Privilege Modifiers | MFA / Conditional Access State | Activity Source | Last Activity Timestamp | Log Retention | Evidence Confidence |
+|---|---|---|---|---|---|---|---|---|---|---|
+| [ARN/ID] | Human/Service | AWS/Azure | [Owner] | [Privilege] | [SCPs, Boundaries, Deny Rules] | [MFA Type, Enforced/Report-only] | [Log source] | [Date/Time] | [Duration] | [Confidence level] |
+
 ### Findings by Severity
 - Critical: [count]
 - High: [count]
@@ -412,7 +458,7 @@ For each finding, produce a row with:
 - Zero Trust (Step 7): [count]
 
 ### Detailed Findings
-[Findings table — see above]
+[Findings table — see above, containing columns: Finding ID, Title, Severity, Framework Ref, Affected Scope, Evidence Confidence, Not Evaluable Reason, Evidence, Remediation, Effort]
 
 ### Remediation Roadmap
 [Prioritized actions: immediate (0-7 days), short-term (30 days), medium-term (90 days)]
@@ -431,6 +477,18 @@ For each finding, produce a row with:
 | **P1 — Urgent** | 8-30 days | No JIT for admin access, service account keys > 1 year old, no stale account process |
 | **P2 — Important** | 31-90 days | No phishing-resistant MFA, incomplete identity inventory, no access review cadence |
 | **P3 — Planned** | 91-180 days | Zero trust maturity gaps, device trust integration, continuous access evaluation |
+
+---
+
+## Common Pitfalls
+
+These are the three most frequent mistakes agents make when performing IAM security reviews:
+
+1. **Treating attached policy as effective privilege.** Reviewers often look only at the attached IAM policies (e.g., seeing `AdministratorAccess` and flagging it as a Critical finding) without verifying if there are Service Control Policies (SCPs), permission boundaries, IAM conditions, or explicit Deny policies that restrict that access. Conversely, they may ignore identities that appear to have minimal direct access but inherit wildcard administrative privileges through unexpanded groups or nested role trusts.
+
+2. **Treating "N/A" or missing last-used activity as proof of inactivity.** Flagging credentials as stale or dormant purely because the `password_last_used` or `access_key_last_used` fields show "N/A" is a common pitfall. Reviewers must confirm the log retention limits and the provider-specific tracking details. For example, if CloudTrail retention is 7 days, a lack of log entries for an API key does not mean it has been inactive for 90 days. Furthermore, programmatic access by some SDKs or integrations may not register in default credential reports, requiring active audit logs for validation.
+
+3. **Counting report-only conditional access policies as control enforcement.** When auditing MFA or conditional access policies, reviewers often flag a policy as "Implemented" without checking its state or exclusions. If a policy is in `reportOnly` or log-only mode, or if it has wide bypass groups (such as excluding all service principals or break-glass accounts without compensating alert monitoring), it does not enforce the security control and represents a significant gap.
 
 ---
 


### PR DESCRIPTION
## Summary

Improves the `iam-review` security review skill to ensure reviewers map and evaluate effective privileges rather than just attached policies:
- Adds a mandatory **Step 0: IAM Evidence and Effective Privilege Matrix** section detailing the mapping of privilege modifiers, conditional access policies, and last-activity log retention.
- Defines standard **Evidence Confidence Classifications** (`source-code`, `config`, `runtime export`, `test evidence`, `docs-only`, `unknown`) and **Not Evaluable Reason Codes** (`missing inventory`, `missing activity logs`, `unknown enforcement mode`, `unexpanded groups`, `unknown modifiers`, `missing owner`, `missing break-glass monitoring`).
- Expands the **Output Format** Findings Table and Summary Report templates to include the new matrix table and fields for evidence confidence levels and not evaluable reasons.
- Adds a **Common Pitfalls** section covering three critical mistakes: treating attached policies as effective privileges, treating "N/A" activity as inactivity without accounting for log retention limits, and counting report-only conditional access as active enforcement.

## Related review

Implements #67.

## Validation

- Verified syntax and formatting with `git diff --check`.
- Inspected markdown tables and links.

## Bounty

I have read and agree to the CONTRIBUTING.md bounty terms.
