### PR TITLE
Improve API security checks for Next.js App Router

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: api-security
 description: >
-  Reviews REST and GraphQL APIs against the OWASP API Security Top 10:2023.
+  Reviews REST, GraphQL, and framework-native API surfaces against the OWASP API Security Top 10:2023.
   Auto-invoked when reviewing OpenAPI/Swagger specs, API endpoint code, or
-  GraphQL schemas. Covers BOLA, BFLA, authentication, rate limiting, and
-  SSRF. Produces findings mapped to API1-API10 with remediation guidance.
+  GraphQL schemas. Covers BOLA, BFLA, authentication, rate limiting, SSRF,
+  and Next.js App Router handlers or Server Actions. Produces findings
+  mapped to API1-API10 with remediation guidance.
 tags: [appsec, api, rest, graphql]
 role: [appsec-engineer, security-engineer]
 phase: [design, build, review]
@@ -21,7 +22,7 @@ argument-hint: "[target-file-or-directory]"
 
 # API Security Review -- OWASP API Security Top 10:2023
 
-A structured, repeatable process for reviewing REST and GraphQL APIs against the OWASP API Security Top 10:2023. This skill produces findings mapped to API1 through API10 with associated CWE identifiers, severity ratings, and actionable remediation guidance. It applies to OpenAPI/Swagger specifications, API endpoint source code, GraphQL schemas, and API gateway configurations.
+A structured, repeatable process for reviewing REST, GraphQL, and framework-native API surfaces against the OWASP API Security Top 10:2023. This skill produces findings mapped to API1 through API10 with associated CWE identifiers, severity ratings, and actionable remediation guidance. It applies to OpenAPI/Swagger specifications, API endpoint source code, GraphQL schemas, Next.js App Router Route Handlers, Server Actions/Server Functions, and API gateway configurations.
 
 ---
 
@@ -31,11 +32,11 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 
 Before analyzing any endpoint, establish a complete inventory of the API surface under review.
 
-1. **Identify the API style** -- REST (OpenAPI/Swagger), GraphQL, gRPC, or hybrid. Each style has distinct attack patterns.
-2. **Catalog all endpoints and operations** -- For REST, list every path and HTTP method. For GraphQL, list all queries, mutations, and subscriptions.
+1. **Identify the API style** -- REST (OpenAPI/Swagger), GraphQL, gRPC, Next.js App Router/Server Actions, or hybrid. Each style has distinct attack patterns.
+2. **Catalog all endpoints and operations** -- For REST, list every path and HTTP method. For GraphQL, list all queries, mutations, and subscriptions. For Next.js App Router projects, include `app/**/route.ts`, exported HTTP verb handlers, module-level or inline `"use server"` Server Actions, `<form action={...}>`, `formAction={...}`, and Client Component imports of server action functions.
 3. **Map authentication mechanisms** -- OAuth 2.0 flows, API keys, JWTs, session cookies, mTLS, or custom tokens. Note which endpoints require authentication and which are public.
 4. **Identify authorization models** -- RBAC, ABAC, ownership-based, or no authorization. Document how object-level and function-level access control decisions are made.
-5. **Catalog data objects** -- List the resources/entities exposed by the API and their sensitivity classification (PII, financial, internal, public).
+5. **Catalog data objects and intended audience** -- List the resources/entities exposed by the API and their sensitivity classification (PII, financial, internal, public). Distinguish intentionally public metadata endpoints from private data or mutation surfaces before reporting missing authentication.
 6. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, or cost-control mechanisms at the gateway or application layer.
 7. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
 
@@ -62,7 +63,7 @@ Each finding produced by this review must include the following fields:
 | **OWASP API Risk** | API1:2023 through API10:2023 identifier |
 | **Severity** | Critical, High, Medium, Low, or Informational |
 | **CWE** | Applicable CWE identifier (e.g., CWE-639) |
-| **API Style** | REST, GraphQL, gRPC, or General |
+| **API Style** | REST, GraphQL, gRPC, Next.js App Router, or General |
 | **Location** | File path and line number(s), or OpenAPI spec path |
 | **Description** | What the vulnerability is and why it matters |
 | **Evidence** | Relevant code snippet or spec excerpt demonstrating the issue |
@@ -89,7 +90,7 @@ The final review output must be structured as follows:
 ## API Security Review Report
 
 **Scope:** [API name, version, endpoints reviewed]
-**API Style:** [REST / GraphQL / gRPC / Hybrid]
+**API Style:** [REST / GraphQL / gRPC / Next.js App Router / Hybrid]
 **Specification:** [OpenAPI spec path, if applicable]
 **Date:** [review date]
 **Reviewer:** AI Agent -- api-security skill v1.0.0
@@ -118,7 +119,7 @@ The final review output must be structured as follows:
 - **OWASP API Risk:** API[N]:2023 -- [Name]
 - **Severity:** [Critical|High|Medium|Low|Informational]
 - **CWE:** CWE-[number] -- [name]
-- **API Style:** [REST|GraphQL|gRPC|General]
+- **API Style:** [REST|GraphQL|gRPC|Next.js App Router|General]
 - **Location:** [file:line or spec path]
 - **Description:** [explanation]
 - **Evidence:**
@@ -201,6 +202,40 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 ---
 
+## Next.js App Router and Server Actions Considerations
+
+Next.js App Router projects may expose API attack surface without traditional `pages/api` routes or OpenAPI paths. Treat these as first-class API surfaces during inventory and finding classification.
+
+### Route Handler Inventory
+
+Route Handlers live under `app/**/route.ts` or `app/**/route.js` and export HTTP verb functions such as `GET`, `POST`, `PUT`, `PATCH`, and `DELETE`. Review `RouteContext`, `params`, `NextRequest`, and `request.nextUrl.searchParams` usage for object identifiers, field selectors, and privilege switches.
+
+Public Route Handlers are valid when they serve intentional public metadata, health, or documentation-style responses. Do not report a missing auth finding solely because a handler is unauthenticated. First classify data sensitivity, intended audience, side effects, and cache behavior.
+
+### Server Actions and Server Functions
+
+Server Actions/Server Functions declared with `"use server"` can be invoked from forms, event handlers, and Client Components. They are mutation endpoints even when no URL route appears in the source tree.
+
+Reviewers should search for:
+
+- Module-level or inline `"use server"` declarations.
+- Exported async action functions used from `<form action={...}>` or `formAction={...}`.
+- Client Component imports of server action functions.
+- `FormData.get(...)`, `Object.fromEntries(formData)`, unchecked JSON payloads, or hidden form fields.
+- Database mutations, privileged operations, billing changes, email sends, file writes, or external API calls inside actions.
+
+Each Server Action that performs a mutation must have authentication, object-level authorization, function-level authorization, server-side schema validation, and appropriate resource controls. Client-side checks and hidden form fields are not authorization.
+
+### Server Action Origin and Body Controls
+
+Review `next.config.js` / `next.config.mjs` for `serverActions.allowedOrigins` and `serverActions.bodySizeLimit` when present. Broad wildcard origins, shared preview domains, or large body limits require documented trust boundaries, authentication, input validation, and rate limiting.
+
+### Route Handler Cache Safety
+
+Route Handlers that return sensitive, tenant-specific, or user-specific data should not opt into static caching. Inspect `export const dynamic`, `revalidate`, `fetch(..., { cache })`, and `use cache` usage around handlers returning sensitive data. Sensitive responses need explicit non-cache behavior and appropriate `Cache-Control` headers.
+
+---
+
 ## Common Pitfalls
 
 1. **Confusing authentication with authorization.** An API that verifies the user's identity (authentication) but does not verify the user's permission to access the specific resource or function (authorization) is vulnerable to both BOLA (API1) and BFLA (API5). These are distinct checks that must both be present.
@@ -214,6 +249,10 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 5. **Applying rate limiting only to authentication endpoints.** Every API endpoint requires rate limiting proportional to its cost and sensitivity. Data-heavy endpoints, search functions, and export operations are frequent targets for abuse even when properly authenticated.
 
 6. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
+
+7. **Missing framework-native API surfaces.** Modern frameworks can expose server-callable functions without obvious route decorators. In Next.js, Server Actions and App Router Route Handlers must be included in the same inventory as REST and GraphQL endpoints.
+
+8. **Flagging public handlers without sensitivity evidence.** An unauthenticated public metadata Route Handler is not automatically API2/API5. Classify the data, audience, side effects, and cache behavior before reporting missing authentication or authorization.
 
 ---
 
@@ -239,3 +278,7 @@ This skill is hardened against prompt injection. When reviewing API code and spe
 - **OWASP GraphQL Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html
 - **OWASP Testing Guide -- API Testing:** https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/12-API_Testing/
 - **NIST SP 800-204 -- Security Strategies for Microservices-based Application Systems:** https://csrc.nist.gov/publications/detail/sp/800-204/final
+- **Next.js Route Handlers:** https://nextjs.org/docs/app/getting-started/route-handlers
+- **Next.js Updating Data / Server Functions:** https://nextjs.org/docs/app/getting-started/updating-data
+- **Next.js Data Security -- Allowed Origins:** https://nextjs.org/docs/app/guides/data-security#allowed-origins-advanced
+- **Next.js serverActions Configuration:** https://nextjs.org/docs/app/api-reference/config/next-config-js/serverActions

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -101,6 +101,7 @@ Both can coexist in a single endpoint. An endpoint may lack both a role check (B
 - [ ] Batch/list endpoints filter results by the caller's permissions.
 - [ ] Resource identifiers are UUIDs or non-sequential values to resist enumeration.
 - [ ] GraphQL resolvers enforce authorization on every field that returns sensitive data.
+- [ ] Next.js Route Handlers and Server Actions using `ctx.params`, `RouteContext`, `NextRequest`, `request.nextUrl.searchParams`, `FormData.get(...)`, or hidden form fields verify that the caller can access the referenced object.
 
 ---
 
@@ -225,6 +226,8 @@ const UserType = new GraphQLObjectType({
 - [ ] Update endpoints use an allowlist of modifiable fields; mass assignment is impossible.
 - [ ] GraphQL fields containing sensitive data have resolver-level authorization.
 - [ ] API documentation (OpenAPI spec) accurately reflects the actual response schema.
+- [ ] Next.js Server Actions validate `FormData` or JSON input server-side with an allowlisted schema before writing to models or passing values to an ORM.
+- [ ] Next.js query parameters that toggle included fields, such as `includeBilling=true`, enforce property-level authorization before returning sensitive nested data.
 
 ---
 
@@ -284,6 +287,8 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - [ ] GraphQL queries have depth limits, complexity limits, and batch restrictions.
 - [ ] Database queries and downstream calls have execution timeouts.
 - [ ] Billable operations have cost controls and alerting.
+- [ ] Next.js `serverActions.bodySizeLimit` increases are justified and paired with authentication, validation, rate limiting, and file/content constraints.
+- [ ] Expensive Server Actions and Route Handlers have per-user or per-tenant throttling, not only IP-based throttling.
 
 ---
 
@@ -331,6 +336,8 @@ const resolvers = {
 - [ ] Each HTTP method on each endpoint has an independent authorization check.
 - [ ] GraphQL mutations enforce role/permission checks in resolvers or directives.
 - [ ] The authorization policy is deny-by-default; endpoints are inaccessible unless explicitly permitted.
+- [ ] Next.js Server Actions that delete, update, publish, bill, invite, email, export, or otherwise mutate privileged state enforce function-level authorization inside the action.
+- [ ] Client-side UI hiding, hidden form fields, and disabled buttons are not treated as function-level authorization evidence.
 
 ---
 
@@ -472,6 +479,9 @@ Document doc = builder.parse(request.getInputStream());
 - [ ] TLS 1.2+ is enforced with strong cipher suites.
 - [ ] XML parsers disable external entity processing and DTD loading.
 - [ ] Default credentials are changed or removed on all infrastructure components.
+- [ ] Next.js `serverActions.allowedOrigins` is minimal and does not use broad shared preview or wildcard domains without a documented trust boundary.
+- [ ] Sensitive Next.js Route Handlers do not opt into unsafe static caching through `dynamic = "force-static"`, `revalidate`, `fetch(..., { cache })`, or `use cache`.
+- [ ] Sensitive Route Handler responses set appropriate cache headers such as `Cache-Control: no-store`.
 
 ---
 
@@ -515,6 +525,172 @@ Document doc = builder.parse(request.getInputStream());
 - [ ] No debug, test, or playground endpoints are accessible in production.
 - [ ] Internal APIs are not reachable from external networks.
 - [ ] CI/CD pipelines validate that code routes match the API specification.
+- [ ] Next.js inventory includes `app/**/route.ts`, exported HTTP verb handlers, module-level or inline `"use server"` functions, `<form action={...}>`, `formAction={...}`, and Client Component server-action imports.
+- [ ] Public Route Handlers are labeled with intended audience and data sensitivity before missing authentication is classified as a finding.
+
+---
+
+## Next.js App Router and Server Actions Supplement
+
+Use this supplement when reviewing Next.js App Router applications. It is not a separate OWASP category; it helps map framework-native API surfaces to API1-API10 without over-reporting intentionally public handlers.
+
+### Inventory Patterns
+
+Search for:
+
+- `app/**/route.ts` and `app/**/route.js`
+- `export async function GET|POST|PUT|PATCH|DELETE`
+- `"use server"` at module or inline function scope
+- `<form action={...}>` and `formAction={...}`
+- Client Component imports of server action functions
+- `FormData.get(...)`, `Object.fromEntries(formData)`, `RouteContext`, `ctx.params`, `NextRequest`, and `request.nextUrl.searchParams`
+- `serverActions.allowedOrigins`, `serverActions.bodySizeLimit`, `dynamic = "force-static"`, `revalidate`, `fetch(..., { cache })`, and `use cache`
+
+### Vulnerable Server Action
+
+```typescript
+// VULNERABLE: Server Action is callable from a form but has no auth, ownership, or schema validation
+"use server";
+
+import { db } from "@/lib/db";
+
+export async function deleteProject(formData: FormData) {
+  const projectId = String(formData.get("projectId"));
+  await db.project.delete({ where: { id: projectId } });
+}
+```
+
+Security mapping:
+
+- API1:2023 when the object ID is user-controlled and no ownership/relationship check exists.
+- API2:2023 when the action does not require an authenticated server-side user.
+- API3:2023 when `FormData` or JSON fields are bound directly to data models.
+- API4:2023 when the action accepts large payloads or triggers expensive work without quotas.
+- API5:2023 when the action performs privileged mutations without role or permission checks.
+
+Remediation:
+
+```typescript
+"use server";
+
+import { z } from "zod";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+
+const deleteProjectInput = z.object({
+  projectId: z.string().uuid(),
+});
+
+export async function deleteProject(formData: FormData) {
+  const user = await auth.requireUser();
+  const input = deleteProjectInput.parse({
+    projectId: formData.get("projectId"),
+  });
+
+  const project = await db.project.findFirst({
+    where: { id: input.projectId, ownerId: user.id },
+    select: { id: true },
+  });
+
+  if (!project) {
+    throw new Error("Not authorized");
+  }
+
+  await db.project.delete({ where: { id: project.id } });
+}
+```
+
+### Route Handler False-Positive Calibration
+
+Do not report missing authentication solely because a Route Handler is public.
+
+```typescript
+// BENIGN: intentional public product metadata with no privileged data or side effects
+export async function GET() {
+  return Response.json({
+    product: "public-docs",
+    docsVersion: "2026.06",
+  });
+}
+```
+
+Require a finding only when the handler returns sensitive data, performs side effects, exposes tenant/user state, or contradicts its intended public audience.
+
+### Route Params and Query Params
+
+```typescript
+// VULNERABLE: user-controlled params and search params drive object lookup and sensitive field inclusion
+import type { NextRequest } from "next/server";
+
+export async function GET(request: NextRequest, ctx: RouteContext<"/api/projects/[id]">) {
+  const { id } = await ctx.params;
+  const includeBilling = request.nextUrl.searchParams.get("includeBilling") === "true";
+
+  return Response.json(
+    await db.project.findUnique({
+      where: { id },
+      include: { billing: includeBilling },
+    })
+  );
+}
+```
+
+Check that route params and query params are:
+
+- Validated for type and format.
+- Bound to the authenticated user's tenant, ownership, or explicit permission.
+- Prevented from toggling sensitive response properties unless property-level authorization passes.
+
+### Server Action Origin and Body Controls
+
+```javascript
+// RISKY: broad origin and large body limit without documented trust boundary
+module.exports = {
+  experimental: {
+    serverActions: {
+      allowedOrigins: ["*.example.com", "*.preview.example.com"],
+      bodySizeLimit: "50mb",
+    },
+  },
+};
+```
+
+Review evidence:
+
+- `allowedOrigins` is narrow and tied to controlled hosts or reverse proxies.
+- Preview domains are not shared with untrusted users or arbitrary branches.
+- `bodySizeLimit` changes are justified by a specific use case.
+- Large body actions require authentication, validation, throttling, and content/file constraints.
+
+### Route Handler Cache Safety
+
+```typescript
+// VULNERABLE: sensitive admin data is statically cached
+export const dynamic = "force-static";
+
+export async function GET() {
+  const users = await db.user.findMany({
+    select: { id: true, email: true, role: true },
+  });
+
+  return Response.json(users);
+}
+```
+
+Review `dynamic`, `revalidate`, `fetch(..., { cache })`, and `use cache` around handlers returning user, tenant, admin, regulated, or billing data. Sensitive responses should avoid static caching and should return explicit non-cache headers.
+
+### Next.js Review Checklist
+
+- [ ] Route Handler inventory includes every `app/**/route.ts` / `route.js` file and exported HTTP verb function.
+- [ ] Server Action inventory includes module-level and inline `"use server"` functions plus their form, button, and Client Component call sites.
+- [ ] Public handlers have documented public intent and return only non-sensitive data.
+- [ ] Server Actions authenticate the caller inside the action before side effects.
+- [ ] Server Actions and Route Handlers enforce object-level and function-level authorization server-side.
+- [ ] `FormData`, JSON bodies, route params, and query params are schema-validated and allowlisted.
+- [ ] Query params cannot enable sensitive fields or nested includes without property-level authorization.
+- [ ] `serverActions.allowedOrigins` is minimal and justified for proxy or preview deployments.
+- [ ] `serverActions.bodySizeLimit` increases are paired with authentication, validation, throttling, and content/file constraints.
+- [ ] Sensitive Route Handlers do not opt into static caching and set appropriate non-cache headers.
 
 ---
 


### PR DESCRIPTION
﻿Addresses #409.

## Summary
- adds Next.js App Router and Server Actions to the API surface inventory
- adds review guidance for Server Action auth/authz, FormData validation, allowed origins, body limits, and Route Handler caching
- adds false-positive calibration for intentionally public Route Handlers so reviewers do not flag public metadata endpoints as missing-auth findings without sensitivity or side-effect evidence

## Evidence
Before, `api-security` focused on REST, GraphQL, gRPC, specs, and gateways. Next.js `app/**/route.ts` handlers and `"use server"` Server Actions could be missed because they do not always look like traditional API routes.

After, the skill explicitly asks reviewers to search for:
- `app/**/route.ts` / exported HTTP verb handlers
- module-level or inline `"use server"` functions
- `<form action={...}>`, `formAction={...}`, and Client Component server-action call sites
- `FormData.get(...)`, `RouteContext`, `NextRequest`, `nextUrl.searchParams`
- `serverActions.allowedOrigins`, `serverActions.bodySizeLimit`, `dynamic`, `revalidate`, and cache usage

## Validation
- frontmatter check passed locally
- indexed-file existence check passed locally
- `git diff --check` passed locally

## Bounty Tier
- [ ] Minor ($50) - Doc update, small logic tweak, typo fix
- [x] Moderate ($100) - New edge case coverage, FP reduction with evidence
- [ ] Substantial ($150) - Rewritten detection logic, major coverage expansion

## Bounty Info
- [x] I have read and agree to the CONTRIBUTING.md bounty terms
- Preferred payment method: can be provided privately after acceptance
