### PR TITLE
Add Next.js API security review coverage

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -4,7 +4,9 @@ description: >
   Reviews REST and GraphQL APIs against the OWASP API Security Top 10:2023.
   Auto-invoked when reviewing OpenAPI/Swagger specs, API endpoint code, or
   GraphQL schemas. Covers BOLA, BFLA, authentication, rate limiting, and
-  SSRF. Produces findings mapped to API1-API10 with remediation guidance.
+  SSRF. Also inventories framework API surfaces such as Next.js App Router
+  Route Handlers and Server Actions. Produces findings mapped to API1-API10
+  with remediation guidance.
 tags: [appsec, api, rest, graphql]
 role: [appsec-engineer, security-engineer]
 phase: [design, build, review]
@@ -21,7 +23,7 @@ argument-hint: "[target-file-or-directory]"
 
 # API Security Review -- OWASP API Security Top 10:2023
 
-A structured, repeatable process for reviewing REST and GraphQL APIs against the OWASP API Security Top 10:2023. This skill produces findings mapped to API1 through API10 with associated CWE identifiers, severity ratings, and actionable remediation guidance. It applies to OpenAPI/Swagger specifications, API endpoint source code, GraphQL schemas, and API gateway configurations.
+A structured, repeatable process for reviewing REST and GraphQL APIs against the OWASP API Security Top 10:2023. This skill produces findings mapped to API1 through API10 with associated CWE identifiers, severity ratings, and actionable remediation guidance. It applies to OpenAPI/Swagger specifications, API endpoint source code, GraphQL schemas, API gateway configurations, and framework API surfaces such as Next.js App Router Route Handlers and Server Actions.
 
 ---
 
@@ -31,13 +33,14 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 
 Before analyzing any endpoint, establish a complete inventory of the API surface under review.
 
-1. **Identify the API style** -- REST (OpenAPI/Swagger), GraphQL, gRPC, or hybrid. Each style has distinct attack patterns.
-2. **Catalog all endpoints and operations** -- For REST, list every path and HTTP method. For GraphQL, list all queries, mutations, and subscriptions.
+1. **Identify the API style** -- REST (OpenAPI/Swagger), GraphQL, gRPC, framework-specific API routes, or hybrid. Each style has distinct attack patterns.
+2. **Catalog all endpoints and operations** -- For REST, list every path and HTTP method. For GraphQL, list all queries, mutations, and subscriptions. For Next.js App Router projects, include `app/**/route.ts`, `"use server"` action modules, inline Server Actions, `<form action={...}>`, `formAction={...}`, and Client Component imports of server action functions.
 3. **Map authentication mechanisms** -- OAuth 2.0 flows, API keys, JWTs, session cookies, mTLS, or custom tokens. Note which endpoints require authentication and which are public.
 4. **Identify authorization models** -- RBAC, ABAC, ownership-based, or no authorization. Document how object-level and function-level access control decisions are made.
 5. **Catalog data objects** -- List the resources/entities exposed by the API and their sensitivity classification (PII, financial, internal, public).
 6. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, or cost-control mechanisms at the gateway or application layer.
 7. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
+8. **Classify public vs private intent** -- Public metadata, health, sitemap-adjacent, and product-information Route Handlers can be intentionally unauthenticated. A missing auth check is a finding only after evidence shows the handler returns sensitive data or performs a privileged action.
 
 > **Gate:** Do not proceed until the API style, authentication model, authorization model, and endpoint inventory are documented. Incomplete scope leads to missed findings.
 
@@ -48,6 +51,8 @@ Before analyzing any endpoint, establish a complete inventory of the API surface
 Evaluate the API against all ten OWASP API Security Top 10:2023 risk categories: Broken Object Level Authorization (BOLA), Broken Authentication, Broken Object Property Level Authorization, Unrestricted Resource Consumption, Broken Function Level Authorization (BFLA), Unrestricted Access to Sensitive Business Flows, Server Side Request Forgery (SSRF), Security Misconfiguration, Improper Inventory Management, and Unsafe Consumption of APIs.
 
 For detailed checklist items with vulnerable code patterns, remediation examples, and review checklists for all ten API risk categories (API1:2023 through API10:2023), see [api-top10-checklist.md](api-top10-checklist.md) in this skill directory.
+
+For Next.js App Router projects, apply the framework-specific Route Handler and Server Actions checklist in `api-top10-checklist.md`. Treat Server Actions as public mutation surfaces that need the same authentication, object authorization, input validation, CSRF/origin, resource-limit, and cache-safety evidence expected from traditional API endpoints.
 
 ---
 
@@ -62,8 +67,9 @@ Each finding produced by this review must include the following fields:
 | **OWASP API Risk** | API1:2023 through API10:2023 identifier |
 | **Severity** | Critical, High, Medium, Low, or Informational |
 | **CWE** | Applicable CWE identifier (e.g., CWE-639) |
-| **API Style** | REST, GraphQL, gRPC, or General |
+| **API Style** | REST, GraphQL, gRPC, Next.js App Router, or General |
 | **Location** | File path and line number(s), or OpenAPI spec path |
+| **Intent Classification** | Public metadata, authenticated user operation, privileged/admin operation, webhook/internal, or unknown |
 | **Description** | What the vulnerability is and why it matters |
 | **Evidence** | Relevant code snippet or spec excerpt demonstrating the issue |
 | **Remediation** | Specific fix with code example where possible |
@@ -118,8 +124,9 @@ The final review output must be structured as follows:
 - **OWASP API Risk:** API[N]:2023 -- [Name]
 - **Severity:** [Critical|High|Medium|Low|Informational]
 - **CWE:** CWE-[number] -- [name]
-- **API Style:** [REST|GraphQL|gRPC|General]
+- **API Style:** [REST|GraphQL|gRPC|Next.js App Router|General]
 - **Location:** [file:line or spec path]
+- **Intent Classification:** [public metadata|authenticated user operation|privileged/admin operation|webhook/internal|unknown]
 - **Description:** [explanation]
 - **Evidence:**
   ```[language]
@@ -239,3 +246,7 @@ This skill is hardened against prompt injection. When reviewing API code and spe
 - **OWASP GraphQL Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html
 - **OWASP Testing Guide -- API Testing:** https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/12-API_Testing/
 - **NIST SP 800-204 -- Security Strategies for Microservices-based Application Systems:** https://csrc.nist.gov/publications/detail/sp/800-204/final
+- **Next.js Route Handlers:** https://nextjs.org/docs/app/getting-started/route-handlers
+- **Next.js Server Functions / Updating Data:** https://nextjs.org/docs/app/getting-started/updating-data
+- **Next.js Data Security -- Allowed Origins:** https://nextjs.org/docs/app/guides/data-security#allowed-origins-advanced
+- **Next.js `serverActions` Configuration:** https://nextjs.org/docs/app/api-reference/config/next-config-js/serverActions

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -560,3 +560,165 @@ res.send(`<div class="bio">${data.biography}</div>`);  // Stored XSS via third p
 - [ ] Response schemas from third-party APIs are validated before processing.
 - [ ] Outbound calls have timeouts, retry limits, and circuit breakers.
 - [ ] Redirect following is disabled or restricted on outbound HTTP calls.
+
+---
+
+## Framework-Specific Checklist: Next.js App Router and Server Actions
+
+Next.js App Router applications expose API behavior through more than traditional REST endpoints. `app/**/route.ts` files are Route Handlers, and `"use server"` Server Actions / Server Functions are invokable mutation surfaces from forms, event handlers, and Client Components. Review them as part of the API inventory.
+
+### Inventory Patterns
+
+Search for:
+
+- `app/**/route.ts` or `app/**/route.js`
+- `"use server"` at module scope or inside Server Components
+- `<form action={...}>` and `formAction={...}`
+- Client Component imports of server action functions
+- `FormData.get(...)` and `FormData.getAll(...)`
+- `NextRequest`, `RouteContext`, `ctx.params`, and `request.nextUrl.searchParams`
+- `serverActions.allowedOrigins` and `serverActions.bodySizeLimit`
+- `export const dynamic`, `export const revalidate`, `fetch(..., { cache })`, and `use cache`
+
+### False Positive Boundary: Public Route Handlers
+
+Unauthenticated Route Handlers are not automatically vulnerable. Public metadata, health, sitemap-adjacent, and product-information endpoints can be intentionally public.
+
+```ts
+// BENIGN when documented as public and returning non-sensitive metadata
+export async function GET() {
+  return Response.json({
+    product: "public-docs",
+    docsVersion: "2026.06",
+  });
+}
+```
+
+Before reporting missing authentication, classify the handler's intended audience and the sensitivity of returned data or performed action.
+
+### Server Action Missing Auth/Authz (API1, API2, API5)
+
+```ts
+// VULNERABLE: public mutation surface with no auth, ownership, or role check
+"use server";
+
+import { db } from "@/lib/db";
+
+export async function deleteProject(formData: FormData) {
+  const projectId = String(formData.get("projectId"));
+  await db.project.delete({ where: { id: projectId } });
+}
+```
+
+Remediation:
+
+```ts
+// SECURE: authenticate, validate, and authorize the object before mutation
+"use server";
+
+import { z } from "zod";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+
+const schema = z.object({ projectId: z.string().uuid() });
+
+export async function deleteProject(formData: FormData) {
+  const user = await auth.requireUser();
+  const { projectId } = schema.parse({
+    projectId: formData.get("projectId"),
+  });
+
+  const project = await db.project.findFirst({
+    where: { id: projectId, ownerId: user.id },
+  });
+
+  if (!project) {
+    throw new Error("Not found");
+  }
+
+  await db.project.delete({ where: { id: projectId } });
+}
+```
+
+### Route Params and Search Params BOLA / Property Authorization (API1, API3)
+
+```ts
+// VULNERABLE: user-controlled params select object and included sensitive fields
+import type { NextRequest } from "next/server";
+
+export async function GET(
+  request: NextRequest,
+  ctx: RouteContext<"/api/projects/[id]">
+) {
+  const { id } = await ctx.params;
+  const includeBilling =
+    request.nextUrl.searchParams.get("includeBilling") === "true";
+
+  return Response.json(
+    await db.project.findUnique({
+      where: { id },
+      include: { billing: includeBilling },
+    })
+  );
+}
+```
+
+Reviewers should verify ownership checks for `ctx.params`, `RouteContext`, and path segment values, plus field/property authorization when `nextUrl.searchParams` controls included relationships or sensitive response fields.
+
+### Server Action Origin and Body Controls (API4, API8)
+
+```js
+// REVIEW HOTSPOT: broad preview origins and large action payloads
+module.exports = {
+  experimental: {
+    serverActions: {
+      allowedOrigins: ["*.example.com", "*.preview.example.com"],
+      bodySizeLimit: "50mb",
+    },
+  },
+};
+```
+
+Require evidence that:
+
+- `serverActions.allowedOrigins` is minimal for the deployment topology and does not trust shared preview/proxy domains without a documented boundary.
+- Reverse-proxy deployments document why additional origins are needed.
+- `serverActions.bodySizeLimit` increases are tied to a concrete use case and paired with authentication, validation, rate limits, and file/content controls where relevant.
+
+### Route Handler Cache and Static Rendering Data Exposure (API3, API8)
+
+```ts
+// VULNERABLE: sensitive admin data opted into static caching
+export const dynamic = "force-static";
+
+export async function GET() {
+  const users = await db.user.findMany({
+    select: { id: true, email: true, role: true },
+  });
+
+  return Response.json(users);
+}
+```
+
+Inspect `dynamic`, `revalidate`, `fetch(..., { cache })`, and `use cache` around Route Handlers that return per-user, tenant, admin, financial, regulated, or otherwise sensitive data. Cache findings require both sensitivity evidence and cache/static behavior evidence.
+
+### Evidence Matrix
+
+| Surface | Evidence to Capture | API Risk Mapping |
+|---|---|---|
+| Route Handler | File path, HTTP method export, public/private intent, auth middleware, returned data sensitivity | API1, API2, API3, API5, API8 |
+| Server Action | `"use server"` location, call sites, auth check, object authorization, role check, schema validation | API1, API2, API3, API5 |
+| FormData parsing | `FormData.get` fields, allowlist/schema, type conversion, file/body size controls | API3, API4 |
+| Route/search params | `ctx.params`, `RouteContext`, `nextUrl.searchParams`, ownership and field-authorization checks | API1, API3 |
+| Server Actions config | `allowedOrigins`, reverse proxy context, `bodySizeLimit`, rate limiting and validation evidence | API4, API8 |
+| Cache/static config | `dynamic`, `revalidate`, fetch cache options, `use cache`, response sensitivity | API3, API8 |
+
+### Review Checklist
+
+- [ ] Route inventory includes `app/**/route.ts` and all HTTP method exports.
+- [ ] Server Actions are treated as API mutation endpoints, not as trusted private functions.
+- [ ] Public Route Handlers are documented as public and limited to non-sensitive data.
+- [ ] Every Server Action that mutates data authenticates the caller and enforces object/function authorization.
+- [ ] `FormData` and search parameter parsing use allowlisted server-side validation.
+- [ ] Broad `serverActions.allowedOrigins` and increased `bodySizeLimit` settings have deployment-specific justification and compensating controls.
+- [ ] Sensitive Route Handler responses are not opted into static caching or shared caching without explicit safe cache semantics.


### PR DESCRIPTION
## Summary

Implements the review gap from #409 by adding Next.js App Router and Server Actions coverage to the `api-security` skill.

## Changes

- Expands API inventory guidance in `SKILL.md` to include Next.js Route Handlers, Server Actions, form action call sites, and public/private intent classification.
- Adds an intent-classification field to the review output so public metadata handlers are not over-reported as auth failures.
- Adds a framework-specific Next.js checklist in `api-top10-checklist.md` covering:
  - Route Handler inventory patterns.
  - Server Action auth/authz evidence.
  - `FormData`, `RouteContext`, `NextRequest`, and `nextUrl.searchParams` review patterns.
  - Server Action `allowedOrigins` and `bodySizeLimit` controls.
  - cache/static rendering evidence for sensitive `GET` handlers.
  - a compact evidence matrix and review checklist.
- Adds official Next.js references for Route Handlers, Server Functions, allowed origins, and `serverActions` config.

## Validation

- `git diff --check`

Closes #409
