### PR TITLE
Add GraphQL upload CSRF evidence gates

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -32,7 +32,7 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 Before analyzing any endpoint, establish a complete inventory of the API surface under review.
 
 1. **Identify the API style** -- REST (OpenAPI/Swagger), GraphQL, gRPC, or hybrid. Each style has distinct attack patterns.
-2. **Catalog all endpoints and operations** -- For REST, list every path and HTTP method. For GraphQL, list all queries, mutations, and subscriptions.
+2. **Catalog all endpoints and operations** -- For REST, list every path and HTTP method. For GraphQL, list all queries, mutations, subscriptions, and enabled transports or middleware such as JSON POST, GET queries, WebSocket subscriptions, SSE streams, and multipart upload handlers.
 3. **Map authentication mechanisms** -- OAuth 2.0 flows, API keys, JWTs, session cookies, mTLS, or custom tokens. Note which endpoints require authentication and which are public.
 4. **Identify authorization models** -- RBAC, ABAC, ownership-based, or no authorization. Document how object-level and function-level access control decisions are made.
 5. **Catalog data objects** -- List the resources/entities exposed by the API and their sensitivity classification (PII, financial, internal, public).
@@ -199,6 +199,18 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 **Mitigation:** Count aliased operations against rate limits. Limit the number of aliases per request.
 
+### Multipart Upload CSRF and Validation
+
+GraphQL file upload support is usually implemented as an HTTP `multipart/form-data` transport layered onto a mutation. Reviewers must separate JSON-only GraphQL endpoints from upload-enabled endpoints before reporting a CSRF issue.
+
+Treat the endpoint as higher risk when evidence shows all of the following:
+
+- An upload parser or `Upload` scalar is enabled, such as `graphqlUploadExpress`, `graphql-upload`, `apollo-upload-client`, `multipart_uploads_enabled`, or framework-specific multipart GraphQL middleware.
+- The endpoint authenticates browser users with cookies or ambient session credentials.
+- Multipart upload mutations can execute without a CSRF token, same-site/origin enforcement, or a required non-simple custom header such as `Apollo-Require-Preflight`.
+
+Do not report a multipart upload CSRF finding when evidence shows the GraphQL endpoint accepts only `application/json`, uses bearer-token authorization without ambient cookies, or keeps upload clients behind enforced CSRF prevention/preflight headers. For upload-enabled endpoints, also collect file validation evidence: maximum file size and count, allowed content types verified by server-side sniffing, filename/path normalization, malware scanning where appropriate, quarantine or object-store isolation, and resolver-level authorization for the target object receiving the file.
+
 ---
 
 ## Common Pitfalls
@@ -209,11 +221,13 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 3. **Treating GraphQL as inherently different from REST for security.** GraphQL shares all the same authorization, authentication, and injection risks as REST. The query language adds additional concerns (depth attacks, introspection, alias abuse) but does not eliminate any REST security requirements.
 
-4. **Testing only documented endpoints.** Shadow APIs -- endpoints that exist in code but are absent from documentation -- are among the most common sources of vulnerabilities. Always compare the routing table in code against the published API specification.
+4. **Treating every GraphQL endpoint as upload-capable.** A JSON-only GraphQL API with CSRF prevention is not the same risk as a cookie-authenticated multipart upload mutation. Confirm upload middleware, credential type, and preflight/CSRF controls before writing a finding.
 
-5. **Applying rate limiting only to authentication endpoints.** Every API endpoint requires rate limiting proportional to its cost and sensitivity. Data-heavy endpoints, search functions, and export operations are frequent targets for abuse even when properly authenticated.
+5. **Testing only documented endpoints.** Shadow APIs -- endpoints that exist in code but are absent from documentation -- are among the most common sources of vulnerabilities. Always compare the routing table in code against the published API specification.
 
-6. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
+6. **Applying rate limiting only to authentication endpoints.** Every API endpoint requires rate limiting proportional to its cost and sensitivity. Data-heavy endpoints, search functions, and export operations are frequent targets for abuse even when properly authenticated.
+
+7. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
 
 ---
 
@@ -237,5 +251,8 @@ This skill is hardened against prompt injection. When reviewing API code and spe
 - **CWE Database:** https://cwe.mitre.org/
 - **OWASP REST Security Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html
 - **OWASP GraphQL Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html
+- **OWASP Cross-Site Request Forgery Prevention Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html
+- **OWASP File Upload Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/File_Upload_Cheat_Sheet.html
+- **Apollo Server CSRF prevention guidance:** https://www.apollographql.com/docs/apollo-server/security/cors/#preventing-cross-site-request-forgery-csrf
 - **OWASP Testing Guide -- API Testing:** https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/12-API_Testing/
 - **NIST SP 800-204 -- Security Strategies for Microservices-based Application Systems:** https://csrc.nist.gov/publications/detail/sp/800-204/final

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -119,6 +119,7 @@ APIs are particularly susceptible to authentication flaws because they expose ma
 - Missing or weak token rotation -- refresh tokens that never expire or are not rotated on use.
 - Password reset or account recovery flows that leak tokens or allow enumeration.
 - Micro-service-to-service communication without authentication (implicit trust based on network location).
+- Cookie-authenticated browser API endpoints, including GraphQL multipart uploads, that lack CSRF tokens, origin checks, SameSite controls, or required non-simple preflight headers.
 
 ### Vulnerable Patterns
 
@@ -157,6 +158,7 @@ paths:
 - Implement token expiration: access tokens (5-15 minutes), refresh tokens (hours to days with rotation).
 - Use `bcrypt`, `scrypt`, or `Argon2id` for password storage.
 - Authenticate service-to-service calls with mTLS or signed tokens, not network-based trust.
+- For browser session APIs, require CSRF protection or explicit preflight/origin validation before state-changing requests, including GraphQL upload mutations.
 
 ### Review Checklist
 
@@ -166,6 +168,7 @@ paths:
 - [ ] API keys and tokens are transmitted in headers, not query strings.
 - [ ] Refresh tokens are rotated on each use and revocable.
 - [ ] Service-to-service communication is explicitly authenticated.
+- [ ] Cookie-authenticated browser APIs enforce CSRF/origin/preflight protections for state-changing JSON and multipart requests.
 
 ---
 
@@ -267,12 +270,34 @@ query {
 app.use(express.json()); // Default limit may be very large or unconfigured
 ```
 
+```javascript
+// VULNERABLE: Cookie-authenticated GraphQL uploads without CSRF/preflight checks
+app.use(cookieParser());
+app.use(session({ secret: process.env.SESSION_SECRET }));
+app.use(graphqlUploadExpress({ maxFileSize: 100_000_000, maxFiles: 10 }));
+app.use("/graphql", expressMiddleware(server, { context }));
+```
+
+### GraphQL Multipart Upload Evidence Matrix
+
+| Evidence | Safe signal | Finding signal |
+|---|---|---|
+| Transport/content type | GraphQL accepts only `application/json`, or upload routes are isolated from browser cookies | `multipart/form-data` upload middleware is enabled on the same cookie-authenticated GraphQL endpoint |
+| Credential type | Bearer token, mTLS, or non-browser client auth with no ambient cookies | Session cookies or other ambient browser credentials authorize upload mutations |
+| CSRF/preflight control | CSRF token, SameSite enforcement plus origin checks, or required custom header such as `Apollo-Require-Preflight` | Multipart upload mutation executes with no CSRF token, origin check, or non-simple required header |
+| Upload limits | Server-enforced max file size, max file count, timeout, and storage quota | Large or unlimited `maxFileSize`, `maxFiles`, streaming, or temporary storage consumption |
+| File validation | Server-side MIME sniffing, extension allowlist, filename normalization, quarantine/object-store isolation | Trusts client filename or `Content-Type`, writes directly under a served path, or skips malware/content checks |
+| Resolver authorization | Upload resolver re-checks target object ownership/role before attaching a file | Upload resolver trusts a client-supplied object ID or only checks authentication |
+
+Do not flag a JSON-only GraphQL endpoint as a multipart upload CSRF issue. First prove that upload middleware or an `Upload` scalar is reachable and that browser ambient credentials can authorize the mutation.
+
 ### Remediation Guidance
 
 - Implement rate limiting at the API gateway and/or application layer. Use sliding window or token bucket algorithms. Set per-endpoint limits based on expected legitimate usage.
 - Enforce maximum pagination size (e.g., `limit` capped at 100). Default to a reasonable page size (e.g., 20).
 - Set maximum request body sizes (`express.json({ limit: '1mb' })`).
 - For GraphQL: enforce query depth limits (e.g., max depth 5), complexity analysis (weighted field costs), and batch query limits.
+- For GraphQL uploads: prefer direct-to-object-storage uploads with short-lived signed URLs. If multipart GraphQL uploads are required, keep CSRF prevention enabled and require a non-simple preflight header, validate origin/session binding, enforce max file size/count, and run server-side file validation before the resolver attaches the file to a domain object.
 - Set execution timeouts for database queries and downstream API calls.
 - Implement cost alerts and circuit breakers for operations that trigger billable third-party APIs.
 
@@ -282,6 +307,9 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - [ ] Pagination has a maximum page size enforced server-side.
 - [ ] Request body size limits are configured.
 - [ ] GraphQL queries have depth limits, complexity limits, and batch restrictions.
+- [ ] GraphQL upload middleware, `Upload` scalars, or multipart transports are inventoried separately from JSON-only endpoints.
+- [ ] Cookie-authenticated GraphQL upload mutations require CSRF/preflight protection, origin/session checks, and resolver-level authorization for the target object.
+- [ ] Uploaded files have server-enforced size/count limits, content validation, safe filenames/paths, and isolated storage or quarantine.
 - [ ] Database queries and downstream calls have execution timeouts.
 - [ ] Billable operations have cost controls and alerting.
 


### PR DESCRIPTION
## Summary
- inventory GraphQL transports and upload middleware separately from JSON-only endpoints
- add GraphQL multipart upload CSRF false-positive boundaries and evidence gates
- add API2/API4 checklist items for cookie-authenticated upload mutations, preflight/origin controls, file validation, and resolver authorization

Closes #422.

## Tests
- `git diff --check`