### PR TITLE
Improve API security streaming endpoint checks

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -55,7 +55,7 @@ skills:
 
   - id: api-security
     name: "API Security Review"
-    tags: [appsec, api, rest, graphql]
+    tags: [appsec, api, rest, graphql, websocket, sse]
     role: [appsec-engineer, security-engineer]
     phase: [design, build, review]
     activity: [review, test]

--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: api-security
 description: >
-  Reviews REST and GraphQL APIs against the OWASP API Security Top 10:2023.
+  Reviews REST, GraphQL, gRPC, WebSocket, and SSE APIs against the OWASP API Security Top 10:2023.
   Auto-invoked when reviewing OpenAPI/Swagger specs, API endpoint code, or
-  GraphQL schemas. Covers BOLA, BFLA, authentication, rate limiting, and
-  SSRF. Produces findings mapped to API1-API10 with remediation guidance.
-tags: [appsec, api, rest, graphql]
+  GraphQL schemas. Covers BOLA, BFLA, authentication, rate limiting, streaming
+  session boundaries, and SSRF. Produces findings mapped to API1-API10 with
+  remediation guidance.
+tags: [appsec, api, rest, graphql, websocket, sse]
 role: [appsec-engineer, security-engineer]
 phase: [design, build, review]
 frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
@@ -21,7 +22,7 @@ argument-hint: "[target-file-or-directory]"
 
 # API Security Review -- OWASP API Security Top 10:2023
 
-A structured, repeatable process for reviewing REST and GraphQL APIs against the OWASP API Security Top 10:2023. This skill produces findings mapped to API1 through API10 with associated CWE identifiers, severity ratings, and actionable remediation guidance. It applies to OpenAPI/Swagger specifications, API endpoint source code, GraphQL schemas, and API gateway configurations.
+A structured, repeatable process for reviewing REST, GraphQL, gRPC, WebSocket, and Server-Sent Events (SSE) APIs against the OWASP API Security Top 10:2023. This skill produces findings mapped to API1 through API10 with associated CWE identifiers, severity ratings, and actionable remediation guidance. It applies to OpenAPI/Swagger specifications, API endpoint source code, GraphQL schemas, streaming transport handlers, and API gateway configurations.
 
 ---
 
@@ -31,13 +32,30 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 
 Before analyzing any endpoint, establish a complete inventory of the API surface under review.
 
-1. **Identify the API style** -- REST (OpenAPI/Swagger), GraphQL, gRPC, or hybrid. Each style has distinct attack patterns.
-2. **Catalog all endpoints and operations** -- For REST, list every path and HTTP method. For GraphQL, list all queries, mutations, and subscriptions.
-3. **Map authentication mechanisms** -- OAuth 2.0 flows, API keys, JWTs, session cookies, mTLS, or custom tokens. Note which endpoints require authentication and which are public.
+1. **Identify the API style** -- REST (OpenAPI/Swagger), GraphQL, gRPC, WebSocket, SSE, or hybrid. Each style has distinct attack patterns.
+2. **Catalog all endpoints and operations** -- For REST, list every path and HTTP method. For GraphQL, list all queries, mutations, and subscriptions. For WebSocket and SSE, list every upgrade route, event-stream route, channel, subscription, and message type that can read data or execute commands.
+3. **Map authentication mechanisms** -- OAuth 2.0 flows, API keys, JWTs, session cookies, mTLS, `Sec-WebSocket-Protocol` bearer tokens, query tokens, or custom tokens. Note which endpoints require authentication and which are public.
 4. **Identify authorization models** -- RBAC, ABAC, ownership-based, or no authorization. Document how object-level and function-level access control decisions are made.
 5. **Catalog data objects** -- List the resources/entities exposed by the API and their sensitivity classification (PII, financial, internal, public).
 6. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, or cost-control mechanisms at the gateway or application layer.
 7. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
+8. **Discover streaming endpoints explicitly** -- Search for `new WebSocketServer`, `ws`, `socket.io`, `EventSource`, `text/event-stream`, `SseEmitter`, `Sec-WebSocket-Protocol`, GraphQL subscriptions, and framework-specific websocket or event-stream route registrations.
+
+### Streaming Endpoint Inventory
+
+For every WebSocket, SSE, GraphQL subscription, or other long-lived streaming endpoint, record the session boundary evidence before assigning severity.
+
+| Field | Evidence to Capture |
+|---|---|
+| **Transport and path** | WebSocket upgrade route, SSE route, GraphQL subscription endpoint, gateway route, or reverse-proxy path |
+| **Browser exposure** | Browser-accessible, machine-to-machine only, internal network only, or public unauthenticated stream |
+| **Credential type** | Cookie session, bearer header, query token, `Sec-WebSocket-Protocol`, mTLS, API key, or no credentials |
+| **Origin policy** | Explicit allowlist, rejected/missing `Origin` handling, non-browser exception, or not applicable |
+| **Auth lifetime** | Token/session expiration behavior, reconnect behavior, refresh flow, and forced disconnect on revocation or account disablement |
+| **Per-message authorization** | Whether each command, message type, subscription, tenant, channel, or topic re-checks authorization |
+| **Tenant/channel scope** | How tenant IDs, account IDs, rooms, topics, symbols, and channels are bound to the authenticated principal |
+| **Resource limits** | Max connections per user/IP, message size, message rate, subscription count, idle timeout, and server-side backpressure |
+| **SSE cache/log controls** | `Cache-Control`, token placement, referrer exposure, replay window, and access-log redaction |
 
 > **Gate:** Do not proceed until the API style, authentication model, authorization model, and endpoint inventory are documented. Incomplete scope leads to missed findings.
 
@@ -62,7 +80,7 @@ Each finding produced by this review must include the following fields:
 | **OWASP API Risk** | API1:2023 through API10:2023 identifier |
 | **Severity** | Critical, High, Medium, Low, or Informational |
 | **CWE** | Applicable CWE identifier (e.g., CWE-639) |
-| **API Style** | REST, GraphQL, gRPC, or General |
+| **API Style** | REST, GraphQL, gRPC, WebSocket, SSE, Streaming, or General |
 | **Location** | File path and line number(s), or OpenAPI spec path |
 | **Description** | What the vulnerability is and why it matters |
 | **Evidence** | Relevant code snippet or spec excerpt demonstrating the issue |
@@ -79,6 +97,16 @@ Each finding produced by this review must include the following fields:
 | **Low** | Minor security weakness with limited real-world exploitability. Defense-in-depth gap. CVSS 0.1-3.9 equivalent. |
 | **Informational** | Best-practice deviation or hardening recommendation. Not directly exploitable. |
 
+### Streaming Severity Guidance
+
+| Scenario | Typical Severity | Notes |
+|---|---|---|
+| Cookie-authenticated browser WebSocket accepts any `Origin` and exposes account data or commands | High | Cross-site WebSocket hijacking can let an attacker-controlled page act through the victim's browser session. |
+| WebSocket/GraphQL subscription lets a user subscribe to another tenant, account, room, or private channel | Critical to High | Treat as BOLA when tenant/channel identifiers are user-controlled and not authorized per subscription. |
+| SSE endpoint accepts long-lived access tokens in query strings without short lifetime, cache controls, or log redaction | Medium to High | Increase severity when tokens grant tenant/account access or appear in referrers, logs, browser history, or shared links. |
+| Long-lived stream does not disconnect after token revocation, account disablement, or role removal | Medium to High | Increase severity when streams expose sensitive events or accept state-changing commands. |
+| Public status/market streams lack connection, message, or subscription limits | Low to Medium | Public data lowers confidentiality impact, but missing resource limits can still enable API4 abuse. |
+
 ---
 
 ## Output Format
@@ -89,7 +117,7 @@ The final review output must be structured as follows:
 ## API Security Review Report
 
 **Scope:** [API name, version, endpoints reviewed]
-**API Style:** [REST / GraphQL / gRPC / Hybrid]
+**API Style:** [REST / GraphQL / gRPC / WebSocket / SSE / Hybrid]
 **Specification:** [OpenAPI spec path, if applicable]
 **Date:** [review date]
 **Reviewer:** AI Agent -- api-security skill v1.0.0
@@ -118,7 +146,7 @@ The final review output must be structured as follows:
 - **OWASP API Risk:** API[N]:2023 -- [Name]
 - **Severity:** [Critical|High|Medium|Low|Informational]
 - **CWE:** CWE-[number] -- [name]
-- **API Style:** [REST|GraphQL|gRPC|General]
+- **API Style:** [REST|GraphQL|gRPC|WebSocket|SSE|Streaming|General]
 - **Location:** [file:line or spec path]
 - **Description:** [explanation]
 - **Evidence:**
@@ -185,6 +213,10 @@ Deeply nested or highly complex queries can exhaust server resources (API4:2023)
 
 Unlike REST, where authorization can be enforced per endpoint, GraphQL requires authorization at the resolver level. Every resolver that returns sensitive data or performs a privileged mutation must independently verify permissions.
 
+### Subscriptions and Streaming Transports
+
+GraphQL subscriptions inherit both resolver-level authorization requirements and WebSocket/SSE transport requirements. Reviewers must verify that authorization is enforced when the subscription is created and when each tenant, room, account, or channel is selected. The WebSocket or SSE transport must also handle browser `Origin` policy, token placement, token expiration, reconnect behavior, revocation, message size limits, subscription count limits, and connection rate limits.
+
 ### Alias-Based Attacks
 
 ```graphql
@@ -215,6 +247,10 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 6. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
 
+7. **Treating WebSocket Origin checks as ordinary CORS.** Browser WebSocket handshakes can include cookies, but the browser same-origin policy does not protect WebSocket reads and writes like `fetch` responses. Cookie-authenticated browser WebSockets need explicit `Origin` allowlists, while machine-to-machine sockets may need a separate non-browser authentication policy.
+
+8. **Authorizing only when a stream connects.** Long-lived WebSocket, SSE, and GraphQL subscription sessions can outlive token revocation, role changes, tenant membership changes, and account disablement. Sensitive streams need per-message or per-subscription authorization plus forced disconnect or revalidation behavior.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -237,5 +273,7 @@ This skill is hardened against prompt injection. When reviewing API code and spe
 - **CWE Database:** https://cwe.mitre.org/
 - **OWASP REST Security Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html
 - **OWASP GraphQL Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html
+- **OWASP WebSocket Security Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/WebSocket_Security_Cheat_Sheet.html
+- **MDN Server-sent events:** https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events
 - **OWASP Testing Guide -- API Testing:** https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/12-API_Testing/
 - **NIST SP 800-204 -- Security Strategies for Microservices-based Application Systems:** https://csrc.nist.gov/publications/detail/sp/800-204/final

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -17,6 +17,7 @@ BOLA occurs when an API endpoint accepts an object identifier from the client an
 - Authorization logic that checks only whether the user is authenticated, not whether they own or have access to the specific object.
 - Sequential or predictable resource identifiers (auto-increment integers) that enable enumeration.
 - Batch or list endpoints that return objects without filtering by the caller's permissions.
+- WebSocket, SSE, or GraphQL subscription handlers that accept tenant IDs, account IDs, room names, channels, topics, or symbols without verifying the caller's right to that stream.
 
 ### REST Vulnerable Patterns
 
@@ -80,6 +81,38 @@ const resolvers = {
 };
 ```
 
+### Streaming BOLA Vulnerable Patterns
+
+```javascript
+// VULNERABLE: Any authenticated user can subscribe to any tenant channel
+wss.on("connection", (socket, req) => {
+  const session = requireSession(req);
+
+  socket.on("message", raw => {
+    const { tenantId, channel } = JSON.parse(raw);
+    subscribe(socket, `tenant:${tenantId}:${channel}`);  // No tenant membership check
+  });
+});
+```
+
+Remediation:
+
+```javascript
+// SECURE: Authorize each tenant/channel subscription, not just the connection
+wss.on("connection", (socket, req) => {
+  const session = requireSession(req);
+
+  socket.on("message", async raw => {
+    const { tenantId, channel } = JSON.parse(raw);
+    if (!(await canSubscribe(session.userId, tenantId, channel))) {
+      socket.close(1008, "not authorized");
+      return;
+    }
+    subscribe(socket, `tenant:${tenantId}:${channel}`);
+  });
+});
+```
+
 ### BOLA vs BFLA Distinction
 
 BOLA and BFLA (API5:2023) are frequently confused. The distinction is critical for accurate findings:
@@ -101,6 +134,8 @@ Both can coexist in a single endpoint. An endpoint may lack both a role check (B
 - [ ] Batch/list endpoints filter results by the caller's permissions.
 - [ ] Resource identifiers are UUIDs or non-sequential values to resist enumeration.
 - [ ] GraphQL resolvers enforce authorization on every field that returns sensitive data.
+- [ ] WebSocket messages, SSE streams, and GraphQL subscriptions enforce per-message or per-subscription tenant/channel authorization.
+- [ ] Long-lived streams revalidate access or disconnect when tenant membership, account status, role, or token state changes.
 
 ---
 
@@ -116,6 +151,9 @@ APIs are particularly susceptible to authentication flaws because they expose ma
 - Authentication endpoints without brute-force protection (rate limiting, account lockout, CAPTCHA).
 - JWT validation that is missing or incomplete -- no signature verification, no expiration check, acceptance of the `none` algorithm.
 - API keys transmitted in URL query strings (logged in server access logs, browser history, proxies).
+- WebSocket/SSE tokens transmitted in query strings without short lifetime, replay controls, cache controls, or access-log redaction.
+- Cookie-authenticated browser WebSockets that accept any `Origin` or do not record an explicit non-browser exception.
+- `Sec-WebSocket-Protocol` bearer token handling that is not parsed, allowlisted, or redacted from logs.
 - Missing or weak token rotation -- refresh tokens that never expire or are not rotated on use.
 - Password reset or account recovery flows that leak tokens or allow enumeration.
 - Micro-service-to-service communication without authentication (implicit trust based on network location).
@@ -149,11 +187,36 @@ paths:
           in: query  # Should be in header
 ```
 
+```javascript
+// VULNERABLE: Cookie-authenticated WebSocket accepts any browser Origin
+const wss = new WebSocketServer({ server, path: "/account/events" });
+
+wss.on("connection", (socket, req) => {
+  const session = parseCookieSession(req.headers.cookie);
+  if (!session?.userId) {
+    socket.close();
+    return;
+  }
+  socket.on("message", msg => handleAccountCommand(session.userId, msg));
+});
+```
+
+```javascript
+// VULNERABLE: SSE bearer token is placed in a long-lived query string
+app.get("/events", (req, res) => {
+  const claims = verifyJwt(req.query.token);
+  streamTenantEvents(res, req.query.tenantId, claims.sub);
+});
+```
+
 ### Remediation Guidance
 
 - Enforce rate limiting on all authentication endpoints (e.g., 5 attempts per minute per IP/account).
 - Validate JWT signatures using a strong algorithm (RS256, ES256). Reject `none` and `HS256` if RSA is expected (algorithm confusion attack).
 - Transmit API keys and tokens in HTTP headers (`Authorization` header), never in URL query strings.
+- For browser-exposed cookie-authenticated WebSockets, validate the handshake `Origin` against an explicit allowlist. For non-browser clients that omit `Origin`, require a separate strong authentication policy instead of a blanket exception.
+- If SSE or WebSocket compatibility requires query tokens, use short-lived single-purpose tokens, avoid caching, avoid referrer leakage, and redact query strings from logs.
+- When using `Sec-WebSocket-Protocol` for bearer material, parse only expected subprotocol values and redact token-like values from telemetry and errors.
 - Implement token expiration: access tokens (5-15 minutes), refresh tokens (hours to days with rotation).
 - Use `bcrypt`, `scrypt`, or `Argon2id` for password storage.
 - Authenticate service-to-service calls with mTLS or signed tokens, not network-based trust.
@@ -164,6 +227,9 @@ paths:
 - [ ] JWTs are validated for signature, expiration (`exp`), issuer (`iss`), and audience (`aud`).
 - [ ] The `none` algorithm and algorithm confusion attacks are prevented by explicit algorithm allowlisting.
 - [ ] API keys and tokens are transmitted in headers, not query strings.
+- [ ] Browser-exposed cookie-authenticated WebSockets validate `Origin` during the handshake.
+- [ ] SSE and WebSocket query tokens are short-lived, scoped, non-cacheable, and redacted from logs.
+- [ ] `Sec-WebSocket-Protocol` token/subprotocol handling is explicitly parsed, allowlisted, and redacted.
 - [ ] Refresh tokens are rotated on each use and revocable.
 - [ ] Service-to-service communication is explicitly authenticated.
 
@@ -267,6 +333,16 @@ query {
 app.use(express.json()); // Default limit may be very large or unconfigured
 ```
 
+```javascript
+// VULNERABLE: No connection, message, or subscription limits on a stream
+wss.on("connection", socket => {
+  socket.on("message", raw => {
+    const { topic } = JSON.parse(raw);
+    subscribe(socket, topic); // Unlimited topics and unbounded message size
+  });
+});
+```
+
 ### Remediation Guidance
 
 - Implement rate limiting at the API gateway and/or application layer. Use sliding window or token bucket algorithms. Set per-endpoint limits based on expected legitimate usage.
@@ -275,6 +351,7 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - For GraphQL: enforce query depth limits (e.g., max depth 5), complexity analysis (weighted field costs), and batch query limits.
 - Set execution timeouts for database queries and downstream API calls.
 - Implement cost alerts and circuit breakers for operations that trigger billable third-party APIs.
+- For streaming APIs, enforce maximum concurrent connections per user/IP, maximum subscriptions per connection, message size limits, message rate limits, idle timeouts, and server-side backpressure.
 
 ### Review Checklist
 
@@ -282,6 +359,8 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - [ ] Pagination has a maximum page size enforced server-side.
 - [ ] Request body size limits are configured.
 - [ ] GraphQL queries have depth limits, complexity limits, and batch restrictions.
+- [ ] WebSocket, SSE, and GraphQL subscription endpoints enforce connection, message, subscription, and idle-time limits.
+- [ ] Streaming handlers reject oversized messages and close abusive connections predictably.
 - [ ] Database queries and downstream calls have execution timeouts.
 - [ ] Billable operations have cost controls and alerting.
 
@@ -453,10 +532,12 @@ Document doc = builder.parse(request.getInputStream());
 ### Remediation Guidance
 
 - Configure CORS with an explicit allowlist of permitted origins. Never use `*` with `credentials: true`.
+- Configure browser WebSocket `Origin` checks separately from CORS. Do not assume CORS middleware protects WebSocket handshakes.
 - Set security response headers on all API responses:
   - `Strict-Transport-Security: max-age=31536000; includeSubDomains`
   - `X-Content-Type-Options: nosniff`
   - `Cache-Control: no-store` on sensitive responses
+- For authenticated SSE responses, set `Cache-Control: no-store`, avoid sensitive tokens in URLs where possible, and ensure access logs and referrers do not expose bearer material.
 - Return generic error messages in production. Log detailed errors server-side with correlation IDs.
 - Disable unnecessary HTTP methods. Return `405 Method Not Allowed` for unsupported methods.
 - Disable XML External Entity processing: set `factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)`.
@@ -466,6 +547,8 @@ Document doc = builder.parse(request.getInputStream());
 ### Review Checklist
 
 - [ ] CORS is configured with an explicit origin allowlist; wildcard is not used with credentials.
+- [ ] Browser WebSocket handshakes enforce an explicit `Origin` policy when cookies or browser sessions are accepted.
+- [ ] Authenticated SSE responses are non-cacheable and do not expose bearer material through logs, referrers, or shared URLs.
 - [ ] Security headers are present on all API responses.
 - [ ] Error responses in production are generic; no stack traces, SQL queries, or internal paths.
 - [ ] Only required HTTP methods are enabled per endpoint.
@@ -485,6 +568,7 @@ Document doc = builder.parse(request.getInputStream());
 - Multiple API versions running simultaneously (`/api/v1/`, `/api/v2/`, `/api/v3/`) where older versions lack security patches.
 - Debug or test endpoints present in production (`/api/debug/`, `/api/test/`, `/api/internal/`, `/graphql/playground`).
 - Undocumented endpoints that exist in code but are absent from the OpenAPI specification.
+- Undocumented WebSocket upgrade routes, `socket.io` namespaces, SSE routes, `text/event-stream` responses, or GraphQL subscriptions that are absent from API inventory.
 - API endpoints exposed to the public internet that should be internal-only.
 - Deprecated endpoints that remain functional after the announced retirement date.
 - Different security configurations between environments (staging allows unauthenticated access, production does not, but staging is publicly accessible).
@@ -498,6 +582,7 @@ Document doc = builder.parse(request.getInputStream());
 4. Flag any endpoint marked as deprecated that is still reachable.
 5. Check for environment-specific routes (debug, test, internal) that should not exist in production.
 6. Verify that older API versions have equivalent security controls to current versions.
+7. Search streaming indicators such as `new WebSocketServer`, `ws`, `socket.io`, `EventSource`, `text/event-stream`, `SseEmitter`, `Sec-WebSocket-Protocol`, and GraphQL subscription definitions.
 ```
 
 ### Remediation Guidance
@@ -511,6 +596,7 @@ Document doc = builder.parse(request.getInputStream());
 ### Review Checklist
 
 - [ ] The API inventory is documented and matches the actual deployed endpoints.
+- [ ] WebSocket, SSE, and GraphQL subscription endpoints are included in the same inventory as request/response APIs.
 - [ ] Deprecated API versions are retired or have equivalent security controls.
 - [ ] No debug, test, or playground endpoints are accessible in production.
 - [ ] Internal APIs are not reachable from external networks.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `api-security`
**Skill path:** `skills/appsec/api-security/`

### What Was Wrong

The skill covered REST, GraphQL, and gRPC API review well, but it did not explicitly inventory or classify WebSocket, Server-Sent Events (SSE), or GraphQL subscription endpoints. That left reviewers without concrete evidence gates for browser WebSocket `Origin` handling, cookie-authenticated streams, query-token SSE, long-lived session revocation, tenant/channel subscription authorization, and streaming resource limits.

This addresses #423.

### What This PR Fixes

- Adds WebSocket/SSE/streaming endpoint discovery to the API inventory gate.
- Adds a streaming endpoint evidence table covering credential type, browser exposure, Origin policy, auth lifetime, per-message authorization, tenant/channel scope, limits, and SSE cache/log controls.
- Adds severity guidance for cross-site WebSocket hijacking, tenant subscription BOLA, query-token SSE exposure, revocation gaps, and public stream resource abuse.
- Updates the output template and GraphQL section to include WebSocket, SSE, and subscription transport concerns.
- Expands the detailed API Top 10 checklist with streaming-specific BOLA, authentication, resource-consumption, misconfiguration, and inventory checks.
- Adds concrete vulnerable/remediation examples for tenant subscription BOLA, cookie-authenticated WebSocket Origin gaps, SSE query-token exposure, and missing stream limits.
- Updates `index.yaml` tags so the skill is discoverable for `websocket` and `sse` searches.

### Evidence

**Before (skill misses this):**
```javascript
const wss = new WebSocketServer({ server, path: /account/events });

wss.on(connection, (socket, req) => {
  const session = parseCookieSession(req.headers.cookie);
  if (!session?.userId) socket.close();
  socket.on(message, msg => handleAccountCommand(session.userId, msg));
});
```

The previous skill could catch generic auth/rate-limit issues, but did not tell reviewers to record browser exposure, cookie auth, WebSocket `Origin`, or per-message command authorization.

**After (now correctly handled):**
```text
Streaming Endpoint Inventory evidence:
- Transport and path
- Browser exposure
- Credential type
- Origin policy
- Auth lifetime / revocation behavior
- Per-message authorization
- Tenant/channel scope
- Resource limits
- SSE cache/log controls
```

### Test Cases Added/Updated
- [ ] Added vulnerable test cases (`tests/vulnerable/`)
- [ ] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass / not applicable: documentation-only skill improvement; added vulnerable and secure examples directly to `api-top10-checklist.md`.

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Validation

- `git diff --check`
- Frontmatter required-field check for all `SKILL.md` files
- `index.yaml` referenced-file existence check
- Verified the remote branch contains only the intended API security files.

### Sources Checked

- OWASP WebSocket Security Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/WebSocket_Security_Cheat_Sheet.html
- OWASP API Security Top 10 2023: https://owasp.org/API-Security/editions/2023/en/0x11-t10/
- MDN Server-sent events: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** PayPal or crypto; details can be provided privately after maintainer acceptance