### PR TITLE
Add projected service account token evidence

### DIFF
--- a/skills/cloud/container-security/SKILL.md
+++ b/skills/cloud/container-security/SKILL.md
@@ -185,6 +185,12 @@ Produce the final report using the structure defined in the Output Format sectio
 | deploy/app | production | Baseline (not Restricted) | runAsRoot, no seccomp |
 | deploy/worker | production | Privileged | privileged: true |
 
+### Service Account Token Evidence
+
+| Workload | ServiceAccount | SA Automount | Pod Automount | Token Type | Audience | Expiration | Mounted Containers | RBAC Scope | External Trust | Risk |
+|----------|----------------|--------------|---------------|------------|----------|------------|--------------------|------------|----------------|------|
+| deploy/controller | namespace-controller | false | false | projected | `https://kubernetes.default.svc` | 600s | controller only | Role in namespace | none | Low |
+
 ### Prioritized Remediation Plan
 
 1. **[Critical]** <finding> -- <action>
@@ -257,6 +263,7 @@ Produce the final report using the structure defined in the Output Format sectio
 5. **`readOnlyRootFilesystem` breaks many applications.** When recommending this control, also recommend adding writable `emptyDir` volume mounts for directories the application needs to write to (e.g., `/tmp`, `/var/cache`).
 6. **Network policies are additive, not subtractive.** A default-deny policy must be explicitly created. Without it, all pod-to-pod traffic is allowed regardless of other NetworkPolicy resources.
 7. **Distroless images have no shell.** While this is excellent for security, note that debugging requires ephemeral containers (`kubectl debug`). Flag this as a consideration, not a problem.
+8. **`automountServiceAccountToken: false` is not the whole story.** A pod can disable default automount and still explicitly mount a projected service-account token. Record token audience, expiration, mount path, mounted containers, RBAC scope, and any external workload-identity trust policy before deciding severity.
 
 ---
 
@@ -285,6 +292,9 @@ Produce the final report using the structure defined in the Output Format sectio
 - Kubernetes Pod Security Admission: https://kubernetes.io/docs/concepts/security/pod-security-admission/
 - Kubernetes Network Policies: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 - Kubernetes RBAC: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Kubernetes Service Accounts: https://kubernetes.io/docs/concepts/security/service-accounts/
+- Configure Service Accounts for Pods: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+- Kubernetes TokenRequest API: https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/
 - Docker Security Best Practices: https://docs.docker.com/develop/security-best-practices/
 - Dockerfile Best Practices: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
 - NSA/CISA Kubernetes Hardening Guide: https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF

--- a/skills/cloud/container-security/cis-benchmarks.md
+++ b/skills/cloud/container-security/cis-benchmarks.md
@@ -254,6 +254,65 @@ spec:
   automountServiceAccountToken: false
 ```
 
+Do not stop at the default automount setting. Reviewers must also look for explicitly projected service-account tokens and verify their audience, lifetime, mount scope, and RBAC blast radius.
+
+**Discovery patterns:**
+
+```yaml
+serviceAccountName:
+automountServiceAccountToken:
+serviceAccountToken:
+audience:
+expirationSeconds:
+volumeMounts:
+```
+
+**Projected token evidence matrix:**
+
+| Evidence | Safe signal | Finding signal |
+|----------|-------------|----------------|
+| Automount level | `automountServiceAccountToken: false` at ServiceAccount or Pod level when default token is not needed | Default automount left enabled for an app that does not call the Kubernetes API |
+| Token type | Short-lived projected `serviceAccountToken` volume used intentionally | Legacy Secret-backed token or unclear token source |
+| Audience | Narrow audience for Kubernetes API or documented external STS/workload identity | Generic audience such as `api`, wildcard-like usage, or no audience evidence |
+| Expiration | Short lifetime appropriate for the workload, such as minutes to one hour | Long-lived projected token or missing `expirationSeconds` evidence |
+| Mount scope | Token mounted only into the container that needs API access | Token volume mounted into unrelated app, sidecar, init, debug, or ephemeral containers |
+| RBAC scope | Namespaced Role with least-privilege verbs/resources | ClusterRole or wildcard verbs/resources not justified by the workload |
+| External identity | Issuer, audience, namespace, service account, and subject are bound in the external trust policy | Kubernetes token can be exchanged for cloud credentials without subject/audience restrictions |
+
+**Severity guidance:**
+
+- **High:** Broad or long-lived token mounted into unnecessary containers with privileged RBAC or external workload-identity trust.
+- **Medium:** Projected token lacks clear audience, expiration, or per-container mount evidence.
+- **Low/Informational:** Intentional short-lived projected token, mounted read-only into one controller container, with namespace-scoped RBAC and documented workload-identity conditions.
+
+**Remediation examples:**
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: namespace-controller
+spec:
+  template:
+    spec:
+      serviceAccountName: namespace-controller
+      automountServiceAccountToken: false
+      containers:
+        - name: controller
+          volumeMounts:
+            - name: k8s-api-token
+              mountPath: /var/run/secrets/tokens
+              readOnly: true
+      volumes:
+        - name: k8s-api-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  audience: https://kubernetes.default.svc
+                  expirationSeconds: 600
+```
+
 ### CIS 5.2 -- Pod Security Standards
 
 Evaluate workload configurations against Kubernetes Pod Security Standards. The three levels are:


### PR DESCRIPTION
## Summary
- add service-account token evidence fields to the container security report template
- expand CIS 5.1.6 guidance beyond default automount checks to projected token audience, expiration, mount scope, RBAC, and external trust policies
- add severity guidance and a remediation example for short-lived projected Kubernetes service-account tokens

Closes #424.

## Tests
- `git diff --check`