### PR TITLE
Improve container service account token review

### DIFF
--- a/skills/cloud/container-security/SKILL.md
+++ b/skills/cloud/container-security/SKILL.md
@@ -13,7 +13,7 @@ phase: [build, deploy, operate]
 frameworks: [CIS-Docker-v1.6.0, CIS-Kubernetes-v1.9.0, NIST-SP-800-190]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -59,6 +59,7 @@ NIST SP 800-190 identifies five risk categories: image risks, registry risks, or
 - Access to Dockerfiles and container build configurations
 - Kubernetes manifests (YAML), Helm charts, or Kustomize overlays
 - RBAC configuration files (Roles, ClusterRoles, RoleBindings)
+- ServiceAccount definitions, token projection volumes, and workload identity annotations
 - NetworkPolicy definitions
 - Pod Security Standard configurations or OPA/Gatekeeper policies
 - Container registry configurations (if available)
@@ -99,6 +100,12 @@ Use Glob to locate all relevant configuration files.
 **/*-ingress.yaml
 **/*-networkpolicy.yaml
 **/*-rbac.yaml
+**/*-role.yaml
+**/*-rolebinding.yaml
+**/*-clusterrole.yaml
+**/*-clusterrolebinding.yaml
+**/*-serviceaccount.yaml
+**/*-serviceaccount.yml
 **/*-psp.yaml
 **/*-podsecuritypolicy.yaml
 ```
@@ -109,7 +116,26 @@ Classify findings by type: Dockerfiles, Kubernetes manifests, Helm charts, Kusto
 
 ### Step 2 through Step 6: CIS Benchmark and NIST SP 800-190 Evaluation
 
-Evaluate all container and Kubernetes configurations against CIS Docker Benchmark v1.6.0, CIS Kubernetes Benchmark v1.9.0, and NIST SP 800-190 countermeasures. This covers Dockerfile security, Pod Security Standards, RBAC, Network Policies, Secrets Management, Control Plane configuration, and Container Runtime Hardening.
+Evaluate all container and Kubernetes configurations against CIS Docker Benchmark v1.6.0, CIS Kubernetes Benchmark v1.9.0, and NIST SP 800-190 countermeasures. This covers Dockerfile security, Pod Security Standards, RBAC, ServiceAccount token exposure, Network Policies, Secrets Management, Control Plane configuration, and Container Runtime Hardening.
+
+For Kubernetes workloads, build an evidence chain from the workload to the ServiceAccount, ServiceAccount token source, token mount scope, and effective RBAC:
+
+| Evidence | What to Record |
+|----------|----------------|
+| Workload identity | Namespace, workload kind/name, `serviceAccountName`, and whether the default ServiceAccount is used implicitly |
+| Auto-mount state | `automountServiceAccountToken` at the ServiceAccount and Pod template levels, including inherited/default behavior |
+| Token projection | `projected.serviceAccountToken` path, `audience`, `expirationSeconds`, and target volume name |
+| Mount scope | Each container, init container, and sidecar that mounts the token volume; whether the mount is read-only |
+| Effective RBAC | Role/ClusterRole permissions reachable through RoleBinding/ClusterRoleBinding for that ServiceAccount |
+| External trust | Workload identity annotations or federation bindings that trust the projected token audience/subject |
+
+Flag any of the following as findings:
+
+- Default ServiceAccount used by application workloads, especially when token auto-mounting is not explicitly disabled.
+- ServiceAccount tokens mounted into containers that do not call the Kubernetes API or an external identity provider.
+- Projected tokens with missing/default audience, overly broad audience, or long `expirationSeconds` without justification.
+- Workload identity annotations or federation bindings that are not tied to a narrow namespace, ServiceAccount subject, and intended audience.
+- ServiceAccount tokens combined with wildcard, cluster-wide, or secret-reading RBAC.
 
 For detailed CIS benchmark checklist items, NIST SP 800-190 countermeasure tables, and comprehensive security context evaluation criteria, see [cis-benchmarks.md](cis-benchmarks.md) in this skill directory.
 
@@ -126,8 +152,8 @@ Produce the final report using the structure defined in the Output Format sectio
 
 | Severity | Definition | Examples |
 |----------|-----------|----------|
-| **Critical** | Container escape, cluster compromise, or credential exposure | Privileged containers, Docker socket mounts, cluster-admin bound to application SA, secrets in plaintext manifests, `hostPID`/`hostNetwork` on app pods |
-| **High** | Significant security gap enabling lateral movement or privilege escalation | Running as root, missing network policies, wildcard RBAC, `allowPrivilegeEscalation: true`, host path mounts to sensitive directories |
+| **Critical** | Container escape, cluster compromise, or credential exposure | Privileged containers, Docker socket mounts, cluster-admin bound to application SA, secrets in plaintext manifests, service account token with cluster-admin RBAC mounted into app containers, `hostPID`/`hostNetwork` on app pods |
+| **High** | Significant security gap enabling lateral movement or privilege escalation | Running as root, missing network policies, wildcard RBAC, broad service account token audience with long expiration, `allowPrivilegeEscalation: true`, host path mounts to sensitive directories |
 | **Medium** | Missing hardening that weakens defense-in-depth | No resource limits, mutable image tags, missing seccomp profile, read-write root filesystem, secrets as env vars |
 | **Low** | Best-practice deviation with limited immediate risk | No HEALTHCHECK in Dockerfile, ADD instead of COPY, missing liveness/readiness probes, using default namespace |
 | **Informational** | Observation with no direct security impact | Image size optimization, multi-stage build suggestions, label recommendations |
@@ -173,6 +199,7 @@ Produce the final report using the structure defined in the Output Format sectio
 - **File:** <path>
 - **Line(s):** <line numbers>
 - **Resource:** <Deployment/StatefulSet name>
+- **ServiceAccount / Token Evidence:** <namespace/name, auto-mount state, projected token audience/expiry, mounted containers, effective RBAC>
 - **Container:** <container name>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration>
@@ -184,6 +211,13 @@ Produce the final report using the structure defined in the Output Format sectio
 |----------|-----------|-----------|------------|
 | deploy/app | production | Baseline (not Restricted) | runAsRoot, no seccomp |
 | deploy/worker | production | Privileged | privileged: true |
+
+### ServiceAccount Token Evidence Matrix
+
+| Workload | Namespace | ServiceAccount | Token Source | Audience | Expiration | Mounted Containers | Effective RBAC | Status |
+|----------|-----------|----------------|--------------|----------|------------|--------------------|----------------|--------|
+| deploy/app | production | app-sa | projected volume | api://vault | 600s | app only | get/list secrets in namespace | Review |
+| deploy/worker | production | default (implicit) | auto-mounted default | Kubernetes API | default | worker, sidecar | wildcard ClusterRole | Fail |
 
 ### Prioritized Remediation Plan
 
@@ -220,7 +254,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | 2 | etcd | TLS configuration, peer authentication, unique CA |
 | 3 | Control Plane Configuration | Authentication, authorization, admission controllers, audit logging |
 | 4 | Worker Nodes | Kubelet configuration, file permissions, TLS bootstrapping |
-| 5 | Policies | RBAC, Pod Security Standards, network policies, secrets management |
+| 5 | Policies | RBAC, ServiceAccount token mounting, Pod Security Standards, network policies, secrets management |
 
 ### NIST SP 800-190 -- Risk Categories and Countermeasures
 
@@ -228,7 +262,7 @@ Produce the final report using the structure defined in the Output Format sectio
 |--------------|-----------|---------------------|
 | Image Risks | Vulnerabilities, malware, embedded secrets, unpatched software | Minimal base images, scanning, signing, immutable references |
 | Registry Risks | Unauthorized access, stale images, insufficient authentication | Registry authentication, image lifecycle policies |
-| Orchestrator Risks | Unrestricted access, mixed sensitivity workloads, insufficient logging | RBAC, namespaces, network policies, audit logging |
+| Orchestrator Risks | Unrestricted access, mixed sensitivity workloads, insufficient logging, over-broad workload identity tokens | RBAC, namespaces, network policies, service account token scoping, audit logging |
 | Container Risks | Runtime privilege escalation, unbounded resources, writable filesystems | Non-root, capabilities, resource limits, read-only FS |
 | Host OS Risks | Shared kernel, large attack surface, unpatched hosts | Minimal host OS, regular patching, immutable infrastructure |
 
@@ -257,6 +291,7 @@ Produce the final report using the structure defined in the Output Format sectio
 5. **`readOnlyRootFilesystem` breaks many applications.** When recommending this control, also recommend adding writable `emptyDir` volume mounts for directories the application needs to write to (e.g., `/tmp`, `/var/cache`).
 6. **Network policies are additive, not subtractive.** A default-deny policy must be explicitly created. Without it, all pod-to-pod traffic is allowed regardless of other NetworkPolicy resources.
 7. **Distroless images have no shell.** While this is excellent for security, note that debugging requires ephemeral containers (`kubectl debug`). Flag this as a consideration, not a problem.
+8. **`automountServiceAccountToken: false` is not the whole token story.** Workloads can still mount explicit projected ServiceAccount tokens for Kubernetes API calls or cloud workload identity. Review the projected token audience, expiration, mounted containers, and effective RBAC before marking the workload safe.
 
 ---
 
@@ -285,6 +320,8 @@ Produce the final report using the structure defined in the Output Format sectio
 - Kubernetes Pod Security Admission: https://kubernetes.io/docs/concepts/security/pod-security-admission/
 - Kubernetes Network Policies: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 - Kubernetes RBAC: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Kubernetes ServiceAccounts: https://kubernetes.io/docs/concepts/security/service-accounts/
+- Kubernetes ServiceAccount token projection: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 - Docker Security Best Practices: https://docs.docker.com/develop/security-best-practices/
 - Dockerfile Best Practices: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
 - NSA/CISA Kubernetes Hardening Guide: https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF
@@ -293,4 +330,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Added ServiceAccount token evidence coverage for projected token audience, expiration, mount scope, workload identity bindings, and effective RBAC.
 - **1.0.0** -- Initial release. Full coverage of CIS Docker Benchmark v1.6.0 Section 4-5, CIS Kubernetes Benchmark v1.9.0 Sections 1-5, and NIST SP 800-190 countermeasures across all five risk categories.

--- a/skills/cloud/container-security/cis-benchmarks.md
+++ b/skills/cloud/container-security/cis-benchmarks.md
@@ -254,6 +254,138 @@ spec:
   automountServiceAccountToken: false
 ```
 
+Review both the ServiceAccount object and each workload's Pod template. The Pod-level setting overrides the ServiceAccount-level setting, and a missing value can still result in a token being mounted by default.
+
+#### ServiceAccount Token Projection and Workload Identity Evidence
+
+Kubernetes clusters commonly use bound, projected ServiceAccount tokens for Kubernetes API access and cloud workload identity. These tokens are safer than legacy static Secret-backed tokens, but they still need explicit review.
+
+Record the following evidence for each workload:
+
+| Evidence | Review Question |
+|----------|-----------------|
+| `serviceAccountName` | Is the workload using a purpose-specific ServiceAccount instead of `default`? |
+| `automountServiceAccountToken` | Is auto-mounting disabled when no Kubernetes API token is needed? |
+| `projected.serviceAccountToken.audience` | Is the audience narrow and tied to the exact API or external identity provider? |
+| `projected.serviceAccountToken.expirationSeconds` | Is the token short-lived and justified for the workload? |
+| `volumeMounts` | Is the token mounted only into containers that need it, including init and sidecar containers? |
+| RBAC bindings | Are verbs/resources namespace-scoped and least-privileged? |
+| Workload identity annotations | Do cloud IAM bindings constrain namespace, ServiceAccount, subject, and audience? |
+
+```yaml
+# BAD: Default Kubernetes API token is available to every container in the pod.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reporting
+spec:
+  template:
+    spec:
+      serviceAccountName: default
+      containers:
+        - name: app
+          image: example/reporting:1.0
+        - name: log-sidecar
+          image: example/log-forwarder:1.0
+
+---
+# BAD: Projected token has a broad external audience, long lifetime, and is
+# mounted into a sidecar that does not need cloud identity.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: export-worker
+spec:
+  template:
+    spec:
+      serviceAccountName: export-worker
+      automountServiceAccountToken: false
+      volumes:
+        - name: cloud-identity
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  audience: https://iam.example.com/
+                  expirationSeconds: 86400
+      containers:
+        - name: worker
+          image: example/export-worker:1.0
+          volumeMounts:
+            - name: cloud-identity
+              mountPath: /var/run/secrets/tokens
+              readOnly: true
+        - name: metrics-sidecar
+          image: example/metrics:1.0
+          volumeMounts:
+            - name: cloud-identity
+              mountPath: /var/run/secrets/tokens
+              readOnly: true
+```
+
+```yaml
+# GOOD: Auto-mounted API tokens are disabled, and the projected token is
+# short-lived, audience-scoped, read-only, and mounted only into the container
+# that exchanges it with the intended identity provider.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: export-worker
+  namespace: production
+automountServiceAccountToken: false
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: export-worker
+  namespace: production
+spec:
+  template:
+    spec:
+      serviceAccountName: export-worker
+      automountServiceAccountToken: false
+      volumes:
+        - name: cloud-identity
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  audience: api://export-worker-prod
+                  expirationSeconds: 600
+      containers:
+        - name: worker
+          image: example/export-worker:1.0
+          volumeMounts:
+            - name: cloud-identity
+              mountPath: /var/run/secrets/tokens
+              readOnly: true
+        - name: metrics-sidecar
+          image: example/metrics:1.0
+```
+
+Severity guidance:
+
+- **Critical:** Projected or auto-mounted ServiceAccount token can reach cluster-admin, wildcard cluster-wide permissions, or broad secret access from an application workload.
+- **High:** Token has broad audience, excessive lifetime, or is mounted into unnecessary containers while the ServiceAccount has meaningful namespace permissions.
+- **Medium:** Token scope is partly constrained but lacks documented audience/expiration justification, read-only mount, or container-level mount minimization.
+- **Low:** Minor documentation or naming issue where effective RBAC and token mount scope are already least-privileged.
+
+Suggested grep patterns:
+
+```
+serviceAccountName:
+automountServiceAccountToken:
+projected:
+serviceAccountToken:
+audience:
+expirationSeconds:
+volumeMounts:
+eks.amazonaws.com/role-arn
+iam.gke.io/gcp-service-account
+azure.workload.identity/client-id
+```
+
 ### CIS 5.2 -- Pod Security Standards
 
 Evaluate workload configurations against Kubernetes Pod Security Standards. The three levels are:

--- a/skills/cloud/container-security/tests/benign/serviceaccount-token-projection.yaml
+++ b/skills/cloud/container-security/tests/benign/serviceaccount-token-projection.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: export-worker
+  namespace: production
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: export-worker-read-config
+  namespace: production
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["export-worker-config"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: export-worker-read-config
+  namespace: production
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: export-worker-read-config
+subjects:
+  - kind: ServiceAccount
+    name: export-worker
+    namespace: production
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: export-worker
+  namespace: production
+spec:
+  template:
+    spec:
+      serviceAccountName: export-worker
+      automountServiceAccountToken: false
+      volumes:
+        - name: cloud-identity
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  audience: api://export-worker-prod
+                  expirationSeconds: 600
+      containers:
+        - name: worker
+          image: example/export-worker:1.0
+          volumeMounts:
+            - name: cloud-identity
+              mountPath: /var/run/secrets/tokens
+              readOnly: true
+        - name: metrics-sidecar
+          image: example/metrics:1.0

--- a/skills/cloud/container-security/tests/vulnerable/serviceaccount-token-projection.yaml
+++ b/skills/cloud/container-security/tests/vulnerable/serviceaccount-token-projection.yaml
@@ -1,0 +1,53 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: export-worker-broad
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: export-worker-broad
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: export-worker-broad
+subjects:
+  - kind: ServiceAccount
+    name: export-worker
+    namespace: production
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: export-worker
+  namespace: production
+spec:
+  template:
+    spec:
+      serviceAccountName: export-worker
+      automountServiceAccountToken: false
+      volumes:
+        - name: cloud-identity
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  audience: https://iam.example.com/
+                  expirationSeconds: 86400
+      containers:
+        - name: worker
+          image: example/export-worker:1.0
+          volumeMounts:
+            - name: cloud-identity
+              mountPath: /var/run/secrets/tokens
+              readOnly: true
+        - name: metrics-sidecar
+          image: example/metrics:1.0
+          volumeMounts:
+            - name: cloud-identity
+              mountPath: /var/run/secrets/tokens
+              readOnly: true


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `container-security`
**Skill path:** `skills/cloud/container-security/`

### What Was Wrong

Fixes #424.

The existing container-security skill covered default ServiceAccounts and `automountServiceAccountToken`, but it did not require reviewers to build evidence for bound/projected ServiceAccount tokens used by Kubernetes API access or cloud workload identity.

That missed real production variants:

- projected `serviceAccountToken` volumes with broad/default `audience`
- long-lived projected tokens via excessive `expirationSeconds`
- token volumes mounted into sidecars/init containers that do not need them
- projected tokens not tied back to effective RBAC and external workload identity trust
- false sense of safety when `automountServiceAccountToken: false` is set but explicit token projection is still present

### What This PR Fixes

- Adds a ServiceAccount token evidence chain to `SKILL.md`
- Extends discovery patterns for ServiceAccount, Role, RoleBinding, ClusterRole, and ClusterRoleBinding manifests
- Adds a report field and evidence matrix for ServiceAccount/token review
- Expands CIS 5.1.5/5.1.6 guidance in `cis-benchmarks.md`
- Adds severity guidance for token + RBAC combinations
- Adds grep patterns for projected tokens and common cloud workload identity annotations
- Adds vulnerable and benign Kubernetes samples for projected ServiceAccount token review

### Evidence

**Before (skill can miss this):**

```yaml
spec:
  serviceAccountName: export-worker
  automountServiceAccountToken: false
  volumes:
    - name: cloud-identity
      projected:
        sources:
          - serviceAccountToken:
              path: token
              audience: https://iam.example.com/
              expirationSeconds: 86400
  containers:
    - name: worker
      volumeMounts:
        - name: cloud-identity
          mountPath: /var/run/secrets/tokens
          readOnly: true
    - name: metrics-sidecar
      volumeMounts:
        - name: cloud-identity
          mountPath: /var/run/secrets/tokens
          readOnly: true
```

The previous guidance could stop at `automountServiceAccountToken: false` and miss that the workload still mounts a projected token with broad external audience, 24h lifetime, sidecar exposure, and broad secret-reading RBAC.

**After (now explicitly handled):**

```text
ServiceAccount / Token Evidence:
- workload: deploy/export-worker in production
- ServiceAccount: production/export-worker
- auto-mount: disabled at the pod template
- token source: projected serviceAccountToken
- audience: api://export-worker-prod
- expiration: 600s
- mounted containers: worker only
- effective RBAC: Role-scoped get on one ConfigMap
```

The skill now asks reviewers to connect token projection, mount scope, external trust, and RBAC before marking the workload safe.

### Test Cases Added/Updated

- [x] Added vulnerable test cases (`tests/vulnerable/serviceaccount-token-projection.yaml`)
- [x] Added benign test cases (`tests/benign/serviceaccount-token-projection.yaml`)
- [x] Existing tests still pass

### Verification

- `git diff --check`
- PowerShell frontmatter validation matching `.github/workflows/lint-skills.yml`
- Python/PyYAML parse of both new Kubernetes YAML samples

### Bounty Tier

- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info

- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Crypto; details can be confirmed privately after acceptance
