### PR TITLE
Improve sast-config taint and suppression evidence guidance

### DIFF
--- a/skills/devsecops/sast-config/SKILL.md
+++ b/skills/devsecops/sast-config/SKILL.md
@@ -208,7 +208,8 @@ rules:
           # nosemgrep: custom.crypto.weak-random
           ...
     message: >
-      Weak PRNG used in potentially security-sensitive context. Use
+      Weak PRNG used in a security-sensitive token, session, nonce, key, or
+      authorization context. Use
       secrets.token_bytes() or crypto.getRandomValues() for security purposes.
     languages: [python, javascript]
     severity: WARNING
@@ -229,6 +230,46 @@ rules:
 - [ ] `confidence` is documented (HIGH, MEDIUM, LOW).
 - [ ] `languages` is explicitly specified.
 - [ ] `pattern-not` or `pattern-not-inside` handles known safe patterns to reduce false positives.
+
+#### 3.3 Source-to-Sink and Context Evidence
+
+For vulnerability classes that depend on data flow, reviewers should not accept
+a broad point pattern as sufficient evidence. This includes injection, SSRF,
+path traversal, unsafe deserialization, template injection, weak randomness, and
+secret generation rules. A rule that matches every source or every sink can be
+useful as an inventory aid, but it should not be treated as a high-confidence
+security gate without source-to-sink evidence.
+
+**What to verify:**
+
+- [ ] Semgrep rules for flow-sensitive classes use `mode: taint`, or the rule
+      explicitly documents why a point pattern is sufficient.
+- [ ] `pattern-sources`, `pattern-sinks`, `pattern-sanitizers`, and
+      `pattern-propagators` are reviewed for the framework being scanned.
+- [ ] CodeQL path queries define appropriate remote sources, sinks, barriers,
+      and additional flow steps for the language/framework.
+- [ ] Each custom source-to-sink rule has at least one vulnerable fixture that
+      proves flow through a local variable or helper.
+- [ ] Each custom source-to-sink rule has at least one benign fixture that proves
+      a real sanitizer or non-security context is not flagged.
+
+**Weak randomness context gate:**
+
+The `custom.crypto.weak-random` example above should only be a blocking finding
+when the random value reaches a security-sensitive context such as a session ID,
+CSRF token, password reset code, API key, invite code, nonce, key material, or
+authorization decision. Non-security uses such as A/B test bucketing, UI
+animation jitter, randomized sort order, or sampling should be suppressed by the
+rule or reported only as informational hardening.
+
+```python
+# Vulnerable: random value becomes a password reset code.
+reset_code = str(random.randint(100000, 999999))
+send_password_reset(user.email, reset_code)
+
+# Benign: random value only controls a cosmetic experiment.
+variant = "new_nav" if random.random() < 0.5 else "old_nav"
+```
 
 ---
 
@@ -350,21 +391,27 @@ ticket         |
 **Suppression requirements:**
 
 ```python
-# Semgrep inline suppression -- MUST include justification
-value = request.args.get("id")  # nosemgrep: python.django.security.injection.sql.sql-injection -- validated by ORM layer, not raw SQL
+# Semgrep inline suppression -- MUST include actionable justification
+value = request.args.get("id")  # nosemgrep: python.django.security.injection.sql.sql-injection -- owner: appsec, ticket: SEC-1234, reviewed: 2025-02-01, expires: 2025-05-01, reason: validated by ORM layer, not raw SQL
 
 # CodeQL suppression via query filter (in codeql-config.yml)
-# Document in SAST-SUPPRESSIONS.md with ticket reference
+# Document in SAST-SUPPRESSIONS.md with owner, ticket, review date, expiry, and risk category
 ```
 
 **What to verify:**
 
 - Every suppression has a documented justification (not just `nosemgrep`).
+- Every suppression has an owner, ticket/reference, review date or expiry date,
+  and a risk category.
+- Suppressions are scoped to one finding or rule instance whenever possible;
+  broad rule-level suppressions require extra approval and compensating evidence.
+- Suppressions that hide reachable sinks without equivalent validation evidence
+  are treated as security findings, not as routine false-positive cleanup.
 - Suppressions are reviewed periodically (quarterly).
 - False positive rate is tracked as a metric (target: < 20% FP rate).
 - True positive findings have a defined SLA (Critical: 7 days, High: 30 days, Medium: 90 days).
 
-**Finding classification:** No false positive management process is **Medium**. Suppressions without justification is **High**. No SLA for true positive remediation is **Medium**.
+**Finding classification:** No false positive management process is **Medium**. Suppressions without justification is **High**. Suppressions without owner/ticket/expiry evidence are **Medium**. Suppressions that hide exploitable sinks without compensating evidence are **High**. No SLA for true positive remediation is **Medium**.
 
 ---
 


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `sast-config`
**Skill path:** `skills/devsecops/sast-config/`

### What Was Wrong

This follows up on review issue #443.

The `sast-config` skill already gives strong guidance for SAST coverage, custom Semgrep rules, CodeQL queries, CI integration, and false-positive management. The main gap was that broad point-pattern rules could still be treated as sufficient for flow-sensitive vulnerability classes.

Two concrete examples:

- The weak-random example matched broad calls such as `random.random()` and `Math.random()` while the message said "potentially security-sensitive context." Without a context gate, benign randomness for A/B testing or UI jitter could be treated as a security finding.
- Suppression guidance required a justification, but did not explicitly require owner, ticket/reference, review/expiry date, risk category, or scoped approval for broad suppressions.

### What This PR Fixes

- Adds a new `Source-to-Sink and Context Evidence` subsection.
- Requires taint-mode or equivalent flow-sensitive evidence for injection, SSRF, path traversal, unsafe deserialization, template injection, weak randomness, and secret generation rules.
- Adds fixture expectations for vulnerable and benign examples.
- Clarifies that weak-random findings should be blocking only when the random value reaches token/session/nonce/key/authorization contexts.
- Strengthens suppression evidence requirements with owner, ticket/reference, review or expiry date, risk category, and scope guidance.
- Updates finding classification for suppressions that lack owner/ticket/expiry evidence or hide reachable sinks.

### Evidence

**Before (skill can encourage noisy point-pattern behavior):**
```yaml
- id: custom.crypto.weak-random
  patterns:
    - pattern-either:
        - pattern: random.random()
        - pattern: random.randint(...)
        - pattern: Math.random()
  message: >
    Weak PRNG used in potentially security-sensitive context.
```

**After (now correctly scoped by review guidance):**
```markdown
The `custom.crypto.weak-random` example above should only be a blocking finding
when the random value reaches a security-sensitive context such as a session ID,
CSRF token, password reset code, API key, invite code, nonce, key material, or
authorization decision.
```

**Suppression evidence before:**
```python
# nosemgrep: python.django.security.injection.sql.sql-injection -- validated by ORM layer, not raw SQL
```

**Suppression evidence after:**
```python
# nosemgrep: python.django.security.injection.sql.sql-injection -- owner: appsec, ticket: SEC-1234, reviewed: 2025-02-01, expires: 2025-05-01, reason: validated by ORM layer, not raw SQL
```

### Test Cases Added/Updated
- [ ] Added vulnerable test cases (`tests/vulnerable/`)
- [ ] Added benign test cases (`tests/benign/`)
- [x] Existing frontmatter checks still pass
- [x] Prompt injection scan logic still passes
- [x] `git diff --check` passes

This is a documentation/skill-guidance improvement, so the vulnerable and benign examples were added directly to the skill text rather than as executable test fixtures.

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** GitHub Sponsors or PayPal; I can provide details privately on acceptance.
