### PR TITLE
Improve detection engineering Sigma source freshness

### DIFF
--- a/skills/secops/detection-engineering/SKILL.md
+++ b/skills/secops/detection-engineering/SKILL.md
@@ -13,7 +13,7 @@ phase: [operate]
 frameworks: [MITRE-ATT&CK-v16, Sigma, Palantir-ADS]
 difficulty: advanced
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -164,6 +164,17 @@ fields:
 ```
 
 **Sigma rule field requirements:**
+
+Before accepting a Sigma rule as conforming, record which Sigma source was
+checked. The Sigma documentation has moved between the SigmaHQ site and GitHub
+wiki pages; a stale rule-creation URL can make a review look verified while the
+reviewer never checked the current rule syntax or repository conventions.
+
+| Source Evidence | What to Record | Review Handling |
+|-----------------|----------------|-----------------|
+| Sigma specification source | Current Sigma docs page or specification repository URL | Use for core fields, modifiers, condition syntax, and rule semantics |
+| SigmaHQ rule convention source | SigmaHQ wiki or rule-convention page | Use for repository contribution expectations such as `status`, `date`, `modified`, and style |
+| Reviewed date | Date the source was checked | Mark rule conformance **Not Evaluable** if the only source is stale or unreachable |
 
 | Field | Required | Description |
 |-------|----------|-------------|
@@ -521,4 +532,12 @@ This skill processes user-supplied content that may include log samples, detecti
 9. **Atomic Red Team** -- https://github.com/redcanaryco/atomic-red-team
 10. **MITRE Cyber Analytics Repository (CAR)** -- https://car.mitre.org/
 11. **Detection Engineering Maturity Model** -- Kyle Bailey, https://kyle-bailey.medium.com/detection-engineering-maturity-matrix-f4f3181a5cc7
-12. **Sigma Rule Creation Guide (SigmaHQ)** -- https://sigmahq.io/docs/guide/rules.html
+12. **Sigma Rules Documentation** -- https://sigmahq.io/docs/basics/rules.html
+13. **Sigma Rule Creation Guide (SigmaHQ Wiki)** -- https://github.com/SigmaHQ/sigma/wiki/Rule-Creation-Guide
+14. **SigmaHQ Rule Conventions** -- https://sigmahq.io/sigma-specification/sigmahq/sigmahq-rule-convention.html
+
+---
+
+## 10. Changelog
+
+- **1.0.1** -- Added Sigma source-currency evidence and replaced stale Sigma rule-creation reference with current official Sigma documentation.

--- a/skills/secops/detection-engineering/tests/sigma-source-currency.md
+++ b/skills/secops/detection-engineering/tests/sigma-source-currency.md
@@ -1,0 +1,35 @@
+# Detection Engineering Sigma Source Currency
+
+These fixtures document how the `detection-engineering` skill should treat Sigma documentation source freshness.
+
+## Vulnerable: Stale Sigma Rule Creation Link
+
+```text
+Sigma conformance source: https://sigmahq.io/docs/guide/rules.html
+Reviewed date: not recorded
+Claim supported: rule field requirements and repository conventions
+Source status: not checked
+```
+
+**Expected result:** Not Evaluable. The source is stale and no reviewed date is recorded, so the reviewer cannot prove the rule was checked against current Sigma documentation or SigmaHQ conventions.
+
+## Benign: Current Sigma Rules Documentation
+
+```text
+Sigma specification source: https://sigmahq.io/docs/basics/rules.html
+SigmaHQ convention source: https://sigmahq.io/sigma-specification/sigmahq/sigmahq-rule-convention.html
+Reviewed date: 2026-06-04
+Claim supported: required fields, modifiers, false-positive guidance, and repository conventions
+```
+
+**Expected result:** Pass. The sources are current, official, reachable, and tied to the Sigma conformance claim.
+
+## Benign: SigmaHQ Rule Creation Wiki
+
+```text
+SigmaHQ rule creation guide: https://github.com/SigmaHQ/sigma/wiki/Rule-Creation-Guide
+Reviewed date: 2026-06-04
+Claim supported: community rule-authoring expectations and metadata conventions
+```
+
+**Expected result:** Pass as repository-convention evidence when paired with the current Sigma rules documentation for syntax semantics.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** detection-engineering
**Skill path:** `skills/secops/detection-engineering/`

### What Was Wrong
Fixes #513.

The skill asks reviewers to author and validate Sigma rules, but its Sigma Rule Creation Guide reference used `https://sigmahq.io/docs/guide/rules.html`, which now returns 404. That can make a Sigma conformance review look source-backed even when the reviewer did not verify current rule syntax or SigmaHQ conventions.

### What This PR Fixes

- Replaces the stale Sigma rule-creation reference with current official Sigma rules documentation.
- Adds Sigma source evidence fields: specification source, SigmaHQ convention source, and reviewed date.
- Adds current SigmaHQ rule-creation and rule-convention references.
- Adds an edge-case fixture covering stale-source and verified-source handling.

### Evidence

Verified on June 4, 2026 that the replacement sources return HTTP 200:

- `https://sigmahq.io/docs/basics/rules.html`
- `https://github.com/SigmaHQ/sigma/wiki/Rule-Creation-Guide`
- `https://sigmahq.io/sigma-specification/sigmahq/sigmahq-rule-convention.html`

### Test Cases Added/Updated
- [x] Added edge-case fixture: `skills/secops/detection-engineering/tests/sigma-source-currency.md`
- [x] Existing checks still pass for the touched skill.

Validation run locally:
- `git diff --check HEAD~1 HEAD`
- required frontmatter field sweep for all `SKILL.md` files
- index file-existence validation
- prompt-injection phrase scan on newly added lines
- HTTP 200 check for the replacement official Sigma references

### Bounty Tier
- [x] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [ ] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Can provide privately if accepted
