### PR TITLE
Improve IaC Checkov source evidence

### DIFF
--- a/skills/cloud/iac-security/SKILL.md
+++ b/skills/cloud/iac-security/SKILL.md
@@ -56,6 +56,7 @@ The OWASP IaC Security Cheat Sheet categorizes common IaC vulnerabilities. SLSA 
 - Access to module registries or module source references
 - Variable definition files and environment-specific overrides
 - State file references (for understanding current deployment, if available)
+- Scanner output, if available, including tool/version, framework, rule ID, resource, file/line, and any current policy `Guide:` URL emitted by Checkov, tfsec, or KICS.
 
 ---
 
@@ -157,6 +158,7 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Status:** Fail
 - **Severity:** Critical / High / Medium / Low
 - **Equivalent Rule:** Checkov CKV_XXX_NN / tfsec xxx-xxx / KICS xxxxxxxx
+- **Rule Source:** <current scanner documentation or policy guide URL, plus tool version/framework if available>
 - **File:** <path>
 - **Line(s):** <line numbers>
 - **Description:** <what was found>
@@ -219,6 +221,9 @@ This skill applies checks equivalent to the following high-impact rules:
 | KICS | 3406e4d3 | S3 public ACL |
 | KICS | 5b4f3042 | Unrestricted security group |
 
+**Checkov source freshness:** Do not cite the deprecated `https://www.checkov.io/5.Policy%20Index/` path as proof for a Checkov rule. Use current Checkov documentation for scanner behavior, the Checkov custom-policy docs for organization-specific checks, and the policy `Guide:` URL emitted in current Checkov output when a finding provides one. Many current Checkov guide links resolve to Prisma Cloud Application Security Policy Reference pages, which list the policy name, Checkov ID, framework, and severity. If no current guide URL is available, record the Checkov version, framework, rule ID, and that the policy source could not be verified.
+
+
 ---
 
 ## Common Pitfalls
@@ -230,6 +235,7 @@ This skill applies checks equivalent to the following high-impact rules:
 5. **Confusing `aws_s3_bucket_acl` with `aws_s3_bucket_public_access_block`.** The public access block overrides ACLs. Check both, but the access block is the stronger control.
 6. **Terraform state file secrets.** Even when variables are marked `sensitive`, they may appear in plaintext in the state file. Verify state encryption and access controls.
 7. **Provider-specific encryption defaults.** Some providers encrypt by default (e.g., AWS S3 since January 2023). Know the defaults before flagging missing explicit encryption configuration.
+8. **Stale scanner-policy references.** Checkov rule IDs and policy guide URLs move over time. Treat stale policy-index links as evidence-quality gaps, and prefer current scanner output, Checkov docs, or Prisma Cloud policy-reference pages before claiming a finding maps to a specific CKV rule.
 
 ---
 
@@ -254,7 +260,10 @@ This skill applies checks equivalent to the following high-impact rules:
 - OWASP Infrastructure as Code Security Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Infrastructure_as_Code_Security_Cheat_Sheet.html
 - SLSA v1.0 Specification: https://slsa.dev/spec/v1.0/
 - CIS Benchmarks: https://www.cisecurity.org/cis-benchmarks
-- Checkov Policy Index: https://www.checkov.io/5.Policy%20Index/
+- Checkov Documentation: https://www.checkov.io/
+- Checkov Custom Policies Overview: https://www.checkov.io/3.Custom%20Policies/Custom%20Policies%20Overview.html
+- Prisma Cloud Application Security Policy Reference (AWS General Policies): https://docs.prismacloud.io/en/enterprise-edition/policy-reference/aws-policies/aws-general-policies/aws-general-policies
+- Prisma Cloud Application Security Policy Reference (Kubernetes Policy Index): https://docs.prismacloud.io/en/enterprise-edition/policy-reference/kubernetes-policies/kubernetes-policy-index/kubernetes-policy-index
 - tfsec Documentation: https://aquasecurity.github.io/tfsec/
 - KICS (Keeping Infrastructure as Code Secure): https://docs.kics.io/
 - cfn-nag Rules: https://github.com/stelligent/cfn_nag

--- a/skills/cloud/iac-security/tests/benign/current-checkov-policy-source-evidence.md
+++ b/skills/cloud/iac-security/tests/benign/current-checkov-policy-source-evidence.md
@@ -1,0 +1,22 @@
+# Benign Fixture: Current Checkov Policy Source Evidence
+
+## Scenario
+
+An IaC review maps a Kubernetes finding to Checkov and records:
+
+```yaml
+tool: Checkov
+version: 3.2.x
+framework: kubernetes
+rule_id: CKV_K8S_23
+rule_title: Admission of root containers not minimized
+guide_url: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/kubernetes-policies/kubernetes-policy-index/bc-k8s-22
+source_status: current
+custom_policy: false
+```
+
+The review uses current Checkov documentation for scanner behavior and the Prisma Cloud policy-reference guide URL emitted by the Checkov finding for policy details.
+
+## Expected Result
+
+Do not flag this as stale. The review records the scanner version, framework, rule ID, current policy source, and custom-policy status instead of relying on the deprecated Checkov policy-index path.

--- a/skills/cloud/iac-security/tests/vulnerable/stale-checkov-policy-index-reference.md
+++ b/skills/cloud/iac-security/tests/vulnerable/stale-checkov-policy-index-reference.md
@@ -1,0 +1,15 @@
+# Vulnerable Fixture: Stale Checkov Policy Index Reference
+
+## Scenario
+
+An IaC review cites this source as the proof for every Checkov rule mapping:
+
+```markdown
+Checkov Policy Index: https://www.checkov.io/5.Policy%20Index/
+```
+
+The review maps findings to `CKV_AWS_17`, `CKV_AWS_19`, `CKV_AWS_24`, and `CKV_TF_1`, but it does not record the Checkov version, framework/runner, current scanner `Guide:` URL, Prisma Cloud policy-reference source, or whether the rule came from a custom policy.
+
+## Expected Finding
+
+Flag this as stale and under-evidenced. The old Checkov policy-index path should not be used as the sole proof for Checkov rule mappings. The review should capture the scanner version, framework, rule ID/title, current guide URL when available, and whether the rule source is built-in, custom, stale, unavailable, or inferred.

--- a/skills/cloud/iac-security/tool-rules.md
+++ b/skills/cloud/iac-security/tool-rules.md
@@ -4,6 +4,25 @@ This file contains the detailed tool-specific rule sets, detection patterns, and
 
 ---
 
+## Scanner Rule Source Evidence
+
+When mapping a finding to a Checkov, tfsec, KICS, or cfn-nag rule, record the source that proves the rule mapping. For Checkov findings, prefer current scanner output and the policy `Guide:` URL emitted with the finding. Current Checkov examples show per-finding guide links that point to Prisma Cloud policy-reference pages rather than the deprecated umbrella `https://www.checkov.io/5.Policy%20Index/` path.
+
+Capture the following for each scanner-backed rule mapping:
+
+| Field | Why It Matters |
+|---|---|
+| Tool and version | Rule behavior and IDs can change across scanner releases |
+| Framework/runner | Checkov rule scope differs across Terraform, Terraform plan, CloudFormation, Kubernetes, Helm, Dockerfile, ARM, Bicep, and other runners |
+| Rule ID and title | Distinguishes CKV, CKV2, BC, tfsec, KICS, and custom policy identifiers |
+| Policy guide URL | Shows the current policy source, severity, supported framework, and remediation context |
+| Custom/external policy source | Separates built-in checks from organization-specific Python/YAML policies |
+| Verification status | Marks whether the guide URL is current, stale, unavailable, or only inferred from local scanner output |
+
+Do not treat scanner suppressions such as `checkov:skip`, `tfsec:ignore`, `nosec`, or `skipcq` as proof that a finding is safe. Report them as suppression evidence and verify whether the mapped rule still applies.
+
+---
+
 ## Hardcoded Secrets Detection
 
 Scan for credentials, tokens, and keys embedded directly in IaC files. This is the highest-priority check because hardcoded secrets in version control are immediately exploitable.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `iac-security`
**Skill path:** `skills/cloud/iac-security/`

### What Was Wrong

The skill cited a stale Checkov policy-index path as the reference for Checkov rule mappings:

```markdown
https://www.checkov.io/5.Policy%20Index/
```

The current Checkov docs and examples point reviewers toward current scanner behavior docs, custom-policy docs, and per-finding `Guide:` URLs. Many current Checkov guide URLs resolve to Prisma Cloud policy-reference pages that list policy name, Checkov ID, framework, and severity. Without source/version fields, the skill could cite CKV mappings without enough evidence to prove the current rule source, scanner version, runner, or custom-policy status.

### What This PR Fixes

- Replaces the stale Checkov Policy Index reference with current Checkov documentation and Prisma Cloud policy-reference examples.
- Adds a `Rule Source` field to detailed findings so equivalent scanner rules carry source/version evidence.
- Adds scanner-output context prerequisites for tool/version, framework, rule ID, resource, file/line, and guide URL.
- Adds a `Scanner Rule Source Evidence` section to `tool-rules.md`.
- Clarifies that scanner suppressions such as `checkov:skip`, `tfsec:ignore`, `nosec`, or `skipcq` are suppression evidence, not proof that a finding is safe.
- Adds focused fixtures for stale policy-index-only proof versus current Checkov/Prisma policy-source evidence.

### Evidence

**Before (stale and under-evidenced):**
```markdown
Checkov Policy Index: https://www.checkov.io/5.Policy%20Index/
```

**After (current and evidence-bearing):**
```yaml
tool: Checkov
version: 3.2.x
framework: kubernetes
rule_id: CKV_K8S_23
guide_url: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/kubernetes-policies/kubernetes-policy-index/bc-k8s-22
source_status: current
custom_policy: false
```

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass

Added fixtures:

- `tests/vulnerable/stale-checkov-policy-index-reference.md`
- `tests/benign/current-checkov-policy-source-evidence.md`

Validation run locally:

```text
git diff --check: pass
frontmatter required-field check: pass
index file-existence validation: pass
prompt-injection pattern scan: pass
```

### Bounty Tier
- [x] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [ ] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** To be provided privately after acceptance, consistent with CONTRIBUTING.md stating payment method is confirmed when the first contribution is accepted.

## Pull Request Checklist

- [x] Skill follows the format specification in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] At least one real framework is cited with correct control IDs
- [x] All framework references verified against primary sources (not blogs or AI output)
- [x] Prompt Injection Safety Notice section included
- [x] `injection-hardened: true` set in frontmatter
- [x] `allowed-tools` scoped to minimum necessary permissions
- [x] Tested with at least one AI coding agent (which one: Codex)
- [x] No prohibited patterns per [SECURITY.md](../SECURITY.md)
- [x] `index.yaml` updated with new skill entry (if adding a skill; not applicable for existing skill improvement)

## What This PR Does

Improves `iac-security` by refreshing stale Checkov policy-source evidence and requiring current scanner/source details when mapping findings to Checkov, tfsec, KICS, or cfn-nag equivalents.

## Framework References

- OWASP Infrastructure as Code Security Cheat Sheet
- SLSA v1.0
- CIS Benchmarks
- Checkov documentation and custom-policy documentation
- Prisma Cloud Application Security Policy Reference

## Testing

Tested locally with the repo's workflow logic: frontmatter field validation, index file-existence validation, prompt-injection scan, and `git diff --check`.

Closes #527
