### PR TITLE
Improve DNS CISA PDNS source scope

### DIFF
--- a/skills/network/dns-security/SKILL.md
+++ b/skills/network/dns-security/SKILL.md
@@ -232,6 +232,9 @@ If a cloud-based protective DNS service is used (Cisco Umbrella, Cloudflare Gate
 - Domain categorization covers: malware C2, phishing, newly registered domains (NRDs < 30 days), DGA-generated domains.
 - Block pages or NXDOMAIN responses are returned for blocked categories.
 - Logs are forwarded to SIEM.
+- Service eligibility, authority, and operational scope are documented. For CISA Protective DNS, record whether the organization is an FCEB agency or limited critical-infrastructure pilot participant, since the service page does not describe it as generally available to all organizations.
+- Deployment architecture is documented. CISA describes Protective DNS as implemented upstream from agency networks, complementing internal DNS architecture, and covering mobile, roaming, and cloud assets that send traffic directly to Protective DNS.
+- Response behavior and alerting are tested. When Protective DNS matches a request to a threat intelligence indicator, document whether the service blocks, redirects, or sinkholes the response and whether alerts/logs are sent to the origin agency and CISA.
 
 **Finding classification:** No DNS filtering/RPZ deployed is **High**. RPZ feeds not automatically updated is **Medium**. DNS resolution paths that bypass protective DNS is **High**.
 
@@ -328,6 +331,12 @@ abcdef0123456789.dnscat.example.com TXT
 |----------|-------------------|--------------------|--------------|--------------|
 | ns1      | Enabled/Disabled  | DoT/DoH/Plaintext  | Yes/No       | Yes/No       |
 
+### Protective DNS Service Evidence (if applicable)
+
+| Service | Eligibility / Scope | Routing Coverage | Block / Redirect / Sinkhole Tested | Alerts and Logs | Notes |
+|---------|---------------------|------------------|------------------------------------|----------------|-------|
+| CISA Protective DNS / Umbrella / Gateway / Quad9 / Other | <FCEB / CI pilot / commercial / internal> | <on-prem / roaming / cloud / mobile> | <Yes/No> | <SIEM / provider portal / email / API> | <bypass paths, policy gaps, source URL> |
+
 ### Findings
 
 #### [F-001] <Finding Title>
@@ -384,6 +393,8 @@ abcdef0123456789.dnscat.example.com TXT
 
 4. **Ignoring DNS over TCP.** DNS is not UDP-only. DNS over TCP (port 53) supports large responses and is required for zone transfers. Some tunneling tools prefer TCP for reliability. Firewall rules and monitoring must cover both UDP and TCP port 53.
 
+5. **Treating CISA Protective DNS as a generic commercial resolver.** The current CISA service page describes Protective DNS Resolver as a service for FCEB agencies and limited critical-infrastructure pilot participants. For other organizations, cite general NSA/CISA PDNS selection guidance or the organization's commercial/internal provider instead of implying CISA onboarding is broadly available.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -407,7 +418,8 @@ This skill processes DNS configuration files that may contain user-supplied zone
 - RFC 8484 -- DNS over HTTPS: https://datatracker.ietf.org/doc/html/rfc8484
 - RFC 7719 -- DNS Terminology: https://datatracker.ietf.org/doc/html/rfc7719
 - ISC Response Policy Zones (RPZ): https://www.isc.org/rpz/
-- CISA Protective DNS: https://www.cisa.gov/protective-dns
+- CISA Protective Domain Name System (DNS) Resolver: https://www.cisa.gov/resources-tools/services/protective-domain-name-system-dns-resolver
+- NSA/CISA Guidance on Strengthening Cyber Defense Through Protective DNS: https://www.cisa.gov/news-events/alerts/2021/03/04/joint-nsa-and-cisa-guidance-strengthening-cyber-defense-through-protective-dns
 
 ---
 

--- a/skills/network/dns-security/tests/benign/current-cisa-pdns-scope-evidence.md
+++ b/skills/network/dns-security/tests/benign/current-cisa-pdns-scope-evidence.md
@@ -1,0 +1,27 @@
+# Benign Fixture: Current CISA PDNS Scope Evidence
+
+## Scenario
+
+A DNS security review cites the current CISA service page:
+
+```markdown
+CISA Protective Domain Name System (DNS) Resolver -- https://www.cisa.gov/resources-tools/services/protective-domain-name-system-dns-resolver
+```
+
+The review records:
+
+```yaml
+service_scope: FCEB agency or limited critical-infrastructure pilot participant
+deployment_model: upstream from agency networks, complementing internal DNS architecture
+routing_coverage:
+  - on-premises recursive resolvers
+  - mobile assets
+  - roaming assets
+  - cloud assets
+provider_response: block, redirect, or sinkhole matched threat-intelligence indicators
+alerts_and_logs: origin agency and CISA receive alerts/logs; SIEM forwarding verified
+```
+
+## Expected Result
+
+Do not flag this as stale or overbroad. The review uses the current CISA source and keeps CISA PDNS availability, deployment model, traffic routing, response behavior, and alert/log evidence scoped to what the service page describes.

--- a/skills/network/dns-security/tests/vulnerable/stale-cisa-protective-dns-reference.md
+++ b/skills/network/dns-security/tests/vulnerable/stale-cisa-protective-dns-reference.md
@@ -1,0 +1,15 @@
+# Vulnerable Fixture: Stale CISA Protective DNS Reference
+
+## Scenario
+
+A DNS security review cites:
+
+```markdown
+CISA Protective DNS: https://www.cisa.gov/protective-dns
+```
+
+It recommends CISA Protective DNS as a generic protective resolver for any organization, but it does not verify service eligibility, routing coverage, upstream/internal-DNS architecture, block/redirect/sinkhole behavior, alert delivery, or SIEM/log forwarding.
+
+## Expected Finding
+
+Flag this as stale and overbroad. The current CISA service page uses the Protective Domain Name System Resolver page and describes service availability for FCEB agencies plus limited critical-infrastructure pilot participants. The review should record eligibility/scope, DNS routing coverage, provider response behavior, alert/log delivery, and the current source URL.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `dns-security`
**Skill path:** `skills/network/dns-security/`

### What Was Wrong

The skill referenced a stale short CISA Protective DNS URL:

```markdown
https://www.cisa.gov/protective-dns
```

The current official source is the CISA Protective Domain Name System (DNS) Resolver service page. The current page is also more specific than a generic protective resolver reference: it describes service availability for FCEB agencies and limited critical-infrastructure pilot participants, upstream deployment that complements internal DNS, coverage for mobile/roaming/cloud assets, and block/redirect/sinkhole behavior with alerts/logs.

### What This PR Fixes

- Replaces the stale CISA Protective DNS reference with the current CISA Protective DNS Resolver service page.
- Adds NSA/CISA general PDNS guidance as a broader reference when CISA service onboarding is not applicable.
- Adds CISA PDNS eligibility, authority, and operational-scope checks.
- Adds routing coverage checks for on-premises recursive resolvers, mobile, roaming, and cloud assets.
- Adds response-behavior and alert/log evidence for block, redirect, sinkhole, origin-agency alerting, CISA alerting, and SIEM forwarding.
- Adds a Protective DNS Service Evidence table to the output format.
- Adds fixtures for stale/generic CISA PDNS claims versus current source-scoped CISA PDNS evidence.

### Evidence

**Before (stale and overbroad):**
```markdown
CISA Protective DNS: https://www.cisa.gov/protective-dns
```

**After (current and source-scoped):**
```markdown
CISA Protective Domain Name System (DNS) Resolver -- https://www.cisa.gov/resources-tools/services/protective-domain-name-system-dns-resolver
```

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass

Added fixtures:

- `tests/vulnerable/stale-cisa-protective-dns-reference.md`
- `tests/benign/current-cisa-pdns-scope-evidence.md`

Validation run locally:

```text
git diff --check: pass
frontmatter required-field check: pass
index file-existence validation: pass
prompt-injection pattern scan: pass
```

### Bounty Tier
- [x] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [ ] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** To be provided privately after acceptance, consistent with CONTRIBUTING.md stating payment method is confirmed when the first contribution is accepted.

## Pull Request Checklist

- [x] Skill follows the format specification in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] At least one real framework is cited with correct control IDs
- [x] All framework references verified against primary sources (not blogs or AI output)
- [x] Prompt Injection Safety Notice section included
- [x] `injection-hardened: true` set in frontmatter
- [x] `allowed-tools` scoped to minimum necessary permissions
- [x] Tested with at least one AI coding agent (which one: Codex)
- [x] No prohibited patterns per [SECURITY.md](../SECURITY.md)
- [x] `index.yaml` updated with new skill entry (if adding a skill; not applicable for existing skill improvement)

## What This PR Does

Improves `dns-security` by refreshing stale CISA Protective DNS source evidence and adding source-scoped service eligibility, routing, response-behavior, alerting, and log evidence.

## Framework References

- NIST SP 800-81 Rev. 2
- CIS Controls v8 Control 9.2
- CISA Protective DNS Resolver service page
- NSA/CISA Protective DNS guidance

## Testing

Tested locally with the repo's workflow logic: frontmatter field validation, index file-existence validation, prompt-injection scan, and `git diff --check`.

Closes #529
