### PR TITLE
Improve OWASP auth session evidence

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -47,7 +47,7 @@ skills:
     role: [appsec-engineer, security-engineer]
     phase: [build, review]
     activity: [review, test]
-    frameworks: [OWASP-Top-10-2021]
+    frameworks: [OWASP-Top-10-2021, OWASP-ASVS-5.0, NIST-SP-800-63B-4]
     difficulty: intermediate
     time_estimate: "30-60min"
     file: skills/appsec/owasp-top-10-web/SKILL.md

--- a/skills/appsec/owasp-top-10-web/SKILL.md
+++ b/skills/appsec/owasp-top-10-web/SKILL.md
@@ -440,7 +440,7 @@ angular\.js|jquery\s*["\'].*1\.|lodash.*3\.|moment\(\)|request\(  # (npm 'reques
 # Session management
 session\.id|sessionId|JSESSIONID|connect\.sid|session_token
 # Weak password policy
-minLength.*([0-9]|1[0-4])|passwordMinLength|min_password_length|RequiredLength\s*=\s*([0-9]|1[0-4])\b
+\b(minLength|passwordMinLength|min_password_length)\b\s*[:=]\s*([0-9]|1[0-4])\b|RequiredLength\s*=\s*([0-9]|1[0-4])\b
 # Legacy composition or usability-hostile password policy
 requireUppercase|requireLowercase|requireDigit|requireSymbol|RequireUppercase|RequireDigit|RequireNonAlphanumeric|disallowSpaces|disallowUnicode|onpaste.*preventDefault|onpaste.*return\s+false
 # Password transformation before verification

--- a/skills/appsec/owasp-top-10-web/SKILL.md
+++ b/skills/appsec/owasp-top-10-web/SKILL.md
@@ -9,10 +9,10 @@ description: >
 tags: [appsec, web, owasp]
 role: [appsec-engineer, security-engineer]
 phase: [build, review]
-frameworks: [OWASP-Top-10-2021]
+frameworks: [OWASP-Top-10-2021, OWASP-ASVS-5.0, NIST-SP-800-63B-4]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.1"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -399,10 +399,17 @@ angular\.js|jquery\s*["\'].*1\.|lodash.*3\.|moment\(\)|request\(  # (npm 'reques
 **What to Look For:**
 
 - No protection against credential stuffing or brute-force attacks (missing rate limiting on login).
-- Weak password policies (no minimum length, no complexity requirements, no check against breached password lists).
+- Weak or stale password policy evidence:
+  - no assurance context recorded for whether passwords are single-factor or paired with MFA;
+  - single-factor password minimum below 15 characters, or MFA-only password minimum below 8 characters;
+  - no blocklist or breached-password check;
+  - legacy composition rules treated as stronger than length, blocklist, rate limiting, and MFA evidence;
+  - paste/password-manager blocking, space/Unicode rejection, or too-low maximum length;
+  - password verification that truncates, lowercases, strips, normalizes, or otherwise transforms the submitted secret before hashing/verifying.
 - Credentials transmitted over unencrypted connections.
 - Session tokens in URLs (logged in proxies, referer headers, browser history).
 - Session IDs that do not rotate after successful authentication.
+- Session evidence that lacks ASVS 5.0 context: backend token verification, reference-token entropy, regeneration on authentication and re-authentication, inactivity timeout, absolute lifetime, concurrent-session policy, and federated/SSO session coordination.
 - Missing multi-factor authentication on privileged accounts.
 - "Remember me" tokens that never expire or use predictable values.
 - Password recovery that uses knowledge-based questions or sends passwords in plaintext.
@@ -433,11 +440,17 @@ angular\.js|jquery\s*["\'].*1\.|lodash.*3\.|moment\(\)|request\(  # (npm 'reques
 # Session management
 session\.id|sessionId|JSESSIONID|connect\.sid|session_token
 # Weak password policy
-minLength.*[0-5]|passwordMinLength|min_password_length
+minLength.*([0-9]|1[0-4])|passwordMinLength|min_password_length|RequiredLength\s*=\s*([0-9]|1[0-4])\b
+# Legacy composition or usability-hostile password policy
+requireUppercase|requireLowercase|requireDigit|requireSymbol|RequireUppercase|RequireDigit|RequireNonAlphanumeric|disallowSpaces|disallowUnicode|onpaste.*preventDefault|onpaste.*return\s+false
+# Password transformation before verification
+password.*(toLowerCase|lower\(|trim\(|strip\(|substring\(|slice\(|substr\()|candidate.*(toLowerCase|lower\(|trim\(|strip\(|substring\(|slice\(|substr\()
 # Session in URL
 session.*=.*req\.query|token.*=.*req\.query|url.*session
 # Missing session rotation
 regenerate|rotateSession|session\.create|session_regenerate_id
+# Session evidence gaps
+token_entropy|inactivity_timeout|absolute_lifetime|maxAge|idleTimeout|reauth|federated|sso
 # Certificate validation bypass
 rejectUnauthorized\s*:\s*false|verify\s*=\s*False|CERT_NONE|InsecureRequestWarning.*disable
 ```
@@ -445,11 +458,15 @@ rejectUnauthorized\s*:\s*false|verify\s*=\s*False|CERT_NONE|InsecureRequestWarni
 **Mitigations:**
 
 - Implement rate limiting and account lockout on authentication endpoints.
-- Enforce minimum password length of 12 characters (NIST 800-63B requires at least 8; OWASP ASVS V2.1.1 recommends at least 12); verifiers SHOULD permit at least 64; check passwords against breached-password databases (e.g., HaveIBeenPwned API).
+- Record password assurance context before grading length: single-factor passwords should be at least 15 characters, while passwords used only as part of MFA can be shorter but should still be at least 8 characters.
+- Do not require arbitrary uppercase/lowercase/digit/symbol composition rules. Prefer length, blocklists, breached-password checks, rate limiting, phishing-resistant MFA, and exact verifier evidence.
+- Permit paste and password managers; allow spaces and Unicode where the platform can verify them exactly; support at least 64-character maximum passwords and avoid silently truncating or case-transforming submitted passwords before hashing.
+- Check passwords against breached-password and organization-specific blocklists without logging the submitted secret.
 - Regenerate session IDs after login, privilege escalation, and re-authentication.
 - Set session cookies with `Secure`, `HttpOnly`, and `SameSite=Lax` (or `Strict`) attributes.
 - Implement multi-factor authentication for all users, mandatory for administrative accounts.
-- Set absolute and idle session timeouts appropriate to the application's risk profile.
+- Set absolute and idle session timeouts appropriate to the application's risk profile, document concurrent-session behavior, and coordinate local session lifetime with federated SSO/IdP session controls.
+- Verify reference session tokens with a trusted backend service, generate them with CSPRNG entropy, and require at least 128 bits of entropy for reference tokens.
 - Never expose session tokens in URLs.
 
 ---
@@ -628,6 +645,35 @@ Present findings in this structure:
 
 ### Findings
 
+### A07 Authentication and Session Evidence
+
+Use these tables whenever authentication or session management is in scope, even if no A07 finding is reported.
+
+**Password Policy Evidence**
+
+| Control | Evidence | Status |
+|---------|----------|--------|
+| Assurance context | single-factor / MFA factor / federated / unknown | Pass / Fail / Not Evaluable |
+| Minimum length | configured minimum plus MFA context | Pass / Fail / Not Evaluable |
+| Maximum length | accepted maximum and truncation behavior | Pass / Fail / Not Evaluable |
+| Composition rules | none / present / blocks spaces or Unicode | Pass / Fail / Not Evaluable |
+| Blocklist / breached check | source, timing, and failure handling | Pass / Fail / Not Evaluable |
+| Paste / password-manager support | UI and server behavior | Pass / Fail / Not Evaluable |
+| Exact verification | no lowercase/strip/truncate/normalize before hashing | Pass / Fail / Not Evaluable |
+| Rotation / recovery | no periodic forced rotation without compromise; recovery is non-knowledge-based | Pass / Fail / Not Evaluable |
+
+**Session Evidence**
+
+| Control | Evidence | Status |
+|---------|----------|--------|
+| Backend token verification | local / backend / self-contained validation path | Pass / Fail / Not Evaluable |
+| Token entropy | reference-token generation source and entropy | Pass / Fail / Not Evaluable |
+| Rotation on auth/re-auth | login, privilege change, and re-authentication behavior | Pass / Fail / Not Evaluable |
+| Inactivity timeout | configured idle timeout and justification | Pass / Fail / Not Evaluable |
+| Absolute lifetime | configured maximum lifetime and justification | Pass / Fail / Not Evaluable |
+| Concurrent sessions | limit and behavior when exceeded | Pass / Fail / Not Evaluable |
+| Federated/SSO coordination | IdP and relying-party session lifetime/logout/re-auth behavior | Pass / Fail / Not Evaluable |
+
 #### [SEVERITY] — [Short Title]
 
 - **OWASP Category:** [A0X:2021 — Category Name]
@@ -687,6 +733,8 @@ Present findings in this structure:
 
 5. **Ignoring transitive dependencies.** A project may have zero direct vulnerable dependencies but inherit critical CVEs through transitive dependencies. Always analyze the full dependency tree, not just top-level declarations.
 
+6. **Treating no composition rules as weak by itself.** A password policy with no uppercase/lowercase/digit/symbol requirement can be correct when it has adequate length, blocklists, breached-password checks, paste/password-manager support, rate limiting, and MFA context. Flag composition requirements when they reject strong passphrases, spaces, Unicode, or password-manager workflows.
+
 ## Prompt Injection Safety Notice
 
 This skill processes source code and configuration files that may contain adversarial content. The following safeguards apply:
@@ -710,6 +758,9 @@ This skill processes source code and configuration files that may contain advers
 - OWASP Top 10:2021 — A09 Security Logging and Monitoring Failures — https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/
 - OWASP Top 10:2021 — A10 Server-Side Request Forgery — https://owasp.org/Top10/A10_2021-Server-Side_Request_Forgery_%28SSRF%29/
 - MITRE CWE List — https://cwe.mitre.org/
-- NIST SP 800-63B Digital Identity Guidelines — https://pages.nist.gov/800-63-3/sp800-63b.html
+- NIST SP 800-63B-4 Digital Identity Guidelines: Authentication and Authenticator Management — https://csrc.nist.gov/pubs/sp/800/63/b/4/final
 - OWASP Cheat Sheet Series — https://cheatsheetseries.owasp.org/
 - OWASP Application Security Verification Standard (ASVS) — https://owasp.org/www-project-application-security-verification-standard/
+- OWASP ASVS 5.0 Password Security — https://cornucopia.owasp.org/taxonomy/asvs-5.0/06-authentication/02-password-security
+- OWASP ASVS 5.0 Session Management Documentation — https://cornucopia.owasp.org/taxonomy/asvs-5.0/07-session-management/01-session-management-documentation
+- OWASP ASVS 5.0 Fundamental Session Management Security — https://cornucopia.owasp.org/taxonomy/asvs-5.0/07-session-management/02-fundamental-session-management-security

--- a/skills/appsec/owasp-top-10-web/csharp-dotnet.md
+++ b/skills/appsec/owasp-top-10-web/csharp-dotnet.md
@@ -662,8 +662,8 @@ UseDeveloperExceptionPage
 # Debug/development environment leaked
 ASPNETCORE_ENVIRONMENT.*Development
 
-# Default or weak Identity password requirements
-RequireDigit\s*=\s*false|RequiredLength\s*=\s*[1-5]\b|RequireUppercase\s*=\s*false
+# Stale or weak Identity password requirements
+RequiredLength\s*=\s*([0-9]|1[0-4])\b|RequireUppercase\s*=\s*true|RequireDigit\s*=\s*true|RequireNonAlphanumeric\s*=\s*true|RequiredUniqueChars\s*=\s*[2-9]\b
 
 # Missing security headers
 # (absence check — grep for these to confirm they exist)
@@ -700,31 +700,54 @@ else
 }
 ```
 
-**2. Default Identity password policy too weak**
+**2. Stale Identity password policy**
 
 ```csharp
-// VULNERABLE — trivially brute-forceable passwords accepted
+// VULNERABLE — short minimum plus legacy composition rules can reject strong passphrases
 builder.Services.Configure<IdentityOptions>(options =>
 {
-    options.Password.RequiredLength = 4;
-    options.Password.RequireDigit = false;
-    options.Password.RequireUppercase = false;
-    options.Password.RequireLowercase = false;
-    options.Password.RequireNonAlphanumeric = false;
-});
-```
-
-```csharp
-// SECURE — strong password policy
-builder.Services.Configure<IdentityOptions>(options =>
-{
-    options.Password.RequiredLength = 12;
+    options.Password.RequiredLength = 8;
     options.Password.RequireDigit = true;
     options.Password.RequireUppercase = true;
     options.Password.RequireLowercase = true;
     options.Password.RequireNonAlphanumeric = true;
     options.Password.RequiredUniqueChars = 4;
 });
+```
+
+```csharp
+// SECURE — length-first policy; add breached-password/blocklist checks in a custom validator
+builder.Services.Configure<IdentityOptions>(options =>
+{
+    options.Password.RequiredLength = 15;
+    options.Password.RequireDigit = false;
+    options.Password.RequireUppercase = false;
+    options.Password.RequireLowercase = false;
+    options.Password.RequireNonAlphanumeric = false;
+    options.Password.RequiredUniqueChars = 1;
+});
+```
+
+```csharp
+// SECURE — example custom validator hook for blocklist and exact submitted password checks
+builder.Services.AddScoped<IPasswordValidator<ApplicationUser>, BlocklistPasswordValidator>();
+
+public sealed class BlocklistPasswordValidator : IPasswordValidator<ApplicationUser>
+{
+    public Task<IdentityResult> ValidateAsync(
+        UserManager<ApplicationUser> manager,
+        ApplicationUser user,
+        string? password)
+    {
+        if (password is null || KnownBadPasswordList.Contains(password, StringComparer.OrdinalIgnoreCase))
+        {
+            return Task.FromResult(IdentityResult.Failed(
+                new IdentityError { Code = "BlockedPassword", Description = "Choose a different password." }));
+        }
+
+        return Task.FromResult(IdentityResult.Success);
+    }
+}
 ```
 
 **3. Missing security headers**

--- a/skills/appsec/owasp-top-10-web/tests/auth-session-evidence.md
+++ b/skills/appsec/owasp-top-10-web/tests/auth-session-evidence.md
@@ -1,0 +1,141 @@
+# Authentication and Session Evidence Fixtures
+
+These fixtures calibrate `owasp-top-10-web` A07 checks against NIST SP 800-63B-4 and OWASP ASVS 5.0 password/session evidence.
+
+## Vulnerable Fixture 1: Single-Factor Password Uses Legacy Baseline
+
+```ts
+const passwordPolicy = {
+  minLength: 12,
+  mfaRequired: false,
+  breachedPasswordCheck: true,
+  requireUppercase: false,
+  requireDigit: false,
+  requireSymbol: false,
+  allowPaste: true
+};
+```
+
+Expected result:
+
+- Report A07 as `Fail` because this is a single-factor password context with a stale minimum length.
+- Record the assurance context instead of treating `minLength: 12` as acceptable by itself.
+- Do not add a composition-rule finding because the absence of composition rules is not the problem.
+
+## Vulnerable Fixture 2: Composition Rules Reject Strong Passphrases
+
+```ts
+const passwordPolicy = {
+  minLength: 12,
+  requireUppercase: true,
+  requireDigit: true,
+  requireSymbol: true,
+  disallowSpaces: true,
+  disallowUnicode: true,
+  blockPasswordManagers: true
+};
+
+passwordInput.addEventListener("paste", event => event.preventDefault());
+```
+
+Expected result:
+
+- Report legacy composition and usability-hostile password policy evidence.
+- Flag space/Unicode rejection and paste/password-manager blocking.
+- Recommend length, blocklist, rate limiting, and MFA evidence instead of arbitrary composition rules.
+
+## Vulnerable Fixture 3: Password Transformed Before Verification
+
+```python
+def verify_password(submitted: str, stored_hash: str) -> bool:
+    normalized = submitted.strip().lower()[:32]
+    return argon2.verify(stored_hash, normalized)
+```
+
+Expected result:
+
+- Report exact-verification failure because the submitted password is stripped, lowercased, and truncated before verification.
+- Record maximum-length and transformation evidence.
+- Do not recommend normalization that would surprise users or weaken the verifier.
+
+## Vulnerable Fixture 4: Session Evidence Too Generic
+
+```yaml
+session:
+  token_entropy_bits: unknown
+  backend_verification: unknown
+  rotates_on_login: true
+  rotates_on_reauth: unknown
+  inactivity_timeout: undocumented
+  absolute_lifetime: undocumented
+  concurrent_session_policy: undocumented
+  sso_session_coordination: unknown
+```
+
+Expected result:
+
+- Report `Not Evaluable` or `Fail` for missing ASVS 5.0 session evidence.
+- Require backend token verification, reference-token entropy, rotation on authentication and re-authentication, idle/absolute lifetime, concurrent-session policy, and SSO coordination.
+
+## Benign Fixture 1: Modern Password Policy Without Composition Rules
+
+```ts
+const passwordPolicy = {
+  minLength: 15,
+  maxLength: 128,
+  mfaRequired: false,
+  requireUppercase: false,
+  requireLowercase: false,
+  requireDigit: false,
+  requireSymbol: false,
+  allowPaste: true,
+  allowSpaces: true,
+  allowUnicode: true,
+  blocklist: ["password", "qwerty123456789", "companyname2026"],
+  breachedPasswordCheck: true
+};
+```
+
+Expected result:
+
+- Do not report absence of composition rules as weak.
+- Mark password evidence as acceptable when length, blocklist, paste/password-manager support, and exact verification are documented.
+
+## Benign Fixture 2: MFA Context Explains Shorter Password Minimum
+
+```yaml
+password:
+  min_length: 8
+  use_context: "one factor in phishing-resistant MFA"
+  blocklist: "HIBP k-anonymity plus tenant-specific terms"
+  composition_rules: "none"
+  paste_password_manager_support: true
+mfa:
+  required: true
+  method: "FIDO2/WebAuthn platform authenticator"
+```
+
+Expected result:
+
+- Do not apply the single-factor password minimum without considering MFA context.
+- Record the assurance context and MFA evidence in the A07 table.
+
+## Benign Fixture 3: ASVS 5.0 Session Evidence Present
+
+```yaml
+session:
+  backend_verification: "server-side session lookup"
+  reference_token_entropy_bits: 192
+  generated_by: "CSPRNG"
+  rotates_on_login: true
+  rotates_on_reauth: true
+  inactivity_timeout: "30 minutes, risk accepted"
+  absolute_lifetime: "12 hours"
+  concurrent_session_policy: "maximum 3 active sessions; oldest session terminated"
+  sso_session_coordination: "local logout calls IdP logout and clears relying-party session"
+```
+
+Expected result:
+
+- Mark session evidence as `Pass` for backend verification, entropy, rotation, idle/absolute lifetime, concurrent-session policy, and SSO coordination.
+- Do not create a broad A07 session finding when all table fields are documented and implemented.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `owasp-top-10-web`
**Skill path:** `skills/appsec/owasp-top-10-web/`

Addresses #526.

### What Was Wrong
The A07 guidance still used older password-policy wording around a 12-character recommendation and could treat absence of composition rules as weak. It also did not force reviewers to record whether a password is used as a single factor, as one MFA factor, or in a federated flow before grading password length and verifier behavior.

The session-management output was also too broad for ASVS 5.0 evidence. It mentioned session rotation and URL tokens, but did not require backend verification, reference-token entropy, idle/absolute lifetime documentation, concurrent-session policy, re-authentication rotation, or SSO/federated-session coordination.

### What This PR Fixes
- Updates `owasp-top-10-web` frontmatter and index metadata to include OWASP ASVS 5.0 and NIST SP 800-63B-4.
- Updates A07 password checks for assurance context, single-factor 15-character minimum, MFA-context 8-character minimum, at least 64-character maximum support, blocklist/breached-password evidence, paste/password-manager support, and exact verification without truncation/case transformation.
- Reframes composition rules as a potential false-positive or usability-hostile signal rather than a default strength requirement.
- Adds A07 password-policy and session-evidence output tables.
- Adds ASVS 5.0 session evidence for backend token verification, reference-token entropy, auth/re-auth rotation, inactivity timeout, absolute lifetime, concurrent-session policy, and federated/SSO coordination.
- Updates the .NET supplement so ASP.NET Identity examples no longer recommend arbitrary composition requirements as the secure baseline.
- Adds focused vulnerable and benign fixtures in `skills/appsec/owasp-top-10-web/tests/auth-session-evidence.md`.

### Evidence
**Before:**
```md
Enforce minimum password length of 12 characters ... OWASP ASVS V2.1.1 recommends at least 12
Weak password policies: no complexity requirements
```

**After:**
```md
Record password assurance context before grading length: single-factor passwords should be at least 15 characters, while passwords used only as part of MFA can be shorter but should still be at least 8 characters.
Do not require arbitrary uppercase/lowercase/digit/symbol composition rules.
```

### Test Cases Added/Updated
- [x] Added vulnerable test cases
- [x] Added benign test cases
- [x] Existing checks still pass

Added fixture: `skills/appsec/owasp-top-10-web/tests/auth-session-evidence.md`

### Validation
- `git diff --check HEAD~1..HEAD`
- Frontmatter required-field check across `45` skill files
- Touched index file-existence check
- Content assertions for SP 800-63B-4 / ASVS 5.0 auth-session evidence
- New fixture prompt-injection pattern scan
- Source URL checks returned HTTP 200 for NIST SP 800-63B-4, OWASP ASVS project page, ASVS 5.0 password security, ASVS 5.0 session documentation, and ASVS 5.0 fundamental session management security

### Bounty Tier
- [ ] **Minor** ($50) -- Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) -- New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) -- Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Can be provided privately after maintainer acceptance.