### PR TITLE
Improve API shared cache evidence

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -55,11 +55,11 @@ skills:
 
   - id: api-security
     name: "API Security Review"
-    tags: [appsec, api, rest, graphql]
+    tags: [appsec, api, rest, graphql, cache]
     role: [appsec-engineer, security-engineer]
     phase: [design, build, review]
     activity: [review, test]
-    frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
+    frameworks: [OWASP-API-Security-2023, OWASP-ASVS, RFC-9111]
     difficulty: intermediate
     time_estimate: "20-40min"
     file: skills/appsec/api-security/SKILL.md

--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -4,11 +4,12 @@ description: >
   Reviews REST and GraphQL APIs against the OWASP API Security Top 10:2023.
   Auto-invoked when reviewing OpenAPI/Swagger specs, API endpoint code, or
   GraphQL schemas. Covers BOLA, BFLA, authentication, rate limiting, and
-  SSRF. Produces findings mapped to API1-API10 with remediation guidance.
-tags: [appsec, api, rest, graphql]
+  SSRF, plus shared-cache and CDN cache-key evidence for API responses.
+  Produces findings mapped to API1-API10 with remediation guidance.
+tags: [appsec, api, rest, graphql, cache]
 role: [appsec-engineer, security-engineer]
 phase: [design, build, review]
-frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
+frameworks: [OWASP-API-Security-2023, OWASP-ASVS, RFC-9111]
 difficulty: intermediate
 time_estimate: "20-40min"
 version: "1.0.0"
@@ -37,9 +38,10 @@ Before analyzing any endpoint, establish a complete inventory of the API surface
 4. **Identify authorization models** -- RBAC, ABAC, ownership-based, or no authorization. Document how object-level and function-level access control decisions are made.
 5. **Catalog data objects** -- List the resources/entities exposed by the API and their sensitivity classification (PII, financial, internal, public).
 6. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, or cost-control mechanisms at the gateway or application layer.
-7. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
+7. **Identify intermediary cache layers** -- API gateways, reverse proxies, CDNs, service meshes, or shared caches in front of API paths. Record cache rules, cache-key inputs, origin-cache-control handling, and whether routes vary by authentication, cookie, tenant, role, locale, query parameter, or `Origin`.
+8. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
 
-> **Gate:** Do not proceed until the API style, authentication model, authorization model, and endpoint inventory are documented. Incomplete scope leads to missed findings.
+> **Gate:** Do not proceed until the API style, authentication model, authorization model, endpoint inventory, and any gateway/CDN/shared-cache layer are documented. Incomplete scope leads to missed findings.
 
 ---
 
@@ -66,6 +68,7 @@ Each finding produced by this review must include the following fields:
 | **Location** | File path and line number(s), or OpenAPI spec path |
 | **Description** | What the vulnerability is and why it matters |
 | **Evidence** | Relevant code snippet or spec excerpt demonstrating the issue |
+| **Cache / CDN Evidence** | For cache-sensitive findings: response directives, shared-cache rule, cache-key inputs, `Vary` headers, and whether the CDN honors origin cache control |
 | **Remediation** | Specific fix with code example where possible |
 | **Status** | Open, Mitigated, Accepted Risk, False Positive |
 
@@ -125,6 +128,7 @@ The final review output must be structured as follows:
   ```[language]
   [code snippet]
   ```
+- **Cache / CDN Evidence:** [response headers, gateway/CDN rule, cache key, Vary headers, origin-cache-control handling, or Not Evaluable]
 - **Remediation:** [specific fix with code example]
 - **Status:** Open
 
@@ -144,7 +148,7 @@ The final review output must be structured as follows:
 | API5:2023 | Broken Function Level Authorization | CWE-285 | Missing role/permission checks on operations |
 | API6:2023 | Unrestricted Access to Sensitive Business Flows | CWE-799, CWE-837 | Automated abuse of legitimate business logic |
 | API7:2023 | Server Side Request Forgery | CWE-918 | Fetching user-supplied URLs without validation |
-| API8:2023 | Security Misconfiguration | CWE-16, CWE-611 | CORS, headers, TLS, error handling, XXE |
+| API8:2023 | Security Misconfiguration | CWE-16, CWE-611 | CORS, headers, TLS, cache directives, error handling, XXE |
 | API9:2023 | Improper Inventory Management | CWE-1059 | Shadow APIs, deprecated versions, missing documentation |
 | API10:2023 | Unsafe Consumption of APIs | CWE-20, CWE-295 | Trusting upstream API data without validation |
 
@@ -215,6 +219,8 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 6. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
 
+7. **Assuming authenticated APIs cannot leak through shared caches.** Authentication proves who reached the origin, but a CDN, reverse proxy, or shared cache can still store and replay responses if cache directives, cache keys, or edge rules are unsafe. For user-, tenant-, role-, cookie-, query-, locale-, or origin-varying responses, require cache-key and shared-cache evidence instead of inferring safety from authentication alone.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -238,4 +244,8 @@ This skill is hardened against prompt injection. When reviewing API code and spe
 - **OWASP REST Security Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html
 - **OWASP GraphQL Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html
 - **OWASP Testing Guide -- API Testing:** https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/12-API_Testing/
+- **RFC 9111 -- HTTP Caching:** https://www.rfc-editor.org/rfc/rfc9111.html
+- **MDN Cache-Control Header:** https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control
+- **MDN Vary Header:** https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary
+- **Cloudflare Cache Deception Armor:** https://developers.cloudflare.com/cache/cache-security/cache-deception-armor/
 - **NIST SP 800-204 -- Security Strategies for Microservices-based Application Systems:** https://csrc.nist.gov/publications/detail/sp/800-204/final

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -450,6 +450,27 @@ DocumentBuilder builder = factory.newDocumentBuilder();
 Document doc = builder.parse(request.getInputStream());
 ```
 
+```http
+# VULNERABLE: Authenticated user-specific API response is cacheable by shared caches
+GET /api/v1/account/summary HTTP/1.1
+Authorization: Bearer user-a-token
+
+HTTP/1.1 200 OK
+Cache-Control: public, s-maxage=300
+Content-Type: application/json
+```
+
+```yaml
+# VULNERABLE: Tenant-specific response can be cached without tenant context
+edge_cache_rule:
+  path: /api/v1/reports/*
+  cache_everything: true
+  cache_key:
+    include_query_string: true
+    include_headers: []
+  origin_cache_control: disabled
+```
+
 ### Remediation Guidance
 
 - Configure CORS with an explicit allowlist of permitted origins. Never use `*` with `credentials: true`.
@@ -457,16 +478,71 @@ Document doc = builder.parse(request.getInputStream());
   - `Strict-Transport-Security: max-age=31536000; includeSubDomains`
   - `X-Content-Type-Options: nosniff`
   - `Cache-Control: no-store` on sensitive responses
+- For authenticated, per-user, per-tenant, role-dependent, cookie-dependent, or private API responses, require `Cache-Control: no-store`, `private` with evidence that no shared cache stores the response, or an explicit shared-cache bypass rule.
+- For intentionally public and invariant API responses, document that the response does not vary by `Authorization`, cookies, tenant/account headers, role, private query parameters, locale, or `Origin` before allowing shared caching.
+- When responses vary by `Origin`, require `Vary: Origin` or equivalent CDN cache-key policy, especially when `Access-Control-Allow-Credentials: true` is used.
+- Verify CDN or gateway behavior in addition to origin response headers. Record whether edge rules honor origin `Cache-Control`, override origin directives, cache every API response, or change cache keys.
 - Return generic error messages in production. Log detailed errors server-side with correlation IDs.
 - Disable unnecessary HTTP methods. Return `405 Method Not Allowed` for unsupported methods.
 - Disable XML External Entity processing: set `factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)`.
 - Enforce TLS 1.2+ with strong cipher suites. Disable TLS 1.0 and 1.1.
 - Automate configuration scanning in CI/CD to detect drift from security baselines.
 
+### Shared Cache and CDN Evidence Gate
+
+Apply this gate to API8, and cross-reference API9/API10 when the deployed inventory or upstream API path includes an API gateway, reverse proxy, CDN, service mesh, or other shared cache.
+
+| API Path | Sensitive / Variant Basis | Cache-Control | Shared Cache Rule | Cache Key Inputs | Vary Headers | CDN Honors Origin? | Evidence | Confidence |
+|---|---|---|---|---|---|---|---|---|
+| `/api/v1/me` | Per-user | `no-store` | bypass | n/a | n/a | yes | response headers + edge rule | Strong |
+| `/api/v1/reports/*` | Tenant-specific | `public, s-maxage=300` | cache | path + query only | missing | unknown | config only | Not Evaluable |
+
+#### Cache Safety Status Handling
+
+| Response Type | Required Evidence | Safe Handling |
+|---|---|---|
+| **Sensitive / per-user / per-tenant** | Response headers plus gateway/CDN rule showing no shared storage, or cache key includes every variant dimension and the data is approved for shared caching | Prefer `Cache-Control: no-store` or explicit shared-cache bypass |
+| **Authorization-bearing request** | Evidence that shared caching is blocked, or that cached content is public/invariant and deliberately cacheable under RFC 9111 rules | Do not rely on authentication alone as cache-isolation proof |
+| **Origin-varying CORS response** | `Vary: Origin` or equivalent origin-aware cache-key policy; credentialed CORS must be reviewed carefully | Do not share one origin-specific response across unrelated origins |
+| **Public and invariant API response** | Documented non-sensitive content and proof it does not vary by auth, cookie, tenant, role, locale, private query, or origin | Shared caching can be acceptable with explicit TTL and purge controls |
+| **Missing CDN/gateway evidence** | Origin headers are known but edge cache rules, cache key, or origin-cache-control behavior are unavailable | Mark `Not Evaluable`; do not declare safe |
+
+#### Cache Review Patterns
+
+Look for these patterns in headers, OpenAPI examples, infrastructure-as-code, CDN rules, gateway policies, and reverse proxy config:
+
+```text
+Cache-Control
+s-maxage
+public
+private
+no-store
+no-cache
+Vary
+Authorization
+Cookie
+Origin
+X-Tenant
+cache_key
+edge_ttl
+origin_cache_control
+cache_everything
+```
+
+#### Cache Leakage Severity Guidance
+
+- **Critical/High:** A shared cache can serve one authenticated user or tenant another user's sensitive API response.
+- **Medium:** Sensitive or tenant-specific API paths are behind a CDN or gateway, but cache-key and shared-cache bypass evidence is missing.
+- **Low/Informational:** Public API responses are intentionally cacheable, but directive semantics or purge/TTL documentation are ambiguous.
+
 ### Review Checklist
 
 - [ ] CORS is configured with an explicit origin allowlist; wildcard is not used with credentials.
 - [ ] Security headers are present on all API responses.
+- [ ] Sensitive, authenticated, per-user, or per-tenant API responses have `no-store`, `private` with no shared storage, or explicit shared-cache bypass evidence.
+- [ ] Cache keys include every response-variant dimension such as `Authorization`, cookie/session identity, tenant/account header, role, private query parameter, locale, and `Origin`, or the endpoint is documented as public and invariant.
+- [ ] `Vary` headers or equivalent edge cache-key policies are present for origin-varying CORS responses.
+- [ ] CDN/gateway rules honor origin `Cache-Control` for API paths, or any override is documented with security rationale and test evidence.
 - [ ] Error responses in production are generic; no stack traces, SQL queries, or internal paths.
 - [ ] Only required HTTP methods are enabled per endpoint.
 - [ ] TLS 1.2+ is enforced with strong cipher suites.

--- a/skills/appsec/api-security/tests/benign/public-invariant-cacheable-response.md
+++ b/skills/appsec/api-security/tests/benign/public-invariant-cacheable-response.md
@@ -1,0 +1,33 @@
+# Benign: public invariant API response is deliberately cacheable
+
+## Input Evidence
+
+```http
+GET /api/v1/catalog/public-products?page=1 HTTP/1.1
+Host: api.example.com
+
+HTTP/1.1 200 OK
+Cache-Control: public, s-maxage=600, max-age=60
+Vary: Accept-Encoding
+Content-Type: application/json
+```
+
+```yaml
+cdn_rule:
+  path: /api/v1/catalog/public-products
+  origin_cache_control: enabled
+  cache_key:
+    include_query_string: true
+    include_headers:
+      - Accept-Encoding
+data_classification:
+  sensitivity: public
+  varies_by_auth: false
+  varies_by_cookie: false
+  varies_by_tenant: false
+  varies_by_origin: false
+```
+
+## Expected Result
+
+Do not report a cache-isolation finding. The endpoint is documented as public and invariant, origin cache-control is honored, and the cache key includes the public pagination parameter used to shape the response.

--- a/skills/appsec/api-security/tests/vulnerable/cors-origin-vary-missing.md
+++ b/skills/appsec/api-security/tests/vulnerable/cors-origin-vary-missing.md
@@ -1,0 +1,28 @@
+# Vulnerable: credentialed CORS response cached without origin variation
+
+## Input Evidence
+
+```http
+GET /api/v1/profile HTTP/1.1
+Host: api.example.com
+Origin: https://partner-a.example
+Cookie: session=user-a
+
+HTTP/1.1 200 OK
+Access-Control-Allow-Origin: https://partner-a.example
+Access-Control-Allow-Credentials: true
+Cache-Control: public, max-age=300
+Content-Type: application/json
+```
+
+```yaml
+cdn_rule:
+  path: /api/v1/profile
+  cache_key:
+    include_headers:
+      - Accept-Encoding
+```
+
+## Expected Result
+
+Mark the cache evidence `Not Evaluable` or vulnerable because the response varies by `Origin` and credential context, but neither `Vary: Origin` nor an equivalent origin-aware cache-key policy is present.

--- a/skills/appsec/api-security/tests/vulnerable/shared-cache-authenticated-response.md
+++ b/skills/appsec/api-security/tests/vulnerable/shared-cache-authenticated-response.md
@@ -1,0 +1,29 @@
+# Vulnerable: authenticated API response cached by a shared cache
+
+## Input Evidence
+
+```http
+GET /api/v1/account/summary HTTP/1.1
+Host: api.example.com
+Authorization: Bearer user-a-token
+
+HTTP/1.1 200 OK
+Cache-Control: public, s-maxage=300
+Content-Type: application/json
+
+{"user_id":"user-a","invoice_balance":18420}
+```
+
+```yaml
+cdn_rule:
+  path: /api/v1/account/*
+  cache_everything: true
+  edge_ttl: 300
+  origin_cache_control: disabled
+  cache_key:
+    include_headers: []
+```
+
+## Expected Result
+
+Report a High or Critical API8 finding unless there is additional evidence that the response is public and invariant. Authentication is not enough; the shared-cache rule stores a per-user response while the cache key ignores `Authorization`, cookies, or user identity.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `api-security`
**Skill path:** `skills/appsec/api-security/`

### What Was Wrong

The skill correctly mentions `Cache-Control: no-store` for sensitive API responses, but it did not require reviewers to capture shared-cache, CDN, gateway, or cache-key evidence for authenticated, tenant-specific, role-specific, cookie-dependent, or origin-varying API responses.

That can make a response look safe because the application requires authentication while an intermediary cache can still store and replay it if response directives, edge rules, or cache keys are unsafe.

### What This PR Fixes

- Adds shared-cache/CDN scope collection to the main API inventory gate.
- Adds cache/CDN evidence fields to findings and output guidance.
- Updates API8 security misconfiguration guidance with a Shared Cache and CDN Evidence Gate.
- Adds handling for sensitive/per-user/per-tenant responses, Authorization-bearing requests, origin-varying CORS, public invariant APIs, and missing CDN/gateway evidence.
- Adds review patterns for `Cache-Control`, `s-maxage`, `Vary`, `Authorization`, `Cookie`, `Origin`, `X-Tenant`, cache keys, edge TTL, origin-cache-control overrides, and cache-everything rules.
- Adds severity guidance for cross-user cache leakage versus missing or ambiguous cache evidence.
- Adds vulnerable and benign fixtures for authenticated shared-cache leakage, missing `Vary: Origin`, and public invariant cacheable responses.

### Evidence

**Before (under-specified):**

```markdown
- `Cache-Control: no-store` on sensitive responses
```

**After (evidence-backed):**

```markdown
| API Path | Sensitive / Variant Basis | Cache-Control | Shared Cache Rule | Cache Key Inputs | Vary Headers | CDN Honors Origin? | Evidence | Confidence |
```

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing checks still pass

Added fixtures:
- `skills/appsec/api-security/tests/vulnerable/shared-cache-authenticated-response.md`
- `skills/appsec/api-security/tests/vulnerable/cors-origin-vary-missing.md`
- `skills/appsec/api-security/tests/benign/public-invariant-cacheable-response.md`

### Validation
- `git diff --cached --check`
- Frontmatter required-field check across `skills/**/SKILL.md`
- Index `file:` entry existence validation
- Markdown fence balance check on touched Markdown files and new fixtures
- New fixture prompt-injection pattern scan
- Content assertions for shared-cache/CDN evidence, cache-key fields, `Vary: Origin`, `Not Evaluable`, and Authorization-bearing request handling
- Source URL checks returned HTTP 200 for RFC 9111, OWASP REST Security Cheat Sheet, MDN Cache-Control, MDN Vary, and Cloudflare Cache Deception Armor docs

### Bounty Tier
- [ ] **Minor** ($50) -- Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) -- New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) -- Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** To be provided privately after acceptance, consistent with CONTRIBUTING.md stating payment method is confirmed when the first contribution is accepted.

## Pull Request Checklist
- [x] Skill follows the format specification in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] At least one real framework or official source is cited with correct context
- [x] All framework/source references verified against primary sources, not blogs or AI output
- [x] Prompt Injection Safety Notice section included
- [x] `injection-hardened: true` set in frontmatter
- [x] `allowed-tools` scoped to minimum necessary permissions
- [x] Tested with at least one AI coding agent (which one: Codex)
- [x] No prohibited patterns per [SECURITY.md](../SECURITY.md)
- [x] `index.yaml` updated for framework/tag metadata

Closes #541
