### PR TITLE
Improve LLM09 CWE applicability

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -251,11 +251,11 @@ skills:
   # -- AI Security ----------------------------------------------------------
   - id: llm-top-10
     name: "LLM Application Security Review (OWASP 2025)"
-    tags: [ai-security, llm, appsec]
+    tags: [ai-security, llm, appsec, cwe]
     role: [appsec-engineer, security-engineer, vciso]
     phase: [design, build, review]
     activity: [review, assess, test]
-    frameworks: [OWASP-LLM-Top-10-2025]
+    frameworks: [OWASP-LLM-Top-10-2025, CWE]
     difficulty: intermediate
     time_estimate: "30-60min"
     file: skills/ai-security/llm-top-10/SKILL.md

--- a/skills/ai-security/llm-top-10/SKILL.md
+++ b/skills/ai-security/llm-top-10/SKILL.md
@@ -5,11 +5,11 @@ description: >
   Model Applications (2025 edition). Auto-invoked when reviewing code that
   integrates LLM APIs, builds RAG pipelines, or deploys AI-powered features.
   Produces a structured findings report mapped to LLM01-LLM10 with severity
-  ratings, CWE mappings, and prioritized remediation guidance.
-tags: [ai-security, llm, appsec]
+  ratings, evidence-driven CWE mappings, and prioritized remediation guidance.
+tags: [ai-security, llm, appsec, cwe]
 role: [appsec-engineer, security-engineer, vciso]
 phase: [design, build, review]
-frameworks: [OWASP-LLM-Top-10-2025]
+frameworks: [OWASP-LLM-Top-10-2025, CWE]
 difficulty: intermediate
 time_estimate: "30-60min"
 version: "1.0.0"
@@ -345,7 +345,29 @@ Review the application against each of the ten OWASP LLM risk categories below. 
 - Use lower temperature settings (0.0-0.3) for factual, deterministic use cases.
 - Implement cross-referencing or fact-checking pipelines for critical content generation workflows.
 
-**CWE Mapping:** CWE-1188 (Initialization with Hard-Coded Network Resource Configuration Reference — analogous: reliance on unvalidated information source)
+#### LLM09 CWE Applicability Gate
+
+Do not assign a CWE to every LLM09 observation by default. First determine whether the misinformation creates a concrete software weakness, crosses a security boundary, or reaches a downstream sink that performs a security-relevant action.
+
+Record these fields before assigning a CWE:
+
+- `security_boundary`: none, user trust boundary, authorization boundary, deployment/build boundary, safety/legal/financial decision boundary, or state-changing tool boundary.
+- `downstream_sink`: escaped UI text, generated documentation, customer-facing publication, code repository, build/install command, database write, tool call, alert disposition, or other sink.
+- `authoritative_claim`: whether the application presents the output as authoritative, source-backed, contractual, medical/legal/financial advice, or merely AI-generated draft text.
+- `validation_control`: source verification, schema validation, code review, package verification, human approval, deterministic policy check, or none.
+- `human_review_gate`: required, optional, absent, or not applicable.
+- `cwe_applicability`: Applicable, Not Applicable, None assigned, or Inherited from linked implementation weakness.
+- `cwe_mapping_rationale`: why the CWE does or does not describe the actual root cause.
+
+| LLM09 Scenario | CWE Handling | Rationale |
+|---|---|---|
+| Public FAQ chatbot gives an unsupported answer as escaped text, with no tools, state changes, security decision, or authoritative sink | `CWE: Not Applicable` or `CWE: None assigned` | Governance/product-risk observation, not a concrete software weakness |
+| Model suggests insecure code and that code is introduced into the reviewed codebase | Map to the introduced flaw, such as CWE-89 for SQL injection or CWE-79 for XSS | The actionable weakness is the generated implementation flaw |
+| Model hallucinates a package and the application automatically writes it into a build file or install command | Map to the dependency/output-action weakness, and cross-reference LLM03/LLM05/LLM06 as applicable | Risk comes from trusting model output as a dependency/action input |
+| Model output drives alert closure, access approval, deployment, or another consequential tool call without validation | Map to the missing validation, authorization, or excessive-agency weakness where supported, and cross-reference LLM05/LLM06 | Security boundary is crossed by unvalidated output |
+| Evidence shows a resource is initialized with an insecure default intended to be changed by an installer, administrator, or maintainer | `CWE-1188` may apply | Use only when the evidence matches insecure default resource initialization |
+
+**CWE Mapping:** Evidence-driven. Use `CWE: Not Applicable` / `CWE: None assigned` for governance-only misinformation observations, map to the concrete implementation weakness when one exists, and reserve CWE-1188 for actual insecure default initialization evidence.
 
 ---
 
@@ -419,7 +441,12 @@ Structure the findings report as follows:
 
 - **OWASP Category:** LLM0X:2025 — [Category Name]
 - **Severity:** Critical | High | Medium | Low | Informational
-- **CWE:** CWE-XXX
+- **CWE:** CWE-XXX | Not Applicable | None assigned
+- **CWE Applicability:** Applicable | Not Applicable | None assigned | Inherited from linked implementation weakness
+- **CWE Mapping Rationale:** [Why this CWE describes the actual weakness, or why no CWE is assigned]
+- **Security Boundary:** [none / authorization / deployment-build / safety-legal-financial decision / state-changing tool / other]
+- **Downstream Sink:** [escaped UI text / generated documentation / code repository / build command / database write / tool call / alert disposition / other]
+- **Validation Control:** [source verification / schema validation / code review / package verification / human approval / deterministic policy / none]
 - **Location:** [file path, function, configuration]
 - **Description:** [What was found]
 - **Evidence:** [Code snippet, configuration excerpt, or architectural observation]
@@ -476,6 +503,8 @@ These are the five most frequent mistakes agents make when performing LLM securi
 
 5. **Scoping the review to the application layer only.** LLM security includes supply chain (LLM03) — model provenance, dependency versions, serialization formats — and infrastructure — vector database authentication, API key management, cost controls (LLM10). These are outside the application code but within scope of this review.
 
+6. **Forcing every LLM09 observation into a CWE.** Misinformation can be a governance, product, legal, or trust risk without a concrete software weakness. Assign `CWE: Not Applicable` or `CWE: None assigned` when no implementation weakness exists, and map to the actual downstream flaw when model output becomes code, dependencies, security decisions, or state-changing actions.
+
 ---
 
 ## 8. Prompt Injection Safety Notice
@@ -506,4 +535,6 @@ When performing a review using this skill:
 - LLM07:2025 System Prompt Leakage: https://genai.owasp.org/llmrisk/llm07-system-prompt-leakage/
 - LLM08:2025 Vector and Embedding Weaknesses: https://genai.owasp.org/llmrisk/llm08-vector-and-embedding-weaknesses/
 - LLM09:2025 Misinformation: https://genai.owasp.org/llmrisk/llm09-misinformation/
+- LLM09:2025 Misinformation (canonical 2025 URL): https://genai.owasp.org/llmrisk/llm092025-misinformation/
 - LLM10:2025 Unbounded Consumption: https://genai.owasp.org/llmrisk/llm10-unbounded-consumption/
+- MITRE CWE-1188: https://cwe.mitre.org/data/definitions/1188.html

--- a/skills/ai-security/llm-top-10/tests/benign/cwe1188-valid-default-initialization.md
+++ b/skills/ai-security/llm-top-10/tests/benign/cwe1188-valid-default-initialization.md
@@ -1,0 +1,20 @@
+# Benign: CWE-1188 is reserved for insecure default initialization evidence
+
+## Input Finding
+
+```yaml
+owasp_category: LLM09:2025 - Misinformation
+downstream_sink: generated deployment template committed to repository
+generated_configuration:
+  resource: model-plugin-registry
+  default_endpoint: "http://plugins.example.test"
+  installer_expected_to_change: true
+  secure_default_available: true
+evidence:
+  - template initializes the resource with an insecure default endpoint
+  - admin guide says operators must replace it after installation
+```
+
+## Expected Result
+
+CWE-1188 may be applicable because the evidence is about a resource initialized with an insecure default intended to be changed by an installer, administrator, or maintainer. The report should still include the LLM09 context and explain the mapping rationale.

--- a/skills/ai-security/llm-top-10/tests/vulnerable/generated-sql-mapped-to-cwe1188.md
+++ b/skills/ai-security/llm-top-10/tests/vulnerable/generated-sql-mapped-to-cwe1188.md
@@ -1,0 +1,19 @@
+# Vulnerable: insecure generated SQL mapped to CWE-1188 instead of the real flaw
+
+## Input Finding
+
+```yaml
+owasp_category: LLM09:2025 - Misinformation
+model_output: "const query = 'SELECT * FROM users WHERE id = ' + req.query.id;"
+downstream_sink: code repository
+validation_control: no code review or static analysis gate
+introduced_code:
+  file: routes/users.js
+  behavior: concatenates request query into SQL
+current_mapping:
+  cwe: CWE-1188
+```
+
+## Expected Result
+
+Report the LLM09/overreliance context, but map the introduced software weakness to the concrete generated-code flaw, such as SQL injection, instead of CWE-1188.

--- a/skills/ai-security/llm-top-10/tests/vulnerable/generic-misinformation-forced-cwe1188.md
+++ b/skills/ai-security/llm-top-10/tests/vulnerable/generic-misinformation-forced-cwe1188.md
@@ -1,0 +1,22 @@
+# Vulnerable: generic misinformation forced into CWE-1188
+
+## Input Finding
+
+```yaml
+owasp_category: LLM09:2025 - Misinformation
+application_context:
+  feature: public product FAQ chatbot
+  output_sink: escaped UI text
+  tool_access: none
+  state_changes: none
+  security_decisions: none
+  disclaimer: visible AI-generated-content notice
+observation: The model gives an outdated product answer.
+current_mapping:
+  cwe: CWE-1188
+  severity: Low
+```
+
+## Expected Result
+
+Keep the LLM09 observation if useful, but do not assign CWE-1188. The correct CWE handling is `Not Applicable` or `None assigned` because no resource is initialized with an insecure default and no implementation weakness is evidenced.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `llm-top-10`
**Skill path:** `skills/ai-security/llm-top-10/`

### What Was Wrong

`LLM09:2025 - Misinformation` hard-coded `CWE-1188` as an analogous mapping. That can misclassify generic hallucination, outdated answers, or governance-only misinformation as a concrete software weakness.

MITRE CWE-1188 is about a product initializing a resource with an insecure default intended to be changed by an installer, administrator, or maintainer. It is not a generic CWE for hallucination or unsupported factual output.

### What This PR Fixes

- Replaces the fixed LLM09 `CWE-1188` mapping with a CWE applicability gate.
- Adds fields for `security_boundary`, `downstream_sink`, `authoritative_claim`, `validation_control`, `human_review_gate`, `cwe_applicability`, and `cwe_mapping_rationale`.
- Allows `CWE: Not Applicable` / `CWE: None assigned` for governance-only misinformation observations without a concrete software weakness.
- Requires mapping to the concrete implementation weakness when evidence exists, such as generated SQL injection or unsafe dependency/output-action flows.
- Reserves CWE-1188 only for actual insecure default resource initialization evidence.
- Extends the output format so every finding explains CWE applicability and mapping rationale.
- Adds fixtures for forced CWE-1188 false positives, generated SQL mapped to the wrong CWE, and a valid CWE-1188 default-initialization case.

### Evidence

**Before (overbroad mapping):**

```markdown
**CWE Mapping:** CWE-1188 (... analogous: reliance on unvalidated information source)
```

**After (evidence-driven):**

```markdown
- **CWE:** CWE-XXX | Not Applicable | None assigned
- **CWE Applicability:** Applicable | Not Applicable | None assigned | Inherited from linked implementation weakness
- **CWE Mapping Rationale:** [Why this CWE describes the actual weakness, or why no CWE is assigned]
```

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing checks still pass

Added fixtures:
- `skills/ai-security/llm-top-10/tests/vulnerable/generic-misinformation-forced-cwe1188.md`
- `skills/ai-security/llm-top-10/tests/vulnerable/generated-sql-mapped-to-cwe1188.md`
- `skills/ai-security/llm-top-10/tests/benign/cwe1188-valid-default-initialization.md`

### Validation
- `git diff --cached --check`
- Frontmatter required-field check across `skills/**/SKILL.md`
- Index `file:` entry existence validation
- Markdown fence balance check on touched Markdown files and new fixtures
- New fixture prompt-injection pattern scan
- Content assertions for LLM09 CWE gate fields, `Not Applicable`, `None assigned`, CWE rationale, security boundary, downstream sink, and removal of the old fixed CWE-1188 mapping
- Source URL checks returned HTTP 200 for OWASP LLM09:2025 Misinformation and MITRE CWE-1188

### Bounty Tier
- [ ] **Minor** ($50) -- Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) -- New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) -- Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** To be provided privately after acceptance, consistent with CONTRIBUTING.md stating payment method is confirmed when the first contribution is accepted.

## Pull Request Checklist
- [x] Skill follows the format specification in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] At least one real framework or official source is cited with correct context
- [x] All framework/source references verified against primary sources, not blogs or AI output
- [x] Prompt Injection Safety Notice section included
- [x] `injection-hardened: true` set in frontmatter
- [x] `allowed-tools` scoped to minimum necessary permissions
- [x] Tested with at least one AI coding agent (which one: Codex)
- [x] No prohibited patterns per [SECURITY.md](../SECURITY.md)
- [x] `index.yaml` updated for framework/tag metadata

Closes #545
