### PR TITLE
Improve API security ASVS source evidence

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -59,7 +59,7 @@ skills:
     role: [appsec-engineer, security-engineer]
     phase: [design, build, review]
     activity: [review, test]
-    frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
+    frameworks: [OWASP-API-Security-2023, OWASP-ASVS-5.0.0]
     difficulty: intermediate
     time_estimate: "20-40min"
     file: skills/appsec/api-security/SKILL.md

--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -8,7 +8,7 @@ description: >
 tags: [appsec, api, rest, graphql]
 role: [appsec-engineer, security-engineer]
 phase: [design, build, review]
-frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
+frameworks: [OWASP-API-Security-2023, OWASP-ASVS-5.0.0]
 difficulty: intermediate
 time_estimate: "20-40min"
 version: "1.0.0"
@@ -38,8 +38,9 @@ Before analyzing any endpoint, establish a complete inventory of the API surface
 5. **Catalog data objects** -- List the resources/entities exposed by the API and their sensitivity classification (PII, financial, internal, public).
 6. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, or cost-control mechanisms at the gateway or application layer.
 7. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
+8. **Record framework source versions** -- Default to OWASP API Security Top 10:2023 and OWASP ASVS 5.0.0. If an engagement explicitly requires a legacy ASVS version, label it as legacy and record why it is in scope.
 
-> **Gate:** Do not proceed until the API style, authentication model, authorization model, and endpoint inventory are documented. Incomplete scope leads to missed findings.
+> **Gate:** Do not proceed until the API style, authentication model, authorization model, endpoint inventory, and framework source versions are documented. Incomplete scope or stale framework labels lead to missed findings and misleading control mappings.
 
 ---
 
@@ -60,6 +61,7 @@ Each finding produced by this review must include the following fields:
 | **ID** | Sequential finding identifier (e.g., API-SEC-001) |
 | **Title** | Brief, descriptive name of the vulnerability |
 | **OWASP API Risk** | API1:2023 through API10:2023 identifier |
+| **ASVS Mapping** | Version-qualified ASVS requirement IDs or chapter references (for example, `v5.0.0-4.3.1`), or `N/A` with a reason |
 | **Severity** | Critical, High, Medium, Low, or Informational |
 | **CWE** | Applicable CWE identifier (e.g., CWE-639) |
 | **API Style** | REST, GraphQL, gRPC, or General |
@@ -93,6 +95,9 @@ The final review output must be structured as follows:
 **Specification:** [OpenAPI spec path, if applicable]
 **Date:** [review date]
 **Reviewer:** AI Agent -- api-security skill v1.0.0
+**Framework Sources:**
+- OWASP API Security Top 10:2023 -- https://owasp.org/API-Security/editions/2023/en/0x11-t10/
+- OWASP ASVS 5.0.0 -- https://github.com/OWASP/ASVS/releases/tag/v5.0.0_release
 
 ### Summary
 
@@ -116,6 +121,7 @@ The final review output must be structured as follows:
 
 #### API-SEC-001: [Title]
 - **OWASP API Risk:** API[N]:2023 -- [Name]
+- **ASVS Mapping:** [v5.0.0-control-id(s), ASVS 5.0.0 chapter reference, or N/A with reason]
 - **Severity:** [Critical|High|Medium|Low|Informational]
 - **CWE:** CWE-[number] -- [name]
 - **API Style:** [REST|GraphQL|gRPC|General]
@@ -147,6 +153,20 @@ The final review output must be structured as follows:
 | API8:2023 | Security Misconfiguration | CWE-16, CWE-611 | CORS, headers, TLS, error handling, XXE |
 | API9:2023 | Improper Inventory Management | CWE-1059 | Shadow APIs, deprecated versions, missing documentation |
 | API10:2023 | Unsafe Consumption of APIs | CWE-20, CWE-295 | Trusting upstream API data without validation |
+
+---
+
+## OWASP ASVS 5.0.0 Mapping Notes
+
+Use ASVS as supporting verification evidence, not as a replacement for the OWASP API Top 10 risk classification. Default to ASVS 5.0.0 for new reviews. When citing exact ASVS requirements, use version-qualified IDs such as `v5.0.0-4.3.1` because OWASP notes that identifiers can change between ASVS versions. If a client or audit scope requires ASVS 4.0.3, call it out as a legacy baseline and do not describe it as current.
+
+| API Review Area | Primary ASVS 5.0.0 Anchor | Use When |
+|---|---|---|
+| API and web service controls | V4 -- API and Web Service | HTTP response headers, intermediary headers, GraphQL controls, and WebSocket controls directly map to API-specific requirements. |
+| Authorization | V8 -- Authorization | BOLA, BFLA, object ownership, tenant isolation, and function permission decisions. |
+| Authentication, sessions, and tokens | V6 -- Authentication; V7 -- Session Management; V9 -- Self-contained Tokens; V10 -- OAuth and OIDC | Broken authentication, JWT/session weaknesses, OAuth/OIDC flow issues, and token validation flaws. |
+| Validation and business logic | V1 -- Encoding and Sanitization; V2 -- Validation and Business Logic | Injection-adjacent API input handling, schema validation, and sensitive business flow abuse. |
+| Configuration, transport, and data protection | V12 -- Secure Communication; V13 -- Configuration; V14 -- Data Protection; V16 -- Security Logging and Error Handling | TLS, CORS, error handling, sensitive data exposure, observability, and audit evidence. |
 
 ---
 
@@ -215,6 +235,8 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 6. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
 
+7. **Calling ASVS 4.0.3 current.** ASVS 5.0.0 is the current default baseline for new reports. Treat ASVS 4.0.3 as legacy-only scope, and include the ASVS version in every exact requirement mapping.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -233,7 +255,8 @@ This skill is hardened against prompt injection. When reviewing API code and spe
 
 - **OWASP API Security Top 10:2023:** https://owasp.org/API-Security/editions/2023/en/0x11-t10/
 - **OWASP API Security Project:** https://owasp.org/www-project-api-security/
-- **OWASP Application Security Verification Standard (ASVS) 4.0.3:** https://owasp.org/www-project-application-security-verification-standard/
+- **OWASP Application Security Verification Standard (ASVS) Project:** https://owasp.org/www-project-application-security-verification-standard/
+- **OWASP ASVS 5.0.0 Release:** https://github.com/OWASP/ASVS/releases/tag/v5.0.0_release
 - **CWE Database:** https://cwe.mitre.org/
 - **OWASP REST Security Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html
 - **OWASP GraphQL Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html

--- a/skills/appsec/api-security/tests/benign/current-asvs500-source-evidence.md
+++ b/skills/appsec/api-security/tests/benign/current-asvs500-source-evidence.md
@@ -1,0 +1,19 @@
+# Benign: Current ASVS 5.0.0 Source Evidence
+
+Scenario: An API security review report records current framework sources before classifying findings.
+
+Report excerpt:
+
+- Framework sources:
+  - OWASP API Security Top 10:2023: https://owasp.org/API-Security/editions/2023/en/0x11-t10/
+  - OWASP ASVS 5.0.0: https://github.com/OWASP/ASVS/releases/tag/v5.0.0_release
+- Finding: GraphQL query depth and cost controls are missing.
+- OWASP API Risk: API4:2023 -- Unrestricted Resource Consumption
+- ASVS Mapping: `v5.0.0-4.3.1`
+- CWE: CWE-770 -- Allocation of Resources Without Limits or Throttling
+
+Expected skill behavior:
+
+- Do not flag this report as stale framework evidence.
+- Accept ASVS 5.0.0 as the current default source version for new API reviews.
+- Accept version-qualified ASVS requirement IDs, and allow `N/A` only when the report records why no ASVS control applies.

--- a/skills/appsec/api-security/tests/vulnerable/stale-asvs403-current-report.md
+++ b/skills/appsec/api-security/tests/vulnerable/stale-asvs403-current-report.md
@@ -1,0 +1,16 @@
+# Vulnerable: Stale ASVS 4.0.3 Current-Baseline Report
+
+Scenario: An API security review report is generated for a new 2026 engagement.
+
+Report excerpt:
+
+- Frameworks applied: OWASP API Security Top 10:2023, OWASP ASVS 4.0.3
+- ASVS Reference: V13.2.3
+- Source evidence: OWASP ASVS project page checked; current baseline is ASVS 4.0.3
+- Finding: GraphQL depth limiting is missing, mapped to API4:2023 and ASVS V13
+
+Expected skill behavior:
+
+- Flag this as stale framework evidence because ASVS 4.0.3 must not be labeled current for new reports.
+- Require OWASP ASVS 5.0.0 as the default baseline, or require the report to label ASVS 4.0.3 as an explicitly scoped legacy framework.
+- Require version-qualified ASVS identifiers such as `v5.0.0-4.3.1` when exact ASVS requirements are cited.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `api-security`
**Skill path:** `skills/appsec/api-security/`

Closes #549.

### What Was Wrong

The skill listed ASVS as an unversioned framework and still referenced ASVS 4.0.3, while OWASP lists ASVS 5.0.0 as the latest stable release. API review reports also did not require framework source/version evidence or version-qualified ASVS IDs, so reports could silently cite stale ASVS controls as if they were current.

### What This PR Fixes

- Updates `api-security` frontmatter and `index.yaml` to `OWASP-ASVS-5.0.0`.
- Adds a framework-source gate during API inventory.
- Adds `Framework Sources` and `ASVS Mapping` fields to the report template.
- Adds ASVS 5.0.0 mapping notes for API-specific, auth, authorization, token, transport, configuration, data-protection, and logging chapters.
- Adds a common pitfall warning against calling ASVS 4.0.3 current.
- Adds one vulnerable fixture for stale ASVS 4.0.3 evidence and one benign fixture for current ASVS 5.0.0 evidence.

### Evidence

**Before (skill permits stale/unversioned ASVS evidence):**
```text
Frameworks applied: OWASP API Security Top 10:2023, OWASP ASVS 4.0.3
Source evidence: OWASP ASVS project page checked; current baseline is ASVS 4.0.3
ASVS Reference: V13.2.3
```

**After (now correctly handled):**
```text
Framework Sources:
- OWASP API Security Top 10:2023 -- https://owasp.org/API-Security/editions/2023/en/0x11-t10/
- OWASP ASVS 5.0.0 -- https://github.com/OWASP/ASVS/releases/tag/v5.0.0_release
ASVS Mapping: v5.0.0-4.3.1
```

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass

### Validation

- `git diff --cached --check` passed before commit.
- Frontmatter, index path, markdown fence, touched-file prompt scan, and ASVS content assertions passed.
- Workflow-equivalent prompt injection scan passed.
- Official source reachability checks returned HTTP 200 for:
  - OWASP API Security Top 10:2023
  - OWASP ASVS project page
  - OWASP ASVS 5.0.0 release
  - OWASP ASVS 5.0.0 V4 API and Web Service source file

### Bounty Tier
- [ ] **Minor** ($50) -- Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) -- New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) -- Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the CONTRIBUTING.md bounty terms.
- **Preferred payment method:** To be provided privately after acceptance.
