### PR TITLE
Improve agent AI RMF source freshness

### DIFF
--- a/skills/ai-security/agent-security/SKILL.md
+++ b/skills/ai-security/agent-security/SKILL.md
@@ -553,7 +553,7 @@ Glob: **/security_architecture*
 
 **OWASP Agentic AI Threats:** These threat categories are maintained by the OWASP GenAI Security Project working group. The AG01-AG10 numbering and scope used here reflect the documented threat areas. Verify current numbering and content against the latest published version at [genai.owasp.org](https://genai.owasp.org).
 
-**NIST AI RMF 1.0:** Published January 2023. Organized around four functions: GOVERN (policies, culture), MAP (context, risk identification), MEASURE (risk analysis), MANAGE (risk response, monitoring). Reference: [nist.gov/aiframework](https://www.nist.gov/aiframework)
+**NIST AI RMF 1.0:** Published January 2023. Organized around four functions: GOVERN (policies, culture), MAP (context, risk identification), MEASURE (risk analysis), MANAGE (risk response, monitoring). Reference: [NIST AI RMF](https://www.nist.gov/itl/ai-risk-management-framework)
 
 ---
 
@@ -575,7 +575,7 @@ Glob: **/security_architecture*
 
 1. OWASP GenAI Security Project -- Agentic AI Threat Categories -- https://genai.owasp.org
 2. OWASP Top 10 for LLM Applications 2025 -- https://owasp.org/www-project-top-10-for-large-language-model-applications/
-3. NIST AI Risk Management Framework 1.0 (January 2023) -- https://www.nist.gov/aiframework
+3. NIST AI Risk Management Framework 1.0 (January 2023) -- https://www.nist.gov/itl/ai-risk-management-framework
 4. NIST SP 800-53 Rev. 5 -- Security and Privacy Controls (AC-6: Least Privilege, AU-2: Event Logging, AU-10: Non-repudiation) -- https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
 5. MITRE ATLAS -- Adversarial Threat Landscape for AI Systems -- https://atlas.mitre.org
 6. Rehberger, J. "Prompt Injection: Exfiltrating Data via Tool Calls" (2023) -- https://embracethered.com

--- a/skills/ai-security/agent-security/tests/benign/current-nist-ai-rmf-source.md
+++ b/skills/ai-security/agent-security/tests/benign/current-nist-ai-rmf-source.md
@@ -1,0 +1,8 @@
+# Benign: current NIST AI RMF source
+
+This fixture represents an agent-security review guide that cites the current
+official NIST AI RMF landing page:
+
+- NIST AI Risk Management Framework 1.0: https://www.nist.gov/itl/ai-risk-management-framework
+
+Expected result: no source-freshness finding for the NIST AI RMF landing page.

--- a/skills/ai-security/agent-security/tests/vulnerable/stale-nist-ai-rmf-source.md
+++ b/skills/ai-security/agent-security/tests/vulnerable/stale-nist-ai-rmf-source.md
@@ -1,0 +1,9 @@
+# Vulnerable: stale NIST AI RMF source
+
+This fixture represents an agent-security review guide that still cites the retired
+NIST AI RMF short URL:
+
+- NIST AI Risk Management Framework 1.0: https://www.nist.gov/aiframework
+
+Expected finding: replace the stale 404 URL with the current official NIST AI RMF
+landing page.

--- a/skills/ai-security/agentic-top-10/SKILL.md
+++ b/skills/ai-security/agentic-top-10/SKILL.md
@@ -560,7 +560,7 @@ MITRE ATLAS (Adversarial Threat Landscape for AI Systems) provides a knowledge b
 
 ### NIST AI Risk Management Framework (AI RMF 1.0)
 
-The NIST AI RMF provides a structured approach to AI risk management organized around four functions: GOVERN, MAP, MEASURE, and MANAGE. Subcategory mappings in this skill use the AI RMF Playbook suggested action numbering format (e.g., GOVERN 1.2, MAP 3.5) from the companion AI RMF Playbook, not the formal framework subcategory IDs. Reference: [nist.gov/aiframework](https://www.nist.gov/aiframework), [AI RMF Playbook](https://airc.nist.gov/AI_RMF_Playbook)
+The NIST AI RMF provides a structured approach to AI risk management organized around four functions: GOVERN, MAP, MEASURE, and MANAGE. Subcategory mappings in this skill use the AI RMF Playbook suggested action numbering format (e.g., GOVERN 1.2, MAP 3.5) from the companion AI RMF Playbook, not the formal framework subcategory IDs. Reference: [NIST AI RMF](https://www.nist.gov/itl/ai-risk-management-framework), [AI RMF Playbook](https://airc.nist.gov/airmf-resources/playbook/)
 
 ---
 
@@ -609,7 +609,7 @@ This skill is designed to be resilient against prompt injection. The following r
 1. OWASP GenAI Security Project — [genai.owasp.org](https://genai.owasp.org)
 2. OWASP Top 10 for LLM Applications 2025 — [owasp.org/www-project-top-10-for-large-language-model-applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
 3. MITRE ATLAS — [atlas.mitre.org](https://atlas.mitre.org)
-4. NIST AI Risk Management Framework 1.0 — [nist.gov/aiframework](https://www.nist.gov/aiframework)
+4. NIST AI Risk Management Framework 1.0 — [NIST AI RMF](https://www.nist.gov/itl/ai-risk-management-framework)
 5. Rehberger, J. "Prompt Injection: Exfiltrating ChatGPT/Bing Chat Data via Images" (2023) — [embracethered.com](https://embracethered.com)
 6. Greshake, K. et al. "Not What You've Signed Up For: Compromising Real-World LLM-Integrated Applications with Indirect Prompt Injection" (2023) — arXiv:2302.12173
 7. Qi, X. et al. "Fine-tuning Aligned Language Models Compromises Safety, Even When Users Do Not Intend To" (2023) — arXiv:2310.03693

--- a/skills/ai-security/agentic-top-10/tests/benign/current-nist-ai-rmf-playbook-sources.md
+++ b/skills/ai-security/agentic-top-10/tests/benign/current-nist-ai-rmf-playbook-sources.md
@@ -1,0 +1,10 @@
+# Benign: current NIST AI RMF and Playbook sources
+
+This fixture represents an agentic-top-10 review guide that cites current official
+NIST and AIRC sources:
+
+- NIST AI Risk Management Framework 1.0: https://www.nist.gov/itl/ai-risk-management-framework
+- NIST AI RMF Playbook: https://airc.nist.gov/airmf-resources/playbook/
+
+Expected result: no source-freshness finding for the NIST AI RMF or Playbook
+references.

--- a/skills/ai-security/agentic-top-10/tests/vulnerable/stale-nist-ai-rmf-playbook-sources.md
+++ b/skills/ai-security/agentic-top-10/tests/vulnerable/stale-nist-ai-rmf-playbook-sources.md
@@ -1,0 +1,10 @@
+# Vulnerable: stale NIST AI RMF and Playbook sources
+
+This fixture represents an agentic-top-10 review guide that still cites retired
+NIST AI RMF and AIRC Playbook URLs:
+
+- NIST AI Risk Management Framework 1.0: https://www.nist.gov/aiframework
+- NIST AI RMF Playbook: https://airc.nist.gov/AI_RMF_Playbook
+
+Expected finding: replace both stale 404 URLs with the current official NIST and
+AIRC sources.


### PR DESCRIPTION
## Summary

- Refreshes stale NIST AI RMF references in `agent-security` and `agentic-top-10` from the retired `www.nist.gov/aiframework` URL to the current official NIST AI RMF page.
- Refreshes the `agentic-top-10` AI RMF Playbook reference from the retired AIRC path to the current AIRC Playbook page.
- Adds small vulnerable/benign fixtures under both affected skills to document stale vs current source-freshness cases.

Addresses #605.

## Source verification

- Current NIST AI RMF: `https://www.nist.gov/itl/ai-risk-management-framework` -> HTTP 200.
- Current AIRC Playbook: `https://airc.nist.gov/airmf-resources/playbook/` -> HTTP 200.
- Retired NIST short URL: `https://www.nist.gov/aiframework` -> HTTP 404.
- Retired AIRC Playbook URL: `https://airc.nist.gov/AI_RMF_Playbook` -> HTTP 404.

## Validation

- `git diff --cached --check`
- Required frontmatter field check for both touched `SKILL.md` files
- `index.yaml` file-existence check
- Markdown fence-balance check across touched files and fixtures
- Staged diff prompt-injection scan
- Content assertions that stale URLs are absent from production skill files and only present in vulnerable fixtures
- Fresh duplicate search for exact stale URL / AI RMF Playbook source-freshness work