### PR TITLE
Improve model supply chain AI RMF source metadata

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -291,7 +291,7 @@ skills:
     role: [security-engineer, ml-engineer, appsec-engineer]
     phase: [build, review, operate]
     activity: [review, assess]
-    frameworks: [OWASP-LLM03-2025, SLSA-v1.0, MITRE-ATLAS]
+    frameworks: [OWASP-LLM03-2025, SLSA-v1.0, MITRE-ATLAS, NIST-AI-RMF-1.0]
     difficulty: advanced
     time_estimate: "45-90min"
     file: skills/ai-security/model-supply-chain/SKILL.md

--- a/skills/ai-security/model-supply-chain/SKILL.md
+++ b/skills/ai-security/model-supply-chain/SKILL.md
@@ -7,11 +7,11 @@ description: >
   that download pre-trained models, fine-tune foundation models, or deploy models
   from third-party sources. Produces a structured assessment mapped to OWASP
   LLM03:2025, SLSA v1.0 supply chain levels, and MITRE ATLAS poisoning and
-  supply chain techniques.
+  supply chain techniques, and NIST AI RMF 1.0 lifecycle risk controls.
 tags: [ai-security, supply-chain, model-provenance]
 role: [security-engineer, ml-engineer, appsec-engineer]
 phase: [build, review, operate]
-frameworks: [OWASP-LLM03-2025, SLSA-v1.0, MITRE-ATLAS]
+frameworks: [OWASP-LLM03-2025, SLSA-v1.0, MITRE-ATLAS, NIST-AI-RMF-1.0]
 difficulty: advanced
 time_estimate: "45-90min"
 version: "1.0.0"
@@ -454,5 +454,5 @@ Assess whether architectural and procedural controls exist to detect model backd
 - Gu, T. et al. "BadNets: Identifying Vulnerabilities in the Machine Learning Model Supply Chain" (2017) -- arXiv:1708.06733
 - Hubinger, E. et al. "Sleeper Agents: Training Deceptive LLMs that Persist Through Safety Training" (2024) -- arXiv:2401.05566
 - Hugging Face. "Safetensors: A Simple and Safe Serialization Format" -- https://huggingface.co/docs/safetensors
-- NIST AI Risk Management Framework 1.0 -- https://www.nist.gov/aiframework
+- NIST AI Risk Management Framework 1.0 -- https://www.nist.gov/itl/ai-risk-management-framework
 - Open Source Security Foundation (OpenSSF) -- https://openssf.org

--- a/skills/ai-security/model-supply-chain/tests/benign/current-nist-ai-rmf-source.md
+++ b/skills/ai-security/model-supply-chain/tests/benign/current-nist-ai-rmf-source.md
@@ -1,0 +1,9 @@
+# Benign: current NIST AI RMF source
+
+This fixture represents a model supply-chain review guide that maps findings to
+NIST AI RMF and cites the current official NIST AI RMF landing page:
+
+- NIST AI Risk Management Framework 1.0: https://www.nist.gov/itl/ai-risk-management-framework
+
+Expected result: no source-freshness finding for the NIST AI RMF reference, and
+NIST AI RMF remains visible in discovery metadata.

--- a/skills/ai-security/model-supply-chain/tests/vulnerable/stale-nist-ai-rmf-source.md
+++ b/skills/ai-security/model-supply-chain/tests/vulnerable/stale-nist-ai-rmf-source.md
@@ -1,0 +1,9 @@
+# Vulnerable: stale NIST AI RMF source
+
+This fixture represents a model supply-chain review guide that maps findings to
+NIST AI RMF but still cites the retired short URL:
+
+- NIST AI Risk Management Framework 1.0: https://www.nist.gov/aiframework
+
+Expected finding: replace the stale 404 URL with the current official NIST AI RMF
+landing page and keep NIST AI RMF present in skill discovery metadata.


### PR DESCRIPTION
## Summary

- Refreshes the `model-supply-chain` NIST AI RMF reference from the retired `www.nist.gov/aiframework` URL to the current official NIST AI RMF landing page.
- Adds `NIST-AI-RMF-1.0` to the skill frontmatter and `index.yaml` metadata because the skill already maps findings to NIST AI RMF controls in its framework table.
- Adds small vulnerable/benign fixtures for the stale source and corrected metadata/source-freshness cases.

Addresses #607.

## Source verification

- Current NIST AI RMF: `https://www.nist.gov/itl/ai-risk-management-framework` -> HTTP 200.
- Retired NIST short URL: `https://www.nist.gov/aiframework` -> HTTP 404.

## Validation

- `git diff --cached --check`
- Required frontmatter field check for the touched `SKILL.md` file
- `index.yaml` file-existence check
- Metadata consistency check confirming `NIST-AI-RMF-1.0` appears in both skill frontmatter and index metadata
- Markdown fence-balance check across touched files and fixtures
- Staged diff prompt-injection scan
- Content assertions that the stale URL is absent from the production skill file and only present in the vulnerable fixture
- Fresh duplicate search for exact `model-supply-chain` NIST AI RMF source/metadata work