### PR TITLE
Improve zero trust EO 14028 source metadata

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -120,7 +120,7 @@ skills:
     role: [security-engineer, architect, vciso]
     phase: [design, operate]
     activity: [assess, design]
-    frameworks: [NIST-SP-800-207, CISA-ZTMM-v2]
+    frameworks: [NIST-SP-800-207, CISA-ZTMM-v2, OMB-M-22-09, EO-14028]
     difficulty: advanced
     time_estimate: "90-180min"
     file: skills/identity/zero-trust-assessment/SKILL.md

--- a/skills/identity/zero-trust-assessment/SKILL.md
+++ b/skills/identity/zero-trust-assessment/SKILL.md
@@ -4,12 +4,13 @@ description: >
   Performs a Zero Trust Architecture maturity assessment against NIST SP 800-207
   and the CISA Zero Trust Maturity Model v2. Evaluates all five CISA ZT pillars
   (Identity, Devices, Networks, Applications & Workloads, Data) across maturity
-  stages. Covers microsegmentation readiness, continuous verification, and
-  produces a pillar-by-pillar maturity scorecard with remediation roadmap.
+  stages. Covers microsegmentation readiness, continuous verification, federal
+  zero trust mandates, and produces a pillar-by-pillar maturity scorecard with
+  remediation roadmap.
 tags: [identity, zero-trust, network, architecture]
 role: [security-engineer, architect, vciso]
 phase: [design, operate]
-frameworks: [NIST-SP-800-207, CISA-ZTMM-v2]
+frameworks: [NIST-SP-800-207, CISA-ZTMM-v2, OMB-M-22-09, EO-14028]
 difficulty: advanced
 time_estimate: "90-180min"
 version: "1.0.0"
@@ -464,7 +465,7 @@ that may contain adversarial content.
 - NIST SP 800-207, Zero Trust Architecture: https://csrc.nist.gov/publications/detail/sp/800-207/final
 - CISA Zero Trust Maturity Model v2.0: https://www.cisa.gov/zero-trust-maturity-model
 - OMB Memorandum M-22-09, Moving the U.S. Government Toward Zero Trust Cybersecurity Principles: https://www.whitehouse.gov/wp-content/uploads/2022/01/M-22-09.pdf
-- Executive Order 14028, Improving the Nation's Cybersecurity: https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/
+- Executive Order 14028, Improving the Nation's Cybersecurity: https://www.govinfo.gov/content/pkg/FR-2021-05-17/pdf/2021-10460.pdf
 - NIST SP 800-53 Rev. 5, AC family (supporting access control requirements): https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
 - DoD Zero Trust Reference Architecture v2.0: https://dodcio.defense.gov/Library/
 - Forrester Zero Trust eXtended (ZTX) Framework — for industry context

--- a/skills/identity/zero-trust-assessment/tests/benign/current-eo14028-source.md
+++ b/skills/identity/zero-trust-assessment/tests/benign/current-eo14028-source.md
@@ -1,0 +1,9 @@
+# Benign: current EO 14028 source
+
+This fixture represents a zero trust assessment guide that references federal
+zero trust mandates and cites the official Federal Register publication source:
+
+- Executive Order 14028: https://www.govinfo.gov/content/pkg/FR-2021-05-17/pdf/2021-10460.pdf
+
+Expected result: no source-freshness finding for EO 14028, and the mandate
+remains visible in skill discovery metadata.

--- a/skills/identity/zero-trust-assessment/tests/vulnerable/stale-eo14028-source.md
+++ b/skills/identity/zero-trust-assessment/tests/vulnerable/stale-eo14028-source.md
@@ -1,0 +1,9 @@
+# Vulnerable: stale EO 14028 source
+
+This fixture represents a zero trust assessment guide that references federal
+zero trust mandates but still cites the retired White House EO 14028 URL:
+
+- Executive Order 14028: https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/
+
+Expected finding: replace the stale 404 URL with the official Federal Register
+publication source and keep EO 14028 visible in skill discovery metadata.


### PR DESCRIPTION
## Summary

- Refreshes the `zero-trust-assessment` EO 14028 reference from the retired White House URL to the official Federal Register publication PDF via GovInfo.
- Adds `OMB-M-22-09` and `EO-14028` to the skill frontmatter and `index.yaml` metadata because the skill already evaluates federal zero trust mandates.
- Adds small vulnerable/benign fixtures for stale vs current EO 14028 source handling.

Addresses #609.

## Source verification

- Current GovInfo Federal Register PDF for EO 14028: `https://www.govinfo.gov/content/pkg/FR-2021-05-17/pdf/2021-10460.pdf` -> HTTP 200.
- Retired White House EO URL: `https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/` -> HTTP 404.

## Validation

- `git diff --cached --check`
- Required frontmatter field check for the touched `SKILL.md` file
- `index.yaml` file-existence check
- Metadata consistency check confirming `OMB-M-22-09` and `EO-14028` appear in both skill frontmatter and index metadata
- Markdown fence-balance check across touched files and fixtures
- Staged diff prompt-injection scan
- Content assertions that the stale URL is absent from the production skill file and only present in the vulnerable fixture
- Fresh duplicate search for exact `zero-trust-assessment` EO 14028 source/metadata work