### PR TITLE
Improve AWS CloudFront S3 origin evidence

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -3,10 +3,10 @@ name: aws-review
 description: >
   Performs an AWS security posture review against the CIS Amazon Web Services
   Foundations Benchmark v3.0.0. Auto-invoked when reviewing AWS infrastructure,
-  IAM policies, S3 configurations, CloudTrail settings, VPC security groups, or
-  RDS encryption. Walks through all five benchmark sections, evaluates each
-  recommendation, and produces a prioritized findings report with remediation
-  guidance mapped to specific CIS control IDs.
+  IAM policies, S3 configurations, CloudFront-backed S3 origins, CloudTrail
+  settings, VPC security groups, or RDS encryption. Walks through all five
+  benchmark sections, evaluates each recommendation, and produces a prioritized
+  findings report with remediation guidance mapped to specific CIS control IDs.
 tags: [cloud, aws, cis-benchmark]
 role: [cloud-security-engineer, security-engineer]
 phase: [assess, operate]
@@ -38,7 +38,7 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 - Reviewing AWS infrastructure-as-code before deployment
 - Assessing an existing AWS environment's security posture against CIS benchmarks
 - Preparing for a CIS benchmark audit or compliance assessment
-- Evaluating IAM policies, S3 bucket configurations, CloudTrail settings, VPC security groups, or RDS encryption configurations
+- Evaluating IAM policies, S3 bucket configurations, CloudFront-backed S3 origins, CloudTrail settings, VPC security groups, or RDS encryption configurations
 - Onboarding a new AWS account into a security program
 
 ---
@@ -53,6 +53,9 @@ The CIS Amazon Web Services Foundations Benchmark v3.0.0 is a consensus-driven s
 - AWS CLI output or configuration exports (if reviewing a live environment)
 - IAM policy documents (JSON)
 - S3 bucket policies and ACL configurations
+- CloudFront distribution, origin access control (OAC), origin access identity
+  (OAI), and S3 origin bucket policy definitions when S3 content is served
+  through CloudFront
 - VPC, security group, and NACL definitions
 - CloudTrail and CloudWatch configuration files
 
@@ -76,6 +79,11 @@ Use Glob to locate all AWS-related infrastructure definitions.
 **/terraform/**/*.tf
 **/iam-policies/**/*.json
 **/policies/**/*.json
+**/cloudfront*
+**/distributions/**/*.json
+**/cdn/**/*.tf
+**/cdn/**/*.yaml
+**/cdn/**/*.json
 ```
 
 Also locate supporting configuration:
@@ -199,7 +207,8 @@ Produce the final report using the structure defined in the Output Format sectio
 3. **Confusing CloudTrail multi-region with organization trail.** CIS 3.1 requires multi-region, not necessarily an organization trail. Both are valid, but the control checks `is_multi_region_trail`.
 4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
 5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
-6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
+6. **Treating CloudFront as proof that an S3 bucket is private.** A bucket served through CloudFront still needs a private S3 origin posture: OAC or legacy OAI evidence, bucket policy scoped to the distribution, and no public website endpoint exposure. Block Public Access alone does not prove CloudFront is the only access path.
+7. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
 
 ---
 
@@ -223,6 +232,8 @@ Produce the final report using the structure defined in the Output Format sectio
 - AWS Security Best Practices: https://docs.aws.amazon.com/security/
 - AWS IAM Best Practices: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 - AWS CloudTrail Documentation: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/
+- Amazon CloudFront: Restrict access to an Amazon S3 origin: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html
+- Amazon S3: Blocking public access to your Amazon S3 storage: https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html
 - AWS Security Hub: https://docs.aws.amazon.com/securityhub/latest/userguide/
 - AWS VPC Security: https://docs.aws.amazon.com/vpc/latest/userguide/security.html
 - Terraform AWS Provider Documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -215,6 +215,53 @@ Also verify account-level public access block:
 aws_s3_account_public_access_block
 ```
 
+### Supplemental S3/CloudFront origin access evidence
+
+When an S3 bucket is used as a CloudFront origin, do not mark the storage posture as passing solely because a distribution exists or because bucket-level Block Public Access is configured. Verify that CloudFront is the only intended read path and that direct S3 access remains blocked.
+
+**Pass evidence for private S3 origins behind CloudFront:**
+
+```hcl
+resource "aws_cloudfront_origin_access_control" "site" {
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "site" {
+  origin {
+    domain_name              = aws_s3_bucket.site.bucket_regional_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.site.id
+  }
+}
+```
+
+Bucket policy evidence should grant CloudFront access through the service principal and scope access to the distribution ARN:
+
+```json
+{
+  "Effect": "Allow",
+  "Principal": {"Service": "cloudfront.amazonaws.com"},
+  "Action": "s3:GetObject",
+  "Resource": "arn:aws:s3:::example-bucket/*",
+  "Condition": {
+    "StringEquals": {
+      "AWS:SourceArn": "arn:aws:cloudfront::123456789012:distribution/EDFDVBD6EXAMPLE"
+    }
+  }
+}
+```
+
+**Fail or not-evaluable evidence:**
+
+- The CloudFront origin points at an S3 website endpoint. Website endpoints are custom origins and cannot use OAC or OAI.
+- The distribution has an S3 origin but no `origin_access_control_id`, no `origin_access_identity`, and no equivalent CloudFormation `OriginAccessControlId`.
+- The bucket policy grants `Principal: "*"` or broad account access for `s3:GetObject` without a CloudFront `AWS:SourceArn` condition.
+- OAC `signing_behavior` is `never`, because the S3 origin must then be publicly accessible for CloudFront to read it.
+- Legacy OAI is present but the review involves SSE-KMS, dynamic S3 requests, or newer opt-in Regions. Flag this as a migration or hardening finding and prefer OAC.
+
+**Finding classification:** Public S3 read access for a CloudFront-backed origin is **Critical** when sensitive data may be exposed, otherwise **High**. Missing or ambiguous OAC/OAI evidence is **Medium** until direct S3 access can be ruled out.
+
 ### CIS 2.2.1 -- Ensure EBS Volume Encryption is Enabled in all Regions
 
 Check for default EBS encryption:

--- a/skills/cloud/aws-review/tests/benign/cloudfront-oac-s3-origin.md
+++ b/skills/cloud/aws-review/tests/benign/cloudfront-oac-s3-origin.md
@@ -1,0 +1,46 @@
+# Benign: CloudFront OAC restricts S3 origin access
+
+This fixture should be treated as a pass for the supplemental CloudFront/S3 origin evidence gate.
+
+```hcl
+resource "aws_s3_bucket_public_access_block" "site" {
+  bucket                  = aws_s3_bucket.site.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_cloudfront_origin_access_control" "site" {
+  name                              = "site-oac"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "site" {
+  origin {
+    domain_name              = aws_s3_bucket.site.bucket_regional_domain_name
+    origin_id                = "site-s3-origin"
+    origin_access_control_id = aws_cloudfront_origin_access_control.site.id
+  }
+}
+
+data "aws_iam_policy_document" "site_bucket" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.site.arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.site.arn]
+    }
+  }
+}
+```

--- a/skills/cloud/aws-review/tests/vulnerable/cloudfront-public-s3-origin.md
+++ b/skills/cloud/aws-review/tests/vulnerable/cloudfront-public-s3-origin.md
@@ -1,0 +1,33 @@
+# Vulnerable: CloudFront distribution does not restrict direct S3 access
+
+This fixture should be treated as a fail for the supplemental CloudFront/S3 origin evidence gate.
+
+```hcl
+resource "aws_s3_bucket_public_access_block" "site" {
+  bucket                  = aws_s3_bucket.site.id
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_policy" "site" {
+  bucket = aws_s3_bucket.site.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = "*"
+      Action    = "s3:GetObject"
+      Resource  = "${aws_s3_bucket.site.arn}/*"
+    }]
+  })
+}
+
+resource "aws_cloudfront_distribution" "site" {
+  origin {
+    domain_name = aws_s3_bucket_website_configuration.site.website_endpoint
+    origin_id   = "public-site-origin"
+  }
+}
+```


### PR DESCRIPTION
﻿## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** aws-review
**Skill path:** `skills/cloud/aws-review/`

### What Was Wrong
The AWS review skill covered S3 public access blocks, but it did not explicitly test the common CloudFront-backed S3 origin path. That can produce a false pass when a bucket is fronted by CloudFront but still directly readable from S3, uses an S3 website endpoint, lacks OAC/OAI evidence, or has a broad bucket policy that is not scoped to the CloudFront distribution.

AWS documents OAC as the recommended way to restrict access to S3 origins, and notes that S3 website endpoints cannot use OAC/OAI because they are configured as custom origins.

### What This PR Fixes
- Adds CloudFront-backed S3 origin discovery and prerequisite evidence to the AWS review skill.
- Adds a supplemental checklist gate for OAC/OAI, signed OAC requests, bucket policy scoping to `cloudfront.amazonaws.com`, `AWS:SourceArn`, S3 website endpoint handling, and legacy OAI caveats.
- Adds benign and vulnerable fixtures showing the pass/fail distinction.
- Adds AWS primary references for CloudFront S3 origin restriction and S3 Block Public Access.

### Evidence

**Before (skill misses this / false positive on this):**
```hcl
resource "aws_cloudfront_distribution" "site" {
  origin {
    domain_name = aws_s3_bucket_website_configuration.site.website_endpoint
    origin_id   = "public-site-origin"
  }
}
```
The existing storage checks could focus on S3 block settings and miss that the CloudFront origin is a website endpoint with no OAC/OAI path and potentially public direct S3 access.

**After (now correctly handled):**
```hcl
resource "aws_cloudfront_origin_access_control" "site" {
  origin_access_control_origin_type = "s3"
  signing_behavior                  = "always"
  signing_protocol                  = "sigv4"
}
```
The checklist now requires OAC/OAI evidence, distribution linkage, bucket policy scoping to the CloudFront service principal and distribution ARN, and flags public/ambiguous cases.

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** PayPal (`paypal.me/SBozicovich`)

## Validation
- `git diff --check`
- Frontmatter required fields check
- Index file existence check
- Prompt injection pattern scan on touched files
- Code fence balance check on touched files

## References
- AWS CloudFront: Restrict access to an Amazon S3 origin: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html
- Amazon S3: Blocking public access to your Amazon S3 storage: https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html