### PR TITLE
Improve SAST ASVS 5.0.0 source metadata

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -548,7 +548,7 @@ skills:
     role: [security-engineer, appsec-engineer]
     phase: [build]
     activity: [configure, review]
-    frameworks: [OWASP-ASVS-4.0.3, CWE-Top-25]
+    frameworks: [OWASP-ASVS-5.0.0, CWE-Top-25]
     difficulty: intermediate
     time_estimate: "30-60min"
     file: skills/devsecops/sast-config/SKILL.md

--- a/skills/devsecops/sast-config/SKILL.md
+++ b/skills/devsecops/sast-config/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: sast-config
 description: >
-  Reviews and tunes SAST tool configurations against OWASP ASVS 4.0.3 and
+  Reviews and tunes SAST tool configurations against OWASP ASVS 5.0.0 and
   CWE Top 25. Auto-invoked when reviewing Semgrep rules, CodeQL queries, SAST
   CI integration, or false positive triage workflows. Produces a SAST maturity
   assessment covering rule authoring, severity tuning, custom rule development,
@@ -9,10 +9,10 @@ description: >
 tags: [devsecops, sast, semgrep, codeql]
 role: [security-engineer, appsec-engineer]
 phase: [build]
-frameworks: [OWASP-ASVS-4.0.3, CWE-Top-25]
+frameworks: [OWASP-ASVS-5.0.0, CWE-Top-25]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -22,7 +22,7 @@ argument-hint: "[target-file-or-directory]"
 
 # SAST Tool Configuration and Tuning
 
-A structured, repeatable process for reviewing and tuning Static Application Security Testing (SAST) tool configurations against OWASP ASVS 4.0.3 verification requirements and the CWE Top 25 Most Dangerous Software Weaknesses. This skill covers Semgrep rule authoring, CodeQL query patterns, severity tuning, false positive management, custom rule development, and CI integration. All findings map to ASVS controls and CWE identifiers.
+A structured, repeatable process for reviewing and tuning Static Application Security Testing (SAST) tool configurations against OWASP ASVS 5.0.0 verification requirements and the CWE Top 25 Most Dangerous Software Weaknesses. This skill covers Semgrep rule authoring, CodeQL query patterns, severity tuning, false positive management, custom rule development, and CI integration. All findings map to ASVS controls and CWE identifiers.
 
 ---
 
@@ -41,7 +41,7 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 
 ## Context
 
-SAST tools are only as effective as their configuration. Default rule sets produce high false positive rates that erode developer trust, while overly aggressive tuning creates dangerous blind spots. OWASP ASVS 4.0.3 provides 286 verification requirements across 14 chapters -- a subset of these are automatable via SAST. The CWE Top 25 (2024 edition) identifies the most prevalent and impactful weakness types. Effective SAST tuning maps rules to these frameworks, tunes severity to organizational risk context, and integrates into CI with clear pass/fail criteria that developers can act on.
+SAST tools are only as effective as their configuration. Default rule sets produce high false positive rates that erode developer trust, while overly aggressive tuning creates dangerous blind spots. OWASP ASVS 5.0.0 provides current application security verification requirements; a subset of these are automatable via SAST. The CWE Top 25 (2024 edition) identifies the most prevalent and impactful weakness types. Effective SAST tuning maps rules to these frameworks, tunes severity to organizational risk context, and integrates into CI with clear pass/fail criteria that developers can act on.
 
 ---
 
@@ -456,7 +456,7 @@ jobs:
 - SAST tool(s): <Semgrep, CodeQL, SonarQube, etc.>
 - Configuration files analyzed: <list of file paths>
 - Date: <assessment date>
-- Frameworks applied: OWASP ASVS 4.0.3, CWE Top 25
+- Frameworks applied: OWASP ASVS 5.0.0, CWE Top 25
 
 ### CWE Top 25 Coverage
 
@@ -494,7 +494,7 @@ jobs:
 
 ## Framework Reference
 
-### OWASP ASVS 4.0.3 (SAST-Relevant Chapters)
+### OWASP ASVS 5.0.0 (SAST-Relevant Chapters)
 
 | Chapter | Title | SAST Coverage |
 |---------|-------|---------------|
@@ -551,7 +551,8 @@ This skill processes SAST configuration files, custom rules, and code patterns t
 
 ## References
 
-- OWASP ASVS 4.0.3: https://owasp.org/www-project-application-security-verification-standard/
+- OWASP ASVS 5.0.0: https://owasp.org/www-project-application-security-verification-standard/
+- OWASP ASVS 5.0.0 release: https://github.com/OWASP/ASVS/releases/tag/v5.0.0_release
 - CWE Top 25 (2024): https://cwe.mitre.org/top25/archive/2024/2024_cwe_top25.html
 - Semgrep Documentation: https://semgrep.dev/docs/
 - Semgrep Rule Syntax: https://semgrep.dev/docs/writing-rules/rule-syntax/
@@ -564,4 +565,5 @@ This skill processes SAST configuration files, custom rules, and code patterns t
 
 ## Changelog
 
-- **1.0.0** -- Initial release. Full coverage of SAST configuration review against OWASP ASVS 4.0.3 and CWE Top 25, with Semgrep and CodeQL patterns.
+- **1.0.1** -- Refresh OWASP ASVS source references and discovery metadata from 4.0.3 to 5.0.0.
+- **1.0.0** -- Initial release. Full coverage of SAST configuration review against OWASP ASVS and CWE Top 25, with Semgrep and CodeQL patterns.

--- a/skills/devsecops/sast-config/tests/benign/current-asvs-500-source.md
+++ b/skills/devsecops/sast-config/tests/benign/current-asvs-500-source.md
@@ -1,0 +1,10 @@
+# Benign: current ASVS 5.0.0 source
+
+This fixture represents a SAST configuration review guide that uses the current
+OWASP ASVS 5.0.0 baseline and release evidence:
+
+- Frameworks applied: OWASP ASVS 5.0.0, CWE Top 25
+- Project page: https://owasp.org/www-project-application-security-verification-standard/
+- Release page: https://github.com/OWASP/ASVS/releases/tag/v5.0.0_release
+
+Expected result: no framework-freshness finding for the ASVS baseline.

--- a/skills/devsecops/sast-config/tests/vulnerable/stale-asvs-403-source.md
+++ b/skills/devsecops/sast-config/tests/vulnerable/stale-asvs-403-source.md
@@ -1,0 +1,10 @@
+# Vulnerable: stale ASVS 4.0.3 source
+
+This fixture represents a SAST configuration review guide that still treats
+OWASP ASVS 4.0.3 as the current baseline:
+
+- Frameworks applied: OWASP ASVS 4.0.3, CWE Top 25
+- Reference: https://owasp.org/www-project-application-security-verification-standard/
+
+Expected finding: update the SAST review baseline and discovery metadata to
+OWASP ASVS 5.0.0 and cite the current official ASVS release source.


### PR DESCRIPTION
## Summary

- Refreshes `sast-config` from the stale OWASP ASVS 4.0.3 baseline to the current ASVS 5.0.0 baseline.
- Updates skill frontmatter, `index.yaml`, context, output template, framework heading, references, and changelog.
- Adds small vulnerable/benign fixtures for stale vs current ASVS source handling.

Addresses #612.

## Source verification

- OWASP ASVS project page: `https://owasp.org/www-project-application-security-verification-standard/` -> HTTP 200.
- OWASP ASVS 5.0.0 release tag: `https://github.com/OWASP/ASVS/releases/tag/v5.0.0_release` -> HTTP 200.

## Validation

- `git diff --cached --check`
- Required frontmatter field check for the touched `SKILL.md` file
- `index.yaml` file-existence check
- Metadata consistency check confirming `OWASP-ASVS-5.0.0` appears in both skill frontmatter and index metadata and `OWASP-ASVS-4.0.3` does not
- Markdown fence-balance check across touched files and fixtures
- Staged diff prompt-injection scan
- Content assertions that stale ASVS 4.0.3 current-baseline wording is absent from production skill/index files and only present in the vulnerable fixture
- Fresh duplicate search for exact `sast-config` ASVS freshness work