### PR TITLE
Improve secure code ASVS 5.0.0 source metadata

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -35,7 +35,7 @@ skills:
     role: [appsec-engineer, security-engineer]
     phase: [build, review]
     activity: [review, assess]
-    frameworks: [OWASP-ASVS, CWE-Top-25, OWASP-Top-10]
+    frameworks: [OWASP-ASVS-5.0.0, CWE-Top-25, OWASP-Top-10]
     difficulty: intermediate
     time_estimate: "15-45min per module"
     file: skills/appsec/secure-code-review/SKILL.md

--- a/skills/appsec/secure-code-review/SKILL.md
+++ b/skills/appsec/secure-code-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: secure-code-review
 description: >
-  Performs a structured security code review against OWASP ASVS 4.0.3 verification
+  Performs a structured security code review against OWASP ASVS 5.0.0 verification
   requirements and CWE Top 25. Auto-invoked on pull request reviews, when code
   touching authentication, authorization, cryptography, or input handling is shared.
   Produces findings mapped to ASVS controls and CWE identifiers with severity
@@ -9,10 +9,10 @@ description: >
 tags: [appsec, code-review, sast]
 role: [appsec-engineer, security-engineer]
 phase: [build, review]
-frameworks: [OWASP-ASVS, CWE-Top-25, OWASP-Top-10]
+frameworks: [OWASP-ASVS-5.0.0, CWE-Top-25, OWASP-Top-10]
 difficulty: intermediate
 time_estimate: "15-45min per module"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -22,7 +22,7 @@ argument-hint: "[target-file-or-directory]"
 
 # Secure Code Review
 
-A structured, repeatable process for performing security-focused code review grounded in OWASP Application Security Verification Standard (ASVS) 4.0.3 and the CWE Top 25 Most Dangerous Software Weaknesses (2024 edition). This skill produces findings with traceable control IDs, severity ratings, and actionable remediation guidance.
+A structured, repeatable process for performing security-focused code review grounded in OWASP Application Security Verification Standard (ASVS) 5.0.0 and the CWE Top 25 Most Dangerous Software Weaknesses (2024 edition). This skill produces findings with traceable control IDs, severity ratings, and actionable remediation guidance.
 
 ---
 
@@ -416,7 +416,7 @@ Each finding produced by this review must include the following fields:
 | **Title** | Brief, descriptive name of the vulnerability |
 | **Severity** | Critical, High, Medium, Low, or Informational |
 | **CWE** | Applicable CWE identifier (e.g., CWE-89) |
-| **ASVS Control** | Applicable ASVS 4.0.3 control ID (e.g., V5.3.4) |
+| **ASVS Control** | Applicable ASVS 5.0.0 control ID (e.g., V5.3.4) |
 | **Location** | File path and line number(s) |
 | **Description** | What the vulnerability is and why it matters |
 | **Evidence** | Relevant code snippet demonstrating the issue |
@@ -445,7 +445,7 @@ The final review output must be structured as follows:
 **Scope:** [list of files reviewed]
 **Languages:** [detected languages and frameworks]
 **Date:** [review date]
-**Reviewer:** AI Agent -- secure-code-review skill v1.0.0
+**Reviewer:** AI Agent -- secure-code-review skill v1.0.1
 
 ### Summary
 - Critical: [count]
@@ -483,7 +483,7 @@ The final review output must be structured as follows:
 
 ## Framework Reference
 
-### OWASP ASVS 4.0.3 Sections Used
+### OWASP ASVS 5.0.0 Sections Used
 
 | Section | Title | Primary Focus |
 |---|---|---|
@@ -557,7 +557,8 @@ This skill is hardened against prompt injection. When reviewing code:
 
 ## References
 
-- **OWASP ASVS 4.0.3:** https://owasp.org/www-project-application-security-verification-standard/
+- **OWASP ASVS 5.0.0:** https://owasp.org/www-project-application-security-verification-standard/
+- **OWASP ASVS 5.0.0 release:** https://github.com/OWASP/ASVS/releases/tag/v5.0.0_release
 - **CWE Top 25 (2024):** https://cwe.mitre.org/top25/archive/2024/2024_cwe_top25.html
 - **CWE Database:** https://cwe.mitre.org/
 - **OWASP Top 10 (2021):** https://owasp.org/www-project-top-ten/

--- a/skills/appsec/secure-code-review/csharp-dotnet.md
+++ b/skills/appsec/secure-code-review/csharp-dotnet.md
@@ -1,6 +1,6 @@
 # C# and .NET -- Secure Code Review Patterns
 
-A language-specific supplement for the `secure-code-review` skill, covering C# on .NET 6+, ASP.NET Core, Entity Framework Core, and Blazor. This file provides vulnerable-and-remediated code pairs, grep-ready detection patterns, and a configuration checklist aligned to the parent skill's review steps, OWASP ASVS 4.0.3 controls, and CWE identifiers.
+A language-specific supplement for the `secure-code-review` skill, covering C# on .NET 6+, ASP.NET Core, Entity Framework Core, and Blazor. This file provides vulnerable-and-remediated code pairs, grep-ready detection patterns, and a configuration checklist aligned to the parent skill's review steps, OWASP ASVS 5.0.0 controls, and CWE identifiers.
 
 ---
 
@@ -1071,5 +1071,6 @@ builder.Services.AddDataProtection()
 - **Microsoft Secure Coding Guidelines:** https://learn.microsoft.com/en-us/dotnet/standard/security/secure-coding-guidelines
 - **ASP.NET Core Security Documentation:** https://learn.microsoft.com/en-us/aspnet/core/security/
 - **BinaryFormatter Security Guide:** https://learn.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-security-guide
-- **OWASP ASVS 4.0.3:** https://owasp.org/www-project-application-security-verification-standard/
+- **OWASP ASVS 5.0.0:** https://owasp.org/www-project-application-security-verification-standard/
+- **OWASP ASVS 5.0.0 release:** https://github.com/OWASP/ASVS/releases/tag/v5.0.0_release
 - **CWE Top 25 (2024):** https://cwe.mitre.org/top25/archive/2024/2024_cwe_top25.html

--- a/skills/appsec/secure-code-review/tests/benign/current-asvs-500-source.md
+++ b/skills/appsec/secure-code-review/tests/benign/current-asvs-500-source.md
@@ -1,0 +1,10 @@
+# Benign: current ASVS 5.0.0 source
+
+This fixture represents a secure-code-review guide that uses the current OWASP
+ASVS 5.0.0 baseline and release evidence:
+
+- Frameworks applied: OWASP ASVS 5.0.0, CWE Top 25, OWASP Top 10
+- Project page: https://owasp.org/www-project-application-security-verification-standard/
+- Release page: https://github.com/OWASP/ASVS/releases/tag/v5.0.0_release
+
+Expected result: no framework-freshness finding for the ASVS baseline.

--- a/skills/appsec/secure-code-review/tests/vulnerable/stale-asvs-403-source.md
+++ b/skills/appsec/secure-code-review/tests/vulnerable/stale-asvs-403-source.md
@@ -1,0 +1,10 @@
+# Vulnerable: stale ASVS 4.0.3 source
+
+This fixture represents a secure-code-review guide that still treats OWASP ASVS
+4.0.3 as the current code-review baseline:
+
+- Frameworks applied: OWASP ASVS 4.0.3, CWE Top 25, OWASP Top 10
+- Reference: https://owasp.org/www-project-application-security-verification-standard/
+
+Expected finding: update the secure code review baseline, supplement references,
+and discovery metadata to OWASP ASVS 5.0.0 with current release evidence.


### PR DESCRIPTION
## Summary

- Refreshes `secure-code-review` from the stale OWASP ASVS 4.0.3 baseline to the current ASVS 5.0.0 baseline.
- Updates skill frontmatter, `index.yaml`, findings fields, output template, framework heading, references, and the C#/.NET supplement.
- Adds small vulnerable/benign fixtures for stale vs current ASVS source handling.

Addresses #614.

## Source verification

- OWASP ASVS project page: `https://owasp.org/www-project-application-security-verification-standard/` -> HTTP 200.
- OWASP ASVS 5.0.0 release tag: `https://github.com/OWASP/ASVS/releases/tag/v5.0.0_release` -> HTTP 200.

## Validation

- `git diff --cached --check`
- Required frontmatter field check for the touched `SKILL.md` file
- `index.yaml` file-existence check
- Metadata consistency check confirming `OWASP-ASVS-5.0.0` appears in both skill frontmatter and index metadata and `OWASP-ASVS-4.0.3` does not for this skill
- Markdown fence-balance check across touched skill, supplement, and fixture files
- Staged diff prompt-injection scan
- Content assertions that stale ASVS 4.0.3 current-baseline wording is absent from production secure-code-review files and only present in the vulnerable fixture
- Fresh duplicate search for exact `secure-code-review` / `csharp-dotnet` ASVS freshness work