### PR TITLE
Fix documentation skill paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,8 +93,8 @@ Author a completely new security skill from scratch.
 skills/
   [category]/
     [skill-name]/
-      skill.yaml          # Skill definition (detection + remediation)
-      README.md           # Human-readable description, examples, rationale
+      SKILL.md            # Skill entrypoint with YAML frontmatter and guidance
+      *.md                # Optional supporting references, examples, or checklists
       tests/
         vulnerable/       # Code samples that SHOULD trigger the skill
         benign/           # Code samples that should NOT trigger the skill
@@ -111,51 +111,31 @@ skills/
 
 ## Skill Format Reference
 
-Each skill is defined in `skill.yaml` with the following structure:
+Each skill is defined in `SKILL.md` as Markdown with YAML frontmatter. The frontmatter follows this structure:
 
 ```yaml
+---
 name: descriptive-skill-name
-version: "1.0"
+description: >
+  One paragraph explaining what this skill does, when the agent should use it,
+  and what output it produces.
+tags: [appsec, review]
+role: [security-engineer, appsec-engineer]
+phase: [design, review]
+frameworks: [CWE-XXX, OWASP-ASVS]
+difficulty: intermediate
+time_estimate: "30-60min"
+version: "1.0.0"
 author: your-github-handle
-category: injection | xss | auth | crypto | secrets | config | dependency | other
-severity: critical | high | medium | low
-languages:
-  - python
-  - javascript
-  # ... applicable languages
-
-description: |
-  One paragraph explaining what this skill detects, why it matters,
-  and what the real-world impact of this vulnerability class is.
-
-detection:
-  patterns:
-    - pattern: "the detection pattern or rule"
-      description: "what this specific pattern catches"
-  exceptions:
-    - pattern: "patterns to exclude (reduce false positives)"
-      description: "why this is safe"
-
-remediation:
-  approach: |
-    Describe the fix strategy in plain English.
-  automated: true | false
-  fix:
-    description: "what the automated fix does"
-    # fix implementation details
-
-references:
-  - url: "https://cwe.mitre.org/data/definitions/XXX.html"
-    description: "CWE reference"
-  - url: "https://owasp.org/..."
-    description: "OWASP reference"
-
-metadata:
-  cwe: ["CWE-XXX"]
-  owasp: ["A01:2021"]
-  created: "YYYY-MM-DD"
-  last_updated: "YYYY-MM-DD"
+license: MIT
+allowed-tools: Read, Grep, Glob
+context: fork
+injection-hardened: true
+argument-hint: "[target-file-or-directory]"
+---
 ```
+
+After the frontmatter, use Markdown sections for when to use the skill, required context, process, output format, examples, references, and changelog.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -75,96 +75,96 @@ Each skill is a directory with `SKILL.md` as the entrypoint, following the [Agen
 
 | Skill | File | Frameworks |
 |-------|------|------------|
-| Threat Modeling (STRIDE) | `skills/appsec/threat-modeling.md` | STRIDE, PASTA, MITRE ATT&CK |
-| Secure Code Review | `skills/appsec/secure-code-review.md` | OWASP ASVS 4.0.3, CWE Top 25 |
-| OWASP Top 10 (Web) | `skills/appsec/owasp-top-10-web.md` | OWASP Top 10 2021 |
-| API Security Review | `skills/appsec/api-security.md` | OWASP API Security Top 10 2023 |
-| Dependency Scanning | `skills/appsec/dependency-scanning.md` | SLSA v1.0, CycloneDX, SPDX |
+| Threat Modeling (STRIDE) | `skills/appsec/threat-modeling/SKILL.md` | STRIDE, PASTA, MITRE ATT&CK |
+| Secure Code Review | `skills/appsec/secure-code-review/SKILL.md` | OWASP ASVS 4.0.3, CWE Top 25 |
+| OWASP Top 10 (Web) | `skills/appsec/owasp-top-10-web/SKILL.md` | OWASP Top 10 2021 |
+| API Security Review | `skills/appsec/api-security/SKILL.md` | OWASP API Security Top 10 2023 |
+| Dependency Scanning | `skills/appsec/dependency-scanning/SKILL.md` | SLSA v1.0, CycloneDX, SPDX |
 
 ### AI Security
 
 | Skill | File | Frameworks |
 |-------|------|------------|
-| LLM Top 10 Review | `skills/ai-security/llm-top-10.md` | OWASP LLM Top 10 2025 |
-| Agentic AI Top 10 | `skills/ai-security/agentic-top-10.md` | OWASP Agentic AI, MITRE ATLAS |
-| Prompt Injection Testing | `skills/ai-security/prompt-injection.md` | OWASP LLM01:2025, MITRE ATLAS |
-| Model Supply Chain | `skills/ai-security/model-supply-chain.md` | OWASP LLM03:2025, SLSA v1.0 |
-| AI Data Privacy | `skills/ai-security/ai-data-privacy.md` | NIST AI RMF, OWASP LLM02:2025 |
-| Agent Security Architecture | `skills/ai-security/agent-security.md` | OWASP Agentic AI, NIST AI RMF |
+| LLM Top 10 Review | `skills/ai-security/llm-top-10/SKILL.md` | OWASP LLM Top 10 2025 |
+| Agentic AI Top 10 | `skills/ai-security/agentic-top-10/SKILL.md` | OWASP Agentic AI, MITRE ATLAS |
+| Prompt Injection Testing | `skills/ai-security/prompt-injection/SKILL.md` | OWASP LLM01:2025, MITRE ATLAS |
+| Model Supply Chain | `skills/ai-security/model-supply-chain/SKILL.md` | OWASP LLM03:2025, SLSA v1.0 |
+| AI Data Privacy | `skills/ai-security/ai-data-privacy/SKILL.md` | NIST AI RMF, OWASP LLM02:2025 |
+| Agent Security Architecture | `skills/ai-security/agent-security/SKILL.md` | OWASP Agentic AI, NIST AI RMF |
 
 ### Identity & Access
 
 | Skill | File | Frameworks |
 |-------|------|------------|
-| IAM Security Review | `skills/identity/iam-review.md` | NIST SP 800-63B, CIS Controls v8 |
-| Access Review | `skills/identity/access-review.md` | CIS Controls v8, NIST SP 800-53 |
-| RBAC/ABAC Design | `skills/identity/rbac-design.md` | NIST RBAC, NIST SP 800-162 |
-| Zero Trust Assessment | `skills/identity/zero-trust-assessment.md` | NIST SP 800-207, CISA ZTMM v2 |
-| Privileged Access Management | `skills/identity/privileged-access.md` | CIS Controls v8, NIST SP 800-53 |
+| IAM Security Review | `skills/identity/iam-review/SKILL.md` | NIST SP 800-63B, CIS Controls v8 |
+| Access Review | `skills/identity/access-review/SKILL.md` | CIS Controls v8, NIST SP 800-53 |
+| RBAC/ABAC Design | `skills/identity/rbac-design/SKILL.md` | NIST RBAC, NIST SP 800-162 |
+| Zero Trust Assessment | `skills/identity/zero-trust-assessment/SKILL.md` | NIST SP 800-207, CISA ZTMM v2 |
+| Privileged Access Management | `skills/identity/privileged-access/SKILL.md` | CIS Controls v8, NIST SP 800-53 |
 
 ### Cloud Security
 
 | Skill | File | Frameworks |
 |-------|------|------------|
-| AWS Security Review | `skills/cloud/aws-review.md` | CIS AWS Benchmark v3.0 |
-| Azure Security Review | `skills/cloud/azure-review.md` | CIS Azure Benchmark v2.1 |
-| GCP Security Review | `skills/cloud/gcp-review.md` | CIS GCP Benchmark v2.0 |
-| IaC Security | `skills/cloud/iac-security.md` | OWASP IaC Security, SLSA v1.0 |
-| Container Security | `skills/cloud/container-security.md` | CIS Docker v1.6, CIS K8s v1.9 |
+| AWS Security Review | `skills/cloud/aws-review/SKILL.md` | CIS AWS Benchmark v3.0 |
+| Azure Security Review | `skills/cloud/azure-review/SKILL.md` | CIS Azure Benchmark v2.1 |
+| GCP Security Review | `skills/cloud/gcp-review/SKILL.md` | CIS GCP Benchmark v2.0 |
+| IaC Security | `skills/cloud/iac-security/SKILL.md` | OWASP IaC Security, SLSA v1.0 |
+| Container Security | `skills/cloud/container-security/SKILL.md` | CIS Docker v1.6, CIS K8s v1.9 |
 
 ### Vulnerability Management
 
 | Skill | File | Frameworks |
 |-------|------|------------|
-| CVE Triage | `skills/vuln-management/cve-triage.md` | CVSS 4.0, SSVC 2.1, CISA KEV, EPSS |
-| Patch Prioritization | `skills/vuln-management/patch-prioritization.md` | SSVC 2.1, EPSS, CISA KEV |
-| SBOM Analysis | `skills/vuln-management/sbom-analysis.md` | CycloneDX, SPDX, VEX |
-| Scanner Tuning | `skills/vuln-management/scanner-tuning.md` | CVSS 4.0, CWE |
+| CVE Triage | `skills/vuln-management/cve-triage/SKILL.md` | CVSS 4.0, SSVC 2.1, CISA KEV, EPSS |
+| Patch Prioritization | `skills/vuln-management/patch-prioritization/SKILL.md` | SSVC 2.1, EPSS, CISA KEV |
+| SBOM Analysis | `skills/vuln-management/sbom-analysis/SKILL.md` | CycloneDX, SPDX, VEX |
+| Scanner Tuning | `skills/vuln-management/scanner-tuning/SKILL.md` | CVSS 4.0, CWE |
 
 ### Compliance
 
 | Skill | File | Frameworks |
 |-------|------|------------|
-| SOC 2 Gap Analysis | `skills/compliance/soc2-gap.md` | AICPA TSC |
-| ISO 27001 Gap Analysis | `skills/compliance/iso27001-gap.md` | ISO 27001:2022 |
-| PCI DSS Review | `skills/compliance/pci-dss-review.md` | PCI DSS v4.0 |
-| HIPAA Review | `skills/compliance/hipaa-review.md` | HIPAA Security Rule |
-| NIST CSF Assessment | `skills/compliance/nist-csf-assessment.md` | NIST CSF 2.0 |
+| SOC 2 Gap Analysis | `skills/compliance/soc2-gap/SKILL.md` | AICPA TSC |
+| ISO 27001 Gap Analysis | `skills/compliance/iso27001-gap/SKILL.md` | ISO 27001:2022 |
+| PCI DSS Review | `skills/compliance/pci-dss-review/SKILL.md` | PCI DSS v4.0 |
+| HIPAA Review | `skills/compliance/hipaa-review/SKILL.md` | HIPAA Security Rule |
+| NIST CSF Assessment | `skills/compliance/nist-csf-assessment/SKILL.md` | NIST CSF 2.0 |
 
 ### Incident Response
 
 | Skill | File | Frameworks |
 |-------|------|------------|
-| IR Playbook | `skills/incident-response/ir-playbook.md` | NIST SP 800-61 |
-| Forensics Checklist | `skills/incident-response/forensics-checklist.md` | NIST SP 800-86, RFC 3227 |
-| Containment Strategies | `skills/incident-response/containment.md` | NIST SP 800-61, MITRE ATT&CK |
-| Post-Incident Review | `skills/incident-response/post-incident-review.md` | NIST SP 800-61 |
+| IR Playbook | `skills/incident-response/ir-playbook/SKILL.md` | NIST SP 800-61 |
+| Forensics Checklist | `skills/incident-response/forensics-checklist/SKILL.md` | NIST SP 800-86, RFC 3227 |
+| Containment Strategies | `skills/incident-response/containment/SKILL.md` | NIST SP 800-61, MITRE ATT&CK |
+| Post-Incident Review | `skills/incident-response/post-incident-review/SKILL.md` | NIST SP 800-61 |
 
 ### SecOps
 
 | Skill | File | Frameworks |
 |-------|------|------------|
-| Detection Engineering | `skills/secops/detection-engineering.md` | MITRE ATT&CK v16, Sigma |
-| SIEM Rules | `skills/secops/siem-rules.md` | MITRE ATT&CK v16 |
-| Alert Triage | `skills/secops/alert-triage.md` | MITRE ATT&CK v16 |
-| Log Analysis | `skills/secops/log-analysis.md` | MITRE ATT&CK v16, NIST SP 800-92 |
+| Detection Engineering | `skills/secops/detection-engineering/SKILL.md` | MITRE ATT&CK v16, Sigma |
+| SIEM Rules | `skills/secops/siem-rules/SKILL.md` | MITRE ATT&CK v16 |
+| Alert Triage | `skills/secops/alert-triage/SKILL.md` | MITRE ATT&CK v16 |
+| Log Analysis | `skills/secops/log-analysis/SKILL.md` | MITRE ATT&CK v16, NIST SP 800-92 |
 
 ### Network Security
 
 | Skill | File | Frameworks |
 |-------|------|------------|
-| Firewall Rule Audit | `skills/network/firewall-review.md` | CIS Controls v8, NIST SP 800-41 |
-| Network Segmentation | `skills/network/segmentation.md` | NIST SP 800-207, CIS Controls v8 |
-| DNS Security | `skills/network/dns-security.md` | NIST SP 800-81, CIS Controls v8 |
+| Firewall Rule Audit | `skills/network/firewall-review/SKILL.md` | CIS Controls v8, NIST SP 800-41 |
+| Network Segmentation | `skills/network/segmentation/SKILL.md` | NIST SP 800-207, CIS Controls v8 |
+| DNS Security | `skills/network/dns-security/SKILL.md` | NIST SP 800-81, CIS Controls v8 |
 
 ### DevSecOps
 
 | Skill | File | Frameworks |
 |-------|------|------------|
-| Pipeline Security | `skills/devsecops/pipeline-security.md` | SLSA v1.0, OWASP CI/CD Top 10 |
-| Secrets Management | `skills/devsecops/secrets-management.md` | OWASP Secrets Mgmt, NIST SP 800-57 |
-| SAST Configuration | `skills/devsecops/sast-config.md` | OWASP ASVS, CWE Top 25 |
-| DAST Configuration | `skills/devsecops/dast-config.md` | OWASP Top 10, OWASP Testing Guide |
+| Pipeline Security | `skills/devsecops/pipeline-security/SKILL.md` | SLSA v1.0, OWASP CI/CD Top 10 |
+| Secrets Management | `skills/devsecops/secrets-management/SKILL.md` | OWASP Secrets Mgmt, NIST SP 800-57 |
+| SAST Configuration | `skills/devsecops/sast-config/SKILL.md` | OWASP ASVS, CWE Top 25 |
+| DAST Configuration | `skills/devsecops/dast-config/SKILL.md` | OWASP Top 10, OWASP Testing Guide |
 
 ---
 


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** Repository documentation / skill catalog
**Skill path:** `README.md`, `CONTRIBUTING.md`

### What Was Wrong
The README skill catalog still linked to old flattened paths like `skills/appsec/threat-modeling.md`, but this repository ships each skill as a directory with `SKILL.md` as the entrypoint. Those table paths were broken for users browsing or loading skills directly.

The contribution guide also described new skills as `skill.yaml` plus `README.md`, which no longer matches the Agent Skills layout used throughout the repo and in `index.yaml`.

### What This PR Fixes
- Updates all README skill table entries to point at real `skills/.../SKILL.md` files.
- Updates the new-skill structure in CONTRIBUTING.md to use `SKILL.md` and optional supporting Markdown files.
- Replaces the obsolete `skill.yaml` format example with the Markdown + YAML frontmatter format used by the existing skills.

### Evidence
**Before:** `skills/appsec/threat-modeling.md` does not exist, while `skills/appsec/threat-modeling/SKILL.md` does.

**After:** README points to `skills/appsec/threat-modeling/SKILL.md` and the same directory-entrypoint pattern across all listed skills.

### Test Cases Added/Updated
- [ ] Added vulnerable test cases (`tests/vulnerable/`)
- [ ] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass

Docs-only change; no vulnerable/benign fixtures apply.

Validation completed locally:
- `git diff --check HEAD~1..HEAD`
- Ruby check that every README `skills/.../SKILL.md` path exists
- Ruby check that no README skill table path still points at stale `skills/.../*.md` flattened files
- `rg` check that the stale `skill.yaml` contributor-guide reference was removed

### Bounty Tier
- [x] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [ ] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Can be provided privately after acceptance
