### PR TITLE
Improve container system workload and provenance evidence

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -189,7 +189,7 @@ skills:
 
   - id: container-security
     name: "Container & Kubernetes Security Review"
-    tags: [cloud, containers, kubernetes, docker]
+    tags: [cloud, containers, kubernetes, docker, provenance]
     role: [cloud-security-engineer, security-engineer]
     phase: [build, deploy, operate]
     activity: [review, audit]

--- a/skills/cloud/container-security/SKILL.md
+++ b/skills/cloud/container-security/SKILL.md
@@ -7,13 +7,13 @@ description: >
   or container orchestration configurations. Evaluates image security, runtime
   hardening, RBAC, Pod Security Standards, network policies, and secrets
   management. Produces a prioritized findings report with remediation guidance.
-tags: [cloud, containers, kubernetes, docker]
+tags: [cloud, containers, kubernetes, docker, provenance]
 role: [cloud-security-engineer, security-engineer]
 phase: [build, deploy, operate]
 frameworks: [CIS-Docker-v1.6.0, CIS-Kubernetes-v1.9.0, NIST-SP-800-190]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -92,6 +92,9 @@ Use Glob to locate all relevant configuration files.
 **/values-*.yaml
 **/kustomization.yaml
 **/kustomization.yml
+**/kyverno/**/*.yaml
+**/gatekeeper/**/*.yaml
+**/policies/**/*.yaml
 **/base/**/*.yaml
 **/overlays/**/*.yaml
 **/*-deployment.yaml
@@ -103,7 +106,25 @@ Use Glob to locate all relevant configuration files.
 **/*-podsecuritypolicy.yaml
 ```
 
-Classify findings by type: Dockerfiles, Kubernetes manifests, Helm charts, Kustomize overlays, and supporting configs. Record all discovered files.
+Classify findings by type: Dockerfiles, Kubernetes manifests, Helm charts, Kustomize overlays, admission policies, and supporting configs. Record all discovered files. If Helm or Kustomize is present, record whether rendered manifests were reviewed (`helm template`, Kustomize build output, or committed rendered YAML). If only templates/values are available, mark the rendered workload evidence as `Not Evaluable` rather than assuming the template defaults are deployed.
+
+For every Pod template, inventory `containers`, `initContainers`, and `ephemeralContainers` separately. Ephemeral debug containers can carry privileged security contexts and must not disappear behind the main container list.
+
+---
+
+### Step 2A: System Workload Exception Gate
+
+Before assigning Critical/High severity to `hostNetwork`, `hostPID`, `hostIPC`, hostPath, privileged mode, or added capabilities, determine whether the workload is an application workload or a justified platform/system workload.
+
+Record:
+
+- Namespace and owner: `kube-system`, platform namespace, application namespace, or unknown.
+- Component class: CNI, CSI/storage driver, kube-proxy, node exporter, log/EDR agent, admission/controller component, or application.
+- Required privilege: host namespace, capability, hostPath, or privileged mode and why it is needed.
+- Compensating controls: RBAC scope, dedicated service account, image digest/signature/provenance, namespace isolation, NetworkPolicy/effective egress, admission policy exception, and change-control owner.
+- Deny rule for application namespaces: evidence that the same privilege is blocked for ordinary app workloads.
+
+If all exception evidence is present, classify the finding as `System workload exception requires governance` rather than an application workload violation. If evidence is missing, keep the security finding and list the missing exception fields.
 
 ---
 
@@ -144,6 +165,8 @@ Produce the final report using the structure defined in the Output Format sectio
 - Date: <assessment date>
 - Frameworks: CIS Docker Benchmark v1.6.0, CIS Kubernetes Benchmark v1.9.0, NIST SP 800-190
 - Files reviewed: <N Dockerfiles, N K8s manifests, N Helm charts>
+- Rendered manifests reviewed: Yes / No / Not Evaluable
+- Admission policy evidence: Pod Security Admission / Kyverno / Gatekeeper / Other / Not Evaluable
 
 ### Executive Summary
 - Total checks evaluated: <N>
@@ -174,16 +197,26 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Line(s):** <line numbers>
 - **Resource:** <Deployment/StatefulSet name>
 - **Container:** <container name>
+- **Container class:** app / init / sidecar / ephemeral / system workload
+- **System workload exception:** Not applicable / Justified / Missing evidence
+- **Rendered manifest evidence:** Rendered / Template-only / Not Evaluable
+- **Verification performed:** <policy denial, scan result, manifest proof, or Not Evaluable reason>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration>
 - **Remediation:** <fix with code example>
 
 ### Pod Security Standards Compliance Matrix
 
-| Workload | Namespace | PSS Level | Violations |
-|----------|-----------|-----------|------------|
-| deploy/app | production | Baseline (not Restricted) | runAsRoot, no seccomp |
-| deploy/worker | production | Privileged | privileged: true |
+| Workload | Namespace | Containers Inspected | PSS Level | System Exception | Violations |
+|----------|-----------|----------------------|-----------|------------------|------------|
+| deploy/app | production | app/init/ephemeral | Baseline (not Restricted) | N/A | runAsRoot, no seccomp |
+| daemonset/cni | kube-system | app/init/ephemeral | Privileged | Justified / Missing evidence | hostNetwork, NET_ADMIN |
+
+### Image Provenance and Admission Enforcement
+
+| Workload | Image | Reference Type | Signing Present | Admission Verification | Unsigned Image Denied? | Evidence |
+|----------|-------|----------------|-----------------|------------------------|------------------------|----------|
+| deploy/app | ghcr.io/org/app@sha256:... | digest | cosign/keyless | Kyverno/Gatekeeper/enforcer | Yes/No/Not Evaluable | policy/test/log |
 
 ### Prioritized Remediation Plan
 
@@ -251,11 +284,11 @@ Produce the final report using the structure defined in the Output Format sectio
 ## Common Pitfalls
 
 1. **Init containers and sidecar containers are often missed.** Pod Security Standards apply to ALL containers in a pod, including init containers and ephemeral containers. Check every container spec.
-2. **Helm template values may override security settings.** A Helm chart template may set `runAsNonRoot: true`, but `values.yaml` or environment-specific values files may override it to `false`. Always check both the templates and all values files.
+2. **Helm template values may override security settings.** A Helm chart template may set `runAsNonRoot: true`, but `values.yaml` or environment-specific values files may override it to `false`. Always check both the templates and all values files, and prefer rendered manifests. If rendered output is unavailable, mark environment-specific controls as `Not Evaluable`.
 3. **Default namespace is not just a naming issue.** The `default` namespace typically has no NetworkPolicy and no Pod Security Admission labels. Workloads in `default` often bypass all policy controls.
 4. **Base64 encoding is not encryption.** Kubernetes Secrets store data as base64, which is trivially decodable. Secrets committed to version control in manifests are effectively plaintext.
 5. **`readOnlyRootFilesystem` breaks many applications.** When recommending this control, also recommend adding writable `emptyDir` volume mounts for directories the application needs to write to (e.g., `/tmp`, `/var/cache`).
-6. **Network policies are additive, not subtractive.** A default-deny policy must be explicitly created. Without it, all pod-to-pod traffic is allowed regardless of other NetworkPolicy resources.
+6. **Network policies are additive, not subtractive.** A default-deny policy must be explicitly created, and allow policies must be evaluated together. A namespace can have a default-deny policy and still allow broad egress through a second policy.
 7. **Distroless images have no shell.** While this is excellent for security, note that debugging requires ephemeral containers (`kubectl debug`). Flag this as a consideration, not a problem.
 
 ---
@@ -284,7 +317,10 @@ Produce the final report using the structure defined in the Output Format sectio
 - Kubernetes Pod Security Standards: https://kubernetes.io/docs/concepts/security/pod-security-standards/
 - Kubernetes Pod Security Admission: https://kubernetes.io/docs/concepts/security/pod-security-admission/
 - Kubernetes Network Policies: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+- Kubernetes Ephemeral Containers: https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/
 - Kubernetes RBAC: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Helm template command: https://helm.sh/docs/helm/helm_template/
+- Kyverno verifyImages rules: https://kyverno.io/docs/policy-types/cluster-policy/verify-images/
 - Docker Security Best Practices: https://docs.docker.com/develop/security-best-practices/
 - Dockerfile Best Practices: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
 - NSA/CISA Kubernetes Hardening Guide: https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF
@@ -293,4 +329,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.1.0** -- Added system workload exception gates, rendered manifest evidence, ephemeral container inventory, image provenance/admission enforcement evidence, and effective NetworkPolicy review guidance.
 - **1.0.0** -- Initial release. Full coverage of CIS Docker Benchmark v1.6.0 Section 4-5, CIS Kubernetes Benchmark v1.9.0 Sections 1-5, and NIST SP 800-190 countermeasures across all five risk categories.

--- a/skills/cloud/container-security/cis-benchmarks.md
+++ b/skills/cloud/container-security/cis-benchmarks.md
@@ -193,6 +193,8 @@ ENTRYPOINT ["/server"]
 
 Evaluate Kubernetes workload definitions against CIS Kubernetes Benchmark Section 5 (Policies) and Pod Security Standards.
 
+For each workload, inspect `containers`, `initContainers`, and `ephemeralContainers`. Apply Pod Security Standards to each container class and report when ephemeral debug containers were not present or not evaluable from the reviewed manifests.
+
 ### CIS 5.1 -- RBAC and Service Accounts
 
 #### CIS 5.1.1 -- Ensure that the cluster-admin role is only used where required
@@ -264,6 +266,39 @@ Evaluate workload configurations against Kubernetes Pod Security Standards. The 
 | **Baseline** | Minimally restrictive. Prevents known privilege escalations. | Standard workloads |
 | **Restricted** | Heavily restricted. Follows current hardening best practices. | Security-sensitive and untrusted workloads |
 
+#### System Workload Exception Gate
+
+`hostNetwork`, host namespaces, privileged mode, hostPath, and added capabilities remain high-risk controls. Before assigning application workload severity, check whether the workload is a platform component that needs node-level access:
+
+```yaml
+# Possible justified exception, not an automatic app-workload violation
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      hostNetwork: true
+      serviceAccountName: cni-agent
+      containers:
+        - name: cni-agent
+          securityContext:
+            capabilities:
+              add: ["NET_ADMIN"]
+```
+
+Required exception evidence:
+
+- Namespace is `kube-system` or a documented platform namespace.
+- Component class is CNI, CSI, kube-proxy, node exporter, log/EDR agent, admission/controller component, or another named system workload.
+- RBAC is scoped to the component's required API groups/resources/verbs.
+- Image is pinned to a digest or otherwise provenance-controlled, and admission verification evidence exists where available.
+- Admission/PSA/Kyverno/Gatekeeper policy denies the same host namespace/capability pattern for ordinary application namespaces.
+- Owner, change-control path, and compensating controls are documented.
+
+If these fields are complete, report `System workload exception requires governance` with Medium/Informational severity as appropriate. If any required field is missing, keep the underlying High/Critical finding and list the missing exception evidence.
+
 #### CIS 5.2.1 -- Ensure that the cluster has at least one active policy control mechanism installed
 
 Check for Pod Security Admission labels on namespaces:
@@ -318,6 +353,8 @@ spec:
 spec:
   hostNetwork: true  # FAIL for application workloads
 ```
+
+For CNI, CSI, kube-proxy, and node-level agents, run the System Workload Exception Gate before assigning final severity.
 
 #### CIS 5.2.6 -- Minimize the admission of containers with allowPrivilegeEscalation
 
@@ -430,6 +467,15 @@ spec:
 ```
 
 **Critical check:** A default-deny NetworkPolicy should exist in every namespace.
+
+**Effective policy check:** NetworkPolicies are additive. Verify the combined effect of default-deny plus all allow policies in the namespace. A namespace can pass the "has NetworkPolicy" check while still allowing broad egress or ingress through a second policy.
+
+Report:
+
+- Default-deny present: Yes / No / Not Evaluable.
+- Effective ingress reviewed: Yes / No / Not Evaluable.
+- Effective egress reviewed: Yes / No / Not Evaluable.
+- Broad allow policies such as empty `podSelector`, empty `namespaceSelector`, `0.0.0.0/0`, `::/0`, or all ports/protocols.
 
 ### CIS 5.4 -- Secrets Management
 
@@ -592,9 +638,45 @@ Evaluate container runtime configurations against NIST SP 800-190 countermeasure
 |---------------|---------------|
 | **CM-1:** Use minimal base images | Verify Alpine, Distroless, or slim variants in FROM |
 | **CM-2:** Scan images for vulnerabilities | Check for Trivy, Grype, Snyk in CI pipeline |
-| **CM-3:** Sign and verify images | Check for Cosign signatures, Notary, or admission webhooks |
-| **CM-4:** Use immutable tags or digests | `image: nginx@sha256:...` preferred over `image: nginx:1.25` |
+| **CM-3:** Sign and verify images | Check for signing plus admission-time verification that denies unsigned/untrusted images |
+| **CM-4:** Use immutable tags or digests | `image: nginx@sha256:...` preferred over mutable tags; record whether tags are resolved in rendered manifests |
 | **CM-5:** Remove unnecessary packages | No curl, wget, netcat, or shells in production images |
+
+#### Image Provenance and Admission Enforcement
+
+Signing in CI is not the same as cluster enforcement. For every material workload, record whether image provenance is enforced at admission time.
+
+Evidence to collect:
+
+- Image reference type: digest, immutable tag, mutable tag, or `latest`.
+- Signing evidence: Cosign/keyless, Notary, registry attestation, or Not Evaluable.
+- Admission policy: Kyverno `verifyImages`, Gatekeeper/OPA policy, Sigstore policy-controller, registry admission control, or Not Evaluable.
+- Policy mode: enforce, audit/warn only, dry-run, or unknown.
+- Negative test evidence: unsigned image denied, untrusted issuer/subject denied, mutable tag denied, or Not Evaluable.
+
+```yaml
+# Kyverno example: admission-time verification is enforceable when validationFailureAction is Enforce
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: verify-image-signatures
+spec:
+  validationFailureAction: Enforce
+  rules:
+    - name: require-cosign
+      match:
+        any:
+          - resources:
+              kinds: ["Pod"]
+      verifyImages:
+        - imageReferences: ["ghcr.io/example/*"]
+          attestors:
+            - entries:
+                - keyless:
+                    issuer: https://token.actions.githubusercontent.com
+```
+
+Flag a finding when CI signs images but no admission policy verifies them, when policy runs in audit/warn mode only, or when unsigned/untrusted images can still be admitted.
 
 ### NIST 800-190: Orchestrator Countermeasures
 

--- a/skills/cloud/container-security/cis-benchmarks.md
+++ b/skills/cloud/container-security/cis-benchmarks.md
@@ -652,6 +652,7 @@ Evidence to collect:
 - Signing evidence: Cosign/keyless, Notary, registry attestation, or Not Evaluable.
 - Admission policy: Kyverno `verifyImages`, Gatekeeper/OPA policy, Sigstore policy-controller, registry admission control, or Not Evaluable.
 - Policy mode: enforce, audit/warn only, dry-run, or unknown.
+- Keyless identity scope: Fulcio issuer plus exact `subject` or constrained `subjectRegExp`, or Not Evaluable.
 - Negative test evidence: unsigned image denied, untrusted issuer/subject denied, mutable tag denied, or Not Evaluable.
 
 ```yaml
@@ -674,6 +675,7 @@ spec:
             - entries:
                 - keyless:
                     issuer: https://token.actions.githubusercontent.com
+                    subject: https://github.com/example/app/.github/workflows/release.yaml@refs/heads/main
 ```
 
 Flag a finding when CI signs images but no admission policy verifies them, when policy runs in audit/warn mode only, or when unsigned/untrusted images can still be admitted.


### PR DESCRIPTION
Closes #633

## Summary
- add a system workload exception gate for CNI/CSI/kube-proxy/node-level agents before assigning app-workload severity
- require rendered Helm/Kustomize evidence or mark template-only reviews as Not Evaluable
- include `ephemeralContainers` in workload inventory and the Pod Security Standards matrix
- make image signing/provenance falsifiable with admission-enforcement and unsigned-image denial evidence
- add effective NetworkPolicy review so default-deny plus broad allow policies are assessed together
- sync container-security catalog tags with provenance coverage

## Sources
- NIST SP 800-190: https://csrc.nist.gov/publications/detail/sp/800-190/final
- Kubernetes Pod Security Standards: https://kubernetes.io/docs/concepts/security/pod-security-standards/
- Kubernetes ephemeral containers: https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/
- Helm template command: https://helm.sh/docs/helm/helm_template/
- Kyverno verifyImages rules: https://kyverno.io/docs/policy-types/cluster-policy/verify-images/
- Kubernetes Network Policies: https://kubernetes.io/docs/concepts/services-networking/network-policies/

## Validation
- `git diff --check`
- `rg -n "version: \"1\.1\.0\"|provenance|System Workload Exception|Rendered manifests reviewed|ephemeralContainers|Image Provenance|Unsigned Image Denied|verifyImages|validationFailureAction|Effective policy check|rendered manifests|Kubernetes Ephemeral Containers|Kyverno verifyImages" index.yaml skills/cloud/container-security/SKILL.md skills/cloud/container-security/cis-benchmarks.md`
- source link HTTP checks returned 200

Preferred payment details can be provided privately after maintainer acceptance.