### PR TITLE
Improve SBOM trust and VEX product matching guidance

### DIFF
--- a/skills/vuln-management/sbom-analysis/SKILL.md
+++ b/skills/vuln-management/sbom-analysis/SKILL.md
@@ -3,14 +3,14 @@ name: sbom-analysis
 description: >
   Analyzes Software Bills of Materials (SBOMs) for completeness against NTIA
   minimum elements, interprets VEX status documents, performs transitive
-  dependency risk analysis, and detects license conflicts. Supports CycloneDX 1.5
-  and SPDX 2.3 formats with CSAF-based VEX correlation. Auto-invoked when SBOM
-  files are shared, supply chain risk questions arise, or VEX documents require
-  interpretation.
+  dependency risk analysis, and detects license conflicts. Supports CycloneDX 1.5/1.6
+  and SPDX 2.3/3.x formats with CSAF-based VEX correlation, SBOM provenance checks,
+  and product-reference matching. Auto-invoked when SBOM files are shared, supply
+  chain risk questions arise, or VEX documents require interpretation.
 tags: [vuln-management, sbom, supply-chain]
 role: [security-engineer, appsec-engineer]
 phase: [build, operate]
-frameworks: [CycloneDX-1.5, SPDX-2.3, VEX-CSAF, NTIA-SBOM-Minimum-Elements]
+frameworks: [CycloneDX-1.5, CycloneDX-1.6, SPDX-2.3, SPDX-3.x, VEX-CSAF, NTIA-SBOM-Minimum-Elements]
 difficulty: intermediate
 time_estimate: "20-40min"
 version: "1.0.0"
@@ -21,9 +21,9 @@ injection-hardened: true
 argument-hint: "[target-file-or-directory]"
 ---
 
-# SBOM Analysis & VEX Review -- CycloneDX 1.5 / SPDX 2.3 / VEX (CSAF) / NTIA Minimum Elements
+# SBOM Analysis & VEX Review -- CycloneDX 1.5/1.6 / SPDX 2.3/3.x / VEX (CSAF) / NTIA Minimum Elements
 
-> **Frameworks:** CycloneDX 1.5 (OWASP), SPDX 2.3 (Linux Foundation / ISO 5962), VEX via CSAF 2.0 (OASIS), NTIA SBOM Minimum Elements
+> **Frameworks:** CycloneDX 1.5/1.6 (OWASP), SPDX 2.3/3.x (Linux Foundation / ISO 5962), VEX via CSAF 2.0 (OASIS), NTIA SBOM Minimum Elements
 > **Role:** Security Engineer, AppSec Engineer
 > **Time:** 20-40 min
 > **Output:** SBOM completeness assessment, VEX status summary, dependency risk analysis, and license conflict report
@@ -45,9 +45,11 @@ Use this skill when an SBOM file (CycloneDX or SPDX format) is shared for review
 Before starting, collect or confirm:
 
 - [ ] **SBOM file(s):** The actual SBOM document(s) in CycloneDX (JSON/XML) or SPDX (JSON/RDF/tag-value) format
-- [ ] **SBOM format and version:** CycloneDX 1.5, SPDX 2.3, or other (identify version explicitly)
+- [ ] **SBOM format and version:** CycloneDX 1.5/1.6, SPDX 2.3/3.x, or other (identify version explicitly)
 - [ ] **VEX document(s):** Associated VEX statements, if available (CSAF 2.0 format, CycloneDX VEX, or OpenVEX)
 - [ ] **Software identity:** Name, version, and vendor of the software the SBOM describes
+- [ ] **Artifact identity:** Release artifact digest, image digest, package URL (purl), CPE, SWID tag, or other identifiers used to bind the SBOM to the artifact
+- [ ] **Provenance evidence:** SBOM signatures, attestations, certificate chain, issuer/subject, build ID, and release/build timestamps, if available
 - [ ] **Intended use context:** Is this SBOM for procurement evaluation, compliance audit, incident response, or continuous monitoring?
 - [ ] **Compliance requirements:** Applicable mandates (EO 14028 for US federal suppliers, EU Cyber Resilience Act, FDA premarket guidance for medical devices)
 - [ ] **License policy:** Organization's approved/prohibited license list, if applicable
@@ -63,33 +65,77 @@ If the SBOM format is ambiguous, inspect the file structure to determine the for
 
 Determine the SBOM format, version, and structural validity before analyzing content.
 
-**Framework mapping:** CycloneDX 1.5 (OWASP), SPDX 2.3 (Linux Foundation)
+**Framework mapping:** CycloneDX 1.5/1.6 (OWASP), SPDX 2.3/3.x (Linux Foundation)
 
-#### CycloneDX 1.5 Identification
+#### CycloneDX 1.5/1.6 Identification
 
 CycloneDX SBOMs contain:
 - `bomFormat`: "CycloneDX"
-- `specVersion`: "1.5"
-- Top-level keys: `metadata`, `components`, `dependencies`, `compositions`, `vulnerabilities` (optional), `formulation` (new in 1.5)
+- `specVersion`: "1.5" or "1.6"
+- Top-level keys: `metadata`, `components`, `services`, `dependencies`, `compositions`, `vulnerabilities` (optional)
+- CycloneDX 1.5 commonly adds `formulation` for build/deployment details; CycloneDX 1.6 adds richer `declarations`, `evidence`, `attestations`, lifecycle, and signature/provenance fields
 
-#### SPDX 2.3 Identification
+#### SPDX 2.3/3.x Identification
 
-SPDX SBOMs contain:
+SPDX 2.3 SBOMs contain:
 - `spdxVersion`: "SPDX-2.3"
 - `dataLicense`: "CC0-1.0"
 - Top-level keys: `creationInfo`, `packages`, `relationships`, `files` (optional), `snippets` (optional)
 
+SPDX 3.x SBOMs use a profile-based model rather than the exact SPDX 2.x document shape. Identify:
+- `specVersion`: "3.x" or SPDX 3.x JSON-LD/profile metadata
+- Software profile classes such as `Sbom`, `Package`, `File`, `Snippet`, and `SoftwareArtifact`
+- Core properties such as `creationInfo`, `createdBy`, `suppliedBy`, `originatedBy`, `externalIdentifier`, `packageUrl`, `packageVersion`, `verifiedUsing`, and `Relationship`
+
+#### Schema Support Matrix
+
+| Format | Version | Support Level | Notes |
+|---|---|---|---|
+| CycloneDX | 1.5 | Full | Baseline supported format for components, services, dependencies, vulnerabilities, compositions, and formulation |
+| CycloneDX | 1.6 | Full with compatibility notes | Accept and parse 1.6 SBOMs; include lifecycle, declarations, evidence, attestations, and signatures in trust/provenance review |
+| SPDX | 2.3 | Full | Baseline supported format for packages, files, relationships, creation info, external references, and licenses |
+| SPDX | 3.x | Compatible mapping | Map 3.x model objects and profiles to NTIA elements; flag fields that cannot be represented in the 2.3-style output |
+| Other/Unknown | Any | Limited | Do not mark invalid solely because the version is newer; identify unsupported fields and state assumptions |
+
 ```
 SBOM Format Assessment:
 - Format:              [CycloneDX | SPDX | Unknown]
-- Version:             [1.5 | 2.3 | Other]
+- Version:             [1.5 | 1.6 | 2.3 | 3.x | Other]
 - Serialization:       [JSON | XML | RDF | Tag-Value]
 - Valid Structure:     [Yes | No -- list structural errors]
 - Component Count:     [N direct + N transitive = N total]
 - File Size:           [Size]
 ```
 
-### Step 2: NTIA Minimum Elements Completeness Check
+### Step 2: SBOM Trust and Provenance Gate
+
+Before relying on completeness, vulnerability, or license conclusions, determine whether the SBOM is bound to the claimed software artifact and produced by a trustworthy source.
+
+**Framework mapping:** CycloneDX 1.6 `signature`, `declarations`, `evidence`, and `formulation`; SPDX 3.x `verifiedUsing`, `creationInfo`, `createdBy`, `builtTime`, `releaseTime`, and Build profile properties; SLSA/in-toto attestations where provided.
+
+Check and record:
+
+1. **Artifact binding:** Match SBOM references to the release/image/package digest (`sha256`, OCI digest, package hash), package URL, CPE, SWID, or repository release artifact. If the digest is absent or mismatched, treat the SBOM as unbound.
+2. **Signature verification:** Verify enveloped or detached signatures where present (for example, CycloneDX signature, cosign, minisign, GPG, or Sigstore certificate). Record the tool, command, result, and signer identity.
+3. **Attestation verification:** Validate SLSA, in-toto, CycloneDX declarations/attestations, or SPDX build/profile evidence. Confirm the attestation subject digest matches the artifact and SBOM.
+4. **Issuer and subject validation:** Check certificate issuer, identity, repository, workflow, organization, and certificate validity period against the expected vendor/build pipeline.
+5. **Timestamp and release matching:** Compare SBOM creation time, build time, attestation time, and release time. Flag SBOMs generated before dependency resolution, after an unrelated build, or after the published artifact changed.
+6. **Freshness and revocation:** Check whether the SBOM has been superseded, expired, revoked, or replaced by a newer BOM serial/version.
+
+```
+SBOM Trust Assessment:
+- Artifact Binding:       [Verified | Partial | Missing | Mismatch]
+- Signature Status:       [Verified | Present but failed | Not provided | Not applicable]
+- Attestation Status:     [Verified | Present but failed | Not provided | Not applicable]
+- Issuer/Subject Match:   [Matches expected vendor/build | Mismatch | Unknown]
+- Timestamp Alignment:    [Aligned | Stale | Suspicious | Unknown]
+- Trust Decision:         [Trusted | Use with caution | Untrusted]
+- Evidence:               [commands, certificate subject, digest, release URL, or reason unavailable]
+```
+
+Do not mark an SBOM as "Strong" if artifact binding is missing or trust evidence failed. A complete but untrusted SBOM may still be useful for exploratory analysis, but it is not sufficient for compliance or procurement acceptance without follow-up.
+
+### Step 3: NTIA Minimum Elements Completeness Check
 
 Evaluate the SBOM against all seven NTIA "minimum elements for an SBOM" as defined in the July 2021 NTIA publication "The Minimum Elements for a Software Bill of Materials."
 
@@ -97,19 +143,30 @@ Evaluate the SBOM against all seven NTIA "minimum elements for an SBOM" as defin
 
 The seven NTIA minimum elements are:
 
-| # | NTIA Minimum Element | CycloneDX 1.5 Field | SPDX 2.3 Field | Required |
-|---|---|---|---|---|
-| 1 | **Supplier Name** | `component.supplier.name` or `component.publisher` | `Package: PackageSupplier` | Yes |
-| 2 | **Component Name** | `component.name` | `Package: PackageName` | Yes |
-| 3 | **Version of the Component** | `component.version` | `Package: PackageVersion` | Yes |
-| 4 | **Unique Identifier** | `component.bom-ref`, `component.cpe`, `component.purl` | `Package: SPDXID`, `Package: ExternalRef (purl)` | Yes |
-| 5 | **Dependency Relationship** | `dependencies[]` array with `dependsOn` | `Relationship: DEPENDS_ON`, `DEPENDENCY_OF` | Yes |
-| 6 | **Author of SBOM Data** | `metadata.authors[]` or `metadata.manufacture` | `CreationInfo: Creator` | Yes |
-| 7 | **Timestamp** | `metadata.timestamp` | `CreationInfo: Created` | Yes |
+| # | NTIA Minimum Element | CycloneDX 1.5/1.6 Field | SPDX 2.3 Field | SPDX 3.x Mapping | Required |
+|---|---|---|---|---|---|
+| 1 | **Supplier Name** | `component.supplier.name`, `component.publisher`, or `component.manufacturer` | `PackageSupplier` | `Package.suppliedBy` or `originatedBy` | Yes |
+| 2 | **Component Name** | `component.name` | `PackageName` | `Element.name` / package name | Yes |
+| 3 | **Version of the Component** | `component.version` | `PackageVersion` | `Package.packageVersion` | Yes |
+| 4 | **Unique Identifier** | `component.bom-ref`, `component.cpe`, `component.purl`, hashes, SWID | `SPDXID`, `ExternalRef` (purl, CPE), checksums | `spdxId`, `externalIdentifier`, `packageUrl`, `verifiedUsing` | Yes |
+| 5 | **Dependency Relationship** | `dependencies[]` array with `dependsOn` | `Relationship: DEPENDS_ON`, `DEPENDENCY_OF` | `Relationship` objects with dependency semantics | Yes |
+| 6 | **Author of SBOM Data** | `metadata.authors[]`, `metadata.manufacturer`, `metadata.tools` | `CreationInfo: Creator` | `creationInfo.createdBy`, `createdUsing` | Yes |
+| 7 | **Timestamp** | `metadata.timestamp`, lifecycle/build timestamps | `CreationInfo: Created` | `creationInfo.created`, `builtTime`, `releaseTime` | Yes |
 
 #### Completeness Scoring
 
 For each component in the SBOM, evaluate presence of elements 1-5. Elements 6-7 are document-level (evaluated once).
+
+#### Metadata Interpretation Rules
+
+Record why a field is not counted as present:
+
+- **Missing:** The field is absent and no equivalent identifier exists.
+- **Explicit unknown:** SPDX `NOASSERTION`, SPDX `NONE`, CycloneDX empty values, or documented "unknown" values are intentional statements; report them separately from absent fields.
+- **Documented unavailable:** Some OS packages, file entries, services, containers, or generated components may not have supplier/version data available in the same way as application packages. Keep the completeness gap visible, but explain the component type and identifier evidence.
+- **Conflicting:** Multiple suppliers, versions, purls, hashes, or names disagree. Treat as a quality issue even if a field is technically present.
+
+Do not silently downgrade all OS, file, container, or service components as identical to missing application package metadata. Split coverage by component type when the distinction changes the risk conclusion.
 
 ```
 NTIA Completeness Assessment:
@@ -121,6 +178,9 @@ NTIA Completeness Assessment:
 - Dependency Relationships:   [N/N] ([%]) components with at least one relationship
 - SBOM Author:                [Present: name | Missing]
 - Timestamp:                  [Present: ISO 8601 datetime | Missing]
+- Explicit Unknown Values:    [N NOASSERTION/NONE/unknown values by field]
+- Documented Unavailable:     [N fields by component type]
+- Conflicting Metadata:       [N components with conflicting identity fields]
 - Overall Completeness:       [Complete | Partial -- list gaps | Incomplete]
 ```
 
@@ -128,12 +188,12 @@ NTIA Completeness Assessment:
 
 | Rating | Criteria |
 |---|---|
-| **Complete** | All 7 NTIA elements present for 100% of components |
-| **Substantially Complete** | All 7 elements present for >= 90% of components; gaps documented |
-| **Partial** | 5-6 elements present for majority of components; significant gaps in supplier or dependency data |
+| **Complete** | All 7 NTIA elements present for 100% of components and no unresolved conflicting metadata |
+| **Substantially Complete** | All 7 elements present for >= 90% of components; explicit unknown and unavailable values documented by component type |
+| **Partial** | 5-6 elements present for majority of components; significant gaps in supplier, version, identity, or dependency data |
 | **Incomplete** | Fewer than 5 elements consistently present; SBOM not suitable for compliance or risk assessment |
 
-### Step 3: VEX Status Interpretation
+### Step 4: VEX Status Interpretation
 
 If VEX (Vulnerability Exploitability eXchange) documents are provided, interpret the status for each vulnerability-product pair.
 
@@ -160,21 +220,47 @@ When a VEX status is "Not Affected," the document must include one of these just
 | **vulnerable_code_cannot_be_controlled_by_adversary** | The vulnerable code is present and reachable but attacker-controlled input cannot reach it | Requires threat model or data-flow analysis |
 | **inline_mitigations_already_exist** | Built-in mitigations (ASLR, sandboxing, etc.) prevent exploitation | Verify mitigations are active and effective |
 
+#### VEX Product-Reference Matching
+
+Before accepting any VEX status, prove that the VEX product reference maps to the same component or product described by the SBOM. A VEX statement for a similarly named package, adjacent version, different distribution, or different artifact digest must not be applied automatically.
+
+Match in this order:
+
+1. **Exact artifact digest or hash:** OCI digest, release artifact hash, package checksum, or signed subject digest.
+2. **Package URL (purl):** Compare type, namespace, name, version, qualifiers, and subpath. Treat missing qualifiers as lower confidence when they distinguish ecosystems, distributions, architectures, or build variants.
+3. **CPE / SWID / external identifier:** Match vendor, product, version, update, edition, target software/hardware, and language fields where present.
+4. **SBOM internal reference:** CycloneDX `bom-ref`, SPDX `SPDXID`, or SPDX 3.x `spdxId`/element identifier.
+5. **Version range:** Confirm the SBOM component version is included in the VEX affected or not-affected range, including prerelease and distro-patched versions.
+6. **Fallback name matching:** Use only as weak evidence. Flag as ambiguous unless vendor, ecosystem, and version also match.
+
+Classify every VEX-to-SBOM mapping:
+
+| Match Status | Meaning | Action |
+|---|---|---|
+| **Exact** | Digest, purl, CPE/SWID, or internal reference uniquely maps to one SBOM component/product | Apply the VEX status and retain evidence |
+| **Range Match** | Version range clearly includes the SBOM component, but no exact artifact identity is present | Apply with caution and record the range logic |
+| **Ambiguous** | Multiple SBOM components could match, or identity fields partially conflict | Do not suppress vulnerability findings; request vendor clarification |
+| **Unmatched** | No SBOM component/product maps to the VEX product reference | Do not apply the VEX status to the SBOM |
+| **Conflict** | VEX identity disagrees with SBOM digest, purl, CPE/SWID, supplier, or version | Treat as a VEX/SBOM quality finding |
+
 ```
 VEX Assessment:
 - VEX Format:          [CSAF 2.0 | CycloneDX VEX | OpenVEX]
 - Total VEX Entries:   [N]
+- Product Matches:     [N exact, N range, N ambiguous, N unmatched, N conflict]
 - Not Affected:        [N] (justifications: [list categories used])
 - Affected:            [N] (require remediation)
 - Fixed:               [N] (verify deployment)
 - Under Investigation: [N] (monitor for updates)
 ```
 
-### Step 4: Transitive Dependency Analysis
+For "Not Affected" statuses, include both the justification category and the matching evidence. `component_not_present` only proves non-impact when the SBOM itself is trusted and sufficiently complete for the relevant component class.
+
+### Step 5: Transitive Dependency Analysis
 
 Analyze the dependency tree to identify risk concentration in transitive (indirect) dependencies.
 
-**Framework mapping:** CycloneDX 1.5 `dependencies` array, SPDX 2.3 `Relationship` types
+**Framework mapping:** CycloneDX 1.5/1.6 `dependencies` array, SPDX 2.3/3.x `Relationship` types
 
 1. **Build the dependency graph:** Parse the dependency relationships to construct a directed graph from the top-level component to all transitive dependencies
 2. **Identify depth:** Calculate the maximum dependency depth (layers of transitive dependencies)
@@ -203,7 +289,7 @@ Transitive Dependency Analysis:
 - Stale Dependencies:       [N] components with no update in >= 18 months
 ```
 
-### Step 5: License Conflict Detection
+### Step 6: License Conflict Detection
 
 Analyze component licenses for conflicts, compliance risks, and policy violations.
 
@@ -246,9 +332,9 @@ Classify the overall SBOM analysis into one of the following states:
 | Classification | Definition | Criteria |
 |---|---|---|
 | **Critical Supply Chain Risk** | SBOM reveals high-risk supply chain exposure | Known exploited CVEs in dependencies, incomplete SBOM with missing critical elements, or license conflicts blocking distribution |
-| **Elevated Risk** | SBOM has notable gaps or concerning findings | NTIA completeness < 90%, multiple stale transitive dependencies, or VEX "Under Investigation" for critical components |
-| **Acceptable** | SBOM meets minimum requirements with minor gaps | NTIA completeness >= 90%, no critical/high CVEs in dependencies, minor license issues documented |
-| **Strong** | SBOM is comprehensive and low-risk | NTIA 100% complete, all VEX statuses resolved, no critical dependency risks, clean license posture |
+| **Elevated Risk** | SBOM has notable gaps or concerning findings | Trust evidence missing or partial, NTIA completeness < 90%, multiple stale transitive dependencies, ambiguous/unmatched VEX statements, or VEX "Under Investigation" for critical components |
+| **Acceptable** | SBOM meets minimum requirements with minor gaps | Artifact binding verified or documented, NTIA completeness >= 90%, no critical/high CVEs in dependencies, minor license issues documented |
+| **Strong** | SBOM is comprehensive, trusted, and low-risk | Artifact binding and provenance verified, NTIA 100% complete, all VEX statuses exactly matched and resolved, no critical dependency risks, clean license posture |
 
 ---
 
@@ -260,24 +346,36 @@ Produce a structured report with these exact sections:
 ## SBOM Analysis Report
 **Date:** [YYYY-MM-DD]
 **Skill:** sbom-analysis v1.0.0
-**Frameworks:** CycloneDX 1.5, SPDX 2.3, VEX (CSAF), NTIA Minimum Elements
+**Frameworks:** CycloneDX 1.5/1.6, SPDX 2.3/3.x, VEX (CSAF), NTIA Minimum Elements
 **Reviewer:** AI-assisted (human review required for license conflicts and risk decisions)
 
 ### Executive Summary
-[3-5 sentences. State the software being analyzed, SBOM format, NTIA completeness
-rating, number of components, key risk findings (CVEs in dependencies, license
-conflicts), and overall classification.]
+[3-5 sentences. State the software being analyzed, SBOM format, trust/provenance
+decision, NTIA completeness rating, number of components, VEX match quality,
+key risk findings (CVEs in dependencies, license conflicts), and overall classification.]
 
 ### SBOM Overview
 | Field | Value |
 |---|---|
 | Software Name | [Name] |
 | Software Version | [Version] |
-| SBOM Format | [CycloneDX 1.5 / SPDX 2.3] |
+| SBOM Format | [CycloneDX 1.5/1.6 / SPDX 2.3/3.x] |
 | Serialization | [JSON / XML / Other] |
 | Total Components | [N] (direct: [N], transitive: [N]) |
 | SBOM Author | [Author name] |
 | SBOM Timestamp | [ISO 8601] |
+
+### SBOM Trust and Provenance
+
+| Trust Check | Status | Evidence |
+|---|---|---|
+| Artifact binding | [Verified/Partial/Missing/Mismatch] | [digest, purl, release URL, or gap] |
+| Signature verification | [Verified/Failed/Not provided/Not applicable] | [tool, signer, certificate subject, or gap] |
+| Attestation verification | [Verified/Failed/Not provided/Not applicable] | [SLSA/in-toto/CycloneDX/SPDX evidence or gap] |
+| Issuer/subject match | [Pass/Fail/Unknown] | [expected vs observed identity] |
+| Timestamp alignment | [Aligned/Stale/Suspicious/Unknown] | [SBOM/build/release timestamps] |
+
+**Trust Decision:** [Trusted / Use with caution / Untrusted]
 
 ### NTIA Minimum Elements Compliance
 
@@ -290,15 +388,18 @@ conflicts), and overall classification.]
 | Dependency Relationship | [Pass/Fail/Partial] | [N/N] ([%]) | [Notes] |
 | Author of SBOM Data | [Pass/Fail] | Document-level | [Notes] |
 | Timestamp | [Pass/Fail] | Document-level | [Notes] |
+| Explicit unknown values | [Info/Concern] | [N fields] | [NOASSERTION/NONE/unknown values by field] |
+| Documented unavailable fields | [Info/Concern] | [N fields] | [component types and rationale] |
+| Conflicting metadata | [Pass/Fail] | [N components] | [conflicting identity fields] |
 
 **NTIA Completeness Rating:** [Complete / Substantially Complete / Partial / Incomplete]
 
 ### VEX Status Summary
 [If VEX documents are provided]
 
-| CVE ID | Component | VEX Status | Justification | Action |
-|---|---|---|---|---|
-| [CVE-ID] | [component] | [Not Affected/Affected/Fixed/Under Investigation] | [justification if Not Affected] | [action] |
+| CVE ID | VEX Product Ref | SBOM Component Match | Match Status | VEX Status | Justification | Evidence Required | Action |
+|---|---|---|---|---|---|---|---|
+| [CVE-ID] | [purl/CPE/SWID/bom-ref/version range] | [component] | [Exact/Range/Ambiguous/Unmatched/Conflict] | [Not Affected/Affected/Fixed/Under Investigation] | [justification if Not Affected] | [digest/purl/range/code evidence] | [action] |
 
 ### Transitive Dependency Risk
 
@@ -335,7 +436,9 @@ conflicts), and overall classification.]
 ### References
 - NTIA SBOM Minimum Elements: https://www.ntia.gov/sites/default/files/publications/sbom_minimum_elements_report_0.pdf
 - CycloneDX 1.5 Specification: https://cyclonedx.org/docs/1.5/
+- CycloneDX 1.6 Specification: https://cyclonedx.org/docs/1.6/
 - SPDX 2.3 Specification: https://spdx.github.io/spdx-spec/v2.3/
+- SPDX 3.x Specification: https://spdx.github.io/spdx-spec/v3.0.1/
 - VEX (CSAF): https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html
 - Vendor advisory: [URL if applicable]
 ```
@@ -350,11 +453,21 @@ A lightweight SBOM standard supporting multiple use cases (software, hardware, s
 - Schema: https://github.com/CycloneDX/specification
 - Tool Center: https://cyclonedx.org/tool-center/
 
+### CycloneDX 1.6 (OWASP)
+CycloneDX 1.6 extends the SBOM model with stronger support for lifecycles, evidence, declarations, attestations, and signatures. Use these fields to improve provenance, trust, and product-identity analysis rather than treating 1.6 documents as unsupported variants.
+- Specification: https://cyclonedx.org/docs/1.6/
+- Schema: https://github.com/CycloneDX/specification
+
 ### SPDX 2.3 (Linux Foundation / ISO/IEC 5962:2021)
 An international open standard (ISO 5962) for communicating SBOM information including components, licenses, copyrights, and security references. SPDX 2.3 is the latest stable release in the 2.x line.
 - Specification: https://spdx.github.io/spdx-spec/v2.3/
 - License List: https://spdx.org/licenses/
 - Tools: https://tools.spdx.org/
+
+### SPDX 3.x (Linux Foundation)
+SPDX 3.x moves to a modular model with profiles for software, security, licensing, AI, dataset, build, and expanded relationships. Map SPDX 3.x software and build profile objects back to NTIA elements while preserving fields that do not fit the SPDX 2.3 document shape.
+- Specification: https://spdx.github.io/spdx-spec/v3.0.1/
+- Model: https://spdx.github.io/spdx-spec/v3.0.1/model/
 
 ### VEX via CSAF 2.0 (OASIS)
 Vulnerability Exploitability eXchange (VEX) is a form of security advisory that communicates whether a product is affected by a known vulnerability. CSAF 2.0 profile 5 is the primary standardized format for VEX.
@@ -381,6 +494,10 @@ Published by NTIA in July 2021 as part of Executive Order 14028 implementation. 
 
 5. **Failing to track SBOM freshness.** An SBOM is a point-in-time snapshot. Software composition changes with every dependency update, build, or deployment. SBOMs older than the most recent build/release are potentially inaccurate. Check the SBOM timestamp against the software's actual release date and flag stale SBOMs.
 
+6. **Trusting a complete but unbound SBOM.** A complete SBOM can still describe the wrong artifact if it lacks a matching digest, signature, or attestation. Always separate content completeness from artifact provenance.
+
+7. **Applying VEX by component name alone.** VEX statements are product-specific. Do not suppress a vulnerability based only on a similar component name; require exact or well-explained purl, CPE, SWID, internal reference, digest, or version-range matching.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -398,8 +515,10 @@ Published by NTIA in July 2021 as part of Executive Order 14028 implementation. 
 - NTIA Minimum Elements for an SBOM: https://www.ntia.gov/sites/default/files/publications/sbom_minimum_elements_report_0.pdf
 - NTIA SBOM FAQ: https://www.ntia.gov/page/software-bill-materials
 - CycloneDX 1.5 Specification: https://cyclonedx.org/docs/1.5/
+- CycloneDX 1.6 Specification: https://cyclonedx.org/docs/1.6/
 - CycloneDX GitHub: https://github.com/CycloneDX/specification
 - SPDX 2.3 Specification: https://spdx.github.io/spdx-spec/v2.3/
+- SPDX 3.x Specification: https://spdx.github.io/spdx-spec/v3.0.1/
 - SPDX License List: https://spdx.org/licenses/
 - CSAF 2.0 (OASIS): https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html
 - CISA VEX Minimum Requirements: https://www.cisa.gov/sites/default/files/2023-04/minimum-requirements-for-vex-508c.pdf


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

Addresses #634.

### Skill Modified
**Skill name:** sbom-analysis
**Skill path:** `skills/vuln-management/sbom-analysis/`

### What Was Wrong
The skill was strong for baseline CycloneDX 1.5 / SPDX 2.3 SBOM review, but it had four practical gaps:

- Newer SBOMs such as CycloneDX 1.6 and SPDX 3.x could be treated as `Other` rather than accepted with explicit compatibility assumptions.
- Completeness scoring happened before checking whether the SBOM was bound to the claimed artifact or backed by signature/attestation evidence.
- VEX statuses could be interpreted without requiring product-reference matching across digest, purl, CPE, SWID, version range, or SBOM internal references.
- Missing metadata, SPDX `NOASSERTION`/`NONE`, and component-type-specific unavailable supplier/version fields were not separated in the output.

### What This PR Fixes
This PR expands the existing skill guidance while keeping the change scoped to one skill file:

- Adds a schema support matrix for CycloneDX 1.5/1.6, SPDX 2.3/3.x, and unknown/newer formats.
- Adds an SBOM trust and provenance gate before NTIA completeness scoring, including artifact digest binding, signature verification, attestation verification, issuer/subject checks, timestamp alignment, and trust decision output.
- Extends NTIA completeness guidance with SPDX 3.x mappings and rules for missing, explicit unknown, documented unavailable, and conflicting metadata.
- Adds VEX product-reference matching requirements and output fields for exact, range, ambiguous, unmatched, and conflicting matches.
- Updates classification, report template, framework references, common pitfalls, and references so the added checks are reflected end to end.

### Evidence

**Before (skill could over-trust or misclassify this):**
```json
{
  "bomFormat": "CycloneDX",
  "specVersion": "1.6",
  "metadata": {
    "timestamp": "2026-06-04T10:00:00Z",
    "lifecycles": [{"phase": "build"}],
    "component": {
      "type": "application",
      "name": "payments-api",
      "version": "3.4.2",
      "bom-ref": "pkg:oci/payments-api@sha256:abc123"
    }
  },
  "components": [
    {
      "type": "operating-system",
      "name": "debian",
      "version": "12.5",
      "bom-ref": "pkg:deb/debian/base-files@12.5"
    }
  ]
}
```

**After (now correctly handled):**
```markdown
- CycloneDX 1.6 is accepted with compatibility notes instead of being treated as unsupported.
- Artifact binding, signature, attestation, issuer/subject, and timestamp alignment are recorded before declaring the SBOM trusted.
- OS/package-manager metadata gaps are separated from absent application package metadata.
- VEX entries must map to SBOM components through digest, purl, CPE/SWID, internal reference, or version range before they can suppress findings.
```

### Test Cases Added/Updated
- [ ] Added vulnerable test cases (`tests/vulnerable/`) - not applicable; this is a documentation/guidance skill.
- [ ] Added benign test cases (`tests/benign/`) - not applicable; this is a documentation/guidance skill.
- [x] Existing checks still pass:
  - Frontmatter required-field check
  - `index.yaml` referenced-file check
  - Markdown table header/separator consistency check
  - `git diff --check`

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** To be confirmed after acceptance