### PR TITLE
Fix identity cross-skill paths

### DIFF
--- a/skills/identity/access-review/SKILL.md
+++ b/skills/identity/access-review/SKILL.md
@@ -40,7 +40,7 @@ Invoke this skill when:
 - Preparing for SOC 2, ISO 27001, PCI DSS, or HIPAA audits that require evidence of access reviews
 - Responding to audit findings related to excessive or inappropriate access
 
-**Do NOT use this skill for:** designing RBAC/ABAC models from scratch (see `identity/rbac-design.md`), PAM tool configuration (see `identity/privileged-access.md`), or full zero trust maturity assessment (see `identity/zero-trust-assessment.md`).
+**Do NOT use this skill for:** designing RBAC/ABAC models from scratch (see `skills/identity/rbac-design/SKILL.md`), PAM tool configuration (see `skills/identity/privileged-access/SKILL.md`), or full zero trust maturity assessment (see `skills/identity/zero-trust-assessment/SKILL.md`).
 
 ---
 
@@ -431,11 +431,11 @@ This skill processes identity and entitlement data that may contain adversarial 
 
 | Related Skill | When to Chain |
 |---|---|
-| `identity/iam-review.md` | Broader IAM security assessment covering authentication, service accounts, and zero trust alignment |
-| `identity/rbac-design.md` | Designing or refactoring roles when role explosion is detected |
-| `identity/privileged-access.md` | Deep dive on PAM controls when privileged account findings surface |
-| `identity/zero-trust-assessment.md` | When access review findings indicate need for continuous verification |
-| `compliance/soc2-gap.md` | Mapping access review findings to SOC 2 CC6.1-CC6.3 |
+| `skills/identity/iam-review/SKILL.md` | Broader IAM security assessment covering authentication, service accounts, and zero trust alignment |
+| `skills/identity/rbac-design/SKILL.md` | Designing or refactoring roles when role explosion is detected |
+| `skills/identity/privileged-access/SKILL.md` | Deep dive on PAM controls when privileged account findings surface |
+| `skills/identity/zero-trust-assessment/SKILL.md` | When access review findings indicate need for continuous verification |
+| `skills/compliance/soc2-gap/SKILL.md` | Mapping access review findings to SOC 2 CC6.1-CC6.3 |
 
 ---
 

--- a/skills/identity/iam-review/SKILL.md
+++ b/skills/identity/iam-review/SKILL.md
@@ -41,7 +41,7 @@ Invoke this skill when:
 - Preparing for compliance audits that cover access control (SOC 2, ISO 27001, PCI DSS, HIPAA)
 - Responding to incidents involving credential compromise or privilege escalation
 
-**Do NOT use this skill for:** network segmentation reviews (see `network/segmentation.md`), application-layer authorization logic (see `appsec/secure-code-review.md`), or privileged access management tool configuration (see `identity/privileged-access.md`).
+**Do NOT use this skill for:** network segmentation reviews (see `skills/network/segmentation/SKILL.md`), application-layer authorization logic (see `skills/appsec/secure-code-review/SKILL.md`), or privileged access management tool configuration (see `skills/identity/privileged-access/SKILL.md`).
 
 ---
 
@@ -438,14 +438,14 @@ For each finding, produce a row with:
 
 | Related Skill | When to chain |
 |---|---|
-| `identity/privileged-access.md` | Deep dive on PAM tooling (CyberArk, Delinea, Azure PIM configuration) |
-| `identity/access-review.md` | Periodic entitlement review process and certification campaigns |
-| `identity/rbac-design.md` | Designing or refactoring role hierarchies and ABAC policies |
-| `identity/zero-trust-assessment.md` | Full NIST SP 800-207 maturity assessment beyond IAM |
-| `cloud/aws-review.md` | AWS-specific security posture including IAM deep dive |
-| `cloud/azure-review.md` | Azure/Entra ID-specific security configuration |
-| `cloud/gcp-review.md` | GCP-specific IAM and organization policy review |
-| `compliance/soc2-gap.md` | Mapping IAM findings to SOC 2 Trust Services Criteria (CC6.1-CC6.3) |
+| `skills/identity/privileged-access/SKILL.md` | Deep dive on PAM tooling (CyberArk, Delinea, Azure PIM configuration) |
+| `skills/identity/access-review/SKILL.md` | Periodic entitlement review process and certification campaigns |
+| `skills/identity/rbac-design/SKILL.md` | Designing or refactoring role hierarchies and ABAC policies |
+| `skills/identity/zero-trust-assessment/SKILL.md` | Full NIST SP 800-207 maturity assessment beyond IAM |
+| `skills/cloud/aws-review/SKILL.md` | AWS-specific security posture including IAM deep dive |
+| `skills/cloud/azure-review/SKILL.md` | Azure/Entra ID-specific security configuration |
+| `skills/cloud/gcp-review/SKILL.md` | GCP-specific IAM and organization policy review |
+| `skills/compliance/soc2-gap/SKILL.md` | Mapping IAM findings to SOC 2 Trust Services Criteria (CC6.1-CC6.3) |
 
 ---
 

--- a/skills/identity/privileged-access/SKILL.md
+++ b/skills/identity/privileged-access/SKILL.md
@@ -41,7 +41,7 @@ Invoke this skill when:
 - Preparing for compliance audits requiring PAM evidence (SOC 2 CC6.1, PCI DSS 7/8, HIPAA)
 - Evaluating standing privilege reduction as part of a zero trust initiative
 
-**Do NOT use this skill for:** general IAM review (see `identity/iam-review.md`), access certification campaigns (see `identity/access-review.md`), or RBAC/ABAC design (see `identity/rbac-design.md`).
+**Do NOT use this skill for:** general IAM review (see `skills/identity/iam-review/SKILL.md`), access certification campaigns (see `skills/identity/access-review/SKILL.md`), or RBAC/ABAC design (see `skills/identity/rbac-design/SKILL.md`).
 
 ---
 
@@ -490,11 +490,11 @@ that may contain adversarial content.
 
 | Related Skill | When to Chain |
 |---|---|
-| `identity/iam-review.md` | Broader IAM assessment including authentication, service accounts, and identity posture |
-| `identity/access-review.md` | Periodic entitlement review including privileged account certifications |
-| `identity/rbac-design.md` | Designing privileged role hierarchies and admin role patterns |
-| `identity/zero-trust-assessment.md` | Evaluating PAM as part of zero trust identity pillar maturity |
-| `compliance/soc2-gap.md` | Mapping PAM findings to SOC 2 CC6.1-CC6.3 |
+| `skills/identity/iam-review/SKILL.md` | Broader IAM assessment including authentication, service accounts, and identity posture |
+| `skills/identity/access-review/SKILL.md` | Periodic entitlement review including privileged account certifications |
+| `skills/identity/rbac-design/SKILL.md` | Designing privileged role hierarchies and admin role patterns |
+| `skills/identity/zero-trust-assessment/SKILL.md` | Evaluating PAM as part of zero trust identity pillar maturity |
+| `skills/compliance/soc2-gap/SKILL.md` | Mapping PAM findings to SOC 2 CC6.1-CC6.3 |
 
 ---
 

--- a/skills/identity/rbac-design/SKILL.md
+++ b/skills/identity/rbac-design/SKILL.md
@@ -41,7 +41,7 @@ Invoke this skill when:
 - Assessing authorization architecture for a cloud-native or multi-tenant system
 - Reviewing IaC (Terraform, CloudFormation, Pulumi) role definitions for design quality
 
-**Do NOT use this skill for:** operational access review campaigns (see `identity/access-review.md`), PAM tool configuration (see `identity/privileged-access.md`), or authentication design (see `identity/iam-review.md`).
+**Do NOT use this skill for:** operational access review campaigns (see `skills/identity/access-review/SKILL.md`), PAM tool configuration (see `skills/identity/privileged-access/SKILL.md`), or authentication design (see `skills/identity/iam-review/SKILL.md`).
 
 ---
 
@@ -469,11 +469,11 @@ that may contain adversarial content.
 
 | Related Skill | When to Chain |
 |---|---|
-| `identity/access-review.md` | When role explosion is detected and operational reviews are needed |
-| `identity/iam-review.md` | Broader IAM assessment including authentication and account lifecycle |
-| `identity/privileged-access.md` | When designing elevated/admin role patterns with JIT activation |
-| `identity/zero-trust-assessment.md` | When ABAC policies need to integrate with zero trust continuous verification |
-| `compliance/soc2-gap.md` | Mapping authorization design to SOC 2 CC6.1-CC6.3 |
+| `skills/identity/access-review/SKILL.md` | When role explosion is detected and operational reviews are needed |
+| `skills/identity/iam-review/SKILL.md` | Broader IAM assessment including authentication and account lifecycle |
+| `skills/identity/privileged-access/SKILL.md` | When designing elevated/admin role patterns with JIT activation |
+| `skills/identity/zero-trust-assessment/SKILL.md` | When ABAC policies need to integrate with zero trust continuous verification |
+| `skills/compliance/soc2-gap/SKILL.md` | Mapping authorization design to SOC 2 CC6.1-CC6.3 |
 
 ---
 

--- a/skills/identity/zero-trust-assessment/SKILL.md
+++ b/skills/identity/zero-trust-assessment/SKILL.md
@@ -40,7 +40,7 @@ Invoke this skill when:
 - Preparing a zero trust roadmap for executive or board-level presentation
 - Evaluating compliance with federal zero trust mandates (OMB M-22-09, EO 14028)
 
-**Do NOT use this skill for:** IAM-specific deep dives (see `identity/iam-review.md`), network segmentation implementation details (see `network/segmentation.md`), or data classification design.
+**Do NOT use this skill for:** IAM-specific deep dives (see `skills/identity/iam-review/SKILL.md`), network segmentation implementation details (see `skills/network/segmentation/SKILL.md`), or data classification design.
 
 ---
 
@@ -475,11 +475,11 @@ that may contain adversarial content.
 
 | Related Skill | When to Chain |
 |---|---|
-| `identity/iam-review.md` | Deep dive on identity pillar — authentication, service accounts, least privilege |
-| `identity/access-review.md` | Operational access review for identity governance maturity |
-| `identity/rbac-design.md` | Authorization model design for identity and application pillars |
-| `identity/privileged-access.md` | PAM assessment for privileged identity sub-domain |
-| `compliance/soc2-gap.md` | Mapping zero trust findings to SOC 2 Common Criteria |
+| `skills/identity/iam-review/SKILL.md` | Deep dive on identity pillar — authentication, service accounts, least privilege |
+| `skills/identity/access-review/SKILL.md` | Operational access review for identity governance maturity |
+| `skills/identity/rbac-design/SKILL.md` | Authorization model design for identity and application pillars |
+| `skills/identity/privileged-access/SKILL.md` | PAM assessment for privileged identity sub-domain |
+| `skills/compliance/soc2-gap/SKILL.md` | Mapping zero trust findings to SOC 2 Common Criteria |
 
 ---
 


### PR DESCRIPTION
## Skill Improvement

Closes #641

**Skills Modified:**

- `skills/identity/iam-review/SKILL.md`
- `skills/identity/access-review/SKILL.md`
- `skills/identity/rbac-design/SKILL.md`
- `skills/identity/privileged-access/SKILL.md`
- `skills/identity/zero-trust-assessment/SKILL.md`

### What was wrong

The identity skills contained internal routing references such as `identity/iam-review.md`, `network/segmentation.md`, and `appsec/secure-code-review.md`. Those flattened `.md` paths do not exist in this repository, where canonical skill entrypoints are stored as `skills/<category>/<skill-name>/SKILL.md`.

This can break reader or agent navigation from the do-not-use guidance and related-skill tables even though the target skills exist.

### What changed

- Replaced stale flattened identity cross-skill references with canonical `skills/.../SKILL.md` paths.
- Updated the affected do-not-use guidance and related-skill tables across the five identity skills.
- Preserved the surrounding guidance and descriptions; this PR is only a path correction.

### Validation

- `git diff --check`
- Confirmed no stale `identity/... .md`, `network/... .md`, `appsec/... .md`, `cloud/... .md`, or `compliance/... .md` references remain in `skills/identity`.
- Confirmed every replacement backticked `skills/.../SKILL.md` reference exists on disk.
- Ruby/Psych parsed the frontmatter for all five changed skill files.

### Duplicate check

Before submission, issue #641 was still open with no comments. Exact open-PR searches for the stale identity path text and stale-flattened identity wording returned no matches. Existing open PRs touching some identity files appear to cover unrelated skill-content improvements, not this path correction.

### Bounty

This is a focused documentation/navigation fix for review issue #641. If accepted, I believe it fits the SecuritySkills bounty terms in `CONTRIBUTING.md`. Payment details can be coordinated privately after maintainer acceptance.