### PR TITLE
Stabilize GitHub template links

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-skill-proposal.md
+++ b/.github/ISSUE_TEMPLATE/new-skill-proposal.md
@@ -51,7 +51,7 @@ assignees: ''
 - [ ] **Complex** ($500) — Novel detection approach, comprehensive coverage, low FP rate
 
 ## Bounty Info
-- [ ] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
+- [ ] I have read and agree to the [CONTRIBUTING.md](https://github.com/UnitOneAI/SecuritySkills/blob/main/CONTRIBUTING.md) bounty terms
 - **Preferred payment method:** GitHub Sponsors / PayPal / Crypto
 
 ---

--- a/.github/ISSUE_TEMPLATE/skill-review.md
+++ b/.github/ISSUE_TEMPLATE/skill-review.md
@@ -8,7 +8,7 @@ assignees: ''
 
 ## Skill Being Reviewed
 **Skill name:**
-**Skill path:** `skills/[category]/[skill-name]/`
+**Skill path:** `skills/[category]/[skill-name]/SKILL.md`
 
 ## False Positive Analysis
 <!-- Can you find benign code that this skill incorrectly flags? Provide specific code examples. -->
@@ -70,5 +70,5 @@ assignees: ''
 3.
 
 ## Bounty Info
-- [ ] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
+- [ ] I have read and agree to the [CONTRIBUTING.md](https://github.com/UnitOneAI/SecuritySkills/blob/main/CONTRIBUTING.md) bounty terms
 - **Preferred payment method:** GitHub Sponsors / PayPal / Crypto

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,14 +2,14 @@
 
 Please confirm the following before submitting:
 
-- [ ] Skill follows the format specification in [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [ ] Skill follows the format specification in [CONTRIBUTING.md](https://github.com/UnitOneAI/SecuritySkills/blob/main/CONTRIBUTING.md)
 - [ ] At least one real framework is cited with correct control IDs
 - [ ] All framework references verified against primary sources (not blogs or AI output)
 - [ ] Prompt Injection Safety Notice section included
 - [ ] `injection-hardened: true` set in frontmatter
 - [ ] `allowed-tools` scoped to minimum necessary permissions
 - [ ] Tested with at least one AI coding agent (which one: ___)
-- [ ] No prohibited patterns per [SECURITY.md](../SECURITY.md)
+- [ ] No prohibited patterns per [SECURITY.md](https://github.com/UnitOneAI/SecuritySkills/blob/main/SECURITY.md)
 - [ ] `index.yaml` updated with new skill entry (if adding a skill)
 
 ## What This PR Does

--- a/.github/PULL_REQUEST_TEMPLATE/skill-improvement.md
+++ b/.github/PULL_REQUEST_TEMPLATE/skill-improvement.md
@@ -2,7 +2,7 @@
 
 ### Skill Modified
 **Skill name:**
-**Skill path:** `skills/[category]/[skill-name]/`
+**Skill path:** `skills/[category]/[skill-name]/SKILL.md`
 
 ### What Was Wrong
 <!-- Describe the specific issue: false positives, missed variants, broken remediation, etc. -->
@@ -36,5 +36,5 @@
 - [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion
 
 ### Bounty Info
-- [ ] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
+- [ ] I have read and agree to the [CONTRIBUTING.md](https://github.com/UnitOneAI/SecuritySkills/blob/main/CONTRIBUTING.md) bounty terms
 - **Preferred payment method:** GitHub Sponsors / PayPal / Crypto


### PR DESCRIPTION
## Repository Template Improvement

**Files Modified:**

- `.github/ISSUE_TEMPLATE/skill-review.md`
- `.github/ISSUE_TEMPLATE/new-skill-proposal.md`
- `.github/PULL_REQUEST_TEMPLATE.md`
- `.github/PULL_REQUEST_TEMPLATE/skill-improvement.md`

### What was wrong

The newly added GitHub issue and PR templates used repository-relative links such as `../../CONTRIBUTING.md` and `../SECURITY.md`. Those links are correct when reading the template file in-place, but GitHub leaves them as literal relative URLs when the template content is copied into an issue or PR body, which makes the bounty terms and security-policy links fragile for contributors reading the submitted issue/PR.

The skill-review and skill-improvement templates also asked for `skills/[category]/[skill-name]/`, while the repository's actual skill entrypoints use `skills/[category]/[skill-name]/SKILL.md`.

### What changed

- Replaced template links to `CONTRIBUTING.md` and `SECURITY.md` with stable upstream GitHub URLs.
- Updated skill-path placeholders to include the real `SKILL.md` entrypoint.
- Kept the change scoped to template guidance only; no skill content or workflow behavior changed.

### Validation

- `git diff --check`
- Confirmed no `](../...)` or `](../../...)` relative doc links remain in the GitHub templates.
- Confirmed no directory-only `skills/[category]/[skill-name]/` skill-path placeholder remains in the GitHub templates.
- Final duplicate check found no open PR touching `.github/ISSUE_TEMPLATE`, `.github/PULL_REQUEST_TEMPLATE.md`, or `.github/PULL_REQUEST_TEMPLATE/`.

### Bounty

This is a minor documentation/template quality fix. If accepted, I believe it fits the improver bounty lane described in `CONTRIBUTING.md`. Payment details can be coordinated privately after maintainer acceptance.