### PR TITLE
Improve GCP serverless identity and secrets checks

### DIFF
--- a/skills/cloud/gcp-review/SKILL.md
+++ b/skills/cloud/gcp-review/SKILL.md
@@ -3,7 +3,8 @@ name: gcp-review
 description: >
   Performs a GCP security posture review against the CIS Google Cloud Platform
   Foundation Benchmark v2.0.0. Auto-invoked when reviewing GCP infrastructure,
-  IAM bindings, VPC firewall rules, Cloud Audit Logs, or GCS bucket security.
+  IAM bindings, VPC firewall rules, Cloud Run and Cloud Functions v2 settings,
+  Cloud Audit Logs, or GCS bucket security.
   Walks through all seven benchmark sections, evaluates each recommendation,
   and produces a prioritized findings report with remediation guidance mapped
   to specific CIS control IDs.
@@ -13,7 +14,7 @@ phase: [assess, operate]
 frameworks: [CIS-GCP-v2.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -38,7 +39,7 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 - Reviewing GCP infrastructure-as-code before deployment
 - Assessing an existing GCP environment's security posture against CIS benchmarks
 - Preparing for a CIS benchmark audit or compliance assessment
-- Evaluating IAM bindings, org policies, VPC firewall rules, Cloud Audit Logs, or GCS bucket configurations
+- Evaluating IAM bindings, org policies, VPC firewall rules, Cloud Run and Cloud Functions v2 settings, Cloud Audit Logs, or GCS bucket configurations
 - Onboarding a new GCP project or organization into a security program
 
 ---
@@ -53,6 +54,7 @@ The CIS Google Cloud Platform Foundation Benchmark v2.0.0 is a consensus-driven 
 - gcloud CLI output or configuration exports (if reviewing a live environment)
 - IAM policy bindings and org policy definitions
 - VPC and firewall rule definitions
+- Cloud Run services, Cloud Functions v1/v2 resources, runtime service accounts, Secret Manager references, and Workload Identity Federation providers
 - Cloud Audit Logs configuration
 
 ---
@@ -88,6 +90,25 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
+### Step 8.5: Supplemental Serverless Identity and Secrets Review
+
+Cloud Run and Cloud Functions v2 are not covered as deeply as VM and Cloud SQL controls in the CIS GCP v2.0.0 section map, but they can expose public endpoints, service-account permissions, and secrets without VM public IP or firewall evidence. Review serverless resources before closing a GCP posture assessment.
+
+**What to verify:**
+
+- Cloud Run v2 services and Cloud Functions v2 resources are inventoried separately from Cloud Functions v1.
+- Public invocation evidence is explicit: `roles/run.invoker` or Cloud Functions invoker bindings for `allUsers` / `allAuthenticatedUsers`, disabled invoker IAM checks, and ingress mode.
+- Runtime service accounts are not default service accounts and have only the roles needed by the serverless workload.
+- Secret Manager references are distinguished from literal secret values in environment variables; pinned versions are preferred over `latest` for environment-variable secrets.
+- Cross-project secret access is justified and scoped to the runtime service account.
+- Workload Identity Federation providers include issuer, audience, subject mapping, attribute conditions, and service-account impersonation scope.
+
+Treat missing serverless IAM, ingress, or secret-source evidence as **Not Evaluable** rather than inferring safety from the absence of VM, firewall, or public-IP findings.
+
+Use `tests/vulnerable/serverless-public-secret-wif.md` and `tests/benign/serverless-private-secret-wif.md` as evidence fixtures for this supplemental review.
+
+---
+
 ### Step 9: Compile Assessment Report
 
 
@@ -99,8 +120,8 @@ Produce the final report using the structure defined in the Output Format sectio
 
 | Severity | Definition | Examples |
 |----------|-----------|----------|
-| **Critical** | Immediate risk of data breach or unauthorized access | Public GCS buckets, firewall rules allowing 0.0.0.0/0 on SSH/RDP, Cloud SQL with public IP and no SSL, user-managed SA keys with admin roles |
-| **High** | Significant security gap that materially weakens posture | Default service accounts with broad scopes, missing Cloud Audit Logs, no VPC flow logs, instances with public IPs |
+| **Critical** | Immediate risk of data breach or unauthorized access | Public GCS buckets, firewall rules allowing 0.0.0.0/0 on SSH/RDP, Cloud SQL with public IP and no SSL, public serverless admin APIs, user-managed SA keys with admin roles |
+| **High** | Significant security gap that materially weakens posture | Default service accounts with broad scopes, missing Cloud Audit Logs, no VPC flow logs, instances with public IPs, literal serverless environment secrets |
 | **Medium** | Control gap that should be addressed in normal cycle | Missing log metric filters, DNSSEC not enabled, Shielded VM not enabled, uniform bucket access not set |
 | **Low** | Hardening recommendation or defense-in-depth measure | OS Login not enabled, serial port access not explicitly disabled, BigQuery tables without CMEK |
 | **Informational** | Best practice observation, no direct security impact | Default network still exists (non-production), naming conventions, documentation gaps |
@@ -150,6 +171,12 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Evidence:** <specific configuration or code snippet>
 - **Remediation:** <specific fix with code example>
 
+### Supplemental Serverless Findings
+
+| Resource | Public Invoker | Ingress | Runtime Service Account | Secret Source | Secret Version | WIF Condition | Status |
+|----------|----------------|---------|-------------------------|---------------|----------------|---------------|--------|
+| <Cloud Run / Function> | allUsers / restricted / not evaluable | all / internal / not evaluable | <service account> | literal / Secret Manager / none | pinned / latest / not applicable | present / missing / not applicable | Pass / Fail / Not Evaluable |
+
 ### Prioritized Remediation Plan
 
 1. **[Critical]** CIS X.Y -- <action item>
@@ -194,6 +221,8 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Cloud SQL authorized_networks vs. private IP.** CIS 6.5 flags `0.0.0.0/0` in authorized networks, but CIS 6.6 goes further and recommends disabling public IP entirely in favor of private networking.
 5. **BigQuery dataset-level vs. table-level CMEK.** CIS 7.2 checks table-level encryption, while CIS 7.3 checks the dataset default. Both should be evaluated independently.
 6. **Default compute service account identification.** The default SA follows the pattern `PROJECT_NUMBER-compute@developer.gserviceaccount.com`. Grep for this pattern, not just the string "default."
+7. **Serverless exposure without VM evidence.** Cloud Run and Cloud Functions v2 can be public through invoker IAM or disabled invoker checks even when there is no VM public IP or broad firewall rule. Review ingress, invoker IAM, runtime service account, and Secret Manager usage together.
+8. **Assuming keyless federation is automatically safe.** Workload Identity Federation removes static keys, but weak provider mappings or missing `attribute_condition` can over-trust an external identity provider.
 
 ---
 
@@ -219,10 +248,14 @@ Produce the final report using the structure defined in the Output Format sectio
 - Google Cloud Audit Logs: https://cloud.google.com/logging/docs/audit
 - Google Cloud VPC Documentation: https://cloud.google.com/vpc/docs
 - Google Cloud SQL Security: https://cloud.google.com/sql/docs/mysql/configure-ssl-instance
+- Google Cloud Run Authentication: https://cloud.google.com/run/docs/authenticating/overview
+- Google Cloud Run Secrets: https://cloud.google.com/run/docs/configuring/services/secrets
+- Google Cloud Workload Identity Federation: https://cloud.google.com/iam/docs/workload-identity-federation
 - Terraform Google Provider Documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs
 
 ---
 
 ## Changelog
 
+- **1.0.1** -- Add supplemental Cloud Run, Cloud Functions v2, Secret Manager, and Workload Identity Federation evidence gates.
 - **1.0.0** -- Initial release. Full coverage of CIS Google Cloud Platform Foundation Benchmark v2.0.0 sections 1 through 7.

--- a/skills/cloud/gcp-review/benchmark-checklist.md
+++ b/skills/cloud/gcp-review/benchmark-checklist.md
@@ -152,7 +152,7 @@ Check Dataproc clusters for CMEK configuration.
 
 ### CIS 1.18 -- Ensure Secrets Are Not Stored in Cloud Functions Environment Variables by Using Secret Manager
 
-Check Cloud Functions for secrets in environment variables vs. Secret Manager references:
+Check Cloud Functions for secrets in environment variables vs. Secret Manager references. Include both first-generation `google_cloudfunctions_function` resources and second-generation `google_cloudfunctions2_function` resources.
 
 ```hcl
 # BAD: Secret in env var
@@ -170,7 +170,146 @@ resource "google_cloudfunctions_function" {
     version = "latest"
   }
 }
+
+# BAD: Cloud Functions v2 literal secret in service_config
+resource "google_cloudfunctions2_function" "webhook" {
+  service_config {
+    environment_variables = {
+      STRIPE_WEBHOOK_SECRET = "whsec_plaintext_value"
+    }
+  }
+}
 ```
+
+For Cloud Functions v2, also evaluate the underlying Cloud Run service behavior: runtime service account, ingress, invoker IAM, and Secret Manager permissions.
+
+### Supplemental -- Cloud Run and Cloud Functions v2 Serverless IAM and Secrets
+
+Review Cloud Run v2 services, Cloud Functions v2, and Cloud Run functions even when the CIS checklist item does not name them directly.
+
+**Discovery patterns:**
+
+```hcl
+resource "google_cloud_run_v2_service"
+resource "google_cloud_run_service_iam_member"
+resource "google_cloud_run_service_iam_binding"
+resource "google_cloudfunctions2_function"
+resource "google_cloudfunctions2_function_iam_member"
+resource "google_iam_workload_identity_pool_provider"
+resource "google_service_account_iam_member"
+```
+
+**Public invocation and ingress checks:**
+
+```hcl
+# BAD: Public Cloud Run invoker
+resource "google_cloud_run_service_iam_member" "public" {
+  role   = "roles/run.invoker"
+  member = "allUsers"
+}
+
+# BAD: Public internet ingress for an internal/admin service
+resource "google_cloud_run_v2_service" "admin_api" {
+  ingress = "INGRESS_TRAFFIC_ALL"
+}
+
+# GOOD: Private ingress plus named invoker
+resource "google_cloud_run_v2_service" "checkout_api" {
+  ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+}
+
+resource "google_cloud_run_service_iam_member" "private_invoker" {
+  role   = "roles/run.invoker"
+  member = "serviceAccount:edge-proxy@example.iam.gserviceaccount.com"
+}
+```
+
+Flag public invocation as **Critical** for admin, internal, payment, customer-data, or privileged automation APIs. Public unauthenticated access can be acceptable for public web frontends only when the report records data classification, authentication expectations, ingress, and backend authorization evidence.
+
+**Cloud Run and Functions v2 secret checks:**
+
+```hcl
+# BAD: Literal secret value in Cloud Run env
+resource "google_cloud_run_v2_service" "api" {
+  template {
+    containers {
+      env {
+        name  = "PAYMENT_API_KEY"
+        value = "plain-text-secret"
+      }
+    }
+  }
+}
+
+# GOOD: Secret Manager reference with pinned version
+resource "google_cloud_run_v2_service" "api" {
+  template {
+    service_account = google_service_account.runtime.email
+
+    containers {
+      env {
+        name = "PAYMENT_API_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.payment_api_key.secret_id
+            version = "2"
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "runtime_can_read_key" {
+  secret_id = google_secret_manager_secret.payment_api_key.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.runtime.email}"
+}
+```
+
+Do not flag a Secret Manager-backed `secret_key_ref` as plaintext merely because the environment variable name contains `KEY`, `TOKEN`, or `SECRET`. Do flag literal values, broad `roles/secretmanager.secretAccessor` grants, default runtime service accounts, cross-project secret access without justification, and unpinned `latest` versions for environment-variable secrets.
+
+**Workload Identity Federation checks:**
+
+```hcl
+# BAD: Missing attribute_condition for GitHub OIDC provider
+resource "google_iam_workload_identity_pool_provider" "github" {
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.repository" = "assertion.repository"
+  }
+}
+
+# GOOD: Provider scoped to the expected organization/repository
+resource "google_iam_workload_identity_pool_provider" "github" {
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.repository" = "assertion.repository"
+  }
+
+  attribute_condition = "attribute.repository == 'example/checkout-api'"
+}
+```
+
+Verify issuer, audience if configured, subject mapping, provider-specific attributes, `attribute_condition`, and the service-account impersonation binding. Treat keyless federation as lower risk than user-managed service account keys only when these trust constraints are present.
+
+**Serverless evidence matrix:**
+
+| Evidence Area | Pass Evidence | Fail / Not Evaluable Indicator |
+|---|---|---|
+| Runtime identity | Dedicated non-default service account with scoped IAM | Default service account, broad project role, or missing runtime identity |
+| Public invocation | Restricted invoker IAM or documented public frontend rationale | `allUsers`, `allAuthenticatedUsers`, disabled invoker IAM check, or unknown invoker policy |
+| Ingress | Internal, internal-load-balancer, or documented public ingress | Internet ingress for internal/admin service or missing ingress evidence |
+| Secret source | Secret Manager env/volume reference with scoped accessor IAM | Literal secret values, broad accessor IAM, unpinned `latest`, or unknown secret source |
+| WIF trust | Issuer, mapping, conditions, and impersonation scope are constrained | Missing `attribute_condition`, broad subject trust, or project-wide impersonation |
 
 ---
 

--- a/skills/cloud/gcp-review/tests/benign/serverless-private-secret-wif.md
+++ b/skills/cloud/gcp-review/tests/benign/serverless-private-secret-wif.md
@@ -1,0 +1,84 @@
+# Benign Case: Private Serverless API With Scoped Secrets and WIF
+
+## Scenario
+
+A checkout API runs on Cloud Run behind an internal load balancer. Runtime secrets come from Secret Manager, and CI/CD uses Workload Identity Federation constrained to a single GitHub repository.
+
+## Evidence
+
+```hcl
+resource "google_service_account" "runtime" {
+  account_id = "checkout-runtime"
+}
+
+resource "google_secret_manager_secret" "payment_api_key" {
+  secret_id = "payment-api-key"
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "runtime_can_read_key" {
+  secret_id = google_secret_manager_secret.payment_api_key.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.runtime.email}"
+}
+
+resource "google_cloud_run_v2_service" "checkout_api" {
+  name     = "checkout-api"
+  location = "us-central1"
+  ingress  = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+
+  template {
+    service_account = google_service_account.runtime.email
+
+    containers {
+      image = "us-docker.pkg.dev/example/checkout/api:2026-06-04"
+
+      env {
+        name = "PAYMENT_API_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.payment_api_key.secret_id
+            version = "2"
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "google_cloud_run_service_iam_member" "private_invoker" {
+  service  = google_cloud_run_v2_service.checkout_api.name
+  location = google_cloud_run_v2_service.checkout_api.location
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:edge-proxy@example.iam.gserviceaccount.com"
+}
+
+resource "google_iam_workload_identity_pool_provider" "github" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.cicd.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github"
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.repository" = "assertion.repository"
+  }
+
+  attribute_condition = "attribute.repository == 'example/checkout-api'"
+}
+```
+
+## Expected Skill Result
+
+Do not flag this as a plaintext serverless secret or public serverless API. The review can mark the serverless checks **PASS** when evidence confirms:
+
+- Cloud Run ingress is internal-load-balancer scoped.
+- Invoker IAM is restricted to a named service account.
+- Runtime identity is a dedicated non-default service account.
+- Secret source is Secret Manager with a pinned version and scoped runtime accessor binding.
+- WIF provider constrains the trusted external identity with an attribute condition.

--- a/skills/cloud/gcp-review/tests/vulnerable/serverless-public-secret-wif.md
+++ b/skills/cloud/gcp-review/tests/vulnerable/serverless-public-secret-wif.md
@@ -1,0 +1,67 @@
+# Vulnerable Case: Public Serverless API With Literal Secret and Weak WIF
+
+## Scenario
+
+A GCP posture review includes Cloud Run, Cloud Functions v2, and Workload Identity Federation resources. No VM has a public IP and no firewall rule exposes SSH/RDP, but a serverless admin API is public and uses weak identity and secret controls.
+
+## Evidence
+
+```hcl
+resource "google_cloud_run_v2_service" "admin_api" {
+  name     = "admin-api"
+  location = "us-central1"
+  ingress  = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    service_account = "123456789-compute@developer.gserviceaccount.com"
+
+    containers {
+      image = "us-docker.pkg.dev/example/admin/api:latest"
+
+      env {
+        name  = "ADMIN_API_TOKEN"
+        value = "plain-text-token"
+      }
+    }
+  }
+}
+
+resource "google_cloud_run_service_iam_member" "public_invoker" {
+  service  = google_cloud_run_v2_service.admin_api.name
+  location = google_cloud_run_v2_service.admin_api.location
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+resource "google_cloudfunctions2_function" "webhook" {
+  name     = "webhook-handler"
+  location = "us-central1"
+
+  service_config {
+    environment_variables = {
+      STRIPE_WEBHOOK_SECRET = "whsec_plaintext_value"
+    }
+  }
+}
+
+resource "google_iam_workload_identity_pool_provider" "github" {
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.repository" = "assertion.repository"
+  }
+}
+```
+
+## Expected Skill Result
+
+Classify serverless findings as **Critical** or **High** depending on data sensitivity:
+
+- Cloud Run admin API is internet-reachable and unauthenticated via `allUsers`.
+- Runtime uses the default Compute Engine service account.
+- Cloud Run and Functions v2 contain literal secret values.
+- WIF provider lacks an `attribute_condition`, so the external identity provider is over-trusted.
+- The absence of VM public IPs or broad firewall rules is not sufficient evidence of serverless safety.


### PR DESCRIPTION
## Pull Request Checklist

- [x] Skill follows the format specification in CONTRIBUTING.md
- [x] At least one real framework is cited with correct control IDs
- [x] All framework references verified against primary sources already used by the skill, plus Google Cloud serverless docs
- [x] Prompt Injection Safety Notice section included
- [x] `injection-hardened: true` set in frontmatter
- [x] `allowed-tools` scoped to minimum necessary permissions
- [x] Tested with at least one AI coding agent (which one: Codex)
- [x] No prohibited patterns per SECURITY.md
- [x] `index.yaml` updated with new skill entry (not applicable; existing skill)

## What This PR Does

Addresses #652 by adding supplemental GCP serverless identity and secrets evidence gates to `gcp-review`.

The update adds coverage for:

- Cloud Run v2 and Cloud Functions v2 inventory as separate evidence from Functions v1.
- Cloud Run invoker IAM, `allUsers` / `allAuthenticatedUsers`, ingress mode, and public endpoint classification.
- Runtime service account evidence, including default service account risk.
- Secret Manager-backed env vars versus literal environment secrets, pinned versions, scoped accessor IAM, and cross-project secret-access review.
- Workload Identity Federation issuer, subject mapping, attribute conditions, and impersonation binding evidence.

It also adds two focused evidence fixtures:

- `tests/vulnerable/serverless-public-secret-wif.md`
- `tests/benign/serverless-private-secret-wif.md`

This is a Skill Improvement bounty candidate under CONTRIBUTING.md (`$50-150`, likely moderate `$100` if accepted), scoped to the serverless gaps documented in #652.

## Framework References

- CIS Google Cloud Platform Foundation Benchmark v2.0.0, especially IAM, logging, networking, and public access posture checks already mapped in this skill.
- Google Cloud Run authentication and public access guidance.
- Google Cloud Run Secret Manager configuration guidance.
- Google Cloud Workload Identity Federation guidance and best practices.

## Testing

- Ran frontmatter required-field validation across all `skills/**/SKILL.md` files.
- Ran `index.yaml` referenced-file validation.
- Ran Markdown table consistency validation for changed Markdown files.
- Ran `git diff --check` on the committed diff.
- Reviewed `SECURITY.md` prohibited patterns against changed files.