### PR TITLE
Improve threat modeling coverage for async messaging

### DIFF
--- a/skills/appsec/threat-modeling/SKILL.md
+++ b/skills/appsec/threat-modeling/SKILL.md
@@ -13,7 +13,7 @@ phase: [design, review]
 frameworks: [STRIDE, PASTA, MITRE-ATT&CK]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -182,6 +182,25 @@ Every data flow in the DFD must be annotated with the following properties:
 
 Mark any flow with `Authentication: none` or `Failure mode: fail-open` as requiring immediate threat analysis.
 
+### Asynchronous Messaging Trust Boundary Evidence
+
+When the system uses Kafka, RabbitMQ, SQS, Pub/Sub, EventBridge, Celery, or another queue/event bus, model the producer, broker/topic/queue, consumer, dead-letter queue, and redrive path as separate trust-boundary elements. Do not assume that authorization performed by the producer is still valid when the consumer executes the message later.
+
+Capture the following evidence for each asynchronous flow:
+
+| Field | Evidence to Capture | Why It Matters |
+|-------|---------------------|----------------|
+| Producer identity | Service principal, IAM role, API key, or mTLS identity allowed to publish | Detects producer spoofing and over-broad publish permissions |
+| Consumer identity | Service principal, IAM role, runtime account, and subscription scope | Confirms the consumer is authorized for the work it performs |
+| Payload authorization context | Whether the consumer re-checks authorization against current state or trusts producer-provided claims | Prevents stale, forged, or replayed authorization decisions |
+| Delivery semantics | At-most-once, at-least-once, exactly-once where supported, retry count, and ordering guarantee | Surfaces duplicate execution and ordering hazards |
+| Idempotency control | Idempotency key, deduplication window, transaction boundary, or replay guard | Prevents double charges, duplicate provisioning, and repeated side effects |
+| Poison-message handling | Retry policy, backoff, circuit breaker, quarantine, and alerting | Prevents queue starvation and cascading failures |
+| DLQ and redrive controls | Who can read, purge, replay, or redrive messages and how this is audited | Prevents unauthorized replay, data exposure, and evidence loss |
+| Payload sensitivity | PII, credentials, tokens, payment data, or regulated data present in messages | Drives encryption, retention, masking, and access-control requirements |
+
+Flag any asynchronous flow where the consumer trusts producer-provided authorization, performs non-idempotent side effects without a replay guard, or allows unaudited DLQ redrive as requiring immediate threat analysis.
+
 ### Step 4: Apply STRIDE per Element
 
 For every component and data flow identified in the DFD, systematically ask the following questions organized by STRIDE category.
@@ -197,6 +216,7 @@ Threat: An attacker pretends to be another user, service, or system component.
 | Can an attacker replay a valid authentication token? | Stolen JWT without expiration |
 | Are API keys rotated and scoped appropriately? | Leaked long-lived API key |
 | Is multi-factor authentication enforced for privileged accounts? | Admin account takeover |
+| Can an unauthorized producer publish messages to a trusted topic or queue? | Forged queue message accepted as a trusted internal event |
 
 #### T — Tampering (Integrity Threats)
 
@@ -209,6 +229,7 @@ Threat: An attacker modifies data, code, or configuration without authorization.
 | Can CI/CD pipeline artifacts be tampered with? | Compromised build server, dependency confusion |
 | Are configuration files protected from unauthorized modification? | Writable config in production containers |
 | Is input validated and sanitized before processing? | XSS, command injection, deserialization attacks |
+| Can message payloads or attributes be altered before consumer processing? | Tampered event changes account ID, amount, or operation type |
 
 #### R — Repudiation (Audit and Accountability Threats)
 
@@ -221,6 +242,7 @@ Threat: A user or system denies performing an action, and the system cannot prov
 | Are logs centralized and protected from tampering? | Local-only logs on compromised host |
 | Do transactions include non-repudiation controls (digital signatures)? | Disputed financial transactions |
 | Is there sufficient log detail to reconstruct the sequence of events? | Logs missing source IP, user ID, or action detail |
+| Are publish, consume, retry, DLQ, and redrive actions auditable end to end? | Message replay cannot be traced to an actor or approval |
 
 #### I — Information Disclosure (Confidentiality Threats)
 
@@ -233,6 +255,7 @@ Threat: Sensitive data is exposed to unauthorized parties.
 | Do error messages or stack traces leak internal details? | Verbose error pages reveal DB schema |
 | Are secrets stored in environment variables or dedicated vaults? | Hardcoded credentials in source code |
 | Is access to data stores restricted by least-privilege IAM policies? | Over-permissive S3 bucket policy |
+| Do queues, topics, or DLQs retain sensitive payloads longer than necessary? | DLQ exposes PII or tokens to operators outside the normal service path |
 
 #### D — Denial of Service (Availability Threats)
 
@@ -245,6 +268,7 @@ Threat: An attacker makes the system unavailable to legitimate users.
 | Are resource quotas enforced (memory, CPU, storage, connections)? | Memory leak triggered by crafted input |
 | Is the system resilient to dependency failures (circuit breakers)? | Cascading failure from downstream outage |
 | Are there auto-scaling policies and DDoS mitigation services? | Sustained DDoS overwhelms fixed capacity |
+| Can poison messages, retry storms, or unbounded redrive exhaust consumers? | Queue backlog blocks legitimate work or repeatedly triggers expensive jobs |
 
 #### E — Elevation of Privilege (Authorization Threats)
 
@@ -257,6 +281,7 @@ Threat: An attacker gains access to resources or actions beyond their authorized
 | Are privilege boundaries enforced in containerized environments? | Container escape, privileged container |
 | Can an attacker exploit deserialization or injection for code execution? | Remote code execution via insecure deserialization |
 | Are default credentials and unnecessary services removed? | Default admin/admin on management interfaces |
+| Does the consumer re-authorize requested actions instead of trusting the producer? | Compromised producer triggers privileged downstream actions |
 
 ### Step 5: Build Component-Threat Matrix
 
@@ -389,6 +414,12 @@ Rank mitigations using the following prioritization criteria:
 
 ## 5. Output Format — Threat Register
 
+If asynchronous flows are present, include a Queue Evidence Matrix before the threat register:
+
+| Queue/Topic | Producer | Consumer | Authz Recheck | Delivery Semantics | Idempotency Control | DLQ/Redrive Control | Sensitive Payload | Open Threat IDs |
+|-------------|----------|----------|---------------|--------------------|---------------------|---------------------|-------------------|-----------------|
+| `orders.created` | Checkout API | Fulfillment Worker | Yes, current order owner checked before execution | At-least-once, ordered per order ID | `order_id` idempotency key with processed-event table | DLQ redrive requires break-glass approval and audit log | PII: shipping address | TM-007, TM-008 |
+
 Produce the threat register as a structured table. Each row represents one identified threat.
 
 | Threat ID | STRIDE Category | Description | Affected Component | ATT&CK TTP | Likelihood | Impact | Severity | Mitigation | Owner | Status |
@@ -489,3 +520,6 @@ This skill processes user-supplied content that may include system descriptions,
 8. **NIST SP 800-154** — Guide to Data-Centric System Threat Modeling — https://csrc.nist.gov/publications/detail/sp/800-154/draft
 9. **STRIDE Original Paper** — Kohnfelder, L. & Garg, P. (1999). "The Threats to Our Products." Microsoft Internal Document.
 10. **OWASP Risk Rating Methodology** — https://owasp.org/www-community/OWASP_Risk_Rating_Methodology
+11. **Amazon SQS at-least-once delivery** — https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/standard-queues-at-least-once-delivery.html
+12. **Amazon SQS dead-letter queues** — https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html
+13. **Apache Kafka message delivery semantics** — https://kafka.apache.org/documentation/#semantics

--- a/skills/appsec/threat-modeling/tests/vulnerable/async-messaging-design.md
+++ b/skills/appsec/threat-modeling/tests/vulnerable/async-messaging-design.md
@@ -1,0 +1,29 @@
+# Async Messaging Threat Modeling Test Scenario
+
+Use this scenario to verify that the threat-modeling skill captures asynchronous queue trust boundaries, duplicate delivery, idempotency, DLQ handling, and consumer-side authorization.
+
+## Design Under Review
+
+The Checkout API publishes an `orders.created` event to an Amazon SQS standard queue. The event contains `order_id`, `user_id`, `amount`, `shipping_address`, and producer-provided authorization claims. A Fulfillment Worker consumes the event, captures payment, updates order state, and creates a shipment.
+
+The queue uses at-least-once delivery. The Fulfillment Worker does not store processed message IDs or use an idempotency key. If processing fails five times, the message moves to a dead-letter queue. A support role can redrive messages from the DLQ to the source queue without a separate approval or audit event.
+
+## Expected Skill Coverage
+
+The threat model should produce a Queue Evidence Matrix row for `orders.created` that identifies:
+
+- Checkout API as producer and Fulfillment Worker as consumer.
+- At-least-once delivery semantics.
+- Missing idempotency or replay guard before payment capture and shipment creation.
+- Consumer trust in producer-provided authorization claims instead of a current authorization check.
+- PII in the message payload through `shipping_address`.
+- DLQ redrive access that lacks explicit approval and audit evidence.
+
+The threat register should include findings for:
+
+- Spoofing: unauthorized producers publishing trusted `orders.created` events.
+- Tampering: modified message fields such as `amount`, `user_id`, or `shipping_address`.
+- Repudiation: unaudited retry and DLQ redrive actions.
+- Information disclosure: sensitive payload data retained in the DLQ.
+- Denial of service: poison messages or retry storms exhausting consumers.
+- Elevation of privilege: a compromised producer triggering privileged downstream actions because the consumer does not re-authorize.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** threat-modeling  
**Skill path:** `skills/appsec/threat-modeling/`

### What Was Wrong
The skill already mentions message queues in inventory/entry-point examples, but it does not require reviewers to capture asynchronous trust-boundary evidence. That leaves common queue/event risks under-modeled: producer spoofing, trusted producer-provided authorization context, at-least-once duplicate execution, non-idempotent side effects, poison-message retries, sensitive DLQ retention, and unaudited redrive.

Implements #425.

### What This PR Fixes
- Adds an **Asynchronous Messaging Trust Boundary Evidence** section for producer, broker/topic/queue, consumer, DLQ, and redrive paths.
- Adds required evidence fields for producer/consumer identity, payload authorization context, delivery semantics, idempotency, poison-message handling, DLQ/redrive controls, and payload sensitivity.
- Adds STRIDE questions for async messaging across Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, and Elevation of Privilege.
- Adds a Queue Evidence Matrix output before the threat register when async flows are present.
- Adds official references for SQS at-least-once delivery, SQS DLQs, and Kafka delivery semantics.

### Evidence
**Before (skill misses this):**
```text
A design with an orders.created queue, at-least-once delivery, non-idempotent payment/shipment side effects, producer-provided authz claims, and unaudited DLQ redrive could be captured only as a generic Message Queue component.
```

**After (now correctly handled):**
```text
The skill now requires a Queue Evidence Matrix and STRIDE coverage for duplicate delivery, idempotency gaps, consumer-side authorization rechecks, poison messages, sensitive DLQ payloads, and redrive audit controls.
```

Test scenario added: `skills/appsec/threat-modeling/tests/vulnerable/async-messaging-design.md`

### Test Cases Added/Updated
- [x] Added vulnerable test case (`tests/vulnerable/async-messaging-design.md`)
- [ ] Added benign test cases (`tests/benign/`) - not applicable; this is a coverage expansion for threat-modeling evidence rather than a false-positive detector
- [x] Existing validation still passes

### Validation
- [x] `git diff --check`
- [x] Checked the new test fixture for prompt-injection scan patterns
- [x] Confirmed no open PR overlap for issue #425 before submission

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Crypto; payout details can be provided privately after maintainer acceptance.

## Pull Request Checklist

- [x] Skill follows the format specification in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] At least one real framework/source is cited with correct references
- [x] All references verified against primary sources (AWS, Apache Kafka, OWASP/Microsoft/MITRE already present)
- [x] Prompt Injection Safety Notice section included
- [x] `injection-hardened: true` set in frontmatter
- [x] `allowed-tools` scoped to minimum necessary permissions
- [x] Tested with at least one AI coding agent (Codex, using the added async messaging scenario)
- [x] No prohibited patterns per [SECURITY.md](../SECURITY.md) in the new test fixture
- [x] `index.yaml` updated with new skill entry (not applicable; existing skill only)

## What This PR Does

Improves the existing STRIDE threat-modeling skill so async queue/event architectures are modeled as explicit trust boundaries with evidence and output requirements.

## Framework References

- STRIDE / Microsoft threat modeling references already present in the skill
- OWASP Threat Modeling Cheat Sheet already present in the skill
- Amazon SQS at-least-once delivery
- Amazon SQS dead-letter queues
- Apache Kafka message delivery semantics

## Testing

Validated the Markdown changes with `git diff --check`, reviewed the added fixture against the repository injection-pattern scan terms, and added a concrete vulnerable async-messaging design scenario for maintainer review.
