### PR TITLE
Improve OWASP SSRF final destination checks

### DIFF
--- a/skills/appsec/owasp-top-10-web/SKILL.md
+++ b/skills/appsec/owasp-top-10-web/SKILL.md
@@ -562,6 +562,9 @@ log.*req\.body|log.*request\.getParameter|logger\.info\(.*\+.*req
 - PDF generators, image resizers, link previewers, or import-from-URL features.
 - Lack of allowlist validation on destination URLs (scheme, host, port, path).
 - No blocking of requests to private/reserved IP ranges (127.0.0.0/8, 10.0.0.0/8, 169.254.169.254, 172.16.0.0/12, 192.168.0.0/16, fd00::/8).
+- HTTP clients that follow redirects without re-validating the final destination after every hop.
+- Validation that checks only the original hostname or URL string without resolving and checking the effective IP address immediately before the outbound request.
+- DNS rebinding exposure in webhook, import, preview, or callback flows where registration-time validation is not repeated at invocation time.
 
 **CWE Mappings:**
 
@@ -581,6 +584,20 @@ url=|dest=|redirect=|uri=|callback=|src=.*http
 169\.254\.169\.254|metadata\.google|metadata\.azure
 ```
 
+**Verification Evidence Gates:**
+
+Before clearing an SSRF candidate as safe, collect evidence for the effective destination, not only the user-supplied string. A wrapper named `safeFetch`, `validateUrl`, or similar is not enough unless it enforces these gates on the same path as the outbound request.
+
+| Gate | Required evidence | Treat as vulnerable when |
+|------|-------------------|--------------------------|
+| Scheme and host allowlist | The same code path restricts schemes, hosts, and ports to an explicit allowlist before the request is sent. | The allowlist is documented but not called by the sink, or it uses substring/regex matching that accepts attacker-controlled subdomains. |
+| DNS and IP range validation | The code resolves the destination hostname and rejects loopback, link-local, private, multicast, and cloud metadata ranges for every resolved address. | Only the raw hostname is checked, only IPv4 ranges are blocked, or the code assumes a public-looking hostname cannot resolve internally. |
+| Redirect final-destination validation | Redirects are disabled, or each redirect target is re-parsed, re-resolved, and checked with the same allowlist and IP-range rules before following it. | The initial URL is validated but the HTTP client follows redirects automatically to private, link-local, or metadata endpoints. |
+| Time-of-use validation | Webhook and callback invocations repeat destination validation at send time rather than relying only on registration-time approval. | A URL is approved once and later used without re-resolution, allowing DNS rebinding or host ownership changes. |
+| Network egress boundary | Runtime or infrastructure evidence blocks metadata and internal network access even if application validation fails. | The application server can reach cloud metadata services, pod/service CIDRs, or internal admin endpoints unrelated to the feature. |
+
+Record missing gates in the finding evidence so reviewers can distinguish "URL validation exists" from "the effective request destination is constrained."
+
 **Mitigations:**
 
 - Validate and allowlist destination URLs by scheme (https only), host, and port against a known-good list.
@@ -589,6 +606,8 @@ url=|dest=|redirect=|uri=|callback=|src=.*http
 - Disable HTTP redirects in server-side HTTP clients, or re-validate the destination after each redirect.
 - Deploy network-level segmentation so the application server cannot reach internal services it does not need.
 - For webhook features, validate callback URLs at registration time and again at invocation time (DNS rebinding defense).
+- Resolve and validate the effective IP immediately before the request is sent; do not cache validation decisions across requests or trust DNS answers obtained during registration.
+- Use a dedicated outbound proxy or egress gateway that enforces the same host and IP-range policy for SSRF-prone features.
 
 ---
 
@@ -601,6 +620,8 @@ Before finalizing findings, apply this verification checklist to each candidate 
 - [ ] **User input reaches the sink** — for injection findings, you traced that user-controlled input flows into the vulnerable function without adequate sanitization.
 - [ ] **No compensating control** — you checked for middleware, wrappers, or framework-level protections that neutralize the vulnerability.
 - [ ] **Not a test or example** — the code is production code, not a test fixture, documentation example, or intentionally vulnerable training sample.
+
+- [ ] **Effective destination constrained** -- for SSRF findings, redirects, DNS resolution, and invocation-time destination checks were verified on the same path as the outbound request.
 
 **Discard any finding that fails two or more checklist items.** Findings that fail one item should be downgraded to Informational.
 
@@ -637,6 +658,7 @@ Present findings in this structure:
 - **Evidence:** [Code snippet or configuration excerpt]
 - **Remediation:** [Specific, actionable fix with code example where applicable]
 - **Verification:** [How to confirm the fix is effective]
+- **Effective Destination Evidence:** [For SSRF: scheme/host allowlist, resolved IP checks, redirect policy, DNS rebinding/invocation-time validation, and egress controls]
 
 ---
 

--- a/skills/appsec/owasp-top-10-web/csharp-dotnet.md
+++ b/skills/appsec/owasp-top-10-web/csharp-dotnet.md
@@ -1127,9 +1127,13 @@ public async Task<IActionResult> Fetch(
     if (!allowedHosts.Contains(uri.Host, StringComparer.OrdinalIgnoreCase))
         return BadRequest("Host not in allowlist");
 
-    var client = httpClientFactory.CreateClient("external");
-    var response = await client.GetStringAsync(uri);
-    return Ok(response);
+    var client = httpClientFactory.CreateClient("external-no-redirects");
+    using var response = await client.GetAsync(uri);
+
+    if ((int)response.StatusCode is >= 300 and < 400)
+        return BadRequest("Redirects are not followed by this endpoint");
+
+    return Ok(await response.Content.ReadAsStringAsync());
 }
 
 private static bool IsPrivateOrReserved(IPAddress ip)
@@ -1144,6 +1148,14 @@ private static bool IsPrivateOrReserved(IPAddress ip)
         || (bytes[0] == 169 && bytes[1] == 254);                    // 169.254.0.0/16 (link-local / cloud metadata)
 }
 ```
+
+**SSRF final-destination review checklist:**
+
+- [ ] `HttpClientHandler.AllowAutoRedirect` is disabled for user-controlled destinations, or every redirect target is re-validated before following it.
+- [ ] Host allowlists are exact matches or controlled suffix matches; substring checks such as `Contains("example.com")` are not accepted.
+- [ ] DNS resolution happens immediately before the outbound request and every resolved IPv4 and IPv6 address is checked.
+- [ ] The runtime egress layer blocks loopback, link-local, private ranges, and cloud metadata endpoints even if application validation fails.
+- [ ] Webhook or callback URLs are re-resolved and re-validated when invoked, not only when registered.
 
 ---
 

--- a/skills/appsec/owasp-top-10-web/tests/benign/ssrf-final-destination-revalidated.md
+++ b/skills/appsec/owasp-top-10-web/tests/benign/ssrf-final-destination-revalidated.md
@@ -1,0 +1,76 @@
+---
+name: ssrf-final-destination-revalidated
+expected: benign
+category: A10:2021
+cwe: CWE-918
+---
+
+# Benign SSRF Fixture: Redirects Disabled and Destination Revalidated
+
+This fixture should not be flagged as SSRF when reviewing the URL-fetching
+path. The code validates the URL before the request, disables automatic
+redirect following, and resolves every address for the effective destination
+immediately before sending the request.
+
+```csharp
+[HttpGet("preview")]
+public async Task<IActionResult> Preview(
+    [FromQuery] string url,
+    [FromServices] IHttpClientFactory httpClientFactory)
+{
+    if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+    {
+        return BadRequest("invalid URL");
+    }
+
+    if (!IsAllowedDestination(uri))
+    {
+        return BadRequest("destination not allowed");
+    }
+
+    var client = httpClientFactory.CreateClient("no-redirects");
+    using var response = await client.GetAsync(uri);
+
+    if ((int)response.StatusCode is >= 300 and < 400)
+    {
+        return BadRequest("redirects are not followed for previews");
+    }
+
+    return Content(await response.Content.ReadAsStringAsync(), "text/html");
+}
+
+private static bool IsAllowedDestination(Uri uri)
+{
+    if (uri.Scheme != Uri.UriSchemeHttps)
+    {
+        return false;
+    }
+
+    if (!AllowedHosts.Contains(uri.Host, StringComparer.OrdinalIgnoreCase))
+    {
+        return false;
+    }
+
+    foreach (var address in Dns.GetHostAddresses(uri.Host))
+    {
+        if (IsPrivateOrReserved(address))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+```
+
+## Expected Safe Evidence
+
+| Evidence Gate | Fixture State |
+|---------------|---------------|
+| Initial scheme and host allowlist | Present on the request path |
+| DNS and IP range validation | Present before request send |
+| Redirect final-destination validation | Automatic redirects disabled |
+| Time-of-use validation | Validation happens inside the request handler |
+
+The skill should accept this as compensating evidence instead of reporting a
+finding based only on the presence of `GetAsync(uri)`.

--- a/skills/appsec/owasp-top-10-web/tests/vulnerable/ssrf-redirect-final-destination.md
+++ b/skills/appsec/owasp-top-10-web/tests/vulnerable/ssrf-redirect-final-destination.md
@@ -1,0 +1,50 @@
+---
+name: ssrf-redirect-final-destination
+expected: vulnerable
+category: A10:2021
+cwe: CWE-918
+---
+
+# Vulnerable SSRF Fixture: Initial URL Validated, Redirect Destination Trusted
+
+This fixture should be flagged as SSRF. The route validates the original URL
+scheme and hostname, but it then allows the HTTP client to follow redirects
+automatically. A permitted public host can redirect the server to a cloud
+metadata endpoint or another private address.
+
+```csharp
+[HttpGet("preview")]
+public async Task<IActionResult> Preview([FromQuery] string url)
+{
+    if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+    {
+        return BadRequest("invalid URL");
+    }
+
+    if (uri.Scheme != "https" || !AllowedHosts.Contains(uri.Host))
+    {
+        return BadRequest("destination not allowed");
+    }
+
+    using var handler = new HttpClientHandler
+    {
+        AllowAutoRedirect = true
+    };
+    using var client = new HttpClient(handler);
+
+    var html = await client.GetStringAsync(uri);
+    return Content(html, "text/html");
+}
+```
+
+## Expected Finding Evidence
+
+| Evidence Gate | Fixture State |
+|---------------|---------------|
+| Initial scheme and host allowlist | Present |
+| Redirect final-destination validation | Missing |
+| Resolved IP range check after redirect | Missing |
+| Egress control evidence | Missing |
+
+The skill should report that the effective request destination is not
+constrained even though the initial URL string has an allowlist check.


### PR DESCRIPTION
## Skill Modified
**Skill name:** owasp-top-10-web
**Skill path:** `skills/appsec/owasp-top-10-web/`

Addresses #661

## What Was Wrong

The SSRF section documented URL allowlisting, private range blocking, redirects, and DNS rebinding, but it did not require reviewers to prove the effective request destination is constrained on the same outbound path. That leaves two practical gaps:

- unsafe code can validate only the original URL, then follow a redirect to metadata/private/internal destinations;
- safe code can be reported as SSRF because reviewers see `GetAsync(uri)` without recording exact host allowlists, DNS/IP range checks, redirect policy, and invocation-time validation.

## What This PR Fixes

- Adds SSRF effective-destination evidence gates for scheme/host allowlists, DNS/IP validation, redirect final-destination validation, invocation-time validation, and egress controls.
- Adds a dedicated SSRF report field so findings capture the specific destination-control evidence instead of only the source/sink pair.
- Updates the .NET SSRF example to use a no-redirect client and reject redirect responses for user-controlled destinations.
- Adds vulnerable and benign fixtures showing initial URL allowlisting with unsafe redirects versus final-destination-safe handling.

## Evidence

**Before (skill misses this / false positive on this):**
```csharp
using var handler = new HttpClientHandler { AllowAutoRedirect = true };
using var client = new HttpClient(handler);
var html = await client.GetStringAsync(uri);
```

The initial `uri` may have passed scheme/host checks, but the final redirect target is not re-validated.

**After (now correctly handled):**
```csharp
var client = httpClientFactory.CreateClient("external-no-redirects");
using var response = await client.GetAsync(uri);

if ((int)response.StatusCode is >= 300 and < 400)
    return BadRequest("Redirects are not followed by this endpoint");
```

The review now asks for concrete evidence that redirects are disabled or every redirect target is re-parsed, re-resolved, and checked before following it.

## Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass

## Validation

- `git diff --check`
- frontmatter required-field check for all `SKILL.md` files
- `index.yaml` referenced-file check
- Markdown table separator consistency check on changed files
- fixture frontmatter check for the new SSRF test cases
- changed-file prompt-injection pattern scan using the repository CI allowlist/filter behavior
- duplicate-risk review against local `upstream-pr/*` refs for `owasp`, `ssrf`, `redirect`, `final destination`, `DNS rebinding`, and `metadata`

## Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

## Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Provided privately after acceptance