### PR TITLE
Improve NuGet license evidence checks

### DIFF
--- a/skills/appsec/dependency-scanning/SKILL.md
+++ b/skills/appsec/dependency-scanning/SKILL.md
@@ -141,6 +141,25 @@ Not all CVEs carry equal operational risk. Use a three-signal triage model to pr
 4. **Dual-licensed commercial packages**: Some packages offer open-source licenses for non-commercial use and require a commercial license otherwise (e.g., certain database drivers, UI component libraries). Verify that the usage context matches the chosen license.
 5. **No-license dependencies**: Packages without a declared license default to full copyright protection. They cannot be legally redistributed. Replace or obtain explicit permission.
 
+### License Evidence Gates
+
+Do not treat a dependency as license-compliant based only on a scanner summary
+string. Record the source of the license evidence and whether that evidence is
+machine-verifiable, manually confirmed, or missing.
+
+| Evidence Gate | Pass Condition | Finding Condition |
+|---|---|---|
+| SPDX expression evidence | Registry metadata, SBOM, or lockfile records a valid SPDX expression such as `MIT`, `Apache-2.0`, or `MIT OR Apache-2.0` | License is reported only as free text, `UNKNOWN`, `NOASSERTION`, or omitted |
+| Legacy URL evidence | Deprecated `licenseUrl` or equivalent URL is manually fetched or otherwise backed by an archived license text matching the package version | URL is the only evidence, is unavailable, redirects unexpectedly, or cannot be tied to the package version |
+| Unknown license evidence | No packages with `NOASSERTION`, missing license, empty license arrays, or unlicensed markers remain in production/runtime dependencies | Unknown license appears in direct or transitive runtime dependency output |
+| Network-use copyleft context | AGPL or similar network-copyleft dependency is absent from network-accessible services, or legal approval and source-disclosure obligations are documented | AGPL dependency is used by a SaaS/API/server path without an approved disclosure and distribution decision |
+| Dual-license decision record | The report names the selected license option, usage basis, and approving owner for expressions such as `GPL-2.0-only OR commercial` | Dual-license package is accepted without choosing the applicable license or documenting commercial entitlement |
+
+When a tool reports a license as `NOASSERTION`, missing, or available only via a
+legacy URL, classify the dependency as **Not Evaluable** or **High Risk** until
+additional evidence is collected. A permissive-looking URL or package README is
+not enough to downgrade risk unless it is tied to the exact package version.
+
 ### Tooling
 
 - `licensed` (GitHub): Caches and verifies dependency licenses in CI.
@@ -201,9 +220,9 @@ When performing a dependency scan, produce findings in the following structure:
 
 ### License Findings
 
-| # | Package | Version | License | Risk Level | Action Required |
-|---|---------|---------|---------|------------|-----------------|
-| 1 | ...     | ...     | ...     | ...        | ...             |
+| # | Package | Version | License | Evidence Source | Evidence Status | Usage Context | Risk Level | Action Required |
+|---|---------|---------|---------|-----------------|-----------------|---------------|------------|-----------------|
+| 1 | ...     | ...     | ...     | SPDX expression / licenseUrl / package file / scanner output | Verified / Manual Review / Missing / Conflicting | Runtime / Dev / Build / SaaS service | ... | ... |
 
 ### Supply Chain Risk Indicators
 
@@ -224,7 +243,7 @@ When performing a dependency scan, produce findings in the following structure:
 2. **Inventory dependencies**: Read manifest files to enumerate direct dependencies and their declared version ranges.
 3. **Analyze lockfiles**: Read lockfiles to map the full transitive dependency tree with pinned versions.
 4. **Vulnerability scan**: Cross-reference packages and versions against known CVE databases. Apply the EPSS+CVSS+KEV triage model.
-5. **License audit**: Extract license declarations from lockfiles or registry metadata. Flag copyleft and unlicensed packages.
+5. **License audit**: Extract license declarations from lockfiles or registry metadata. Record the evidence source, evidence status, usage context, and license decision for each finding. Flag copyleft, unknown, URL-only, conflicting, and unlicensed packages.
 6. **Typosquatting check**: Review dependency names for patterns described in the detection section.
 7. **Supply chain assessment**: Evaluate SLSA posture -- lockfile presence, pinned versions, provenance availability.
 8. **Report**: Produce the assessment using the output template above, with prioritized remediation recommendations.

--- a/skills/appsec/dependency-scanning/csharp-dotnet.md
+++ b/skills/appsec/dependency-scanning/csharp-dotnet.md
@@ -337,6 +337,39 @@ NuGet packages declare licenses in two ways:
 - Dual-licensed packages (e.g., `MIT OR Apache-2.0`) require verifying which license applies to your usage.
 - Some packages embed a `LICENSE.md` file in the `.nupkg` — verify its contents match the declared expression.
 
+### NuGet License Evidence Gates
+
+NuGet license review should distinguish between verified SPDX metadata,
+deprecated URL-only evidence, missing metadata, and usage-sensitive copyleft
+obligations. A project should not pass license review only because a scanner
+printed a permissive-looking string.
+
+| Evidence Gate | Pass Condition | Finding Condition |
+|---|---|---|
+| SPDX license expression | Package metadata exposes a valid `license` element or `PackageLicenseExpression`, and SBOM/scanner output preserves the expression | Scanner output only shows `NOASSERTION`, `Unknown`, an empty license, or an unstructured string |
+| Deprecated `licenseUrl` | URL-only metadata is manually verified against archived or packaged license text for the exact version | `licenseUrl` is the only evidence, is unreachable, redirects to a generic page, or is accepted without manual review |
+| Embedded license file | `.nupkg` contains `LICENSE`, `LICENSE.txt`, or `LICENSE.md` matching the declared expression | Embedded file conflicts with metadata or is missing when metadata is missing |
+| AGPL SaaS context | Network-accessible services have no AGPL runtime dependency, or legal approval documents source-disclosure obligations | AGPL-licensed dependency appears in runtime/server dependency graph for an API, SaaS, or hosted worker without an approval record |
+| Dual-license selection | Report records the chosen license branch, commercial entitlement if applicable, approving owner, and usage scope | Dual-license package is accepted without selecting the applicable license or proving commercial rights |
+
+When using `dotnet-project-licenses`, `CycloneDX`, `Syft`, or `Trivy`, preserve
+the raw package name, version, license expression, evidence source, dependency
+scope, and transitive path. If tool output collapses `licenseUrl`,
+`NOASSERTION`, or multiple-license expressions into a single string, mark the
+package for manual review instead of downgrading risk.
+
+### NuGet License Report Fields
+
+Add these fields to each .NET license finding:
+
+| Field | Required Evidence |
+|---|---|
+| `license_evidence_source` | `PackageLicenseExpression`, `.nuspec license`, `licenseUrl`, embedded license file, SBOM component, or scanner output |
+| `license_evidence_status` | `verified`, `manual-review`, `missing`, or `conflicting` |
+| `dependency_scope` | Direct/transitive and runtime/dev/build classification |
+| `usage_context` | Library, CLI, desktop app, API, SaaS service, hosted worker, or redistributed artifact |
+| `decision_record` | Required for AGPL, GPL, LGPL/MPL/EPL, dual-license, commercial-license, missing-license, and URL-only findings |
+
 ## .NET-Specific Transitive Dependency Analysis
 
 ### Viewing the Full Dependency Tree

--- a/skills/appsec/dependency-scanning/tests/benign/nuget-dual-license-decision-record.md
+++ b/skills/appsec/dependency-scanning/tests/benign/nuget-dual-license-decision-record.md
@@ -1,0 +1,49 @@
+---
+name: nuget-dual-license-decision-record
+expected: benign
+category: license-compliance
+cwe: CWE-1104
+---
+
+# Benign NuGet License Fixture: Dual License With Decision Record
+
+This fixture should not be flagged as a license compliance finding. The package
+has a dual-license expression, but the report records which branch applies,
+why it applies, and who approved it for the product context.
+
+```json
+{
+  "project": "Warehouse.Cli",
+  "usage_context": "internal CLI",
+  "dependencies": [
+    {
+      "name": "Example.DualLicensed.Client",
+      "version": "1.8.0",
+      "scope": "runtime",
+      "transitive": false,
+      "license": "GPL-2.0-only OR commercial",
+      "license_evidence_source": "PackageLicenseExpression",
+      "license_evidence_status": "verified",
+      "decision_record": {
+        "selected_license": "commercial",
+        "entitlement": "PO-2026-0142",
+        "approved_by": "legal@example.invalid",
+        "usage_scope": "internal CLI only",
+        "review_date": "2026-06-01"
+      }
+    }
+  ]
+}
+```
+
+## Expected Safe Evidence
+
+| Evidence Gate | Fixture State |
+|---|---|
+| SPDX license expression | Present and verified |
+| Dual-license selection | Commercial branch selected |
+| Decision record | Approval, entitlement, scope, and date present |
+| Network-use copyleft context | Not a hosted service |
+
+The skill should accept this as sufficient evidence instead of reporting a
+finding solely because one branch of the expression is GPL.

--- a/skills/appsec/dependency-scanning/tests/benign/nuget-spdx-license-expression.md
+++ b/skills/appsec/dependency-scanning/tests/benign/nuget-spdx-license-expression.md
@@ -1,0 +1,52 @@
+---
+name: nuget-spdx-license-expression
+expected: benign
+category: license-compliance
+cwe: CWE-1104
+---
+
+# Benign NuGet License Fixture: Verified SPDX License Expression
+
+This fixture should not be flagged as a license compliance finding. The package
+license is a valid SPDX expression, the evidence source is modern NuGet package
+metadata, and the package is used in a non-copyleft runtime context.
+
+```xml
+<!-- Example.Library.csproj package metadata -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PackageId>Example.Library</PackageId>
+    <Version>3.4.5</Version>
+    <PackageLicenseExpression>MIT OR Apache-2.0</PackageLicenseExpression>
+  </PropertyGroup>
+</Project>
+```
+
+```json
+{
+  "name": "Example.Library",
+  "version": "3.4.5",
+  "scope": "runtime",
+  "license": "MIT OR Apache-2.0",
+  "license_evidence_source": "PackageLicenseExpression",
+  "license_evidence_status": "verified",
+  "usage_context": "redistributed library",
+  "decision_record": {
+    "selected_license": "MIT",
+    "reason": "permissive branch selected for attribution workflow",
+    "approved_by": "security@example.invalid"
+  }
+}
+```
+
+## Expected Safe Evidence
+
+| Evidence Gate | Fixture State |
+|---|---|
+| SPDX license expression | Valid expression preserved |
+| Evidence source | `PackageLicenseExpression` |
+| Unknown license evidence | None |
+| Dual-license selection | Permissive branch selected and documented |
+
+The skill should accept this package as low risk and preserve the decision
+record in the license findings table.

--- a/skills/appsec/dependency-scanning/tests/vulnerable/nuget-agpl-network-service.md
+++ b/skills/appsec/dependency-scanning/tests/vulnerable/nuget-agpl-network-service.md
@@ -1,0 +1,53 @@
+---
+name: nuget-agpl-network-service
+expected: vulnerable
+category: license-compliance
+cwe: CWE-1104
+---
+
+# Vulnerable NuGet License Fixture: AGPL Runtime Dependency in SaaS API
+
+This fixture should be flagged as a license compliance finding. The dependency
+is used by a hosted API path, the license evidence is AGPL, and there is no
+decision record showing legal approval or source-disclosure obligations.
+
+```xml
+<!-- Directory.Packages.props -->
+<Project>
+  <ItemGroup>
+    <PackageVersion Include="Contoso.ReportEngine" Version="4.2.0" />
+  </ItemGroup>
+</Project>
+```
+
+```json
+{
+  "project": "Billing.Api",
+  "usage_context": "SaaS service",
+  "dependencies": [
+    {
+      "name": "Contoso.ReportEngine",
+      "version": "4.2.0",
+      "scope": "runtime",
+      "transitive": false,
+      "license": "AGPL-3.0-only",
+      "license_evidence_source": "PackageLicenseExpression",
+      "license_evidence_status": "verified",
+      "decision_record": null
+    }
+  ]
+}
+```
+
+## Expected Finding Evidence
+
+| Evidence Gate | Fixture State |
+|---|---|
+| SPDX license expression | Present and verified |
+| Runtime dependency scope | Direct runtime dependency |
+| Network-use copyleft context | SaaS/API usage present |
+| Legal or source-disclosure decision record | Missing |
+
+The skill should report a high-risk license finding because AGPL network-use
+obligations cannot be accepted for a hosted service without a documented
+decision record.

--- a/skills/appsec/dependency-scanning/tests/vulnerable/nuget-noassertion-license.md
+++ b/skills/appsec/dependency-scanning/tests/vulnerable/nuget-noassertion-license.md
@@ -1,0 +1,54 @@
+---
+name: nuget-noassertion-license
+expected: vulnerable
+category: license-compliance
+cwe: CWE-1104
+---
+
+# Vulnerable NuGet License Fixture: Runtime Dependency With NOASSERTION
+
+This fixture should be flagged as a license compliance finding. The scanner
+output contains a runtime dependency with `NOASSERTION` license data and no
+package file or manual review evidence that resolves the missing license.
+
+```json
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/Acme.LegacyParser@2.9.1",
+      "name": "Acme.LegacyParser",
+      "version": "2.9.1",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "NOASSERTION"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "dependency_scope",
+          "value": "runtime"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Expected Finding Evidence
+
+| Evidence Gate | Fixture State |
+|---|---|
+| SPDX license expression | Missing |
+| Unknown license evidence | `NOASSERTION` on runtime dependency |
+| Embedded license file | Not provided |
+| Manual decision record | Missing |
+
+The skill should not downgrade this package because the package name is familiar
+or because the scanner completed successfully. `NOASSERTION` remains not
+evaluable until an exact-version license source is verified.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** dependency-scanning
**Skill path:** `skills/appsec/dependency-scanning/`

Addresses #686

### What Was Wrong

The dependency-scanning skill covered general license risk and had a short NuGet metadata section, but it did not require evidence source/status fields for license findings. That left several practical gaps:

- NuGet packages with only deprecated `licenseUrl` metadata could be treated as if they had verified SPDX evidence.
- Runtime dependencies with `NOASSERTION` or missing license metadata could be downgraded without an exact-version license source.
- AGPL dependencies in hosted API/SaaS paths were not tied to a required legal/source-disclosure decision record.
- Dual-license expressions did not require recording the selected license branch or commercial entitlement.

### What This PR Fixes

- Adds general license evidence gates to the main dependency-scanning skill.
- Expands the license findings report template with evidence source, evidence status, usage context, and action fields.
- Adds NuGet-specific gates for SPDX expression evidence, deprecated `licenseUrl`, embedded license files, AGPL SaaS context, and dual-license selection.
- Adds four NuGet license fixtures covering vulnerable and benign cases.

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass

Added fixtures:
- `skills/appsec/dependency-scanning/tests/vulnerable/nuget-agpl-network-service.md`
- `skills/appsec/dependency-scanning/tests/vulnerable/nuget-noassertion-license.md`
- `skills/appsec/dependency-scanning/tests/benign/nuget-dual-license-decision-record.md`
- `skills/appsec/dependency-scanning/tests/benign/nuget-spdx-license-expression.md`

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Provided privately after acceptance

### Validation

- `git diff --check`
- frontmatter required-field check for all `SKILL.md` files
- `index.yaml` referenced-file check
- changed-file Markdown table consistency check
- dependency-scanning fixture frontmatter check
- changed-file prompt-injection scan
- duplicate-risk check against local `upstream-pr/*` refs; related PRs were dependency reachability, NuGet audit, enrichment, and lockfile integrity, not NuGet license evidence gates.