### PR TITLE
Improve AWS CloudTrail integrity chain checks

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -155,6 +155,7 @@ Produce the final report using the structure defined in the Output Format sectio
 - **File:** <path to relevant config>
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
+- **Linked Evidence:** <related resources that prove the control end-to-end>
 - **Evidence:** <specific configuration or code snippet>
 - **Remediation:** <specific fix with code example>
 
@@ -197,9 +198,10 @@ Produce the final report using the structure defined in the Output Format sectio
 1. **Checking only Terraform state, not all resource definitions.** Security groups and IAM policies may be defined across dozens of files. Always use Glob to find all `.tf` files before evaluating.
 2. **Missing account-level vs. bucket-level S3 public access blocks.** CIS 2.1.4 requires both. An account-level block can override permissive bucket settings, but the bucket-level block should also be set.
 3. **Confusing CloudTrail multi-region with organization trail.** CIS 3.1 requires multi-region, not necessarily an organization trail. Both are valid, but the control checks `is_multi_region_trail`.
-4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
-5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
-6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
+4. **Treating a CloudTrail resource as a complete logging chain.** A trail alone does not prove log integrity. Cross-reference the trail to its log S3 bucket, public access block, bucket policy, KMS key, CloudWatch Logs group, and event selectors before marking CIS 3.x controls as Pass.
+5. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
+6. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
+7. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
 
 ---
 

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -266,6 +266,26 @@ encrypted = true
 
 Evaluate logging configurations against Section 3 recommendations.
 
+### CloudTrail Integrity Evidence Chain
+
+For CIS 3.x CloudTrail controls, do not score each resource in isolation. A
+CloudTrail trail can exist while log integrity is still weak because the linked
+bucket, KMS key, CloudWatch Logs integration, or data event selectors are
+missing or misconfigured. Record the linked resources used to justify a Pass.
+
+| Evidence Gate | Pass Condition | Fail or Not Evaluable Condition |
+|---|---|---|
+| Trail coverage | `aws_cloudtrail` has `enable_logging = true` and `is_multi_region_trail = true`, or live export proves equivalent all-region coverage | Trail is single-region, disabled, absent, or only inferred from one provider alias |
+| Log validation | `enable_log_file_validation = true` is present on the same trail | Log validation missing, false, or not tied to the reviewed trail |
+| Log bucket controls | The trail `s3_bucket_name` resolves to an S3 bucket with public access block and a bucket policy that limits CloudTrail writes, enforces TLS, and avoids broad public principals | Bucket cannot be resolved, public access controls are missing, policy allows public access, or policy is not tied to CloudTrail source ARN/account |
+| KMS protection | The trail has `kms_key_id` and the referenced KMS key/policy permits CloudTrail encryption without broad decrypt/admin exposure | KMS key missing, key policy unavailable, or key policy grants broad access unrelated to CloudTrail logging |
+| CloudWatch integration | `cloud_watch_logs_group_arn` and `cloud_watch_logs_role_arn` are present and the referenced log group is available for CIS 4.x metric filters | CloudWatch fields are missing or filters point to a different/unresolved log group |
+| Object-level data events | Event selectors or advanced event selectors include required S3 read/write object data events for scoped buckets | Management events only, read or write events missing, or selectors cannot be tied to protected buckets |
+
+If any linked resource is absent from IaC or live evidence, mark the affected
+control `Not Evaluable` or `Fail` rather than assuming that a standalone
+CloudTrail declaration proves the full logging chain.
+
 ### CIS 3.1 -- Ensure CloudTrail is enabled in all regions
 
 **Grep patterns:**

--- a/skills/cloud/aws-review/tests/benign/cloudtrail-integrity-chain-complete.md
+++ b/skills/cloud/aws-review/tests/benign/cloudtrail-integrity-chain-complete.md
@@ -1,0 +1,105 @@
+---
+name: cloudtrail-integrity-chain-complete
+expected: benign
+category: CIS-3-Logging
+cwe: CWE-778
+---
+
+# Benign AWS Fixture: CloudTrail Integrity Chain Complete
+
+This fixture should not be flagged for CloudTrail integrity gaps. The trail is
+multi-region, validates log files, writes to a protected S3 bucket, uses a KMS
+key, integrates with CloudWatch Logs, and captures S3 object data events.
+
+```hcl
+resource "aws_s3_bucket" "cloudtrail" {
+  bucket = "example-cloudtrail-logs"
+}
+
+resource "aws_s3_bucket_public_access_block" "cloudtrail" {
+  bucket                  = aws_s3_bucket.cloudtrail.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "cloudtrail" {
+  bucket = aws_s3_bucket.cloudtrail.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyInsecureTransport"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource  = "${aws_s3_bucket.cloudtrail.arn}/*"
+        Condition = { Bool = { "aws:SecureTransport" = "false" } }
+      },
+      {
+        Sid       = "AllowCloudTrailWrite"
+        Effect    = "Allow"
+        Principal = { Service = "cloudtrail.amazonaws.com" }
+        Action    = "s3:PutObject"
+        Resource  = "${aws_s3_bucket.cloudtrail.arn}/AWSLogs/123456789012/*"
+        Condition = {
+          StringEquals = {
+            "aws:SourceArn" = aws_cloudtrail.main.arn
+            "s3:x-amz-acl"  = "bucket-owner-full-control"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_kms_key" "cloudtrail" {
+  description         = "CloudTrail log encryption"
+  enable_key_rotation = true
+}
+
+resource "aws_cloudwatch_log_group" "cloudtrail" {
+  name = "/aws/cloudtrail/main"
+}
+
+resource "aws_iam_role" "cloudtrail_logs" {
+  name = "cloudtrail-cloudwatch-logs"
+}
+
+resource "aws_cloudtrail" "main" {
+  name                          = "main"
+  s3_bucket_name                = aws_s3_bucket.cloudtrail.id
+  enable_logging                = true
+  is_multi_region_trail         = true
+  enable_log_file_validation    = true
+  kms_key_id                    = aws_kms_key.cloudtrail.arn
+  cloud_watch_logs_group_arn    = aws_cloudwatch_log_group.cloudtrail.arn
+  cloud_watch_logs_role_arn     = aws_iam_role.cloudtrail_logs.arn
+  include_global_service_events = true
+
+  event_selector {
+    read_write_type           = "All"
+    include_management_events = true
+
+    data_resource {
+      type   = "AWS::S3::Object"
+      values = ["arn:aws:s3:::sensitive-bucket/"]
+    }
+  }
+}
+```
+
+## Expected Safe Evidence
+
+| Evidence Gate | Fixture State |
+|---|---|
+| Trail coverage | Multi-region and enabled |
+| Log validation | Enabled on the same trail |
+| Log bucket controls | Public access block and CloudTrail/TLS bucket policy present |
+| KMS protection | `kms_key_id` references a rotating KMS key |
+| CloudWatch integration | Log group and role ARN linked |
+| Object-level data events | S3 read/write object selector present |
+
+The skill should treat the linked evidence chain as sufficient for the reviewed
+CloudTrail integrity controls.

--- a/skills/cloud/aws-review/tests/benign/cloudtrail-org-trail-with-cross-referenced-bucket-controls.md
+++ b/skills/cloud/aws-review/tests/benign/cloudtrail-org-trail-with-cross-referenced-bucket-controls.md
@@ -1,0 +1,107 @@
+---
+name: cloudtrail-org-trail-with-cross-referenced-bucket-controls
+expected: benign
+category: CIS-3-Logging
+cwe: CWE-778
+---
+
+# Benign AWS Fixture: Organization Trail With Cross-Referenced Controls
+
+This fixture should not be flagged for the CloudTrail integrity chain. It uses
+an organization trail and shows the linked bucket controls, KMS key, CloudWatch
+Logs integration, and S3 object data events needed to support the CIS 3.x pass
+decision.
+
+```hcl
+resource "aws_s3_bucket" "org_cloudtrail" {
+  bucket = "example-org-cloudtrail-logs"
+}
+
+resource "aws_s3_bucket_public_access_block" "org_cloudtrail" {
+  bucket                  = aws_s3_bucket.org_cloudtrail.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_kms_key" "org_cloudtrail" {
+  description         = "Organization CloudTrail logs"
+  enable_key_rotation = true
+}
+
+resource "aws_cloudwatch_log_group" "org_cloudtrail" {
+  name = "/aws/cloudtrail/org"
+}
+
+resource "aws_iam_role" "org_cloudtrail_logs" {
+  name = "org-cloudtrail-cloudwatch-logs"
+}
+
+resource "aws_cloudtrail" "org" {
+  name                          = "organization"
+  s3_bucket_name                = aws_s3_bucket.org_cloudtrail.id
+  enable_logging                = true
+  is_multi_region_trail         = true
+  is_organization_trail         = true
+  enable_log_file_validation    = true
+  kms_key_id                    = aws_kms_key.org_cloudtrail.arn
+  cloud_watch_logs_group_arn    = aws_cloudwatch_log_group.org_cloudtrail.arn
+  cloud_watch_logs_role_arn     = aws_iam_role.org_cloudtrail_logs.arn
+  include_global_service_events = true
+
+  event_selector {
+    read_write_type           = "All"
+    include_management_events = true
+
+    data_resource {
+      type   = "AWS::S3::Object"
+      values = ["arn:aws:s3:::finance-data/", "arn:aws:s3:::customer-data/"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "org_cloudtrail" {
+  bucket = aws_s3_bucket.org_cloudtrail.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyInsecureTransport"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource  = "${aws_s3_bucket.org_cloudtrail.arn}/*"
+        Condition = { Bool = { "aws:SecureTransport" = "false" } }
+      },
+      {
+        Sid       = "AllowCloudTrailWriteFromOrgTrail"
+        Effect    = "Allow"
+        Principal = { Service = "cloudtrail.amazonaws.com" }
+        Action    = "s3:PutObject"
+        Resource  = "${aws_s3_bucket.org_cloudtrail.arn}/AWSLogs/o-exampleorgid/*"
+        Condition = {
+          StringEquals = {
+            "aws:SourceArn" = aws_cloudtrail.org.arn
+            "s3:x-amz-acl"  = "bucket-owner-full-control"
+          }
+        }
+      }
+    ]
+  })
+}
+```
+
+## Expected Safe Evidence
+
+| Evidence Gate | Fixture State |
+|---|---|
+| Trail coverage | Organization, multi-region, and enabled |
+| Log validation | Enabled on the organization trail |
+| Log bucket controls | Public access block and source-constrained CloudTrail write policy present |
+| KMS protection | Referenced rotating KMS key present |
+| CloudWatch integration | Log group and role ARN linked |
+| Object-level data events | S3 read/write data selectors present |
+
+The skill should accept an organization trail only when the linked evidence
+chain is present, not merely because `is_organization_trail = true` exists.

--- a/skills/cloud/aws-review/tests/vulnerable/cloudtrail-log-bucket-public-policy.md
+++ b/skills/cloud/aws-review/tests/vulnerable/cloudtrail-log-bucket-public-policy.md
@@ -1,0 +1,68 @@
+---
+name: cloudtrail-log-bucket-public-policy
+expected: vulnerable
+category: CIS-3-Logging
+cwe: CWE-532
+---
+
+# Vulnerable AWS Fixture: CloudTrail Log Bucket Policy Is Public
+
+This fixture should be flagged even though the CloudTrail resource has
+multi-region logging, log file validation, CloudWatch integration, and KMS
+encryption. The linked log bucket policy still grants public read access to the
+CloudTrail log prefix.
+
+```hcl
+resource "aws_s3_bucket" "cloudtrail" {
+  bucket = "example-cloudtrail-logs"
+}
+
+resource "aws_s3_bucket_public_access_block" "cloudtrail" {
+  bucket                  = aws_s3_bucket.cloudtrail.id
+  block_public_acls       = true
+  block_public_policy     = false
+  ignore_public_acls      = true
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_policy" "cloudtrail" {
+  bucket = aws_s3_bucket.cloudtrail.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "PublicReadCloudTrailLogs"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "s3:GetObject"
+        Resource  = "${aws_s3_bucket.cloudtrail.arn}/AWSLogs/123456789012/*"
+      }
+    ]
+  })
+}
+
+resource "aws_cloudtrail" "main" {
+  name                       = "main"
+  s3_bucket_name             = aws_s3_bucket.cloudtrail.id
+  enable_logging             = true
+  is_multi_region_trail      = true
+  enable_log_file_validation = true
+  kms_key_id                 = aws_kms_key.cloudtrail.arn
+  cloud_watch_logs_group_arn = aws_cloudwatch_log_group.cloudtrail.arn
+  cloud_watch_logs_role_arn  = aws_iam_role.cloudtrail_logs.arn
+}
+```
+
+## Expected Finding Evidence
+
+| Evidence Gate | Fixture State |
+|---|---|
+| Trail coverage | Present |
+| Log validation | Present |
+| Log bucket controls | Public policy and disabled public-policy block |
+| KMS protection | Present |
+| CloudWatch integration | Present |
+
+The skill should report the bucket policy/public access controls as a CloudTrail
+logging-chain failure instead of passing the trail based on CloudTrail fields
+alone.

--- a/skills/cloud/aws-review/tests/vulnerable/cloudtrail-no-log-validation-or-kms.md
+++ b/skills/cloud/aws-review/tests/vulnerable/cloudtrail-no-log-validation-or-kms.md
@@ -1,0 +1,39 @@
+---
+name: cloudtrail-no-log-validation-or-kms
+expected: vulnerable
+category: CIS-3-Logging
+cwe: CWE-778
+---
+
+# Vulnerable AWS Fixture: CloudTrail Exists Without Integrity Chain
+
+This fixture should be flagged. The trail is enabled and multi-region, but it
+lacks log file validation, KMS encryption, CloudWatch Logs integration, and
+linked S3 bucket controls.
+
+```hcl
+resource "aws_s3_bucket" "cloudtrail" {
+  bucket = "example-cloudtrail-logs"
+}
+
+resource "aws_cloudtrail" "main" {
+  name                  = "main"
+  s3_bucket_name        = aws_s3_bucket.cloudtrail.id
+  enable_logging        = true
+  is_multi_region_trail = true
+}
+```
+
+## Expected Finding Evidence
+
+| Evidence Gate | Fixture State |
+|---|---|
+| Trail coverage | Present |
+| Log validation | Missing |
+| Log bucket controls | Bucket exists, but public access block and policy evidence are missing |
+| KMS protection | Missing `kms_key_id` |
+| CloudWatch integration | Missing |
+| Object-level data events | Missing |
+
+The skill should not mark CIS 3.x logging controls as fully passing based only
+on the standalone trail resource.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** aws-review
**Skill path:** `skills/cloud/aws-review/`

Addresses #691

### What Was Wrong

The AWS review skill mapped CIS 3.x logging controls, but it treated CloudTrail evidence mostly as separate checks. That can let a review pass a standalone trail even when the linked logging chain is incomplete:

- no log file validation on the reviewed trail
- no KMS key/policy evidence for CloudTrail log encryption
- unresolved or public CloudTrail log bucket controls
- missing CloudWatch Logs group/role linkage for CIS 4.x filters
- management-only event selectors when S3 object data events are in scope

### What This PR Fixes

- Adds a `Linked Evidence` field to detailed AWS findings.
- Adds a CloudTrail integrity evidence-chain section to the logging checklist.
- Requires trail coverage, log validation, log bucket controls, KMS protection, CloudWatch integration, and object-level data events to be cross-referenced before marking CIS 3.x controls as Pass.
- Adds four fixtures covering incomplete trails, public log buckets, complete trails, and organization trails with linked controls.

### Evidence

**Before (skill misses this):**
```hcl
resource "aws_cloudtrail" "main" {
  enable_logging        = true
  is_multi_region_trail = true
  s3_bucket_name        = aws_s3_bucket.cloudtrail.id
}
```

A reviewer could see a multi-region trail and miss that validation, KMS, CloudWatch, bucket policy, and data-event selector evidence are absent.

**After (now correctly handled):**
```hcl
resource "aws_cloudtrail" "main" {
  enable_logging             = true
  is_multi_region_trail      = true
  enable_log_file_validation = true
  s3_bucket_name             = aws_s3_bucket.cloudtrail.id
  kms_key_id                 = aws_kms_key.cloudtrail.arn
  cloud_watch_logs_group_arn = aws_cloudwatch_log_group.cloudtrail.arn
  cloud_watch_logs_role_arn  = aws_iam_role.cloudtrail_logs.arn
}
```

The report now has to link the trail to the bucket controls, KMS key, CloudWatch log group, and event selectors instead of scoring resources in isolation.

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass

Added fixtures:
- `skills/cloud/aws-review/tests/vulnerable/cloudtrail-no-log-validation-or-kms.md`
- `skills/cloud/aws-review/tests/vulnerable/cloudtrail-log-bucket-public-policy.md`
- `skills/cloud/aws-review/tests/benign/cloudtrail-integrity-chain-complete.md`
- `skills/cloud/aws-review/tests/benign/cloudtrail-org-trail-with-cross-referenced-bucket-controls.md`

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Provided privately after acceptance

### Validation

- `git diff --check`
- frontmatter required-field check for all `SKILL.md` files
- `index.yaml` referenced-file check
- changed-file Markdown table consistency check
- aws-review fixture frontmatter check
- changed-file prompt-injection scan; hits were existing `password policy` text in the benchmark, not prompt-injection or secrets in new fixtures
- duplicate-risk check against local `upstream-pr/*` refs; related PRs were broad AWS CIS v5 mapping, AWS evidence confidence scope, STS, log-analysis telemetry, and CloudFront S3 origin, not this CloudTrail linked evidence chain.