### PR TITLE
Add CloudTrail linked evidence chain

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-AWS-v3.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -97,6 +97,23 @@ Evaluate all AWS configurations against CIS AWS v3.0.0 Sections 1 through 5, cov
 
 For detailed CIS benchmark checklist items with specific Terraform patterns, grep patterns, and configuration examples for all five sections, see [benchmark-checklist.md](benchmark-checklist.md) in this skill directory.
 
+When evaluating CIS Section 3 logging controls, preserve linked evidence across the CloudTrail logging chain. A CloudTrail resource should not be assessed in isolation when related controls depend on the trail's S3 bucket, bucket public-access controls, bucket policy, KMS key and key policy, CloudWatch Logs group/role, S3 access logging target, and S3 object data-event selectors.
+
+**CloudTrail linked evidence chain:**
+
+| Chain Element | Evidence to Cross-Reference |
+|---|---|
+| Trail scope | `enable_logging`, `is_multi_region_trail`, organization trail status, home region, included/excluded regions. |
+| Log validation | `enable_log_file_validation = true` on every in-scope trail. |
+| Log bucket | Trail `s3_bucket_name` resolves to a bucket resource/export and bucket ARN. |
+| Bucket public access | Account-level and bucket-level public access blocks, ACLs, and bucket policy statements for the log prefix. |
+| KMS encryption | Trail `kms_key_id`, linked KMS key, key rotation where applicable, and key policy allowing CloudTrail without public or broad principals. |
+| CloudWatch integration | `cloud_watch_logs_group_arn`, `cloud_watch_logs_role_arn`, log group retention, and metric filters referencing the same log group. |
+| S3 access logging | CloudTrail log bucket access logging target and write permissions. |
+| Object data events | S3 object read/write event selectors, management events, and data-resource scope when CIS object-level logging applies. |
+
+If one element is missing from the artifacts, mark dependent controls **Not Evaluable** or **Fail** based on the control, rather than treating a multi-region trail alone as complete evidence.
+
 ---
 
 ### Step 7: Compile Assessment Report
@@ -156,6 +173,7 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration or code snippet>
+- **Linked Evidence:** <related trail, bucket, bucket policy, public access block, KMS key, CloudWatch log group/role, selector, or metric-filter resources reviewed>
 - **Remediation:** <specific fix with code example>
 
 ### Prioritized Remediation Plan
@@ -200,6 +218,7 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
 5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
 6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
+7. **Passing CloudTrail controls from the trail resource alone.** CIS 3.x logging evidence spans the trail, S3 log bucket, public access controls, KMS key/policy, CloudWatch log group/role, access logging target, and event selectors. Preserve those linked resources in the finding so missing or public log storage is not hidden by an otherwise valid trail.
 
 ---
 
@@ -223,6 +242,10 @@ Produce the final report using the structure defined in the Output Format sectio
 - AWS Security Best Practices: https://docs.aws.amazon.com/security/
 - AWS IAM Best Practices: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 - AWS CloudTrail Documentation: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/
+- AWS CloudTrail log file integrity validation: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-log-file-validation-intro.html
+- AWS CloudTrail SSE-KMS key policy requirements: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/create-kms-key-policy-for-cloudtrail.html
+- AWS CloudTrail sending events to CloudWatch Logs: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/send-cloudtrail-events-to-cloudwatch-logs.html
+- AWS CloudTrail S3 bucket policy examples: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/create-s3-bucket-policy-for-cloudtrail.html
 - AWS Security Hub: https://docs.aws.amazon.com/securityhub/latest/userguide/
 - AWS VPC Security: https://docs.aws.amazon.com/vpc/latest/userguide/security.html
 - Terraform AWS Provider Documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
@@ -231,4 +254,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Added CloudTrail linked-evidence chain requirements for CIS Section 3 logging controls and detailed findings.
 - **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 (62 recommendations).

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -266,6 +266,14 @@ encrypted = true
 
 Evaluate logging configurations against Section 3 recommendations.
 
+Before marking CIS 3.x controls as Pass, build a linked evidence chain for each in-scope trail:
+
+| Trail | Bucket | Public Access Evidence | Bucket Policy Evidence | KMS Key / Policy | CloudWatch Log Group / Role | S3 Access Logging | Data Event Selectors |
+|---|---|---|---|---|---|---|---|
+| `aws_cloudtrail.main` | `aws_s3_bucket.cloudtrail` | account + bucket block | CloudTrail write-only, no public read | key ARN + policy | log group + role ARN | target bucket | S3 read/write selectors |
+
+Do not treat `enable_logging = true` and `is_multi_region_trail = true` as sufficient linked evidence for the whole logging section. Preserve unresolved references and mark dependent controls **Not Evaluable** when the related bucket, key, log group, selector, or policy artifacts are missing.
+
 ### CIS 3.1 -- Ensure CloudTrail is enabled in all regions
 
 **Grep patterns:**
@@ -281,13 +289,30 @@ resource "aws_cloudtrail" {
 
 Check `enable_log_file_validation = true` on CloudTrail trails.
 
+Record the trail resource name and whether validation is enabled on every organization/member-account trail in scope. If multiple trails exist, do not let one validated trail mask another trail with validation disabled.
+
 ### CIS 3.3 -- Ensure the S3 bucket used to store CloudTrail logs is not publicly accessible
 
 Cross-reference the CloudTrail S3 bucket with public access block configuration.
 
+Required linked evidence:
+
+- Resolve each trail's `s3_bucket_name` to the bucket resource, bucket ARN, or imported bucket identifier.
+- Check bucket-level `aws_s3_bucket_public_access_block` and any account-level public access block evidence when available.
+- Review `aws_s3_bucket_policy`, ACLs, and log-prefix statements for broad principals such as `"*"`, cross-account grants, or public `s3:GetObject`.
+- Confirm the bucket policy permits CloudTrail delivery without granting public read/list access to `AWSLogs/<account-id>/*`.
+- Mark **Fail** if the resolved log bucket or prefix is publicly readable. Mark **Not Evaluable** if the trail bucket cannot be resolved from available artifacts.
+
 ### CIS 3.4 -- Ensure CloudTrail trails are integrated with CloudWatch Logs
 
 Check for `cloud_watch_logs_group_arn` on CloudTrail resources.
+
+Required linked evidence:
+
+- Trail `cloud_watch_logs_group_arn` resolves to the reviewed CloudWatch log group.
+- Trail `cloud_watch_logs_role_arn` resolves to an IAM role that allows CloudTrail to publish to that log group.
+- CIS 4.x metric filters and alarms point to the same log group or an explicitly documented equivalent source.
+- Mark **Not Evaluable** when metric filters exist but the referenced log group cannot be tied back to the CloudTrail trail.
 
 ### CIS 3.5 -- Ensure AWS Config is enabled in all regions
 
@@ -311,9 +336,18 @@ resource "aws_s3_bucket_logging" {
 }
 ```
 
+Confirm the `bucket` value is the same bucket resolved from the CloudTrail `s3_bucket_name`. If only unrelated S3 buckets have access logging, do not count this control as passing for the CloudTrail log bucket.
+
 ### CIS 3.7 -- Ensure CloudTrail logs are encrypted at rest using KMS CMKs
 
 Check for `kms_key_id` on CloudTrail resources.
+
+Required linked evidence:
+
+- Trail `kms_key_id` resolves to a KMS key or alias in the artifacts.
+- Key policy allows CloudTrail encryption/decryption for log delivery without broad public or wildcard principals.
+- Customer-managed symmetric key rotation is reviewed under CIS 3.8 when applicable.
+- Mark **Not Evaluable** if `kms_key_id` is present but the key policy cannot be reviewed and the assessment scope requires key-policy evidence.
 
 ### CIS 3.8 -- Ensure rotation for customer-created symmetric CMKs is enabled
 
@@ -348,9 +382,13 @@ event_selector {
 }
 ```
 
+Cross-reference data-event selectors with the same in-scope trails used for CIS 3.1-3.7. Management-event logging alone does not prove S3 object write data events are enabled.
+
 ### CIS 3.11 -- Ensure that Object-level logging for read events is enabled for S3 buckets
 
 Same as 3.10 -- verify both read and write events are captured.
+
+Record whether read and write selectors cover all required buckets, all in-scope regions/accounts, or only a subset. Use **Not Evaluable** for unresolved data-resource scope rather than assuming full object-level coverage.
 
 ---
 


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `aws-review`
**Skill path:** `skills/cloud/aws-review/SKILL.md`

### What Was Wrong
The AWS review skill mapped CIS Section 3 logging controls, but the CloudTrail guidance could be interpreted from the trail resource alone. That can miss gaps in the linked evidence chain: the log bucket, bucket public access block, bucket policy, KMS key/key policy, CloudWatch Logs group/role, S3 access logging target, and S3 object data-event selectors.

### What This PR Fixes
- Adds a CloudTrail linked-evidence chain to the main AWS review process.
- Adds a `Linked Evidence` field to detailed findings so related resources stay traceable.
- Expands the benchmark checklist for CIS 3.2, 3.3, 3.4, 3.6, 3.7, 3.10, and 3.11.
- Requires trail-to-bucket, bucket policy, public access, KMS, CloudWatch, S3 access logging, and data-event selector cross-references.
- Clarifies when dependent logging controls should be marked Fail or Not Evaluable.
- Adds pitfalls, references, and a changelog entry.

### Evidence
**Before (skill misses this / false positive on this):**
```text
An aws_cloudtrail resource has enable_logging=true and is_multi_region_trail=true,
but its linked S3 log bucket policy allows public s3:GetObject on AWSLogs/* and
the KMS key policy is not reviewed. The old checklist could over-credit the
trail without preserving those linked resources.
```

**After (now correctly handled):**
```text
The skill now requires reviewers to cross-reference the CloudTrail resource with
the log bucket, public access block, bucket policy, KMS key/policy, CloudWatch
integration, access logging target, and object data-event selectors before
marking CIS Section 3 controls complete.
```

### Test Cases Added/Updated
- [ ] Added vulnerable test cases (`tests/vulnerable/`)
- [ ] Added benign test cases (`tests/benign/`)
- [x] Existing validation still passes

Validation run locally:
- `git diff --check`
- frontmatter validation for the modified skill

Note: index validation was not run locally because `yq` is not installed in this environment, and this PR does not add or move indexed files.

### Bounty Tier
- [ ] **Minor** ($50) -- Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) -- New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) -- Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** PayPal or GitHub Sponsors; details to be provided privately after maintainer acceptance

/claim #691
