### PR TITLE
Add workload federation trust gates

### DIFF
--- a/skills/identity/iam-review/SKILL.md
+++ b/skills/identity/iam-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [design, operate]
 frameworks: [NIST-SP-800-63B, NIST-SP-800-207, CIS-Controls-v8]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -217,6 +217,8 @@ IAM-SVC-06: Service accounts without ownership assignment
 IAM-SVC-07: No inventory or lifecycle management for service accounts (CIS 5.5)
 IAM-SVC-08: Service account keys stored in plaintext (code, config files, environment variables)
 IAM-SVC-09: Service accounts without audit logging of usage
+IAM-SVC-10: Workload identity federation trust lacks scoped issuer, subject, audience, or attribute conditions
+IAM-SVC-11: Federated principal has downstream role binding broader than the trust claim scope
 ```
 
 **Platform-specific checks:**
@@ -236,6 +238,46 @@ IAM-SVC-09: Service accounts without audit logging of usage
 2. Short-lived tokens via OIDC/STS (time-bound, auto-expiring)
 3. Managed secrets with automatic rotation (Secrets Manager, Key Vault)
 4. User-managed keys with strict rotation policy (last resort)
+
+#### Workload Identity Federation Trust Review
+
+Keyless federation reduces static credential risk, but it is only safe when the external issuer, audience, subject, mapped attributes, and downstream role binding are constrained to the intended workload. Do not treat "no long-lived keys" as sufficient evidence by itself.
+
+**Review patterns:**
+
+```
+AssumeRoleWithWebIdentity
+oidc-provider
+:sub
+:aud
+federated identity credential
+issuer
+subject
+audiences
+allowed_audiences
+attribute_condition
+attribute_mapping
+principalSet://
+roles/iam.workloadIdentityUser
+```
+
+**Trust evidence matrix:**
+
+| Platform | Issuer / Provider | Subject / Claim Scope | Audience Check | Attribute / Condition Check | Downstream Principal Binding | Role Scope | Confidence |
+|---|---|---|---|---|---|---|---|
+| AWS | OIDC provider ARN | exact repo/branch/env or broad/unknown | `aud` scoped to STS | `sub` / provider controls | role trust policy | account/resource | strong/partial/not evaluable |
+| Azure | issuer URL | exact subject or broad/unknown | `api://AzureADTokenExchange` or approved audience | FIC subject/claims | managed identity or app role binding | subscription/resource | strong/partial/not evaluable |
+| GCP | workload identity provider URI | mapped subject/attributes | allowed audiences | attribute condition | subject/group/attribute/principalSet member | project/resource | strong/partial/not evaluable |
+
+**Finding guidance:**
+
+| Condition | Severity |
+|---|---|
+| Shared public IdP trust without subject or attribute restriction reaches production/admin roles | **High** |
+| Pool-wide, tenant-wide, or wildcard downstream principal binding grants high-privilege access | **High** or **Critical** depending on role scope |
+| Keyless federation present but issuer, subject, audience, or condition evidence is missing | **Not Evaluable** until evidence is supplied |
+| Exact trust scoping plus narrow downstream role/resource scope | Lower risk / acceptable |
+| Broad trust used only for read-only, non-production, time-bounded workflows | **Medium** or documented exception |
 
 ---
 
@@ -380,6 +422,7 @@ For each finding, produce a row with:
 | **Framework Ref** | NIST SP 800-63B section, NIST SP 800-207 tenet, or CIS Control ID |
 | **Affected Scope** | Accounts, roles, policies, or platforms impacted |
 | **Evidence** | Specific configuration, policy, or data supporting the finding |
+| **Trust Claim Evidence** | For federated machine identities: issuer/provider, subject or claim scope, audience, attributes/conditions, downstream binding, and role scope reviewed |
 | **Remediation** | Prioritized fix with implementation guidance |
 | **Effort** | Low (< 1 day) / Medium (1-5 days) / High (> 5 days) |
 
@@ -508,4 +551,17 @@ This skill processes user-supplied content including IAM policies, access config
 
 | Version | Date | Changes |
 |---|---|---|
+| 1.0.1 | 2026-06-04 | Added workload identity federation trust-claim review gates for AWS OIDC, Azure federated identity credentials, and GCP workload identity pools |
 | 1.0.0 | 2025-03-06 | Initial release |
+
+---
+
+## References
+
+- AWS IAM OIDC federation role creation: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html
+- AWS IAM identity-provider controls for shared OIDC providers: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc_secure-by-default.html
+- AWS IAM condition keys for OIDC federation: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_iam-condition-keys.html
+- Azure federated identity credential CLI parameters: https://learn.microsoft.com/en-us/cli/azure/identity/federated-credential
+- Azure managed identity federated identity credential properties: https://learn.microsoft.com/en-us/rest/api/managedidentity/federated-identity-credentials/get
+- Google Cloud Workload Identity Federation: https://cloud.google.com/iam/docs/workload-identity-federation
+- Google Cloud Workload Identity Federation best practices: https://cloud.google.com/iam/docs/best-practices-for-using-workload-identity-federation


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `iam-review`
**Skill path:** `skills/identity/iam-review/SKILL.md`

### What Was Wrong
The IAM review skill correctly prefers workload identity federation and managed identities over long-lived service-account keys, but it did not require reviewers to prove that keyless federation is safely scoped. A broad OIDC issuer, missing subject restriction, missing audience/attribute condition, or pool-wide downstream role binding can still leave a large blast radius even with no static keys.

### What This PR Fixes
- Adds review checklist items for workload federation trust-claim scope and downstream binding scope.
- Adds a dedicated Workload Identity Federation Trust Review subsection.
- Adds search patterns for AWS OIDC, Azure federated identity credentials, and GCP workload identity pools.
- Adds a trust evidence matrix covering issuer/provider, subject/claim scope, audience, attributes/conditions, downstream binding, role scope, and confidence.
- Adds severity guidance for broad public IdP trusts, pool-wide bindings, missing evidence, and safely scoped federation.
- Adds a `Trust Claim Evidence` output field and provider references.

### Evidence
**Before (skill misses this / false positive on this):**
```text
An AWS role trusts token.actions.githubusercontent.com and checks only aud=sts.amazonaws.com,
but does not restrict sub to an exact repository, branch, or environment. The
system has no long-lived keys, so the old review could over-credit service
account hygiene while missing a broad federated trust.
```

**After (now correctly handled):**
```text
The skill now requires issuer, subject/claim scope, audience, attributes or
conditions, downstream principal binding, role scope, and confidence evidence
before treating workload identity federation as safely scoped.
```

### Test Cases Added/Updated
- [ ] Added vulnerable test cases (`tests/vulnerable/`)
- [ ] Added benign test cases (`tests/benign/`)
- [x] Existing validation still passes

Validation run locally:
- `git diff --check`
- frontmatter validation for the modified skill

Note: index validation was not run locally because `yq` is not installed in this environment, and this PR does not add or move indexed files.

### Bounty Tier
- [ ] **Minor** ($50) -- Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) -- New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) -- Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** PayPal or GitHub Sponsors; details to be provided privately after maintainer acceptance

/claim #685
