### PR TITLE
Split CVE facts from per-asset decisions

### DIFF
--- a/skills/vuln-management/cve-triage/SKILL.md
+++ b/skills/vuln-management/cve-triage/SKILL.md
@@ -12,7 +12,7 @@ phase: [operate, respond]
 frameworks: [CVSS-4.0, SSVC-2.1, CISA-KEV, EPSS]
 difficulty: intermediate
 time_estimate: "10-20min per CVE"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob, WebFetch
@@ -49,11 +49,14 @@ Before starting, collect or confirm:
 - [ ] **CVE ID(s):** The specific CVE identifier(s) to triage (e.g., CVE-2024-3094)
 - [ ] **Affected software/version:** Product name, version, and component (e.g., OpenSSL 3.0.2, xz-utils 5.6.0)
 - [ ] **Deployment context:** Where is this software running? (Internet-facing, internal, air-gapped)
+- [ ] **Affected asset list:** Asset IDs, owners, environments, network exposure, mission prevalence, and compensating controls for every materially different deployment context
 - [ ] **Business criticality:** What business function does the affected system support? (Revenue-generating, customer-facing, internal tooling, development)
 - [ ] **Compensating controls:** Are there existing mitigations in place? (WAF, network segmentation, EDR, disabled feature)
 - [ ] **Compliance requirements:** Any regulatory mandates affecting patch timelines? (CISA BOD 22-01 for federal, PCI DSS, HIPAA)
 
 If the CVE ID is provided but other context is missing, proceed with conservative assumptions (internet-facing, business-critical) and flag the assumptions in the output.
+
+If the same CVE affects multiple assets, images, clusters, or business services, separate shared CVE facts from per-asset decisions. Do not assign one environmental score, SSVC decision, SLA, or risk acceptance to all affected deployments unless their exposure, mission prevalence, compensating controls, owner, and remediation constraints are materially the same.
 
 ---
 
@@ -140,8 +143,11 @@ CVSS 4.0 Assessment:
 - Base Severity:       [None | Low | Medium | High | Critical]
 - Threat Score:        [0.0 - 10.0] (with Exploit Maturity applied)
 - Environmental Score: [0.0 - 10.0] (if deployment context available)
+- Score Label:         [CVSS-B | CVSS-BT | CVSS-BE | CVSS-BTE]
 - Vector String:       CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N/E:A
 ```
+
+Use FIRST CVSS v4.0 nomenclature when communicating scores: `CVSS-B` for Base only, `CVSS-BT` when Threat metrics are included, `CVSS-BE` when Environmental metrics are included, and `CVSS-BTE` when Base, Threat, and Environmental metrics are included. Environmental scores are deployment-specific and must be labelled per asset or deployment context.
 
 ### Step 3: CISA KEV Cross-Check
 
@@ -275,6 +281,8 @@ Combine all assessment data to assign a remediation SLA and produce a final reco
 
 **Framework mapping:** Enterprise Vulnerability Management SLA Matrix
 
+For multi-asset findings, assign SLA per asset or deployment context after applying environmental metrics, SSVC mission prevalence, exposure, compensating controls, and operational constraints. Shared CVE facts such as KEV, EPSS, vendor base score, and patch availability should inform every row, but final action can differ by asset.
+
 #### SLA Matrix
 
 | SLA Tier | Timeframe | Criteria | Example Scenario |
@@ -303,6 +311,13 @@ The following conditions may justify a longer SLA (document the justification):
 - Network segmentation prevents attacker access to the vulnerable system
 - VEX (Vulnerability Exploitability eXchange) status is "not_affected" or "fixed"
 
+#### Per-Asset Decision Rules
+
+- Expand one CVE into multiple asset rows when exposure, mission prevalence, compensating controls, owner, patch window, rollback constraint, or environment differs materially.
+- Preserve vendor/base facts once in the shared section; put environmental score, SSVC decision, SLA, owner, and risk acceptance in the per-asset matrix.
+- Mark an asset row **Not Evaluable** when local exposure, mission prevalence, or compensating-control evidence is missing. Do not silently reuse the most severe or least severe asset's SLA.
+- Scope risk acceptance to the asset, business service, image, cluster, or deployment context, not to the CVE in the abstract.
+
 ---
 
 ## Output Format
@@ -312,7 +327,7 @@ Produce a structured report with these exact sections:
 ```markdown
 ## CVE Triage Report: [CVE-YYYY-NNNNN]
 **Date:** [YYYY-MM-DD]
-**Skill:** cve-triage v1.0.0
+**Skill:** cve-triage v1.0.1
 **Frameworks:** CVSS 4.0, SSVC 2.1, EPSS, CISA KEV
 **Reviewer:** AI-assisted (human review required for Immediate/Out-of-Cycle findings)
 
@@ -320,7 +335,7 @@ Produce a structured report with these exact sections:
 [2-3 sentences. State the CVE, its severity, whether it is actively exploited, and the
 recommended SLA tier. Lead with the most critical fact.]
 
-### Vulnerability Overview
+### Shared CVE Facts
 | Field | Value |
 |---|---|
 | CVE ID | [CVE-YYYY-NNNNN] |
@@ -328,13 +343,15 @@ recommended SLA tier. Lead with the most critical fact.]
 | Affected Software | [Product vX.Y.Z] |
 | Affected Component | [Component] |
 | Patch Available | [Yes/No/Workaround] |
+| Vendor/Base Score | [CVSS-B X.X severity] |
+| KEV Status | [Yes/No] |
+| EPSS Score/Date | [score / YYYY-MM-DD] |
 
 ### CVSS 4.0 Assessment
-| Metric Group | Score | Severity |
-|---|---|---|
-| Base | [X.X] | [Critical/High/Medium/Low/None] |
-| Threat | [X.X] | [With Exploit Maturity] |
-| Environmental | [X.X] | [If applicable] |
+| Scope | CVSS Label | Score | Severity | Vector / Notes |
+|---|---|---|---|---|
+| Shared vendor facts | CVSS-B or CVSS-BT | [X.X] | [Critical/High/Medium/Low/None] | [Base or threat vector] |
+| [Asset/context] | CVSS-BE or CVSS-BTE | [X.X] | [Severity] | [Environmental vector and local assumptions] |
 
 **Vector String:** `CVSS:4.0/AV:.../AC:.../...`
 
@@ -353,27 +370,25 @@ recommended SLA tier. Lead with the most critical fact.]
 | Percentile | [Xth] |
 | Interpretation | [Level] |
 
-### SSVC 2.1 Decision
-| Decision Point | Value |
-|---|---|
-| Exploitation | [None/PoC/Active] |
-| Automatable | [No/Yes] |
-| Technical Impact | [Partial/Total] |
-| Mission Prevalence | [Minimal/Support/Essential] |
-| **Decision** | **[Defer/Scheduled/Out-of-Cycle/Immediate]** |
+### Per-Asset Decision Matrix
 
-### Remediation Recommendation
-- **SLA Tier:** [Immediate (24h) / Out-of-Cycle (72h) / Scheduled (30d) / Defer (90d)]
+| Asset / Context | Exposure | Mission Prevalence | Compensating Controls | CVSS Label | CVSS Score | SSVC Decision | SLA | Owner | Status |
+|---|---|---|---|---|---|---|---|---|---|
+| [asset-1] | [internet/internal/isolated] | [Minimal/Support/Essential] | [controls] | [CVSS-BTE] | [X.X] | [Immediate/Out-of-Cycle/Scheduled/Defer] | [24h/72h/30d/90d] | [owner] | [Actionable/Not Evaluable] |
+| [asset-2] | [exposure] | [mission] | [controls] | [CVSS-BE] | [X.X] | [decision] | [SLA] | [owner] | [Actionable/Not Evaluable] |
+
+### Remediation Recommendations
+- **Highest-priority assets:** [assets requiring Immediate/Out-of-Cycle work]
 - **Recommended Action:** [Specific action -- patch to version X, apply workaround Y, disable feature Z]
-- **Escalation Factors:** [List any factors that elevated the SLA tier]
-- **De-escalation Factors:** [List any compensating controls or mitigating factors]
-- **Assumptions Made:** [List any assumptions due to missing context]
+- **Escalation Factors:** [List any shared or per-asset factors that elevated SLA tiers]
+- **De-escalation Factors:** [List any asset-specific compensating controls or mitigating factors]
+- **Assumptions Made:** [List assumptions by asset/context when local evidence is missing]
 
 ### Risk Acceptance (If Deferring)
 [If the recommendation is Scheduled or Defer, include a risk acceptance template:]
 
 > **Risk Acceptance Statement:** The undersigned acknowledges that [CVE-YYYY-NNNNN]
-> affecting [system] remains unpatched. Compensating controls include [controls].
+> affecting [asset/deployment context] remains unpatched. Compensating controls include [controls].
 > This risk will be reassessed on [date]. Accepted by: ________________ Date: ________
 
 ### References
@@ -395,18 +410,19 @@ When triaging multiple CVEs (e.g., from a scan report), produce a summary table 
 **Date:** [YYYY-MM-DD]
 **Total CVEs:** [N]
 
-| CVE ID | CVSS 4.0 | EPSS | KEV | SSVC Decision | SLA | Affected System |
-|---|---|---|---|---|---|---|
-| CVE-YYYY-NNNNN | 9.8 Critical | 0.95 | Yes | Immediate | 24h | [System] |
-| CVE-YYYY-NNNNN | 7.5 High | 0.15 | No | Out-of-Cycle | 72h | [System] |
-| CVE-YYYY-NNNNN | 5.3 Medium | 0.02 | No | Scheduled | 30d | [System] |
-| CVE-YYYY-NNNNN | 3.1 Low | 0.001 | No | Defer | 90d | [System] |
+| CVE ID | Asset / Context | CVSS Label | CVSS Score | EPSS | KEV | SSVC Decision | SLA | Owner |
+|---|---|---|---|---|---|---|---|---|
+| CVE-YYYY-NNNNN | auth-gateway-prod-01 | CVSS-BTE | 9.1 Critical | 0.95 | Yes | Immediate | 24h | AppSec |
+| CVE-YYYY-NNNNN | build-runner-lab-04 | CVSS-BE | 4.2 Medium | 0.95 | Yes | Scheduled | 30d | Platform |
+| CVE-YYYY-NNNNN | [asset] | CVSS-B | 7.5 High | 0.15 | No | Not Evaluable | Needs context | [owner] |
 
 ### Priority Order
-1. [CVE with Immediate SLA -- full assessment below]
-2. [CVE with Out-of-Cycle SLA -- full assessment below]
-3. [Remaining CVEs -- scheduled per standard patch cycle]
+1. [Asset/CVE rows with Immediate SLA -- full assessment below]
+2. [Asset/CVE rows with Out-of-Cycle SLA -- full assessment below]
+3. [Remaining asset/CVE rows -- scheduled per standard patch cycle or Not Evaluable pending context]
 ```
+
+In batch mode, one CVE may appear on multiple rows when affected assets have materially different deployment context. Do not force all affected systems into one `Affected System` cell.
 
 ---
 


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `cve-triage`
**Skill path:** `skills/vuln-management/cve-triage/SKILL.md`

### What Was Wrong
The CVE triage skill combined CVSS 4.0, SSVC, EPSS, and KEV well, but its output shape treated one CVE as one remediation decision. That can over-prioritize low-risk assets or under-prioritize critical ones when the same CVE appears across deployments with different exposure, mission prevalence, compensating controls, and owners.

### What This PR Fixes
- Adds affected-asset context collection for every materially different deployment.
- Requires shared CVE facts to be separated from per-asset decisions.
- Adds CVSS v4 nomenclature labels (`CVSS-B`, `CVSS-BT`, `CVSS-BE`, `CVSS-BTE`).
- Makes Environmental scores deployment-specific instead of global.
- Adds per-asset decision rules for environmental score, SSVC decision, SLA, owner, and risk acceptance.
- Replaces one `Affected System` batch column with asset/context rows.
- Adds `Not Evaluable` handling when local exposure, mission, or compensating-control evidence is missing.

### Evidence
**Before (skill misses this / false positive on this):**
```text
CVE-2026-12345 appears on an internet-facing auth gateway and an isolated lab
runner. The old output could assign one Environmental score, one SSVC decision,
and one SLA to both assets.
```

**After (now correctly handled):**
```text
The skill now keeps vendor/base facts once, then creates per-asset rows with
deployment-specific CVSS labels, SSVC decisions, SLA, owner, assumptions, and
risk acceptance scope.
```

### Test Cases Added/Updated
- [ ] Added vulnerable test cases (`tests/vulnerable/`)
- [ ] Added benign test cases (`tests/benign/`)
- [x] Existing validation still passes

Validation run locally:
- `git diff --check`
- frontmatter validation for the modified skill

Note: index validation was not run locally because `yq` is not installed in this environment, and this PR does not add or move indexed files.

### Bounty Tier
- [ ] **Minor** ($50) -- Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) -- New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) -- Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** PayPal or GitHub Sponsors; details to be provided privately after maintainer acceptance

/claim #684
