### PR TITLE
Add pipeline OIDC trust gates

### DIFF
--- a/skills/devsecops/pipeline-security/SKILL.md
+++ b/skills/devsecops/pipeline-security/SKILL.md
@@ -12,7 +12,7 @@ phase: [build, deploy]
 frameworks: [SLSA-v1.0, OWASP-CICD-Top-10]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -305,6 +305,8 @@ runs-on: self-hosted  # Shared runners are a risk
 - Secrets passed as command-line arguments (visible in process listings).
 - Hardcoded credentials in pipeline configuration files.
 - Missing secret rotation policies.
+- OIDC federation that is present but too broad: wildcard subjects, missing audience checks, unvalidated reusable workflow claims, or production roles without protected-environment evidence.
+- Fork or pull-request triggers that can reach a cloud credential path through broad trust-policy claims.
 
 **Grep patterns:**
 
@@ -327,7 +329,24 @@ runs-on: self-hosted  # Shared runners are a risk
     DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
 ```
 
-**Finding format:** Report credential types in use (long-lived vs. short-lived), whether OIDC/workload identity is used where available, and any secrets exposed in logs or command arguments.
+**OIDC trust-policy evidence to collect:**
+
+| Provider | Claim / Control | Required Evidence |
+|---|---|---|
+| GitHub Actions | issuer, `aud`, `sub`, `repository_owner`, `ref`, `environment`, `job_workflow_ref` | Exact repo/branch/tag/environment or reusable workflow scope; protected environment approval for production roles. |
+| GitLab CI | issuer, audience, project path, ref type/name, environment | Exact project/ref/environment scope and protected branch/tag/environment evidence. |
+| Azure DevOps | issuer, subject identifier, audience, service connection scope | Exact project/pipeline/environment scope and approval gate evidence. |
+| CircleCI / other OIDC providers | issuer, audience, project/org, branch/tag, context | Provider-specific claims mapped to one intended workload and environment. |
+
+**OIDC review rules:**
+
+- Accept OIDC federation as controlled only when issuer, audience, subject/claim scope, repository or project owner, branch/tag/environment, and downstream role policy are all evidenced.
+- For production roles, require protected environment evidence such as required reviewers, deployment-branch rules, or equivalent approval gates.
+- For reusable workflows, verify `job_workflow_ref` or equivalent claims prevent unrelated workflows from minting credentials.
+- For fork and pull-request paths, verify workflow triggers and trust-policy claims prevent untrusted contributors from reaching credential exchange.
+- Treat short token TTL as defense-in-depth; it does not compensate for wildcard subjects or broad downstream role scope.
+
+**Finding format:** Report credential types in use (long-lived vs. short-lived), whether OIDC/workload identity is used where available, OIDC trust-policy claim evidence, protected-environment evidence, fork/reusable workflow credential paths, and any secrets exposed in logs or command arguments.
 
 ---
 
@@ -488,6 +507,7 @@ Produce the final report using the following structure:
 - **File:** <path to relevant config>
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
+- **OIDC Trust Evidence:** <issuer, audience, subject/claim scope, environment protection, reusable workflow claim, fork/PR path, and downstream role scope reviewed when applicable>
 - **Remediation:** <specific fix>
 
 ### Prioritized Remediation Plan
@@ -550,6 +570,9 @@ This skill processes user-supplied content including CI/CD configuration files, 
 - SLSA Build Track: https://slsa.dev/spec/v1.0/levels#build-track
 - OWASP Top 10 CI/CD Security Risks: https://owasp.org/www-project-top-10-ci-cd-security-risks/
 - GitHub Actions Security Hardening: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
+- GitHub Actions OIDC hardening with cloud providers: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers
+- GitLab OIDC ID tokens: https://docs.gitlab.com/ci/secrets/id_token_authentication/
+- Azure DevOps workload identity federation: https://learn.microsoft.com/en-us/azure/devops/pipelines/library/connect-to-azure
 - Sigstore / Cosign: https://docs.sigstore.dev/
 - SLSA GitHub Generator: https://github.com/slsa-framework/slsa-github-generator
 
@@ -557,4 +580,5 @@ This skill processes user-supplied content including CI/CD configuration files, 
 
 ## Changelog
 
+- **1.0.1** -- Added OIDC trust-policy claim, protected-environment, reusable-workflow, and fork/PR credential-path evidence gates.
 - **1.0.0** -- Initial release. Full coverage of SLSA v1.0 build track and OWASP Top 10 CI/CD Security Risks (CICD-SEC-1 through CICD-SEC-10).


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `pipeline-security`
**Skill path:** `skills/devsecops/pipeline-security/SKILL.md`

### What Was Wrong
The pipeline-security skill encouraged OIDC/workload identity over long-lived secrets, but it did not require evidence that the OIDC trust policy is safely scoped. A pipeline can use short-lived tokens and still expose production cloud roles if subject, audience, reusable workflow, fork/PR, or protected-environment claims are too broad.

### What This PR Fixes
- Adds OIDC federation trust-policy review under CICD-SEC-6 credential hygiene.
- Requires evidence for issuer, audience, subject/claim scope, repository/project owner, ref, environment, and reusable workflow claims.
- Adds provider-aware guidance for GitHub Actions, GitLab CI, Azure DevOps, and other OIDC providers.
- Requires protected-environment evidence for production roles.
- Adds fork and pull-request credential-path checks.
- Adds an `OIDC Trust Evidence` field to detailed findings.
- Adds references and changelog entry.

### Evidence
**Before (skill misses this / false positive on this):**
```text
A GitHub Actions workflow uses OIDC to assume an AWS role, but the role trust
policy allows broad repo or branch wildcard subjects. The old skill could treat
OIDC usage as credential hygiene improvement without requiring subject,
audience, environment, reusable-workflow, or fork/PR path evidence.
```

**After (now correctly handled):**
```text
The skill now accepts OIDC as controlled only when issuer, audience, subject,
repository/project owner, branch/tag/environment, protected environment,
reusable workflow, fork/PR path, and downstream role scope are evidenced.
```

### Test Cases Added/Updated
- [ ] Added vulnerable test cases (`tests/vulnerable/`)
- [ ] Added benign test cases (`tests/benign/`)
- [x] Existing validation still passes

Validation run locally:
- `git diff --check`
- frontmatter validation for the modified skill

Note: index validation was not run locally because `yq` is not installed in this environment, and this PR does not add or move indexed files.

### Bounty Tier
- [ ] **Minor** ($50) -- Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) -- New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) -- Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** PayPal or GitHub Sponsors; details to be provided privately after maintainer acceptance

/claim #682
