### PR TITLE
Add API webhook replay evidence gates

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -38,8 +38,9 @@ Before analyzing any endpoint, establish a complete inventory of the API surface
 5. **Catalog data objects** -- List the resources/entities exposed by the API and their sensitivity classification (PII, financial, internal, public).
 6. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, or cost-control mechanisms at the gateway or application layer.
 7. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
+8. **Inventory inbound webhook receivers** -- For each provider, record the endpoint, expected signature scheme, raw-body requirement, timestamp or nonce replay control, idempotency key/event ID, secret rotation process, and side effects triggered by the event.
 
-> **Gate:** Do not proceed until the API style, authentication model, authorization model, and endpoint inventory are documented. Incomplete scope leads to missed findings.
+> **Gate:** Do not proceed until the API style, authentication model, authorization model, endpoint inventory, and webhook receiver inventory are documented. Incomplete scope leads to missed findings.
 
 ---
 
@@ -120,6 +121,7 @@ The final review output must be structured as follows:
 - **CWE:** CWE-[number] -- [name]
 - **API Style:** [REST|GraphQL|gRPC|General]
 - **Location:** [file:line or spec path]
+- **Webhook Evidence:** [provider, raw-body signature evidence, replay window, idempotency key, secret rotation status, if applicable]
 - **Description:** [explanation]
 - **Evidence:**
   ```[language]

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -520,7 +520,7 @@ Document doc = builder.parse(request.getInputStream());
 
 ## API10:2023 -- Unsafe Consumption of APIs
 
-**CWE:** CWE-20 (Improper Input Validation), CWE-295 (Improper Certificate Validation), CWE-319 (Cleartext Transmission of Sensitive Information)
+**CWE:** CWE-20 (Improper Input Validation), CWE-295 (Improper Certificate Validation), CWE-319 (Cleartext Transmission of Sensitive Information), CWE-345 (Insufficient Verification of Data Authenticity), CWE-294 (Authentication Bypass by Capture-replay)
 **Severity:** High to Medium
 
 ### Vulnerable Patterns
@@ -544,6 +544,44 @@ const data = await enrichmentData.json();
 res.send(`<div class="bio">${data.biography}</div>`);  // Stored XSS via third party
 ```
 
+```javascript
+// VULNERABLE: Webhook signature is verified over parsed JSON, not the raw request body.
+app.post('/webhooks/payment', express.json(), async (req, res) => {
+  const expected = hmac(JSON.stringify(req.body), process.env.WEBHOOK_SECRET);
+  if (expected !== req.header('X-Signature')) return res.sendStatus(401);
+
+  await provisionSubscription(req.body.customerId, req.body.planId);
+  res.sendStatus(204);
+});
+```
+
+```python
+# VULNERABLE: Valid signed events can be replayed indefinitely.
+@app.post("/webhooks/billing")
+def billing_webhook():
+    event = verify_signature(request.data, request.headers["Signature"])
+    fulfill_invoice(event["invoice_id"])
+    return "", 204
+```
+
+### Webhook Receiver Evidence
+
+For each inbound webhook endpoint, capture this table before marking the integration ready:
+
+| Provider | Endpoint | Signature Input | Timestamp / Nonce Window | Idempotency Key | Side Effects | Secret Rotation |
+|----------|----------|-----------------|--------------------------|-----------------|--------------|-----------------|
+| Stripe / GitHub / Slack / custom | `/webhooks/...` | Exact raw body plus signed headers | e.g. 5 minutes or stored nonce | Event ID with unique constraint | Billing, provisioning, account changes | Old/new overlap with expiry |
+
+Reviewers should verify:
+
+- signature verification uses the exact raw body bytes and provider-specified signed headers, not reparsed or reserialized JSON;
+- signature comparison is constant-time where the platform provides a safe helper;
+- a timestamp tolerance, nonce cache, or provider event ID prevents captured valid events from being replayed later;
+- non-idempotent side effects use an event ID, delivery ID, or business key with a unique constraint before performing fulfillment, billing, entitlement, or account changes;
+- expected duplicate delivery is treated as benign only when idempotency evidence exists;
+- webhook secret rotation supports overlapping old/new secrets with an expiry and does not permanently accept retired secrets;
+- body-level error responses such as `signature_invalid`, `timestamp_too_old`, or `duplicate_event` are tracked, not only HTTP 2xx/4xx status codes.
+
 ### Remediation Guidance
 
 - Treat all data from external and internal APIs as untrusted input. Validate and sanitize before use.
@@ -552,6 +590,9 @@ res.send(`<div class="bio">${data.biography}</div>`);  // Stored XSS via third p
 - Implement timeouts, retry limits with backoff, and circuit breakers on all outbound API calls.
 - Restrict redirects on outbound calls. If following redirects, re-validate the destination URL.
 - Use parameterized queries when inserting data from any source, including trusted internal APIs.
+- Verify inbound webhook signatures using provider SDKs or raw-body HMAC/JWS verification, with timestamp/nonce replay protection.
+- Persist webhook event IDs or delivery IDs before non-idempotent side effects so provider retries do not duplicate billing, fulfillment, provisioning, or account changes.
+- Document webhook secret rotation with bounded old/new secret overlap and audit evidence for retired secrets.
 
 ### Review Checklist
 
@@ -560,3 +601,7 @@ res.send(`<div class="bio">${data.biography}</div>`);  // Stored XSS via third p
 - [ ] Response schemas from third-party APIs are validated before processing.
 - [ ] Outbound calls have timeouts, retry limits, and circuit breakers.
 - [ ] Redirect following is disabled or restricted on outbound HTTP calls.
+- [ ] Inbound webhook signatures are verified over the exact raw request body and provider-specified headers.
+- [ ] Webhook replay protection exists through timestamp tolerance, nonce cache, or stored provider event IDs.
+- [ ] Webhook handlers are idempotent before billing, fulfillment, provisioning, or account side effects.
+- [ ] Webhook secret rotation allows bounded overlap and rejects retired secrets.

--- a/skills/appsec/api-security/tests/webhook-replay-idempotency.md
+++ b/skills/appsec/api-security/tests/webhook-replay-idempotency.md
@@ -1,0 +1,50 @@
+# Webhook replay and idempotency evidence
+
+## Vulnerable: parsed-body signature and replayable side effects
+
+```javascript
+app.post('/webhooks/payment', express.json(), async (req, res) => {
+  const expected = hmac(JSON.stringify(req.body), process.env.WEBHOOK_SECRET);
+  if (expected !== req.header('X-Signature')) return res.sendStatus(401);
+
+  await provisionSubscription(req.body.customerId, req.body.planId);
+  res.sendStatus(204);
+});
+```
+
+Why this should be flagged:
+
+- The signature is computed over reserialized JSON instead of the exact raw body bytes.
+- There is no timestamp tolerance, nonce cache, or event ID replay guard.
+- Subscription provisioning is non-idempotent and can be repeated by duplicate delivery or replay.
+
+## Benign: raw-body verification plus event ID idempotency
+
+```javascript
+app.post('/webhooks/payment', rawBodyMiddleware, async (req, res) => {
+  const event = verifyProviderSignature({
+    rawBody: req.rawBody,
+    signatureHeader: req.header('X-Provider-Signature'),
+    toleranceSeconds: 300,
+    activeSecrets: [process.env.WEBHOOK_SECRET_CURRENT, process.env.WEBHOOK_SECRET_PREVIOUS],
+  });
+
+  const inserted = await webhookEvents.insertIfAbsent({
+    provider: 'payment',
+    eventId: event.id,
+    receivedAt: new Date(),
+  });
+
+  if (!inserted) return res.status(200).json({ status: 'duplicate_event' });
+
+  await provisionSubscription(event.data.customerId, event.data.planId);
+  res.sendStatus(204);
+});
+```
+
+Why this should pass:
+
+- Signature verification uses the raw body and provider signature header.
+- A bounded timestamp tolerance limits replay.
+- The provider event ID is stored before side effects, making duplicate delivery safe.
+- Old/new secret overlap is explicit and can be expired during rotation.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `api-security`
**Skill path:** `skills/appsec/api-security/`

### What Was Wrong

The skill covered unsafe upstream API consumption and outbound webhook URL SSRF risks, but inbound webhook receiver verification was under-specified. A reviewer could miss handlers that verify signatures over reparsed JSON instead of the exact raw body, accept valid signed events forever, or perform non-idempotent side effects when a provider retries the same event.

### What This PR Fixes

- Adds inbound webhook receiver inventory to the main API review gate.
- Adds a `Webhook Evidence` field to report findings.
- Extends API10 with CWE-345 and CWE-294 for authenticity and replay weaknesses.
- Adds vulnerable examples for parsed-body signature verification and replayable signed events.
- Adds a webhook receiver evidence table covering provider, endpoint, signature input, replay window, idempotency key, side effects, and secret rotation.
- Requires exact raw-body signature verification, timestamp/nonce/event-ID replay controls, idempotent side-effect handling, bounded secret rotation, and duplicate-delivery evidence.
- Adds a focused vulnerable/benign fixture for webhook replay and idempotency.

### Evidence

**Before (skill could miss this):**
```javascript
app.post('/webhooks/payment', express.json(), async (req, res) => {
  const expected = hmac(JSON.stringify(req.body), process.env.WEBHOOK_SECRET);
  if (expected !== req.header('X-Signature')) return res.sendStatus(401);
  await provisionSubscription(req.body.customerId, req.body.planId);
});
```

**After (now required evidence):**
```text
Webhook Receiver Evidence:
- Signature Input: exact raw body plus provider signed headers
- Timestamp / Nonce Window: 5 minutes or stored nonce
- Idempotency Key: provider event ID with unique constraint
- Secret Rotation: bounded old/new overlap with expiry
```

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/`)
- [x] Added benign test cases (`tests/`)
- [x] Existing checks still pass

Added fixture:
- `skills/appsec/api-security/tests/webhook-replay-idempotency.md`

### Validation

- `git diff --check`
- Frontmatter required-field sweep across `skills/**/SKILL.md` and `roles/**/SKILL.md`
- `index.yaml` referenced-file existence check
- Prompt-injection pattern scan with CI exclusions
- Content assertions for webhook receiver inventory, webhook evidence, raw-body verification, timestamp replay control, event ID idempotency, secret rotation, CWE-345, and CWE-294
- Source URL checks returned HTTP 200 for:
  - OWASP API10:2023 Unsafe Consumption of APIs
  - GitHub webhook delivery validation docs
  - Stripe webhook signature docs
  - Stripe duplicate-event handling docs

### Bounty Tier
- [ ] **Minor** ($50) -- Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) -- New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) -- Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** PayPal, to be provided privately after acceptance

Closes #678