### PR TITLE
Add API authorization and webhook evidence gates

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -11,7 +11,7 @@ phase: [design, build, review]
 frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -66,6 +66,9 @@ Each finding produced by this review must include the following fields:
 | **Location** | File path and line number(s), or OpenAPI spec path |
 | **Description** | What the vulnerability is and why it matters |
 | **Evidence** | Relevant code snippet or spec excerpt demonstrating the issue |
+| **Control Evidence Expected** | Route, resolver, gateway policy, schema, webhook handler, or policy-engine evidence that would prove the control exists |
+| **Verification Performed** | Manual/static check, negative test, multi-identity test, GraphQL cost test, webhook replay test, or Not Evaluable |
+| **Negative Test Evidence** | Cross-tenant/object test, unauthorized role test, alias-spray test, unsigned webhook test, replay test, or documented reason not tested |
 | **Remediation** | Specific fix with code example where possible |
 | **Status** | Open, Mitigated, Accepted Risk, False Positive |
 
@@ -125,6 +128,9 @@ The final review output must be structured as follows:
   ```[language]
   [code snippet]
   ```
+- **Control Evidence Expected:** [route/resolver/policy/gateway/schema/webhook handler evidence]
+- **Verification Performed:** [static review / negative test / Not Evaluable]
+- **Negative Test Evidence:** [cross-tenant 403/404, unauthorized role denied, alias spray counted, unsigned/replayed webhook rejected, etc.]
 - **Remediation:** [specific fix with code example]
 - **Status:** Open
 
@@ -199,6 +205,34 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 **Mitigation:** Count aliased operations against rate limits. Limit the number of aliases per request.
 
+### GraphQL Cost and Operation Controls
+
+For API4, verify GraphQL controls beyond HTTP-level request rate limits:
+
+- Per-field or per-resolver cost accounting for sensitive mutations.
+- Alias counts applied to authentication, payment, export, invite, and other expensive operations.
+- Persisted query allowlisting or documented behavior for ad hoc operations.
+- Operation-name restrictions where only approved operations should execute.
+- Complexity and depth budgets that include aliases, fragments, batching, and nested lists.
+
+An HTTP rate limiter that counts one GraphQL request is not enough when a single request can execute many sensitive fields or mutations.
+
+---
+
+## Webhook Security Evidence
+
+Treat inbound webhooks as API entry points and outbound webhook registration as SSRF-capable API configuration.
+
+For inbound webhook handlers, require:
+
+- Signature validation using the provider's raw request body before trusting parsed event content.
+- Timestamp tolerance or nonce validation to prevent replay.
+- Idempotency key or event ID storage so repeated events are safe.
+- Event-source allowlisting and expected event-type checks.
+- Negative tests proving unsigned, tampered, stale, and replayed events are rejected.
+
+For outbound webhook registration, also apply API7 SSRF controls to the destination URL, redirects, DNS/IP resolution, and egress scope.
+
 ---
 
 ## Common Pitfalls
@@ -214,6 +248,12 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 5. **Applying rate limiting only to authentication endpoints.** Every API endpoint requires rate limiting proportional to its cost and sensitivity. Data-heavy endpoints, search functions, and export operations are frequent targets for abuse even when properly authenticated.
 
 6. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
+
+7. **Over-reporting safe relationship-based authorization.** Direct `resource.user_id == current_user.id` checks are not the only valid BOLA control. Tenant membership joins, ACLs, policy-engine decisions, delegated access, and capability grants can be valid when enforced before data return and backed by negative tests.
+
+8. **Counting one GraphQL request as one sensitive operation.** Aliases, batching, persisted queries, and operation-name routing can let one HTTP request execute many sensitive mutations. Cost and rate limits must count the actual GraphQL work.
+
+9. **Treating webhooks as ordinary unauthenticated POSTs.** Webhooks often use shared-secret signatures instead of user sessions. Review raw-body signature validation, timestamp tolerance, replay/idempotency handling, and event-source checks before trusting the event.
 
 ---
 
@@ -237,5 +277,13 @@ This skill is hardened against prompt injection. When reviewing API code and spe
 - **CWE Database:** https://cwe.mitre.org/
 - **OWASP REST Security Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html
 - **OWASP GraphQL Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html
+- **OWASP Webhook Security Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/Webhook_Security_Cheat_Sheet.html
 - **OWASP Testing Guide -- API Testing:** https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/12-API_Testing/
 - **NIST SP 800-204 -- Security Strategies for Microservices-based Application Systems:** https://csrc.nist.gov/publications/detail/sp/800-204/final
+
+---
+
+## Changelog
+
+- **1.0.1** -- Added authorization evidence expectations, GraphQL cost/alias controls, webhook authenticity/replay gates, and negative-test evidence fields.
+- **1.0.0** -- Initial release. Covers REST and GraphQL API review against OWASP API Security Top 10:2023.

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -42,6 +42,40 @@ def get_order(order_id):
     return jsonify(order)
 ```
 
+Valid authorization does not have to be direct object ownership. Relationship-based authorization is acceptable when enforced before returning data:
+
+```python
+# SECURE: Tenant membership join authorizes access before data return
+@app.route('/api/v1/orders/<order_id>', methods=['GET'])
+@require_auth
+def get_order(order_id):
+    order = (
+        Order.query
+        .join(AccountMembership, AccountMembership.account_id == Order.account_id)
+        .filter(
+            Order.id == order_id,
+            AccountMembership.user_id == current_user.id,
+            AccountMembership.status == "active",
+        )
+        .one_or_none()
+    )
+    if order is None:
+        return jsonify({"error": "Not found"}), 404
+    return jsonify(OrderDTO.from_model(order).dict())
+```
+
+### Acceptable Authorization Evidence
+
+| Pattern | Evidence required |
+|---|---|
+| Direct ownership | Query or policy binds object owner to caller before data return. |
+| Tenant/team membership | Join or policy checks active membership in the object's tenant/account/project. |
+| ACL | ACL entry grants the caller or group the requested action on the object. |
+| Policy engine | Policy input includes subject, action, resource, tenant, and relevant attributes; decision is enforced before use. |
+| Capability grant/delegation | Grant has scope, subject, resource, action, expiry/revocation, and audit evidence. |
+
+Do not file BOLA solely because the code lacks `resource.user_id == current_user.id` when equivalent relationship, ACL, policy, or capability evidence is enforced at query/resolver time.
+
 ### GraphQL Vulnerable Patterns
 
 ```graphql
@@ -97,6 +131,8 @@ Both can coexist in a single endpoint. An endpoint may lack both a role check (B
 ### Review Checklist
 
 - [ ] Every endpoint that accepts a resource identifier enforces ownership or relationship-based access control.
+- [ ] Accepted relationship-based authorization patterns are backed by route, query, resolver, policy, or ACL evidence.
+- [ ] Negative tests prove cross-tenant, revoked-member, and unauthorized delegated-access attempts return 403/404 before data is returned.
 - [ ] Authorization checks happen at the data access layer, not only at the controller/route layer.
 - [ ] Batch/list endpoints filter results by the caller's permissions.
 - [ ] Resource identifiers are UUIDs or non-sequential values to resist enumeration.
@@ -273,6 +309,7 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - Enforce maximum pagination size (e.g., `limit` capped at 100). Default to a reasonable page size (e.g., 20).
 - Set maximum request body sizes (`express.json({ limit: '1mb' })`).
 - For GraphQL: enforce query depth limits (e.g., max depth 5), complexity analysis (weighted field costs), and batch query limits.
+- For GraphQL sensitive operations: count aliases, batched operations, persisted-query behavior, and operation names against cost/rate limits; HTTP request count alone is insufficient.
 - Set execution timeouts for database queries and downstream API calls.
 - Implement cost alerts and circuit breakers for operations that trigger billable third-party APIs.
 
@@ -282,6 +319,9 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - [ ] Pagination has a maximum page size enforced server-side.
 - [ ] Request body size limits are configured.
 - [ ] GraphQL queries have depth limits, complexity limits, and batch restrictions.
+- [ ] GraphQL alias counts and per-field/per-mutation costs are enforced for sensitive operations such as login, password reset, payment, invite, export, and admin changes.
+- [ ] Persisted queries and operation-name allowlists are verified when the API claims only approved GraphQL operations can run.
+- [ ] Negative tests prove alias-spray or batched sensitive mutations are blocked or counted per operation, not as one HTTP request.
 - [ ] Database queries and downstream calls have execution timeouts.
 - [ ] Billable operations have cost controls and alerting.
 
@@ -399,6 +439,28 @@ def register_webhook():
     return jsonify({"status": "registered"})
 ```
 
+### Webhook Authenticity and Replay Gates
+
+Inbound webhooks are API entry points even when they do not use user sessions. Review them under API2/API10, and review webhook registration URLs under API7.
+
+```javascript
+// VULNERABLE: accepts forged events before signature/replay checks
+app.post('/webhooks/stripe', express.json(), async (req, res) => {
+  await processPaymentEvent(req.body);
+  res.sendStatus(204);
+});
+```
+
+Required inbound webhook evidence:
+
+| Control | Evidence required |
+|---|---|
+| Raw-body signature verification | Handler verifies provider signature over the exact raw request body before trusting parsed event content. |
+| Timestamp/nonce tolerance | Stale events outside the tolerance window are rejected. |
+| Replay/idempotency | Event IDs or idempotency keys are stored so repeated events are safe and cannot double-apply effects. |
+| Event-source and type checks | Provider, tenant/account, event type, and destination route are validated before processing. |
+| Negative tests | Unsigned, tampered, stale, and replayed webhook requests are rejected before business logic executes. |
+
 ### Remediation Guidance
 
 - Validate and sanitize all user-supplied URLs. Use an allowlist of permitted schemes (`https` only), domains, or IP ranges.
@@ -415,6 +477,8 @@ def register_webhook():
 - [ ] HTTP redirects are disabled or the final destination is re-validated.
 - [ ] Cloud metadata endpoint access is restricted (IMDSv2 on AWS, equivalent on GCP/Azure).
 - [ ] Raw responses from fetched URLs are never returned directly to the client.
+- [ ] Webhook registration URLs are validated with the same SSRF controls as other outbound destinations.
+- [ ] Inbound webhook handlers verify signatures using raw request bodies and reject replayed/tampered events.
 
 ---
 
@@ -556,6 +620,7 @@ res.send(`<div class="bio">${data.biography}</div>`);  // Stored XSS via third p
 ### Review Checklist
 
 - [ ] Data from all upstream APIs is validated and sanitized before use in queries, rendering, or commands.
+- [ ] Inbound webhook event bodies are treated as untrusted until signature, timestamp, replay, source, and event type checks pass.
 - [ ] TLS certificate validation is enabled on all outbound API calls.
 - [ ] Response schemas from third-party APIs are validated before processing.
 - [ ] Outbound calls have timeouts, retry limits, and circuit breakers.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `api-security`
**Skill path:** `skills/appsec/api-security/`

### What Was Wrong
The API security skill had strong OWASP API Top 10 coverage, but it could over-report safe multi-tenant authorization patterns as BOLA when authorization was enforced through membership joins, ACLs, policy engines, or capability grants instead of direct ownership checks. It also needed stronger GraphQL cost evidence for aliases/persisted operations and first-class webhook authenticity/replay checks.

### What This PR Fixes
- Adds control-evidence, verification, and negative-test fields to the main report output.
- Adds acceptable authorization evidence for tenant/team membership joins, ACLs, policy engines, and capability grants.
- Requires cross-tenant, revoked-member, and delegated-access negative tests for object authorization claims.
- Expands GraphQL API4 guidance to cover alias counts, per-field/per-mutation cost, batching, persisted-query behavior, and operation-name allowlists.
- Adds webhook authenticity/replay gates: raw-body signature verification, timestamp/nonce tolerance, idempotency, event-source checks, and negative tests.
- Cross-references outbound webhook registration with SSRF controls.

### Evidence
**Before (safe pattern could be over-reported):**
```python
Order.query
  .join(AccountMembership, AccountMembership.account_id == Order.account_id)
  .filter(
      Order.id == order_id,
      AccountMembership.user_id == current_user.id,
      AccountMembership.status == "active",
  )
```

This is valid relationship-based authorization when enforced before data return.

**After (now correctly handled):**
```text
Acceptable authorization evidence:
- direct ownership
- tenant/team membership
- ACL
- policy engine
- capability grant/delegation

Negative test evidence:
- cross-tenant object denied
- revoked member denied
- unauthorized delegated access denied
- GraphQL alias spray counted or blocked
- unsigned/replayed webhook rejected
```

### Test Cases Added/Updated
- [ ] Added vulnerable test cases (`tests/vulnerable/`)
- [ ] Added benign test cases (`tests/benign/`)
- [x] Existing validation still passes

Validation run locally:
- `git diff --check`
- frontmatter/content validation for the modified skill files

Note: index validation was not run locally because `yq` is not installed in this environment, and this PR does not add or move indexed files.

### Bounty Tier
- [ ] **Minor** ($50) -- Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) -- New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) -- Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** PayPal or GitHub Sponsors; details to be provided privately after maintainer acceptance

/claim #630
