### PR TITLE
Improve container admission exception lifecycle gates

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -189,7 +189,7 @@ skills:
 
   - id: container-security
     name: "Container & Kubernetes Security Review"
-    tags: [cloud, containers, kubernetes, docker]
+    tags: [cloud, containers, kubernetes, docker, admission-control]
     role: [cloud-security-engineer, security-engineer]
     phase: [build, deploy, operate]
     activity: [review, audit]

--- a/skills/cloud/container-security/SKILL.md
+++ b/skills/cloud/container-security/SKILL.md
@@ -6,14 +6,15 @@ description: >
   Auto-invoked when reviewing Dockerfiles, Kubernetes manifests, Helm charts,
   or container orchestration configurations. Evaluates image security, runtime
   hardening, RBAC, Pod Security Standards, network policies, and secrets
-  management. Produces a prioritized findings report with remediation guidance.
-tags: [cloud, containers, kubernetes, docker]
+  management, including admission-control exception lifecycle risk. Produces a
+  prioritized findings report with remediation guidance.
+tags: [cloud, containers, kubernetes, docker, admission-control]
 role: [cloud-security-engineer, security-engineer]
 phase: [build, deploy, operate]
 frameworks: [CIS-Docker-v1.6.0, CIS-Kubernetes-v1.9.0, NIST-SP-800-190]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -101,6 +102,11 @@ Use Glob to locate all relevant configuration files.
 **/*-rbac.yaml
 **/*-psp.yaml
 **/*-podsecuritypolicy.yaml
+**/kyverno/**/*.yaml
+**/gatekeeper/**/*.yaml
+**/*policy*.yaml
+**/*constraint*.yaml
+**/*exception*.yaml
 ```
 
 Classify findings by type: Dockerfiles, Kubernetes manifests, Helm charts, Kustomize overlays, and supporting configs. Record all discovered files.
@@ -112,6 +118,25 @@ Classify findings by type: Dockerfiles, Kubernetes manifests, Helm charts, Kusto
 Evaluate all container and Kubernetes configurations against CIS Docker Benchmark v1.6.0, CIS Kubernetes Benchmark v1.9.0, and NIST SP 800-190 countermeasures. This covers Dockerfile security, Pod Security Standards, RBAC, Network Policies, Secrets Management, Control Plane configuration, and Container Runtime Hardening.
 
 For detailed CIS benchmark checklist items, NIST SP 800-190 countermeasure tables, and comprehensive security context evaluation criteria, see [cis-benchmarks.md](cis-benchmarks.md) in this skill directory.
+
+---
+
+### Admission Exception Lifecycle Gate
+
+Apply this gate whenever a namespace, policy engine, admission webhook, image policy, or deployment process permits workloads that would otherwise violate Pod Security Standards, Kyverno/Gatekeeper policy, image-signature policy, or runtime hardening requirements. Temporary, owned break-glass exceptions are not the same risk as permanent policy bypasses; evidence must separate them.
+
+1. **Inventory exception sources** -- Pod Security Admission namespace labels, Kyverno `PolicyException` resources, Gatekeeper `exemptNamespaces` or excluded namespaces, policy `exclude`/`match` blocks, ValidatingAdmissionPolicy bindings, image-policy allowlists, and GitOps waiver files.
+2. **Record lifecycle ownership** -- For each exception, capture policy/control bypassed, namespace, workload identity, image reference, owner, reason, ticket/change reference, approval source, creation date, expiry/TTL, and review cadence.
+3. **Verify scope minimization** -- Prefer exact workload names, service accounts, namespaces, and immutable image digests. Treat wildcard namespaces, broad registry paths, mutable tags, and all-policy exclusions as high-risk unless strongly justified.
+4. **Check compensating controls** -- Node taints, dedicated namespaces, network isolation, restricted RBAC, audit logging, admission report output, post-incident deletion, and follow-up cleanup evidence.
+5. **Detect stale exceptions** -- Flag expired exceptions still active, missing expiry/review date, missing owner, missing ticket, or exceptions that survive incident closure, deployment completion, or system-component rollout.
+6. **Avoid false positives for controlled system workloads** -- CNI, CSI, node agents, monitoring daemonsets, and emergency debug sessions may legitimately need host access when the exception is narrow, time-bound, audited, and has cleanup evidence.
+
+### Admission Exception Evidence Matrix
+
+| Exception source | Policy/control bypassed | Scope | Owner / ticket | Expiry / review | Compensating controls | Status |
+|---|---|---|---|---|---|---|
+| PSA / Kyverno / Gatekeeper / image policy | privileged / hostPath / unsigned image / namespace exemption | namespace + workload + image digest | owner + reason + ticket | TTL / expiry / review cadence | audit, taint, RBAC, cleanup | Pass / Fail / Not Evaluable |
 
 ---
 
@@ -176,6 +201,7 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Container:** <container name>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration>
+- **Admission Exception Evidence:** <owner, reason, scope, expiry, compensating controls, cleanup evidence if applicable>
 - **Remediation:** <fix with code example>
 
 ### Pod Security Standards Compliance Matrix
@@ -184,6 +210,12 @@ Produce the final report using the structure defined in the Output Format sectio
 |----------|-----------|-----------|------------|
 | deploy/app | production | Baseline (not Restricted) | runAsRoot, no seccomp |
 | deploy/worker | production | Privileged | privileged: true |
+
+### Admission Exception Lifecycle Matrix
+
+| Exception | Policy Bypassed | Scope | Owner | Expiry / Review | Compensating Controls | Status |
+|-----------|-----------------|-------|-------|-----------------|-----------------------|--------|
+| kyverno/allow-debug | restricted/privileged | incident-response/debug-pod | incident commander | 4h TTL | node taint, audit log, deletion evidence | Controlled |
 
 ### Prioritized Remediation Plan
 
@@ -257,6 +289,7 @@ Produce the final report using the structure defined in the Output Format sectio
 5. **`readOnlyRootFilesystem` breaks many applications.** When recommending this control, also recommend adding writable `emptyDir` volume mounts for directories the application needs to write to (e.g., `/tmp`, `/var/cache`).
 6. **Network policies are additive, not subtractive.** A default-deny policy must be explicitly created. Without it, all pod-to-pod traffic is allowed regardless of other NetworkPolicy resources.
 7. **Distroless images have no shell.** While this is excellent for security, note that debugging requires ephemeral containers (`kubectl debug`). Flag this as a consideration, not a problem.
+8. **Temporary admission exceptions become permanent.** A privileged debug pod, unsigned image waiver, or namespace policy exemption may be acceptable for incident response or system agents only when the owner, scope, TTL, audit trail, and cleanup evidence are documented.
 
 ---
 
@@ -283,6 +316,9 @@ Produce the final report using the structure defined in the Output Format sectio
 - NIST SP 800-190 Application Container Security Guide: https://csrc.nist.gov/publications/detail/sp/800-190/final
 - Kubernetes Pod Security Standards: https://kubernetes.io/docs/concepts/security/pod-security-standards/
 - Kubernetes Pod Security Admission: https://kubernetes.io/docs/concepts/security/pod-security-admission/
+- Kubernetes Validating Admission Policy: https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/
+- Kyverno Policy Exceptions: https://kyverno.io/docs/exceptions/
+- Gatekeeper Exempting Namespaces: https://open-policy-agent.github.io/gatekeeper/website/docs/exempt-namespaces/
 - Kubernetes Network Policies: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 - Kubernetes RBAC: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 - Docker Security Best Practices: https://docs.docker.com/develop/security-best-practices/
@@ -293,4 +329,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Added admission-control exception lifecycle evidence gates for owner, scope, TTL, compensating controls, and stale-exception cleanup.
 - **1.0.0** -- Initial release. Full coverage of CIS Docker Benchmark v1.6.0 Section 4-5, CIS Kubernetes Benchmark v1.9.0 Sections 1-5, and NIST SP 800-190 countermeasures across all five risk categories.

--- a/skills/cloud/container-security/cis-benchmarks.md
+++ b/skills/cloud/container-security/cis-benchmarks.md
@@ -406,6 +406,112 @@ ports:
     hostPort: 8080  # FAIL: binds directly to host
 ```
 
+### Admission-Control Exception Lifecycle Review
+
+Admission exceptions are common during incident response, system-agent rollouts,
+and platform migrations. Reviewers should distinguish controlled temporary
+exceptions from silent permanent bypasses.
+
+#### Vulnerable Patterns
+
+```yaml
+# BAD: namespace permanently weakens Pod Security Admission with no owner or expiry
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: production-debug
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+```
+
+```yaml
+# BAD: broad policy exception with mutable image tag and no lifecycle evidence
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: allow-unsigned-tools
+  namespace: policy-exceptions
+spec:
+  exceptions:
+    - policyName: require-signed-images
+      ruleNames:
+        - "*"
+  match:
+    any:
+      - resources:
+          namespaces:
+            - "*"
+          kinds:
+            - Pod
+          images:
+            - "registry.example.com/tools/*:latest"
+```
+
+```yaml
+# BAD: Gatekeeper namespace exemption covers an application namespace indefinitely
+apiVersion: config.gatekeeper.sh/v1alpha1
+kind: Config
+metadata:
+  name: config
+  namespace: gatekeeper-system
+spec:
+  match:
+    - excludedNamespaces:
+        - production
+      processes:
+        - webhook
+        - audit
+```
+
+#### Controlled Temporary Exception Pattern
+
+```yaml
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: ir-debug-hostaccess-20260605
+  namespace: policy-exceptions
+  annotations:
+    security.example.com/owner: incident-commander
+    security.example.com/ticket: INC-2026-0605
+    security.example.com/reason: "4h privileged debug pod on tainted IR node"
+    security.example.com/expires-at: "2026-06-05T08:00:00Z"
+    security.example.com/cleanup-required: "delete debug pod and exception after incident"
+spec:
+  exceptions:
+    - policyName: restricted-pod-security
+      ruleNames:
+        - disallow-privileged
+  match:
+    any:
+      - resources:
+          namespaces:
+            - incident-response
+          kinds:
+            - Pod
+          names:
+            - ir-debug-shell
+          operations:
+            - CREATE
+```
+
+This example can be treated as controlled only when the reviewer also sees
+audit/report evidence that the exception was used narrowly, the debug workload
+ran on a constrained node or namespace, and post-expiry cleanup occurred.
+
+#### Review Checklist
+
+- [ ] Every policy exception has an owner, reason, ticket/change reference, creation date, expiry/TTL, and review cadence.
+- [ ] Exception scope is limited to exact namespace, workload identity, service account, operation, policy/rule, and immutable image digest where possible.
+- [ ] Broad wildcard exceptions (`*`, all namespaces, all policies, mutable tags, registry prefixes) are flagged unless documented as short-lived break-glass.
+- [ ] Production namespace Pod Security Admission downgrades have owner, expiry, approval, and rollback evidence.
+- [ ] Kyverno `PolicyException`, Gatekeeper namespace exemptions, and policy `exclude` blocks are included in the exception inventory.
+- [ ] Admission audit logs, PolicyReports, Gatekeeper audit output, or equivalent evidence show when the exception was used.
+- [ ] Expired exceptions are removed or escalated as stale control gaps.
+- [ ] System daemonset/CNI/CSI/monitoring exceptions are tied to exact workloads and reviewed on a defined cadence.
+
 ### CIS 5.3 -- Network Policies and CNI
 
 #### CIS 5.3.1 -- Ensure that the CNI in use supports NetworkPolicies

--- a/skills/cloud/container-security/cis-benchmarks.md
+++ b/skills/cloud/container-security/cis-benchmarks.md
@@ -427,26 +427,21 @@ metadata:
 ```
 
 ```yaml
-# BAD: broad policy exception with mutable image tag and no lifecycle evidence
-apiVersion: kyverno.io/v2
+# BAD: broad image exception with mutable tag and no lifecycle evidence
+apiVersion: policies.kyverno.io/v1beta1
 kind: PolicyException
 metadata:
   name: allow-unsigned-tools
   namespace: policy-exceptions
 spec:
-  exceptions:
-    - policyName: require-signed-images
-      ruleNames:
-        - "*"
-  match:
-    any:
-      - resources:
-          namespaces:
-            - "*"
-          kinds:
-            - Pod
-          images:
-            - "registry.example.com/tools/*:latest"
+  policyRefs:
+    - name: require-signed-images
+      kind: ImageValidatingPolicy
+  images:
+    - "registry.example.com/tools/*:latest"
+  matchConditions:
+    - name: broad-production-tools
+      expression: "object.metadata.namespace.startsWith('prod')"
 ```
 
 ```yaml
@@ -477,7 +472,7 @@ metadata:
     security.example.com/owner: incident-commander
     security.example.com/ticket: INC-2026-0605
     security.example.com/reason: "4h privileged debug pod on tainted IR node"
-    security.example.com/expires-at: "2026-06-05T08:00:00Z"
+    security.example.com/expires-at: "<incident-start + 4h RFC3339>"
     security.example.com/cleanup-required: "delete debug pod and exception after incident"
 spec:
   exceptions:

--- a/skills/cloud/container-security/tests/admission-exception-lifecycle.md
+++ b/skills/cloud/container-security/tests/admission-exception-lifecycle.md
@@ -1,0 +1,100 @@
+# Admission Exception Lifecycle Calibration
+
+Use these samples to calibrate the `container-security` skill's admission-control
+exception checks.
+
+---
+
+## Should Trigger: Permanent Privileged Namespace Exception
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: production-debug
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+```
+
+Expected finding:
+
+- **Status:** Fail
+- **Severity:** High
+- **Reason:** The production namespace downgrades Pod Security Admission to
+  privileged with no owner, ticket, expiry, review cadence, compensating
+  controls, or cleanup evidence.
+
+---
+
+## Should Trigger: Broad Unsigned Image Policy Exception
+
+```yaml
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: unsigned-tools
+  namespace: policy-exceptions
+spec:
+  exceptions:
+    - policyName: require-signed-images
+      ruleNames:
+        - "*"
+  match:
+    any:
+      - resources:
+          namespaces:
+            - "*"
+          images:
+            - "registry.example.com/tools/*:latest"
+```
+
+Expected finding:
+
+- **Status:** Fail
+- **Severity:** High
+- **Reason:** The exception bypasses all rules for all namespaces and a mutable
+  image tag/prefix, with no owner, reason, approval, expiry, or digest binding.
+
+---
+
+## Should Not Trigger: Controlled IR Debug Exception
+
+```yaml
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: ir-debug-hostaccess-20260605
+  namespace: policy-exceptions
+  annotations:
+    security.example.com/owner: incident-commander
+    security.example.com/ticket: INC-2026-0605
+    security.example.com/reason: "4h privileged debug pod on tainted IR node"
+    security.example.com/expires-at: "2026-06-05T08:00:00Z"
+    security.example.com/cleanup-required: "delete debug pod and exception after incident"
+spec:
+  exceptions:
+    - policyName: restricted-pod-security
+      ruleNames:
+        - disallow-privileged
+  match:
+    any:
+      - resources:
+          namespaces:
+            - incident-response
+          kinds:
+            - Pod
+          names:
+            - ir-debug-shell
+          operations:
+            - CREATE
+```
+
+Expected handling:
+
+- **Status:** Controlled Exception
+- **Reason:** The exception is narrow, time-bound, owned, ticketed, and has a
+  cleanup requirement. Reviewers should still request audit/report evidence that
+  the exception was used only for the named debug workload and removed after
+  expiry.

--- a/skills/cloud/container-security/tests/admission-exception-lifecycle.md
+++ b/skills/cloud/container-security/tests/admission-exception-lifecycle.md
@@ -31,23 +31,20 @@ Expected finding:
 ## Should Trigger: Broad Unsigned Image Policy Exception
 
 ```yaml
-apiVersion: kyverno.io/v2
+apiVersion: policies.kyverno.io/v1beta1
 kind: PolicyException
 metadata:
   name: unsigned-tools
   namespace: policy-exceptions
 spec:
-  exceptions:
-    - policyName: require-signed-images
-      ruleNames:
-        - "*"
-  match:
-    any:
-      - resources:
-          namespaces:
-            - "*"
-          images:
-            - "registry.example.com/tools/*:latest"
+  policyRefs:
+    - name: require-signed-images
+      kind: ImageValidatingPolicy
+  images:
+    - "registry.example.com/tools/*:latest"
+  matchConditions:
+    - name: broad-production-tools
+      expression: "object.metadata.namespace.startsWith('prod')"
 ```
 
 Expected finding:
@@ -71,7 +68,7 @@ metadata:
     security.example.com/owner: incident-commander
     security.example.com/ticket: INC-2026-0605
     security.example.com/reason: "4h privileged debug pod on tainted IR node"
-    security.example.com/expires-at: "2026-06-05T08:00:00Z"
+    security.example.com/expires-at: "<incident-start + 4h RFC3339>"
     security.example.com/cleanup-required: "delete debug pod and exception after incident"
 spec:
   exceptions:


### PR DESCRIPTION
Closes #676.

## Summary
- Add an admission exception lifecycle gate for Pod Security Admission, Kyverno/Gatekeeper, image policy, and admission-control waivers.
- Require owner, reason, ticket/change reference, expiry/TTL, scope minimization, compensating controls, audit/report evidence, and stale-exception cleanup.
- Extend the detailed CIS checklist with vulnerable and controlled exception patterns plus review checks.
- Add calibration fixtures for permanent privileged namespace exceptions, broad unsigned-image exceptions, and controlled incident-response debug exceptions.
- Sync container-security discovery metadata with the new admission-control coverage.

## Validation
- git diff --cached --check
- container-security metadata sync check
- admission exception coverage keyword check
- markdown fence-balance check
- official source URL checks for Kubernetes PSA, ValidatingAdmissionPolicy, Kyverno PolicyException, and Gatekeeper namespace exemptions
- prompt-injection/old-email scan

## Bounty
Improver tier; this is a moderate false-positive reduction and edge-case coverage improvement. Requested bounty: $100.