### PR TITLE
Add DAST realtime auth evidence gates

### DIFF
--- a/skills/devsecops/dast-config/SKILL.md
+++ b/skills/devsecops/dast-config/SKILL.md
@@ -73,6 +73,14 @@ Use Glob and Grep to locate DAST tool configurations, scan policies, and CI inte
 **/nuclei*
 **/.nuclei-templates/
 
+# Realtime transports that need authenticated DAST coverage
+**/*websocket*
+**/*socket.io*
+**/*eventsource*
+**/*sse*
+**/*subscription*
+**/*graphql*
+
 # General DAST CI
 **/.github/workflows/*dast*
 **/.github/workflows/*security*
@@ -269,6 +277,47 @@ jobs:
 - Mutations are handled carefully (exclude destructive mutations from active scanning).
 
 **Finding classification:** No API scanning for applications with API endpoints is **High**. OpenAPI spec out of date is **Medium**. No GraphQL scanning for GraphQL endpoints is **Medium**.
+
+---
+
+#### 3.3 Realtime Transport Coverage
+
+Authenticated HTTP scanning is not sufficient for applications that move sensitive behavior onto long-lived channels after login. WebSocket, Server-Sent Events (SSE), Socket.IO, and GraphQL subscriptions need explicit DAST evidence for connection, subscription, message schema, and session-lifetime behavior.
+
+**Discovery patterns:**
+
+```text
+new WebSocket(
+EventSource(
+io(
+socket.io
+graphql-ws
+graphql-transport-ws
+subscriptions
+text/event-stream
+```
+
+**What to verify:**
+
+- [ ] Realtime endpoints are listed in scope separately from normal HTTP routes.
+- [ ] Connection handshakes are tested with valid, expired, revoked, and missing credentials.
+- [ ] Channel or topic subscription authorization is tested for cross-tenant and cross-project access.
+- [ ] Reconnect behavior re-checks token expiry, role changes, logout, and session revocation.
+- [ ] Existing WebSocket/SSE connections are closed or denied sensitive events after logout.
+- [ ] Message schemas are fuzzed with protocol-aware payloads instead of relying only on HTTP parameter fuzzing.
+- [ ] GraphQL subscriptions and Socket.IO namespaces/rooms have negative authorization evidence.
+- [ ] Reports distinguish HTTP-authenticated coverage from realtime transport coverage.
+
+**Evidence to collect:**
+
+| Surface | Required evidence | Failure to flag |
+|---------|-------------------|-----------------|
+| WebSocket handshake | Authenticated and unauthenticated upgrade attempts, protocol and origin notes | Upgrade accepts stale or missing credentials |
+| Subscription authorization | Allowed and denied tenant/project/channel subscriptions | Cross-tenant subscription succeeds |
+| Session lifetime | Logout, expiry, revocation, and reconnect tests | Stream continues sensitive events after logout |
+| Message schema | Scripted message corpus or Burp/ZAP WebSocket evidence | Scanner only crawled the HTTP page |
+
+**Finding classification:** Realtime endpoints with no authenticated transport testing are **High**. Cross-tenant channel access or stale-token reconnect accepted by WebSocket/SSE is **Critical**. Missing message-schema fuzzing for realtime transports is **Medium**.
 
 ---
 
@@ -481,9 +530,9 @@ DAST tools report findings per-URL, producing hundreds of duplicate alerts for t
 
 | Severity | Definition |
 |----------|-----------|
-| **Critical** | No authenticated scanning; active scanning targeting production; injection scan rules disabled; no scope restrictions. |
-| **High** | No DAST in CI/CD; no API scanning for API endpoints; active scanning disabled entirely; hardcoded credentials in config; destructive endpoints not excluded; authentication verification absent. |
-| **Medium** | No passive scanning on PRs; no scheduled full scan; OpenAPI spec out of date; no triage workflow; no deduplication; ZAP action unpinned; missing GraphQL scanning; missing security header rules. |
+| **Critical** | No authenticated scanning; active scanning targeting production; injection scan rules disabled; no scope restrictions; cross-tenant realtime channel access; stale-token realtime reconnect accepted. |
+| **High** | No DAST in CI/CD; no API scanning for API endpoints; no authenticated realtime transport testing; active scanning disabled entirely; hardcoded credentials in config; destructive endpoints not excluded; authentication verification absent. |
+| **Medium** | No passive scanning on PRs; no scheduled full scan; OpenAPI spec out of date; no triage workflow; no deduplication; ZAP action unpinned; missing GraphQL scanning; missing WebSocket/SSE message-schema fuzzing; missing security header rules. |
 | **Low** | Suboptimal scan duration settings; cosmetic report formatting; non-critical passive rules disabled. |
 
 ---
@@ -518,6 +567,7 @@ DAST tools report findings per-URL, producing hundreds of duplicate alerts for t
 | Passive scanning in CI | Yes/No | <workflow file> |
 | Active scanning (staging) | Yes/No | <workflow file> |
 | API scanning | Yes/No | <OpenAPI/GraphQL import> |
+| Realtime transport coverage | Yes/No | <WebSocket/SSE/Socket.IO/subscription evidence> |
 | Results deduplication | Yes/No | <dedup method> |
 
 ### Findings
@@ -526,6 +576,7 @@ DAST tools report findings per-URL, producing hundreds of duplicate alerts for t
 - **Severity:** Critical / High / Medium / Low
 - **Control Reference:** OWASP Top 10 AXX / WSTG-XXXX-XX
 - **File:** <path to config file>
+- **Transport Evidence:** <HTTP / WebSocket / SSE / Socket.IO / GraphQL subscription evidence>
 - **Description:** <what was found>
 - **Remediation:** <concrete fix with example>
 
@@ -603,6 +654,8 @@ This skill processes DAST configuration files that may contain target URLs, auth
 - OWASP Top 10:2021: https://owasp.org/Top10/
 - OWASP Web Security Testing Guide v4.2: https://owasp.org/www-project-web-security-testing-guide/v42/
 - OWASP ZAP Documentation: https://www.zaproxy.org/docs/
+- OWASP ZAP WebSocket passive scan rules: https://www.zaproxy.org/docs/desktop/addons/websockets/pscanrules/
+- OWASP WebSocket Security Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/WebSocket_Security_Cheat_Sheet.html
 - ZAP Automation Framework: https://www.zaproxy.org/docs/automate/automation-framework/
 - ZAP GitHub Actions: https://www.zaproxy.org/docs/docker/github-actions/
 - ZAP Scan Rules: https://www.zaproxy.org/docs/alerts/

--- a/skills/devsecops/dast-config/tests/realtime-auth-coverage.md
+++ b/skills/devsecops/dast-config/tests/realtime-auth-coverage.md
@@ -1,0 +1,48 @@
+# Realtime authenticated-state DAST coverage
+
+## Vulnerable: HTTP-authenticated scan misses realtime authorization
+
+```yaml
+env:
+  contexts:
+    - name: "staging-app"
+      urls:
+        - "https://staging.example.com"
+      authentication:
+        method: "browser"
+        verification:
+          method: "response"
+          loggedInRegex: "\\Qdashboard\\E"
+
+jobs:
+  - type: spider
+  - type: activeScan
+  - type: report
+```
+
+The scan signs in and covers HTTP routes, but it never records evidence for `wss://staging.example.com/ws`, `EventSource('/events')`, Socket.IO rooms, or GraphQL subscriptions. It should be flagged when the application uses realtime channels for tenant events, because logout, stale token reconnect, and cross-tenant subscription behavior are untested.
+
+## Benign: realtime channels have explicit negative auth evidence
+
+```yaml
+realtimeTransportEvidence:
+  websocket:
+    endpoint: "wss://staging.example.com/ws"
+    handshakeCases:
+      - validSession: "101 Switching Protocols"
+      - missingSession: "401 Unauthorized"
+      - expiredJwt: "401 Unauthorized"
+    subscriptionCases:
+      - ownTenant: "allow project:alpha"
+      - otherTenant: "deny project:beta"
+    reconnectCases:
+      - afterLogout: "connection closed"
+      - afterRoleRevocation: "subscription denied"
+    messageSchemaFuzzing: "scripts/dast/ws-message-corpus.json"
+  sse:
+    endpoint: "https://staging.example.com/events"
+    logoutBehavior: "stream closed before sensitive event delivery"
+    revokedTokenBehavior: "403 on reconnect"
+```
+
+This should pass because realtime transports are treated as separate authenticated surfaces, negative authorization evidence is explicit, and message-schema fuzzing is documented.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `dast-config`
**Skill path:** `skills/devsecops/dast-config/`

### What Was Wrong

The skill covered authenticated HTTP scans, OpenAPI/GraphQL import, and ZAP/Burp configuration, but it could let reviewers treat normal HTTP login evidence as sufficient for realtime transports. Applications that use WebSocket, SSE, Socket.IO, or GraphQL subscriptions after login can still have tenant/channel authorization, logout, stale-token reconnect, and message-schema gaps that HTTP-only DAST evidence will miss.

### What This PR Fixes

- Adds realtime transport discovery patterns for WebSocket, EventSource/SSE, Socket.IO, and GraphQL subscriptions.
- Adds a dedicated realtime transport coverage gate under API scanning.
- Requires connection, subscription authorization, reconnect, logout/session-revocation, and message-schema fuzzing evidence.
- Adds severity guidance for missing realtime authenticated testing, cross-tenant channel access, stale-token reconnect, and missing message-schema fuzzing.
- Adds realtime transport evidence to the report output template.
- Adds official OWASP/ZAP references for WebSocket passive scan rules and WebSocket security guidance.
- Adds a focused vulnerable/benign fixture for realtime authenticated-state DAST coverage.

### Evidence

**Before (skill could miss this):**
```yaml
env:
  contexts:
    - name: staging-app
      urls:
        - https://staging.example.com
      authentication:
        method: browser

jobs:
  - type: spider
  - type: activeScan
```

**After (now required evidence):**
```text
Realtime transport coverage:
- WebSocket handshake: valid, missing, expired, and revoked credentials
- Subscription authorization: own-tenant allowed, other-tenant denied
- Session lifetime: logout and role revocation close or deny streams
- Message schema: protocol-aware fuzzing corpus or tool evidence
```

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/`)
- [x] Added benign test cases (`tests/`)
- [x] Existing checks still pass

Added fixture:
- `skills/devsecops/dast-config/tests/realtime-auth-coverage.md`

### Validation

- `git diff --check`
- Touched `SKILL.md` frontmatter required-field check
- `index.yaml` referenced-file existence check
- Prompt-injection pattern scan with benign auth wording exclusions
- Content assertions for realtime transport coverage, WebSocket/SSE/Socket.IO/GraphQL subscription gates, cross-tenant channel access, stale-token reconnect, report output evidence, and vulnerable/benign fixture expectations
- Source URL checks returned HTTP 200 for:
  - OWASP ZAP WebSocket passive scan rules
  - OWASP WebSocket Security Cheat Sheet

### Bounty Tier
- [ ] **Minor** ($50) -- Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) -- New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) -- Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** PayPal, to be provided privately after acceptance

Closes #664