### PR TITLE
Improve aws-review Access Analyzer external access gates

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -141,13 +141,13 @@ skills:
   # -- Cloud ----------------------------------------------------------------
   - id: aws-review
     name: "AWS Security Posture Review"
-    tags: [cloud, aws, cis-benchmark]
+    tags: [cloud, aws, cis-benchmark, access-analyzer, external-access]
     role: [cloud-security-engineer, security-engineer]
     phase: [assess, operate]
     activity: [audit, review]
     frameworks: [CIS-AWS-v3.0.0]
     difficulty: intermediate
-    time_estimate: "60-90min"
+    time_estimate: "70-100min"
     file: skills/cloud/aws-review/SKILL.md
     compatible_tools: [claude-code, gemini-cli, cursor, codex-cli, openclaw, kiro]
 

--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -5,15 +5,16 @@ description: >
   Foundations Benchmark v3.0.0. Auto-invoked when reviewing AWS infrastructure,
   IAM policies, S3 configurations, CloudTrail settings, VPC security groups, or
   RDS encryption. Walks through all five benchmark sections, evaluates each
-  recommendation, and produces a prioritized findings report with remediation
+  recommendation, validates IAM Access Analyzer external-access evidence and
+  archive lifecycle, and produces a prioritized findings report with remediation
   guidance mapped to specific CIS control IDs.
-tags: [cloud, aws, cis-benchmark]
+tags: [cloud, aws, cis-benchmark, access-analyzer, external-access]
 role: [cloud-security-engineer, security-engineer]
 phase: [assess, operate]
 frameworks: [CIS-AWS-v3.0.0]
 difficulty: intermediate
-time_estimate: "60-90min"
-version: "1.0.0"
+time_estimate: "70-100min"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -55,6 +56,7 @@ The CIS Amazon Web Services Foundations Benchmark v3.0.0 is a consensus-driven s
 - S3 bucket policies and ACL configurations
 - VPC, security group, and NACL definitions
 - CloudTrail and CloudWatch configuration files
+- IAM Access Analyzer analyzer scope, active findings, archive rules, or finding export evidence when reviewing live or exported accounts
 
 ---
 
@@ -85,13 +87,17 @@ Also locate supporting configuration:
 **/.aws/credentials
 **/aws-config-rules/**
 **/security-hub/**
+**/access-analyzer/**
+**/iam-access-analyzer/**
+**/*access-analyzer*.json
+**/*access-analyzer*.yaml
 ```
 
 Record all discovered files. If no AWS configurations are found, report that finding and halt.
 
 ---
 
-### Step 2 through Step 6: CIS Benchmark Evaluation (Sections 1-5)
+### Step 2: CIS Benchmark Evaluation (Sections 1-5)
 
 Evaluate all AWS configurations against CIS AWS v3.0.0 Sections 1 through 5, covering Identity and Access Management, Storage, Logging, Monitoring, and Networking.
 
@@ -99,7 +105,44 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
-### Step 7: Compile Assessment Report
+### Step 3: Access Analyzer External Access Evidence Gate
+
+For AWS accounts that contain IAM, S3, KMS, SQS, Lambda, Secrets Manager, or other resource policies, require current IAM Access Analyzer evidence before accepting external access as controlled.
+
+**Analyzer scope evidence**
+
+Capture whether the analyzer is account-level or organization-level, which accounts and regions it covers, and the configured zone of trust. If no analyzer evidence is available for a reviewed account or region, mark external-access conclusions as `Not Evaluable` instead of assuming policy review alone is complete.
+
+**Finding inventory**
+
+For every active or archived external-access finding, record:
+
+| Field | Required Evidence |
+|-------|-------------------|
+| Finding identity | Finding ID or ARN, resource ARN, resource type, account, region |
+| Principal | External account, organization, federated principal, service principal, or public `*` |
+| Source policy | Bucket/key/queue/function/secret/trust policy statement or IaC source |
+| Finding state | `ACTIVE`, `ARCHIVED`, or equivalent export state, plus first seen and last updated timestamps |
+| Intended access | Business purpose, intended external principal, owner, ticket, expiry, and last revalidation |
+| Archive quality | Archive rule/filter, archive reason, next review date, and trigger for revalidation |
+
+**Finding criteria**
+
+Flag a finding when any of the following are true:
+
+- No analyzer exists for a reviewed account or region that contains resource policies.
+- An active public or cross-account finding lacks an owner, intended principal, business reason, expiry, or last revalidation evidence.
+- An archive rule suppresses findings broadly by resource type, account, wildcard principal, or tag without binding to a specific intended relationship and review cadence.
+- An archived finding has no archive reason, ticket, next review date, or policy/principal change trigger.
+- A resource policy allows external access outside AWS Organizations, partner-account allowlists, `aws:SourceArn`/`aws:SourceAccount` constraints, or other documented trust boundaries.
+
+**False-positive guardrails**
+
+Do not flag controlled external access solely because Access Analyzer reported it. Treat the finding as acceptable when the evidence proves a specific intended principal, bounded resource policy, owner, business purpose, expiry/review cadence, and revalidation trigger. CloudFront origin access, AWS service principals, AWS Organizations sharing, and migration windows can be valid when source conditions and ownership evidence are current.
+
+---
+
+### Step 4: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
 
@@ -156,6 +199,7 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration or code snippet>
+- **Access Analyzer Evidence:** <analyzer scope, finding ID/state, resource ARN, principal, archive reason, owner, expiry/revalidation if applicable>
 - **Remediation:** <specific fix with code example>
 
 ### Prioritized Remediation Plan
@@ -200,6 +244,8 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
 5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
 6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
+7. **Treating archived Access Analyzer findings as automatically safe.** Archived findings still need archive reason, owner, intended principal, expiry, and revalidation evidence; stale archive rules can hide newly risky resource policies.
+8. **Treating every external finding as public exposure.** Partner-account access, AWS Organizations sharing, CloudFront origin access, and service principals can be valid when resource policies are source-bound and the relationship is documented.
 
 ---
 
@@ -225,10 +271,13 @@ Produce the final report using the structure defined in the Output Format sectio
 - AWS CloudTrail Documentation: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/
 - AWS Security Hub: https://docs.aws.amazon.com/securityhub/latest/userguide/
 - AWS VPC Security: https://docs.aws.amazon.com/vpc/latest/userguide/security.html
+- AWS IAM Access Analyzer findings: https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-findings.html
+- AWS IAM Access Analyzer archive rules: https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-archive-rules.html
 - Terraform AWS Provider Documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 
 ---
 
 ## Changelog
 
+- **1.0.1** -- Add Access Analyzer external-access evidence gate, archive lifecycle requirements, and reporting fields for controlled cross-account access.
 - **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 (62 recommendations).

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -146,6 +146,16 @@ aws_accessanalyzer_analyzer
 type = "ACCOUNT"
 ```
 
+**Access Analyzer external-access lifecycle checks:**
+
+- Verify analyzer coverage for every reviewed account and region that contains resource policies.
+- Capture active and archived findings for S3 buckets, KMS keys, SQS queues, Lambda functions, Secrets Manager secrets, IAM role trusts, and other resource policies.
+- Treat missing analyzer evidence as `Not Evaluable` for external-access conclusions, not as a pass.
+- For each active external finding, require intended principal, resource ARN, source policy statement, owner, business purpose, ticket, expiry, and last revalidation evidence.
+- For each archived finding, require archive rule/filter, archive reason, owner, ticket, next review date, and a revalidation trigger for policy/principal/OU changes.
+- Flag broad archive rules that suppress by wildcard principal, whole resource type, account, or tag without binding to a specific intended relationship and review cadence.
+- Do not flag controlled partner, AWS Organizations, CloudFront origin access, or AWS service-principal findings solely because they are external when source conditions and lifecycle evidence are current.
+
 ### CIS 1.21 -- Ensure IAM users are managed centrally via identity federation or AWS Organizations for multi-account environments
 
 Check for SSO/Identity Center configuration:

--- a/skills/cloud/aws-review/tests/access-analyzer-external-access.md
+++ b/skills/cloud/aws-review/tests/access-analyzer-external-access.md
@@ -96,6 +96,7 @@ access_analyzer:
       owner: platform-security
       ticket: SEC-2026-0188
       business_purpose: "partner settlement event ingestion"
+      last_revalidated_at: "<last-review RFC3339>"
       expires_at: "<contract-renewal - 30d RFC3339>"
       next_review_at: "<last-review + 90d RFC3339>"
       revalidate_on:

--- a/skills/cloud/aws-review/tests/access-analyzer-external-access.md
+++ b/skills/cloud/aws-review/tests/access-analyzer-external-access.md
@@ -1,0 +1,110 @@
+# AWS Access Analyzer External Access Calibration
+
+Use these samples to calibrate `aws-review` external-access and archive lifecycle findings.
+
+---
+
+## Should Trigger: Broad Archive Rule Without Lifecycle Evidence
+
+```yaml
+access_analyzer:
+  analyzer_scope:
+    type: ORGANIZATION
+    covered_regions: ["us-east-1", "us-west-2"]
+  archive_rules:
+    - name: archive-all-partner-findings
+      filter:
+        resource_type: AWS::S3::Bucket
+        principal: "*"
+      reason: "partner access is expected"
+      owner: null
+      ticket: null
+      next_review_at: null
+```
+
+Expected finding:
+
+- **Status:** Fail
+- **Severity:** High
+- **Reason:** The archive rule suppresses all S3 external findings with a wildcard principal and no owner, ticket, specific intended relationship, expiry, next review date, or revalidation trigger.
+
+---
+
+## Should Trigger: Active External Finding Without Intended-Access Evidence
+
+```yaml
+access_analyzer:
+  analyzer_scope:
+    type: ACCOUNT
+    covered_regions: ["us-east-1"]
+  findings:
+    - id: finding-123
+      state: ACTIVE
+      resource_type: AWS::KMS::Key
+      resource: arn:aws:kms:us-east-1:111122223333:key/abcd-1234
+      principal:
+        aws_account: "999988887777"
+      source_policy_statement:
+        Sid: AllowExternalDecrypt
+        Effect: Allow
+        Action: ["kms:Decrypt"]
+        Principal:
+          AWS: arn:aws:iam::999988887777:root
+      owner: ""
+      business_purpose: ""
+      expires_at: null
+      last_revalidated_at: null
+```
+
+Expected finding:
+
+- **Status:** Fail
+- **Severity:** High
+- **Reason:** The active KMS external-access finding has no owner, intended principal justification, ticket, expiry, or last revalidation evidence.
+
+---
+
+## Should Not Trigger: Scoped Partner Finding With Current Review Evidence
+
+```yaml
+access_analyzer:
+  analyzer_scope:
+    type: ORGANIZATION
+    zone_of_trust: o-exampleorg
+    covered_accounts: ["111122223333", "444455556666"]
+    covered_regions: ["us-east-1", "us-west-2", "eu-west-1"]
+  findings:
+    - id: finding-456
+      state: ARCHIVED
+      resource_type: AWS::SQS::Queue
+      resource: arn:aws:sqs:us-east-1:111122223333:partner-settlement-events
+      principal:
+        service: events.amazonaws.com
+      intended_external_account: "222233334444"
+      source_policy_statement:
+        Sid: AllowPartnerSettlementEvents
+        Effect: Allow
+        Action: ["sqs:SendMessage"]
+        Principal:
+          Service: events.amazonaws.com
+        Condition:
+          StringEquals:
+            aws:SourceAccount: "222233334444"
+          ArnLike:
+            aws:SourceArn: arn:aws:events:us-east-1:222233334444:rule/settlement-*
+      archive_reason: "approved partner settlement integration"
+      owner: platform-security
+      ticket: SEC-2026-0188
+      business_purpose: "partner settlement event ingestion"
+      expires_at: "<contract-renewal - 30d RFC3339>"
+      next_review_at: "<last-review + 90d RFC3339>"
+      revalidate_on:
+        - policy_change
+        - principal_change
+        - organization_change
+```
+
+Expected handling:
+
+- **Status:** Pass
+- **Reason:** The archived external-access finding is scoped to a specific partner role and queue, constrained by source account/ARN, and has owner, ticket, business purpose, expiry, next review date, and revalidation triggers.


### PR DESCRIPTION
Closes #674.

## Summary
- add an Access Analyzer external-access evidence gate to `aws-review` covering analyzer scope, active findings, archived findings, owner/ticket/expiry, and revalidation evidence
- extend CIS 1.20 checklist guidance for archive rules and controlled cross-account/service-principal access
- add calibration fixtures for broad archive-rule false negatives, active external findings without lifecycle evidence, and a scoped benign partner EventBridge-to-SQS pattern
- sync `index.yaml` discovery metadata with the new `access-analyzer` and `external-access` tags

## Bounty
Improver tier; requesting Moderate ($100) consideration. Payment details can be provided privately after maintainer acceptance.

## Validation
- `git diff --check`
- `git diff HEAD^ --check`
- frontmatter/index metadata sync check
- Access Analyzer keyword coverage check
- markdown fence-balance check
- old email / prompt-injection residue scan
- official AWS reference URL checks: Access Analyzer findings, archive rules, Access Analyzer overview, AWS Security, IAM best practices all returned HTTP 200
