### PR TITLE
Add container system workload provenance gates

### DIFF
--- a/skills/cloud/container-security/SKILL.md
+++ b/skills/cloud/container-security/SKILL.md
@@ -113,6 +113,15 @@ Evaluate all container and Kubernetes configurations against CIS Docker Benchmar
 
 For detailed CIS benchmark checklist items, NIST SP 800-190 countermeasure tables, and comprehensive security context evaluation criteria, see [cis-benchmarks.md](cis-benchmarks.md) in this skill directory.
 
+Before assigning severity for host namespaces, elevated capabilities, privileged mode, or mutable image findings, collect exception and enforcement evidence:
+
+- **System workload exception gate** -- if a workload runs in `kube-system` or a platform namespace as CNI, CSI, kube-proxy, node exporter, logging, EDR, or other node-level infrastructure, record component role, namespace boundary, RBAC scope, image provenance, owner, change-control ticket, and compensating controls before rating it as an application workload violation.
+- **Application namespace denial** -- verify the same host namespace, privileged, or elevated-capability pattern is denied for ordinary application namespaces through Pod Security Admission, Kyverno, Gatekeeper, or equivalent policy.
+- **Image provenance enforcement** -- distinguish CI signing from cluster enforcement. Record digest pinning, attestor identity, policy mode, admission controller, and denial evidence for unsigned, mutable-tag, or untrusted images.
+- **Rendered manifest evidence** -- for Helm or Kustomize reviews, state whether rendered manifests were reviewed and which values or overlays were used. Template-only review is incomplete when environment values can override security settings.
+- **Ephemeral container inventory** -- include `ephemeralContainers` alongside `containers` and `initContainers` in PSS, capability, host namespace, image, and provenance checks.
+- **Effective NetworkPolicy review** -- verify default-deny plus broad allow/egress policies together; do not treat the presence of one NetworkPolicy as proof of segmentation.
+
 ---
 
 ### Step 7: Compile Assessment Report
@@ -132,6 +141,8 @@ Produce the final report using the structure defined in the Output Format sectio
 | **Low** | Best-practice deviation with limited immediate risk | No HEALTHCHECK in Dockerfile, ADD instead of COPY, missing liveness/readiness probes, using default namespace |
 | **Informational** | Observation with no direct security impact | Image size optimization, multi-stage build suggestions, label recommendations |
 
+For platform/system workloads, do not downgrade automatically. Reclassify only when the exception gate proves infrastructure role, least-privilege RBAC, admission denial for app namespaces, signed/digest-pinned image provenance, owner, review date, and compensating controls. Missing exception evidence remains High/Critical.
+
 ---
 
 ## Output Format
@@ -144,6 +155,7 @@ Produce the final report using the structure defined in the Output Format sectio
 - Date: <assessment date>
 - Frameworks: CIS Docker Benchmark v1.6.0, CIS Kubernetes Benchmark v1.9.0, NIST SP 800-190
 - Files reviewed: <N Dockerfiles, N K8s manifests, N Helm charts>
+- Rendered manifests reviewed: <yes/no; command, values files, overlays>
 
 ### Executive Summary
 - Total checks evaluated: <N>
@@ -174,16 +186,20 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Line(s):** <line numbers>
 - **Resource:** <Deployment/StatefulSet name>
 - **Container:** <container name>
+- **Container kind:** <container / initContainer / ephemeralContainer>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration>
+- **Exception evidence:** <system workload role, owner, RBAC scope, compensating controls, or none>
+- **Image provenance evidence:** <digest, signature/attestor, admission policy mode, denial test>
+- **Effective policy evidence:** <PSA/Kyverno/Gatekeeper/NetworkPolicy effective result>
 - **Remediation:** <fix with code example>
 
 ### Pod Security Standards Compliance Matrix
 
-| Workload | Namespace | PSS Level | Violations |
-|----------|-----------|-----------|------------|
-| deploy/app | production | Baseline (not Restricted) | runAsRoot, no seccomp |
-| deploy/worker | production | Privileged | privileged: true |
+| Workload | Namespace | Containers Reviewed | PSS Level | Exceptions | Violations |
+|----------|-----------|---------------------|-----------|------------|------------|
+| deploy/app | production | app, init, ephemeral | Baseline (not Restricted) | none | runAsRoot, no seccomp |
+| daemonset/cilium | kube-system | cilium-agent | Privileged | system workload exception evidence required | hostNetwork, NET_ADMIN |
 
 ### Prioritized Remediation Plan
 
@@ -257,6 +273,9 @@ Produce the final report using the structure defined in the Output Format sectio
 5. **`readOnlyRootFilesystem` breaks many applications.** When recommending this control, also recommend adding writable `emptyDir` volume mounts for directories the application needs to write to (e.g., `/tmp`, `/var/cache`).
 6. **Network policies are additive, not subtractive.** A default-deny policy must be explicitly created. Without it, all pod-to-pod traffic is allowed regardless of other NetworkPolicy resources.
 7. **Distroless images have no shell.** While this is excellent for security, note that debugging requires ephemeral containers (`kubectl debug`). Flag this as a consideration, not a problem.
+8. **System workloads are not ordinary app pods.** CNI, CSI, kube-proxy, and node security agents may require host access, but they still need exception evidence, scoped RBAC, image provenance, and app-namespace denial controls.
+9. **Signing is not enforcement.** A CI job that signs images does not prove the cluster rejects unsigned or mutable images. Require admission-time denial evidence.
+10. **Template-only Helm reviews miss production overrides.** Render charts with the relevant values files or clearly mark the assessment incomplete.
 
 ---
 

--- a/skills/cloud/container-security/cis-benchmarks.md
+++ b/skills/cloud/container-security/cis-benchmarks.md
@@ -592,7 +592,7 @@ Evaluate container runtime configurations against NIST SP 800-190 countermeasure
 |---------------|---------------|
 | **CM-1:** Use minimal base images | Verify Alpine, Distroless, or slim variants in FROM |
 | **CM-2:** Scan images for vulnerabilities | Check for Trivy, Grype, Snyk in CI pipeline |
-| **CM-3:** Sign and verify images | Check for Cosign signatures, Notary, or admission webhooks |
+| **CM-3:** Sign and verify images | Check digest pinning, Cosign/Notary/Sigstore attestors, admission policy mode, and denial evidence proving unsigned or untrusted images are rejected |
 | **CM-4:** Use immutable tags or digests | `image: nginx@sha256:...` preferred over `image: nginx:1.25` |
 | **CM-5:** Remove unnecessary packages | No curl, wget, netcat, or shells in production images |
 

--- a/skills/cloud/container-security/tests/system-workload-provenance.md
+++ b/skills/cloud/container-security/tests/system-workload-provenance.md
@@ -1,0 +1,75 @@
+# System Workload Exception and Image Provenance Fixture
+
+Use this fixture to validate that container-security reviews distinguish platform workload exceptions from ordinary application violations without losing enforcement evidence.
+
+## Benign With Evidence
+
+```yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cilium-agent
+  namespace: kube-system
+  annotations:
+    security.unitone.ai/exception-owner: platform-networking
+    security.unitone.ai/change-ticket: CHG-2026-0604
+    security.unitone.ai/reviewed: "2026-06-04"
+spec:
+  template:
+    spec:
+      hostNetwork: true
+      serviceAccountName: cilium
+      containers:
+        - name: cilium-agent
+          image: quay.io/cilium/cilium@sha256:abc123
+          securityContext:
+            capabilities:
+              add: ["NET_ADMIN", "SYS_ADMIN"]
+```
+
+Required evidence:
+
+- system workload role: CNI agent in `kube-system`
+- scoped RBAC and namespace boundary documented
+- image digest plus signature/attestor evidence recorded
+- admission policy denies the same `hostNetwork` and capability set in application namespaces
+- owner, change-control ticket, review date, and compensating controls recorded
+
+## Vulnerable App Namespace
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app-debug
+  namespace: production
+spec:
+  ephemeralContainers:
+    - name: debug
+      image: busybox:latest
+      securityContext:
+        privileged: true
+```
+
+Expected finding:
+
+- `ephemeralContainers` were included in the PSS matrix.
+- `busybox:latest` is mutable and lacks digest/signature evidence.
+- privileged debug container in an application namespace is High/Critical unless policy denies it.
+
+## Incomplete Provenance
+
+```yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: sign-images
+spec:
+  validationFailureAction: Audit
+  rules:
+    - name: require-cosign
+      verifyImages:
+        - imageReferences: ["ghcr.io/example/*"]
+```
+
+Expected finding: signing guidance is incomplete because policy is audit-only and no denial evidence proves unsigned images are rejected at admission time.


### PR DESCRIPTION
Closes #633

/claim #633

## Summary

- Add a system workload exception gate before host namespace, privileged mode, elevated capability, and mutable-image severity assignment.
- Require evidence for platform role, namespace boundary, scoped RBAC, owner/change control, compensating controls, app-namespace denial, rendered manifest review, and effective NetworkPolicy review.
- Upgrade image provenance guidance from signing/tooling observation to admission-time enforcement evidence with digest, attestor, policy mode, and denial test.
- Add output fields for container kind, exception evidence, image provenance evidence, and effective policy evidence.
- Add a fixture covering CNI system workload exceptions, privileged ephemeral debug containers, and audit-only image verification policy.

## Validation

- `git diff --check`
- frontmatter checks for `skills/cloud/container-security/SKILL.md`
- content assertions for system workload exception gate, app namespace denial, image provenance enforcement, rendered manifest evidence, ephemeral inventory, effective NetworkPolicy review, admission policy mode, `ephemeralContainers`, audit-only policy, and denial evidence
- prompt-safety scan of `skills/cloud/container-security` found only existing benchmark command/example terms such as `curl` and `rm -rf`, not prompt-injection directives