### PR TITLE
Improve OWASP CSP and HSTS evidence gates

### DIFF
--- a/skills/appsec/owasp-top-10-web/SKILL.md
+++ b/skills/appsec/owasp-top-10-web/SKILL.md
@@ -12,7 +12,7 @@ phase: [build, review]
 frameworks: [OWASP-Top-10-2021]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.1"
+version: "1.0.2"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -303,6 +303,8 @@ failedAttempts|failed_attempts|lockout|max_attempts
 - Directory listing enabled on web servers.
 - Default or sample pages/applications deployed to production.
 - Missing or misconfigured security headers (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`).
+- Content Security Policy present but weakened by broad executable sources, reusable/static nonces, missing `frame-ancestors`, or `unsafe-inline` without a documented migration exception.
+- HSTS present but too short-lived for production, missing `includeSubDomains` where subdomains are in scope, or claiming preload readiness without validating the preload requirements.
 - Cloud storage buckets with public access (S3, GCS, Azure Blob).
 - XML parsers configured to allow external entities (XXE).
 - Verbose error pages that expose stack traces, framework versions, or internal paths.
@@ -331,11 +333,23 @@ DEBUG\s*=\s*True|debug\s*:\s*true|NODE_ENV.*development
 DocumentBuilderFactory|SAXParser|XMLReader|etree\.parse|lxml.*parse
 # Missing security headers
 X-Content-Type-Options|X-Frame-Options|Content-Security-Policy|Strict-Transport-Security
+# Weak browser policy evidence
+unsafe-inline|unsafe-eval|script-src.*\*|nonce-[A-Za-z0-9+/=]{6,}|Strict-Transport-Security.*max-age=([0-9]{1,7})([^0-9]|$)
 # Default credentials
 admin.*admin|password.*password|default.*key|changeme|TODO.*password
 # Verbose errors
 stack.*trace|stackTrace|detailed.*error|showErrors\s*:\s*true
 ```
+
+**Security Header Evidence Gate:**
+
+Treat header presence as evidence collection, not as proof of hardening. Before scoring security headers as implemented, record:
+
+- **CSP executable-source policy:** `default-src` and `script-src` must avoid broad wildcards, `http:`, and `unsafe-eval`. If inline scripts are still required, require per-response nonces or hashes and verify the nonce is generated with a CSPRNG for each response rather than hard-coded or reused.
+- **CSP framing and form boundaries:** Require `frame-ancestors` for clickjacking control and `form-action` for form submission boundaries when the application renders forms.
+- **HSTS scope:** Require `Strict-Transport-Security` over HTTPS with production `max-age >= 31536000`. Require `includeSubDomains` when the organization can safely commit all covered subdomains to HTTPS.
+- **Preload claims:** Only mark HSTS preload as verified when the header includes `preload`, satisfies the preload list requirements, and the team has confirmed all covered hosts are HTTPS-ready. Otherwise record it as "not claimed" or "not ready" instead of a failure.
+- **Reverse proxy ownership:** If headers are set at a CDN, ingress, or reverse proxy, require configuration evidence for that layer and one runtime response sample from the protected route class.
 
 **Mitigations:**
 
@@ -343,7 +357,7 @@ stack.*trace|stackTrace|detailed.*error|showErrors\s*:\s*true
 - Remove all default credentials, sample applications, and unused features before deployment.
 - Set `DEBUG=False` / `NODE_ENV=production` in all production configurations.
 - Disable XML external entity processing in all XML parsers by default.
-- Deploy security headers via middleware or reverse proxy — audit with tools like securityheaders.com.
+- Deploy security headers via middleware or reverse proxy, and verify their effective runtime values on representative routes.
 - Configure custom error pages that reveal no internal details; log full errors server-side only.
 - Run periodic configuration audits (CIS Benchmarks, cloud provider security tools).
 
@@ -712,4 +726,6 @@ This skill processes source code and configuration files that may contain advers
 - MITRE CWE List — https://cwe.mitre.org/
 - NIST SP 800-63B Digital Identity Guidelines — https://pages.nist.gov/800-63-3/sp800-63b.html
 - OWASP Cheat Sheet Series — https://cheatsheetseries.owasp.org/
+- OWASP Content Security Policy Cheat Sheet — https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html
+- OWASP HTTP Strict Transport Security Cheat Sheet — https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html
 - OWASP Application Security Verification Standard (ASVS) — https://owasp.org/www-project-application-security-verification-standard/

--- a/skills/appsec/owasp-top-10-web/csharp-dotnet.md
+++ b/skills/appsec/owasp-top-10-web/csharp-dotnet.md
@@ -667,7 +667,10 @@ RequireDigit\s*=\s*false|RequiredLength\s*=\s*[1-5]\b|RequireUppercase\s*=\s*fal
 
 # Missing security headers
 # (absence check — grep for these to confirm they exist)
-X-Content-Type-Options|X-Frame-Options|Content-Security-Policy
+X-Content-Type-Options|X-Frame-Options|Content-Security-Policy|Strict-Transport-Security
+
+# Weak CSP / HSTS evidence
+unsafe-inline|unsafe-eval|script-src.*\*|nonce-[A-Za-z0-9+/=]{6,}|MaxAge\s*=\s*TimeSpan\.From(Days|Hours)\([0-9]{1,2}\)
 
 # Swagger/OpenAPI exposed unconditionally
 UseSwagger\(\)|UseSwaggerUI\(\)
@@ -727,21 +730,48 @@ builder.Services.Configure<IdentityOptions>(options =>
 });
 ```
 
-**3. Missing security headers**
+**3. Missing or weak browser security headers**
 
 ```csharp
-// SECURE — add security headers via middleware
+// VULNERABLE — CSP exists, but unsafe-inline makes reflected/stored XSS easier to execute
 app.Use(async (context, next) =>
 {
+    context.Response.Headers.Append("Content-Security-Policy",
+        "default-src 'self'; script-src 'self' 'unsafe-inline'; frame-ancestors 'none';");
+    await next();
+});
+```
+
+```csharp
+// SECURE — add security headers via middleware and use a fresh nonce for inline script exceptions
+using System.Security.Cryptography;
+
+app.Use(async (context, next) =>
+{
+    var nonce = Convert.ToBase64String(RandomNumberGenerator.GetBytes(16));
+    context.Items["CspNonce"] = nonce;
+
     context.Response.Headers.Append("X-Content-Type-Options", "nosniff");
     context.Response.Headers.Append("X-Frame-Options", "DENY");
     context.Response.Headers.Append("X-XSS-Protection", "0"); // modern recommendation: disable, rely on CSP
     context.Response.Headers.Append("Referrer-Policy", "strict-origin-when-cross-origin");
     context.Response.Headers.Append("Content-Security-Policy",
-        "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; frame-ancestors 'none';");
+        $"default-src 'self'; script-src 'self' 'nonce-{nonce}'; style-src 'self'; img-src 'self' data:; frame-ancestors 'none'; form-action 'self';");
     context.Response.Headers.Append("Permissions-Policy",
         "camera=(), microphone=(), geolocation=()");
     await next();
+});
+```
+
+When reviewing this pattern, confirm that Razor/Blazor views apply the same per-response nonce to only the intended inline scripts and that the nonce is not hard-coded in configuration, constants, or templates.
+
+```csharp
+// SECURE — configure production HSTS with deliberate scope and lifetime
+builder.Services.AddHsts(options =>
+{
+    options.MaxAge = TimeSpan.FromDays(365);
+    options.IncludeSubDomains = true;
+    options.Preload = true; // only after validating all covered hosts are HTTPS-ready
 });
 ```
 


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

Closes #744

### Skill Modified
**Skill name:** `owasp-top-10-web`
**Skill path:** `skills/appsec/owasp-top-10-web/SKILL.md`

### What Was Wrong
The A05 security misconfiguration guidance treated security-header names mostly as presence checks. That can over-score weak browser policy such as CSP with `unsafe-inline`, static/reusable CSP nonces, missing `frame-ancestors` / `form-action`, or HSTS headers with insufficient production lifetime/scope.

### What This PR Fixes
- Adds a CSP/HSTS security-header evidence gate to the main OWASP web skill.
- Requires executable-source, nonce/hash, framing, form-boundary, HSTS lifetime/scope, preload-readiness, and proxy/runtime-response evidence before scoring headers as implemented.
- Updates the C#/.NET supplement with weak CSP detection patterns, a vulnerable `unsafe-inline` example, a per-response nonce example, and production HSTS options.
- Adds OWASP CSP and HSTS cheat sheet references and bumps the skill patch version to `1.0.2`.

### Evidence
**Before (skill could over-score this):**
```http
Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'
Strict-Transport-Security: max-age=300
```

**After (review must capture):**
```http
Content-Security-Policy: default-src 'self'; script-src 'self' 'nonce-perResponseValue'; frame-ancestors 'none'; form-action 'self'
Strict-Transport-Security: max-age=31536000; includeSubDomains
```

### Test Cases Added/Updated
- [ ] Added vulnerable test cases (`tests/vulnerable/`)
- [ ] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass

Docs/skill-guidance update; no executable test fixtures exist for this skill.

Validation completed locally:
- `git diff --check`
- Ruby frontmatter parse and required-field check for `skills/appsec/owasp-top-10-web/SKILL.md`
- Prompt-injection scan using the repository workflow filtering logic
- Content assertions for CSP/HSTS gate terms, OWASP CSP/HSTS references, and the .NET nonce example

### Sources Checked
- OWASP Content Security Policy Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html
- OWASP HTTP Strict Transport Security Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html

### Bounty Tier
- [ ] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the CONTRIBUTING.md bounty terms
- **Preferred payment method:** Can be provided privately after acceptance
