### PR TITLE
Improve OWASP password reset token evidence

### DIFF
--- a/skills/appsec/owasp-top-10-web/SKILL.md
+++ b/skills/appsec/owasp-top-10-web/SKILL.md
@@ -12,7 +12,7 @@ phase: [build, review]
 frameworks: [OWASP-Top-10-2021]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.1"
+version: "1.0.2"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -247,6 +247,8 @@ setHeader\(.*req\.|res\.set\(.*req\.|response\.addHeader.*request\.getParameter
 - Missing rate limiting on sensitive operations (login, password reset, OTP verification, account creation).
 - No account lockout or progressive delays after repeated failed authentication attempts.
 - Password reset flows that leak whether an account exists (different responses for valid vs. invalid emails).
+- Password reset or magic-link tokens that are predictable, reusable, long-lived, stored in plaintext, logged, or accepted after password change.
+- Account state changes during recovery before a valid reset token is presented.
 - Multi-step workflows that can be completed out of order or with steps skipped.
 - Missing trust boundaries — internal services accessible without authentication from external networks.
 - Absence of security requirements or threat model documentation.
@@ -275,15 +277,30 @@ setHeader\(.*req\.|res\.set\(.*req\.|response\.addHeader.*request\.getParameter
 rateLimit|rate_limit|throttle|slowDown
 # Account enumeration
 "user not found"|"email not found"|"no account"|"invalid email"
+# Password reset / recovery token flows
+forgot.?password|reset.?password|passwordResetToken|resetToken|magic.?link|recovery.?token
 # Missing lockout
 failedAttempts|failed_attempts|lockout|max_attempts
 ```
+
+**Password Reset Evidence Gate:**
+
+For password reset, account recovery, and magic-link flows, do not stop at "a reset email is sent." Record evidence for:
+
+- **Generic request behavior:** The request endpoint returns the same response shape and timing class whether or not the account exists.
+- **Token generation:** Tokens or codes are generated with a cryptographically safe random source or a framework token provider, are long enough to resist brute force, and are scoped to one account and purpose.
+- **Token storage:** Custom reset tokens are stored only as a keyed hash or strong one-way hash, never plaintext. Framework-protected tokens must have a configured lifetime.
+- **Single-use and expiry:** Tokens expire after an appropriate short period, are invalidated after successful password change, and older outstanding reset tokens are revoked when a new one is issued or the password changes.
+- **No premature account mutation:** The application does not lock, disable, change MFA, change email, or rotate credentials until the presented token is validated.
+- **Leakage controls:** Reset URLs are not logged, not returned in API responses, not sent to third-party redirects, and reset pages set a restrictive `Referrer-Policy` such as `no-referrer`.
+- **Abuse protection:** Request and token-validation endpoints have rate limits or equivalent throttling so attackers cannot enumerate accounts or brute-force tokens.
 
 **Mitigations:**
 
 - Establish threat modeling early in the design phase (STRIDE, PASTA, or attack trees).
 - Implement rate limiting and account lockout on all authentication and sensitive endpoints.
 - Return generic error messages for authentication failures — never reveal whether a username or email exists.
+- Use single-use, time-limited password reset tokens stored securely, and invalidate reset tokens after use or password change.
 - Enforce all business rules server-side; treat the client as untrusted.
 - Define and enforce trust boundaries between components and network zones.
 - Write abuse cases and negative test cases alongside functional requirements.
@@ -712,4 +729,6 @@ This skill processes source code and configuration files that may contain advers
 - MITRE CWE List — https://cwe.mitre.org/
 - NIST SP 800-63B Digital Identity Guidelines — https://pages.nist.gov/800-63-3/sp800-63b.html
 - OWASP Cheat Sheet Series — https://cheatsheetseries.owasp.org/
+- OWASP Forgot Password Cheat Sheet — https://cheatsheetseries.owasp.org/cheatsheets/Forgot_Password_Cheat_Sheet.html
+- OWASP Authentication Cheat Sheet — https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html
 - OWASP Application Security Verification Standard (ASVS) — https://owasp.org/www-project-application-security-verification-standard/

--- a/skills/appsec/owasp-top-10-web/csharp-dotnet.md
+++ b/skills/appsec/owasp-top-10-web/csharp-dotnet.md
@@ -829,6 +829,9 @@ ValidateIssuer\s*=\s*false|ValidateAudience\s*=\s*false|ValidateLifetime\s*=\s*f
 # Missing account lockout
 LockoutEnabled|MaxFailedAccessAttempts|DefaultLockoutTimeSpan
 
+# Password reset / account recovery token handling
+GeneratePasswordResetTokenAsync|ResetPasswordAsync|DataProtectionTokenProviderOptions|resetToken|passwordResetToken|magicLink
+
 # Hardcoded JWT signing keys
 new SymmetricSecurityKey\(Encoding.*"[A-Za-z0-9+/=]{16,}"
 
@@ -897,7 +900,58 @@ builder.Services.AddIdentity<ApplicationUser, IdentityRole>(options =>
 .AddDefaultTokenProviders();
 ```
 
-**3. Session fixation — not regenerating session on authentication**
+**3. Password reset token lifecycle**
+
+```csharp
+// VULNERABLE — weak/plaintext reset token, account mutated before token validation
+var token = new Random().Next(100000, 999999).ToString();
+user.PasswordResetToken = token;
+user.PasswordResetExpiresAt = DateTimeOffset.UtcNow.AddDays(7);
+user.LockoutEnd = DateTimeOffset.MaxValue;
+await _db.SaveChangesAsync();
+await _email.SendAsync(user.Email, $"https://app.example/reset?token={token}");
+```
+
+```csharp
+// SECURE — ASP.NET Core Identity token provider with short lifetime and generic request response
+builder.Services.Configure<DataProtectionTokenProviderOptions>(options =>
+{
+    options.TokenLifespan = TimeSpan.FromMinutes(30);
+});
+
+app.MapPost("/forgot-password", async (
+    ForgotPasswordRequest request,
+    UserManager<ApplicationUser> users,
+    IEmailSender email) =>
+{
+    var user = await users.FindByEmailAsync(request.Email);
+    if (user is not null)
+    {
+        var token = await users.GeneratePasswordResetTokenAsync(user);
+        var encodedToken = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(token));
+        await email.SendPasswordResetAsync(user.Email!, encodedToken);
+    }
+
+    return Results.Ok(new { message = "If the account exists, reset instructions have been sent." });
+}).RequireRateLimiting("auth");
+
+app.MapPost("/reset-password", async (
+    ResetPasswordRequest request,
+    UserManager<ApplicationUser> users) =>
+{
+    var user = await users.FindByEmailAsync(request.Email);
+    if (user is null)
+        return Results.BadRequest();
+
+    var token = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(request.Token));
+    var result = await users.ResetPasswordAsync(user, token, request.NewPassword);
+    return result.Succeeded ? Results.NoContent() : Results.BadRequest();
+}).RequireRateLimiting("auth");
+```
+
+When reviewing custom reset-token implementations, require evidence that only a token hash is stored server-side, the plaintext token is sent only through the side channel, old tokens are revoked after use or password change, reset URLs are not logged, and the reset page sends `Referrer-Policy: no-referrer`.
+
+**4. Session fixation — not regenerating session on authentication**
 
 ```csharp
 // SECURE — clear and regenerate session on login


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

Closes #747

### Skill Modified
**Skill name:** `owasp-top-10-web`
**Skill path:** `skills/appsec/owasp-top-10-web/SKILL.md`

### What Was Wrong
The skill mentioned password-reset rate limiting and account-enumeration responses, but it did not require reviewers to prove reset-token lifecycle controls. That leaves a gap for weak custom reset tokens, plaintext token storage, reusable or long-lived tokens, premature account mutation, and reset URL leakage.

### What This PR Fixes
- Adds a password reset / account recovery evidence gate to the A04 insecure-design section.
- Requires evidence for generic request behavior, token generation, token storage, single-use/expiry, no premature account mutation, leakage controls, and abuse protection.
- Adds reset-token search patterns and a mitigation line for single-use, time-limited tokens.
- Updates the .NET supplement with reset-token detection patterns and weak custom token vs ASP.NET Core Identity token-provider examples.
- Adds OWASP Forgot Password and Authentication cheat sheet references and bumps the skill patch version to `1.0.2`.

### Evidence
**Before (skill could miss this):**
```csharp
var token = new Random().Next(100000, 999999).ToString();
user.PasswordResetToken = token;
user.PasswordResetExpiresAt = DateTimeOffset.UtcNow.AddDays(7);
user.LockoutEnd = DateTimeOffset.MaxValue;
await email.SendAsync(user.Email, $"https://app.example/reset?token={token}");
```

**After (review must capture):**
```csharp
builder.Services.Configure<DataProtectionTokenProviderOptions>(options =>
{
    options.TokenLifespan = TimeSpan.FromMinutes(30);
});

var token = await users.GeneratePasswordResetTokenAsync(user);
var encodedToken = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(token));
```

### Test Cases Added/Updated
- [ ] Added vulnerable test cases (`tests/vulnerable/`)
- [ ] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass

Docs/skill-guidance update; no executable test fixtures exist for this skill.

Validation completed locally:
- `git diff --check`
- Ruby frontmatter parse and required-field/version check for `skills/appsec/owasp-top-10-web/SKILL.md`
- Prompt-injection scan using the repository workflow filtering logic
- Content assertions for reset-token evidence terms, OWASP references, and the .NET token-provider example
- Duplicate check against current open SecuritySkills issue and PR lists found no `reset token`, `forgot password`, `magic link`, `password reset token`, or `account recovery token` lane

### Sources Checked
- OWASP Forgot Password Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Forgot_Password_Cheat_Sheet.html
- OWASP Authentication Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html

### Bounty Tier
- [ ] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the CONTRIBUTING.md bounty terms
- **Preferred payment method:** Can be provided privately after acceptance
