### PR TITLE
Refresh NuGet config reference

### DIFF
--- a/skills/appsec/dependency-scanning/csharp-dotnet.md
+++ b/skills/appsec/dependency-scanning/csharp-dotnet.md
@@ -415,7 +415,7 @@ Add these to the supply chain risk indicators when scanning a .NET project:
 ## References
 
 - [NuGet Security Best Practices](https://learn.microsoft.com/en-us/nuget/concepts/security-best-practices)
-- [Microsoft Supply Chain Security — Securing the Software Supply Chain](https://learn.microsoft.com/en-us/nuget/concepts/package-source-mapping)
+- [NuGet config file reference](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file)
 - [.NET Package Validation](https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/overview)
 - [NuGet Package Source Mapping](https://learn.microsoft.com/en-us/nuget/consume-packages/package-source-mapping)
 - [Central Package Management](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management)


### PR DESCRIPTION
## Pull Request Checklist

Please confirm the following before submitting:

- [x] Skill follows the format specification in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] At least one real framework is cited with correct control IDs
- [x] All framework references verified against primary sources (not blogs or AI output)
- [x] Prompt Injection Safety Notice section included
- [x] `injection-hardened: true` set in frontmatter
- [x] `allowed-tools` scoped to minimum necessary permissions
- [x] Tested with at least one AI coding agent (which one: Codex CLI)
- [x] No prohibited patterns per [SECURITY.md](../SECURITY.md)
- [x] `index.yaml` updated with new skill entry (if adding a skill; N/A)

## What This PR Does

Closes #749.

This refreshes one stale Microsoft Learn reference in the .NET dependency-scanning supplement. The old `nuget/concepts/package-source-mapping` URL now returns 404 and is also redundant with the live Package Source Mapping reference already listed two lines later.

The replacement is the current NuGet config file reference, which directly documents the `packageSources`, `packageSourceMapping`, and related `nuget.config` sections used by the .NET assessment checklist.

## Framework References

- Microsoft Learn NuGet config file reference: `https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file`
- Existing NuGet Package Source Mapping reference remains: `https://learn.microsoft.com/en-us/nuget/consume-packages/package-source-mapping`

## Testing

Validation performed locally:

- `git diff --check`
- `curl -I -L -s -o /dev/null -w 'old %{http_code} %{url_effective}\n' https://learn.microsoft.com/en-us/nuget/concepts/package-source-mapping` -> `old 404 https://learn.microsoft.com/en-us/nuget/concepts/package-source-mapping`
- `curl -I -L -s -o /dev/null -w 'new %{http_code} %{url_effective}\n' https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file` -> `new 200 https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file`
- `rg -n "nuget/concepts/package-source-mapping|NuGet config file reference|nuget/reference/nuget-config-file" skills/appsec/dependency-scanning/csharp-dotnet.md` confirms the stale URL is absent and the replacement is present.

Payment details can be provided privately after maintainer acceptance.
