### PR TITLE
Improve segmentation PCI source and cadence gates

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -495,11 +495,11 @@ skills:
 
   - id: segmentation
     name: "Network Segmentation Review"
-    tags: [network, segmentation, micro-segmentation]
+    tags: [network, segmentation, micro-segmentation, pci-dss, cde]
     role: [security-engineer, architect]
     phase: [design, operate]
     activity: [review, design]
-    frameworks: [NIST-SP-800-207, CIS-Controls-v8]
+    frameworks: [NIST-SP-800-207, CIS-Controls-v8, PCI-DSS-v4.0.1]
     difficulty: intermediate
     time_estimate: "30-60min"
     file: skills/network/segmentation/SKILL.md

--- a/skills/network/segmentation/SKILL.md
+++ b/skills/network/segmentation/SKILL.md
@@ -14,7 +14,7 @@ phase: [design, operate]
 frameworks: [NIST-SP-800-207, CIS-Controls-v8, PCI-DSS-v4.0.1]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.1.0"
+version: "1.1.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -415,5 +415,6 @@ This skill processes network configurations that may contain user-supplied comme
 
 ## Changelog
 
+- **1.1.1** -- Added PCI CDE source/cadence fixtures for verified v4.0.1 evidence, stale source metadata, and missing service-provider cadence.
 - **1.1.0** -- Added PCI DSS v4.0.1 source-version gates, CDE evidence matrix, service-provider cadence checks, and post-change retest evidence.
 - **1.0.0** -- Initial release. Full coverage of NIST SP 800-207 and CIS Controls v8 Control 12 for network segmentation review.

--- a/skills/network/segmentation/SKILL.md
+++ b/skills/network/segmentation/SKILL.md
@@ -223,13 +223,47 @@ If a DMZ is present, evaluate its architectural soundness:
 
 If PCI scope is identified, verify CDE segmentation meets PCI DSS requirements:
 
+- PCI DSS source version, source document, source review date, and requirement mapping are recorded before assigning PCI-specific pass/fail status.
 - CDE is isolated in dedicated subnets or VLANs with explicit boundary controls.
 - All traffic entering and leaving the CDE traverses a firewall or equivalent PEP.
 - Connected-to systems are identified and documented.
 - Out-of-scope systems cannot route directly to CDE systems.
 - Segmentation testing methodology exists and is executed at least annually (PCI DSS 11.4.5).
+- Service-provider environments record the applicable PCI DSS 11.4.6 cadence and retained evidence; do not treat merchant-only annual test evidence as sufficient for service-provider cadence.
+- Significant network changes include retest evidence before relying on segmentation for PCI scope reduction.
 
 **Finding classification:** CDE not segmented from general corporate network is **Critical**. Missing segmentation testing is **High**.
+
+#### PCI DSS Source-Version Gate
+
+Before issuing PCI-specific findings, record current source evidence:
+
+| Evidence Field | Required Detail |
+|---|---|
+| PCI DSS version | Current assessed version, such as PCI DSS v4.0.1 |
+| Source document | Official PCI SSC document URL or controlled internal copy reference |
+| Source review date | Date the requirement mapping was checked against the source |
+| Requirement mapping | Explicit mapping for CDE segmentation controls, test requirements, and service-provider cadence |
+| Entity type | Merchant, service provider, or both |
+| Applicability rationale | Why PCI segmentation applies or does not apply to the assessed scope |
+
+If these fields are missing, mark PCI-specific status as `Not Evaluable - PCI source gate missing` instead of passing or failing PCI DSS. Continue reporting general segmentation findings under NIST SP 800-207 and CIS Controls.
+
+#### CDE Segmentation Evidence Matrix
+
+For each CDE boundary, collect separate evidence streams:
+
+| Evidence Area | Required Evidence |
+|---|---|
+| Boundary definition | CDE subnet/VLAN/VPC/namespace, connected-to systems, and out-of-scope adjacent zones |
+| Control points | Firewalls, security groups, routing controls, Kubernetes NetworkPolicy, service mesh policy, or equivalent PEP |
+| Test scope | Source zones, destination CDE assets, tested ports/protocols, and denied/allowed expectations |
+| Test results | Date, tester, method, observed result, evidence file, and exception list |
+| Cadence | Annual test evidence for applicable scopes plus service-provider 11.4.6 cadence when applicable |
+| Change retest | Triggering change, retest date, affected boundaries, and approval before scope reduction is relied on again |
+| Exceptions | Owner, reason, expiry, compensating control, and follow-up ticket |
+
+Do not collapse source currency, boundary effectiveness, cadence, and change retest into one score. A successful packet test can prove one control path works while still leaving PCI source mapping or service-provider cadence unevaluable.
 
 ---
 
@@ -242,6 +276,8 @@ Document or verify the existence of a segmentation testing process:
 3. **From the DMZ, attempt to reach internal zones** on unauthorized ports. Expected result: blocked.
 4. **Test VLAN hopping** via double-tagging from user VLANs. Expected result: traffic dropped.
 5. **Validate that segmentation controls survive failover** (HA firewall failover should not open transit paths).
+6. **For PCI CDE scopes, verify cadence evidence** separately for merchant and service-provider obligations, including PCI DSS 11.4.6 where applicable.
+7. **Retest after significant changes** to firewall rules, routing, identity-aware proxies, service mesh policy, Kubernetes namespaces, or CDE-connected systems before relying on segmentation for scope reduction.
 
 ---
 
@@ -283,6 +319,12 @@ Document or verify the existence of a segmentation testing process:
 | DMZ         | App       | Firewall    | Restricted | Pass |
 | App         | Data      | SG only     | Overly permissive | F-002 |
 | User        | Data      | None        | No control | F-001 |
+
+### PCI CDE Evidence Matrix
+
+| Boundary | PCI Source Version | Requirement Mapping Checked | Entity Type | Test Cadence Evidence | Change Retest Evidence | Status |
+|----------|--------------------|-----------------------------|-------------|-----------------------|------------------------|--------|
+| <CDE boundary> | <v4.0.1/source/date> | <yes/no> | <merchant/service provider> | <11.4.5 / 11.4.6 evidence> | <change/retest/ticket> | <Pass/Fail/Not Evaluable> |
 
 ### Findings
 

--- a/skills/network/segmentation/SKILL.md
+++ b/skills/network/segmentation/SKILL.md
@@ -3,17 +3,18 @@ name: segmentation
 description: >
   Performs a structured network segmentation review against NIST SP 800-207
   (Zero Trust Architecture) and CIS Controls v8 (Control 12 -- Network
-  Infrastructure Management). Auto-invoked when reviewing network architecture,
-  VLAN configurations, micro-segmentation policies, or DMZ designs. Produces a
-  segmentation maturity assessment with zone mapping, trust boundary analysis,
-  and remediation guidance.
-tags: [network, segmentation, micro-segmentation]
+  Infrastructure Management), with PCI DSS v4.0.1 CDE source/cadence checks
+  when cardholder-data scope is present. Auto-invoked when reviewing network
+  architecture, VLAN configurations, micro-segmentation policies, DMZ designs,
+  or PCI CDE segmentation. Produces a segmentation maturity assessment with
+  zone mapping, trust boundary analysis, and remediation guidance.
+tags: [network, segmentation, micro-segmentation, pci-dss, cde]
 role: [security-engineer, architect]
 phase: [design, operate]
-frameworks: [NIST-SP-800-207, CIS-Controls-v8]
+frameworks: [NIST-SP-800-207, CIS-Controls-v8, PCI-DSS-v4.0.1]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -33,7 +34,7 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 
 - Architecture reviews for new or modified network designs.
 - Zero Trust readiness assessments.
-- PCI DSS scoping exercises requiring CDE segmentation validation (PCI DSS v4.0 Requirement 1.3).
+- PCI DSS scoping exercises requiring CDE segmentation validation, source-version evidence, and 11.4.5/11.4.6 cadence checks.
 - Post-incident reviews where lateral movement was observed or suspected.
 - Cloud migration planning requiring workload isolation design.
 - Merger/acquisition network integration planning.
@@ -219,7 +220,7 @@ If a DMZ is present, evaluate its architectural soundness:
 
 ---
 
-### Step 5: PCI CDE Segmentation Validation (PCI DSS v4.0 Requirement 1.3)
+### Step 5: PCI CDE Segmentation Validation (PCI DSS v4.0.1 Requirements 1.3, 11.4.5, and 11.4.6)
 
 If PCI scope is identified, verify CDE segmentation meets PCI DSS requirements:
 
@@ -406,7 +407,7 @@ This skill processes network configurations that may contain user-supplied comme
 - NIST SP 800-207 (PDF): https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-207.pdf
 - CIS Controls v8: https://www.cisecurity.org/controls/v8
 - CIS Control 12 -- Network Infrastructure Management: https://www.cisecurity.org/controls/network-infrastructure-management
-- PCI DSS v4.0 Requirement 1 -- Install and Maintain Network Security Controls: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
+- PCI SSC Document Library -- PCI DSS v4.0.1: https://www.pcisecuritystandards.org/document_library
 - Kubernetes Network Policies: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 - Project Calico Documentation: https://docs.tigera.io/calico/latest/about/
 
@@ -414,4 +415,5 @@ This skill processes network configurations that may contain user-supplied comme
 
 ## Changelog
 
+- **1.1.0** -- Added PCI DSS v4.0.1 source-version gates, CDE evidence matrix, service-provider cadence checks, and post-change retest evidence.
 - **1.0.0** -- Initial release. Full coverage of NIST SP 800-207 and CIS Controls v8 Control 12 for network segmentation review.

--- a/skills/network/segmentation/tests/benign/pci-cde-current-source-cadence.md
+++ b/skills/network/segmentation/tests/benign/pci-cde-current-source-cadence.md
@@ -1,0 +1,22 @@
+# Benign: PCI CDE Boundary Has Current Source And Cadence Evidence
+
+This fixture should pass because PCI-specific segmentation conclusions are supported by current source metadata and separate CDE effectiveness evidence.
+
+```text
+pci_dss_version: v4.0.1
+pci_source_document: PCI DSS v4.0.1 from PCI SSC document library
+pci_source_review_date: 2026-06-05
+requirement_mapping_checked: true
+entity_type: service_provider
+cadence_evidence:
+  merchant_requirement: 11.4.5
+  service_provider_requirement: 11.4.6
+  test_frequency: every 6 months and after significant changes
+cde_boundary: cardholder-data services subnet and payment-tokenization namespace
+connected_to_systems: billing-api, token-vault, settlement-batch
+test_scope: origin/destination/port matrix for CDE and connected-to systems
+change_retest_evidence: firewall policy change CHG-1882 retested before production close
+result: pass
+```
+
+Expected result: pass. The reviewer records current PCI source version, review date, requirement mapping, service-provider cadence, CDE boundary, connected-to systems, test scope, and change-retest evidence before accepting the segmentation result.

--- a/skills/network/segmentation/tests/vulnerable/service-provider-cadence-missing.md
+++ b/skills/network/segmentation/tests/vulnerable/service-provider-cadence-missing.md
@@ -1,0 +1,18 @@
+# Vulnerable: Service Provider Uses Merchant-Only Cadence Evidence
+
+This fixture should fail because service-provider segmentation cadence is not separated from merchant annual testing evidence.
+
+```text
+pci_dss_version: v4.0.1
+pci_source_review_date: 2026-06-05
+requirement_mapping_checked: true
+entity_type: service_provider
+segmentation_test_frequency_source: 11.4.5 only
+service_provider_11_4_6_cadence: missing
+last_test_date: 2025-04-01
+significant_change_retest: not recorded
+connected_to_systems: missing
+result: pass
+```
+
+Expected result: fail or Not Evaluable. Service-provider evidence must explicitly address the 11.4.6 cadence, retained evidence, connected-to systems, and significant-change retesting instead of relying only on generic merchant cadence.

--- a/skills/network/segmentation/tests/vulnerable/stale-pci-source-metadata.md
+++ b/skills/network/segmentation/tests/vulnerable/stale-pci-source-metadata.md
@@ -1,0 +1,20 @@
+# Vulnerable: PCI Finding Uses Stale Source Metadata
+
+This fixture should fail because a segmentation result is treated as PCI-complete even though the PCI source gate is missing or stale.
+
+```text
+pci_dss_version: v4.0
+pci_source_document: docs-prv.pcisecuritystandards.org/PCI-DSS-v4_0.pdf
+pci_source_review_date: missing
+requirement_mapping_checked: false
+entity_type: merchant
+cde_boundary: PCI subnet
+segmentation_test:
+  date: 2025-04-01
+  origin: jump-host
+  destination: database-subnet
+  observed: blocked
+claim: CDE segmentation compliant
+```
+
+Expected result: fail or Not Evaluable for PCI DSS. A successful network test does not prove current PCI DSS mapping when the source version, official document, review date, and requirement mapping are stale or missing.


### PR DESCRIPTION
Closes #705.

Summary:
- add PCI DSS v4.0.1 source/version and review-date gates before PCI-specific segmentation conclusions
- add CDE segmentation evidence fields for requirement mapping, CDE boundary, connected-to systems, test cadence, and change-retest evidence
- add service-provider 11.4.6 cadence handling so merchant-only cadence evidence is not over-accepted
- add static fixtures for current PCI CDE source/cadence evidence, stale PCI source metadata, and missing service-provider cadence

Validation:
- `git diff --check`
- changed-file conflict-marker scan
- markdown fence balance check for the skill and new fixtures
- targeted assertions for PCI DSS v4.0.1, source review date, 11.4.6 cadence, connected-to systems, change retest evidence, stale v4.0 source handling, and Not Evaluable outcomes
- frontmatter/version check for `1.1.1`

If this is accepted/merged under the bounty terms, PayPal works here: https://www.paypal.com/paypalme/aogkft