### PR TITLE
Refresh OWASP LLM governance reference

### DIFF
--- a/skills/ai-security/llm-top-10/SKILL.md
+++ b/skills/ai-security/llm-top-10/SKILL.md
@@ -495,7 +495,7 @@ When performing a review using this skill:
 ## 9. References
 
 - OWASP Top 10 for LLM Applications 2025: https://genai.owasp.org/llm-top-10/
-- OWASP LLM AI Security & Governance Checklist: https://genai.owasp.org/llm-top-10/llm-ai-security-and-governance-checklist/
+- OWASP Top 10 for LLM Applications 2025 resource: https://genai.owasp.org/resource/owasp-top-10-for-llm-applications-2025/
 - OWASP GenAI Project Home: https://genai.owasp.org/
 - LLM01:2025 Prompt Injection: https://genai.owasp.org/llmrisk/llm01-prompt-injection/
 - LLM02:2025 Sensitive Information Disclosure: https://genai.owasp.org/llmrisk/llm02-sensitive-information-disclosure/


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `llm-top-10`
**Skill path:** `skills/ai-security/llm-top-10/`

Closes #758.

### What Was Wrong

The references section pointed to a removed OWASP GenAI checklist slug:

`https://genai.owasp.org/llm-top-10/llm-ai-security-and-governance-checklist/`

A live check returns HTTP 404, so reviewers using the skill cannot verify that governance source from the documented link.

### What This PR Fixes

This PR replaces the dead checklist slug with the current OWASP GenAI project-owned 2025 LLM Top 10 resource page:

`https://genai.owasp.org/resource/owasp-top-10-for-llm-applications-2025/`

The change is intentionally narrow because other open PRs are already working on broader `llm-top-10` guidance.

### Evidence

**Before (skill misses this / false positive on this):**
```text
404 https://genai.owasp.org/llm-top-10/llm-ai-security-and-governance-checklist/
```

**After (now correctly handled):**
```text
200 https://genai.owasp.org/resource/owasp-top-10-for-llm-applications-2025/
```

Additional checks:
```text
200 https://genai.owasp.org/llm-top-10/
200 https://genai.owasp.org/llmrisk/llm01-prompt-injection/
```

### Test Cases Added/Updated
- [ ] Added vulnerable test cases (`tests/vulnerable/`) - N/A, documentation reference update
- [ ] Added benign test cases (`tests/benign/`) - N/A, documentation reference update
- [x] Existing tests still pass - `git diff --check` passed; stale URL no longer appears in the repository

### Bounty Tier
- [x] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [ ] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Can provide privately through the maintainer-approved channel after acceptance.
