### PR TITLE
Add zero trust workload identity evidence

### DIFF
--- a/skills/identity/zero-trust-assessment/SKILL.md
+++ b/skills/identity/zero-trust-assessment/SKILL.md
@@ -12,7 +12,7 @@ phase: [design, operate]
 frameworks: [NIST-SP-800-207, CISA-ZTMM-v2]
 difficulty: advanced
 time_estimate: "90-180min"
-version: "1.0.1"
+version: "1.0.2"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -533,5 +533,6 @@ that may contain adversarial content.
 
 | Version | Date | Changes |
 |---|---|---|
+| 1.0.2 | 2026-06-05 | Added workload identity fixtures for service authorization, shared-token gaps, and mTLS-without-authorization gaps. |
 | 1.0.1 | 2026-06-04 | Added workload identity and service-to-service authorization evidence tables, scoring caps, and non-human identity coverage. |
 | 1.0.0 | 2025-03-06 | Initial release |

--- a/skills/identity/zero-trust-assessment/SKILL.md
+++ b/skills/identity/zero-trust-assessment/SKILL.md
@@ -12,7 +12,7 @@ phase: [design, operate]
 frameworks: [NIST-SP-800-207, CISA-ZTMM-v2]
 difficulty: advanced
 time_estimate: "90-180min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -153,7 +153,22 @@ ZT-ID-07: Service/workload identities not governed (no identity for machines)
 ZT-ID-08: No identity threat detection (compromised credential detection)
 ZT-ID-09: Federation trust not validated — implicit trust of partner IdPs
 ZT-ID-10: Session management lacks continuous evaluation (no CAE or equivalent)
+ZT-ID-11: Non-human workload identities share static secrets or broad service accounts
+ZT-ID-12: Workload credential lifetime, rotation, revocation, and owner are not documented
 ```
+
+#### Workload Identity Evidence
+
+Assess workload identity separately from human MFA and user identity governance. Workloads include services, batch jobs, CI/CD jobs, queue consumers, serverless functions, scheduled jobs, automation accounts, and AI agents.
+
+| Evidence Field | Required Detail | Maturity Impact |
+|---|---|---|
+| Workload / non-human subject | Service, job, function, agent, or automation identity name | Missing inventory caps Identity at Initial |
+| Identity provider | Cloud workload identity, service mesh, SPIFFE/SVID, IdP federation, or local mechanism | Shared static secret remains Traditional |
+| Trust domain / issuer | Cluster, tenant, account, mesh trust domain, or federation issuer | Missing boundary prevents Advanced |
+| Credential type and TTL | Certificate, token, federated credential, static key, expiration, and renewal path | Long-lived shared secrets cap at Initial |
+| Owner and lifecycle | Owning team, provisioning source, rotation, revocation, and decommissioning evidence | No owner/lifecycle prevents Advanced |
+| Policy binding | Resource/action scope tied to the workload identity | Broad shared account prevents Advanced |
 
 ---
 
@@ -222,6 +237,7 @@ ZT-NET-08: DNS traffic unencrypted and unmonitored
 ZT-NET-09: No NDR capability — lateral movement detection is blind spot
 ZT-NET-10: Microsegmentation policies not dynamically updated based on threat intelligence
 ZT-NET-11: Legacy protocols (Telnet, FTP, unencrypted LDAP) in use
+ZT-NET-12: mTLS exists but source workload identity is not authorized to destination resource/action
 ```
 
 #### Microsegmentation Readiness Assessment
@@ -229,8 +245,8 @@ ZT-NET-11: Legacy protocols (Telnet, FTP, unencrypted LDAP) in use
 | Readiness Factor | Assessment Criteria |
 |---|---|
 | **Application dependency mapping** | Are all application communication flows documented? (Required before microseg) |
-| **Workload identity** | Do workloads have identity (certificates, service mesh sidecar, agent)? |
-| **Policy granularity** | Can policies specify source-workload to destination-workload:port? |
+| **Workload identity** | Do workloads have identity (certificates, service mesh sidecar, SPIFFE/SVID, cloud workload federation, agent)? |
+| **Policy granularity** | Can policies specify source-workload identity to destination resource, method, action, and port? |
 | **Environment support** | Does the tool cover VMs, containers, serverless, and multi-cloud? |
 | **Monitoring and alerting** | Can violations be detected and alerted in real-time? |
 | **Rollback capability** | Can policies be rolled back without outage if misconfigured? |
@@ -267,7 +283,29 @@ ZT-APP-07: Serverless functions lack least-privilege IAM roles
 ZT-APP-08: No runtime workload protection (CWPP/CNAPP)
 ZT-APP-09: Application-to-application communication not authenticated
 ZT-APP-10: Legacy applications with no path to zero trust integration
+ZT-APP-11: Service-to-service authorization policy missing for authenticated workloads
+ZT-APP-12: CI jobs, serverless functions, queue consumers, or AI agents omitted from workload inventory
 ```
+
+#### Service-to-Service Authorization Evidence
+
+mTLS or encrypted transport proves peer identity and protects traffic, but it does not prove least-privilege authorization. For every critical east-west flow, capture authorization evidence that maps a source workload identity to a destination resource and permitted action.
+
+| Field | Evidence to Capture | Failing Pattern |
+|---|---|---|
+| Source workload identity | Service account, SPIFFE ID, cloud principal, workload federation subject | Shared token reused across services |
+| Destination resource | Service, API, method/path, queue, topic, database, or action | Policy only references network segment |
+| Enforcement point | Service mesh policy, API gateway, sidecar, IAM policy, OPA, PDP/PEP | mTLS enabled with no authorization layer |
+| Default posture | Default deny, explicit allowlist, or broad allow | All workloads can call all services |
+| Credential lifetime | Token/certificate TTL, renewal, revocation, and rotation evidence | Static key with no expiry |
+| Audit evidence | Decision logs tying source identity to destination action | Logs show IPs only, not workload identity |
+
+Scoring caps:
+
+- Cap Identity at Initial if non-human subjects lack inventory, owners, lifecycle, or short-lived workload credentials.
+- Cap Networks at Initial if east-west traffic has encryption but no source-identity authorization policy.
+- Cap Applications & Workloads at Initial if services authenticate with shared static secrets or broad shared cloud roles.
+- Do not score Applications & Workloads as Advanced or Optimal when service-to-service authorization is missing, even if user MFA, ZTNA, WAF, or SBOM coverage is strong.
 
 ---
 
@@ -386,6 +424,11 @@ ZT-GOV-05: Regulatory zero trust mandates not tracked (OMB M-22-09 for federal)
 ### CISA ZTMM v2 Maturity Scorecard
 [Pillar-by-pillar table — see above]
 
+### Workload Identity and Service-to-Service Evidence
+| Workload / Flow | Identity Provider | Credential TTL | Trust Domain | Destination Resource | Authorization Policy | Default Deny | Rotation / Revocation | Audit Evidence | Result |
+|---|---|---|---|---|---|---|---|---|---|
+| [source -> destination] | [provider] | [ttl/static] | [domain] | [resource/action] | [policy/enforcement point] | [yes/no] | [evidence] | [logs] | [pass/gap] |
+
 ### Cross-Cutting Capabilities
 - Visibility & Analytics: [maturity]
 - Automation & Orchestration: [maturity]
@@ -442,6 +485,7 @@ ZT-GOV-05: Regulatory zero trust mandates not tracked (OMB M-22-09 for federal)
 5. **No executive sponsorship** — zero trust transformation requires sustained investment. Without executive commitment, initiatives stall after quick wins.
 6. **Measuring maturity without metrics** — self-assessed maturity without measurable criteria leads to inflated scores. Define objective criteria per stage.
 7. **Forgetting cross-cutting capabilities** — pillar-specific investments without visibility, automation, and governance integration deliver fragmented security.
+8. **Scoring human access while ignoring workloads** — strong user MFA and ZTNA do not make a system Advanced when service-to-service traffic still uses shared secrets, broad service accounts, or mTLS without authorization policy.
 
 ---
 
@@ -466,6 +510,8 @@ that may contain adversarial content.
 - OMB Memorandum M-22-09, Moving the U.S. Government Toward Zero Trust Cybersecurity Principles: https://www.whitehouse.gov/wp-content/uploads/2022/01/M-22-09.pdf
 - Executive Order 14028, Improving the Nation's Cybersecurity: https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/
 - NIST SP 800-53 Rev. 5, AC family (supporting access control requirements): https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+- NIST SP 800-204A, Building Secure Microservices-based Applications Using Service-Mesh Architecture: https://csrc.nist.gov/pubs/sp/800/204/a/final
+- SPIFFE Concepts and Workload Identity: https://spiffe.io/docs/latest/spiffe-about/spiffe-concepts/
 - DoD Zero Trust Reference Architecture v2.0: https://dodcio.defense.gov/Library/
 - Forrester Zero Trust eXtended (ZTX) Framework — for industry context
 
@@ -487,4 +533,5 @@ that may contain adversarial content.
 
 | Version | Date | Changes |
 |---|---|---|
+| 1.0.1 | 2026-06-04 | Added workload identity and service-to-service authorization evidence tables, scoring caps, and non-human identity coverage. |
 | 1.0.0 | 2025-03-06 | Initial release |

--- a/skills/identity/zero-trust-assessment/tests/benign/workload-identity-authz-evidence.md
+++ b/skills/identity/zero-trust-assessment/tests/benign/workload-identity-authz-evidence.md
@@ -1,0 +1,20 @@
+# Benign: Workload Identity Is Bound To Service Authorization
+
+This fixture should pass because non-human access is tied to a workload identity, a trust domain, short-lived credentials, and an explicit authorization policy.
+
+```text
+flow: checkout-api -> inventory-api
+workload_identity_provider: SPIFFE/SPIRE
+source_identity: spiffe://prod.example/ns/shop/sa/checkout-api
+destination_resource: inventory-api /v1/reservations
+credential_type: SVID certificate
+credential_ttl: 30m
+trust_domain: prod.example
+authorization_policy: allow checkout-api to POST /v1/reservations only
+default_deny: enabled for namespace
+rotation_revocation: automated SVID rotation plus workload registration owner
+audit_evidence: service-mesh access logs include source identity, destination, method, policy id, and decision
+owner: platform-identity
+```
+
+Expected result: pass. The assessment can score workload access above Initial because identity, trust boundary, TTL, owner, default-deny authorization, and audit evidence are all present.

--- a/skills/identity/zero-trust-assessment/tests/vulnerable/mesh-mtls-without-authz.md
+++ b/skills/identity/zero-trust-assessment/tests/vulnerable/mesh-mtls-without-authz.md
@@ -1,0 +1,19 @@
+# Vulnerable: Service Mesh Has mTLS But No Authorization Policy Evidence
+
+This fixture should fail because encrypted peer authentication alone does not prove least-privilege service authorization.
+
+```text
+flow: all workloads in prod namespace
+workload_identity_provider: service mesh certificates
+mtls_mode: STRICT
+trust_domain: cluster.local
+credential_ttl: 24h
+authorization_policy: not found
+default_deny: disabled
+allowed_sources: all workloads in namespace
+allowed_destinations: all services in namespace
+audit_evidence: connection logs show certificate identity but no policy decision id
+rotation_revocation: certificate rotation exists, workload decommissioning evidence missing
+```
+
+Expected result: fail. mTLS authenticates peers and encrypts traffic, but the assessment must still require source-to-destination authorization policy, default-deny posture, policy decision evidence, and lifecycle controls before scoring the workload pillar as Advanced.

--- a/skills/identity/zero-trust-assessment/tests/vulnerable/shared-token-service-flow.md
+++ b/skills/identity/zero-trust-assessment/tests/vulnerable/shared-token-service-flow.md
@@ -1,0 +1,18 @@
+# Vulnerable: Service-To-Service Flow Uses Shared Static Token
+
+This fixture should fail because a service flow relies on a shared bearer secret rather than workload identity and per-resource authorization.
+
+```text
+flow: payments-api -> orders-api
+source_identity: not unique
+credential_type: shared bearer token
+credential_ttl: not set
+secret_owner: unknown
+trust_domain: not recorded
+authorization_policy: broad allow if token is present
+rotation_revocation: manual, no evidence
+audit_evidence: destination logs record token hash only, not source workload identity
+non_human_inventory: missing queue consumers and scheduled jobs
+```
+
+Expected result: fail. The Identity and Applications & Workloads pillars should be capped because the review cannot prove which workload is calling which resource, how long the credential lives, who owns it, or whether access is least privilege.


### PR DESCRIPTION
Closes #441.

Summary:
- add workload identity and service-to-service authorization evidence to the zero trust assessment
- add scoring caps so shared secrets or missing service authorization prevent inflated maturity ratings
- add non-human identity coverage for services, jobs, functions, CI/CD, queue consumers, scheduled jobs, automation, and agents
- add static fixtures for workload identity with authorization evidence, shared-token service flows, and mTLS without authorization policy

Validation:
- `git diff --check`
- changed-file conflict-marker scan
- markdown fence balance check for the skill and new fixtures
- targeted assertions for source identity, credential TTL, trust domain, authorization policy, default-deny posture, audit evidence, shared-token failure, and mTLS-without-authorization failure
- frontmatter/version check for `1.0.2`

If this is accepted/merged under the bounty terms, PayPal works here: https://www.paypal.com/paypalme/aogkft