### PR TITLE
Refresh OWASP LLM risk references

### DIFF
--- a/skills/ai-security/llm-top-10/SKILL.md
+++ b/skills/ai-security/llm-top-10/SKILL.md
@@ -498,12 +498,12 @@ When performing a review using this skill:
 - OWASP LLM AI Security & Governance Checklist: https://genai.owasp.org/llm-top-10/llm-ai-security-and-governance-checklist/
 - OWASP GenAI Project Home: https://genai.owasp.org/
 - LLM01:2025 Prompt Injection: https://genai.owasp.org/llmrisk/llm01-prompt-injection/
-- LLM02:2025 Sensitive Information Disclosure: https://genai.owasp.org/llmrisk/llm02-sensitive-information-disclosure/
-- LLM03:2025 Supply Chain Vulnerabilities: https://genai.owasp.org/llmrisk/llm03-supply-chain-vulnerabilities/
+- LLM02:2025 Sensitive Information Disclosure: https://genai.owasp.org/llmrisk/llm022025-sensitive-information-disclosure/
+- LLM03:2025 Supply Chain Vulnerabilities: https://genai.owasp.org/llmrisk/llm032025-supply-chain/
 - LLM04:2025 Data and Model Poisoning: https://genai.owasp.org/llmrisk/llm04-data-and-model-poisoning/
-- LLM05:2025 Improper Output Handling: https://genai.owasp.org/llmrisk/llm05-improper-output-handling/
-- LLM06:2025 Excessive Agency: https://genai.owasp.org/llmrisk/llm06-excessive-agency/
-- LLM07:2025 System Prompt Leakage: https://genai.owasp.org/llmrisk/llm07-system-prompt-leakage/
-- LLM08:2025 Vector and Embedding Weaknesses: https://genai.owasp.org/llmrisk/llm08-vector-and-embedding-weaknesses/
-- LLM09:2025 Misinformation: https://genai.owasp.org/llmrisk/llm09-misinformation/
-- LLM10:2025 Unbounded Consumption: https://genai.owasp.org/llmrisk/llm10-unbounded-consumption/
+- LLM05:2025 Improper Output Handling: https://genai.owasp.org/llmrisk/llm052025-improper-output-handling/
+- LLM06:2025 Excessive Agency: https://genai.owasp.org/llmrisk/llm062025-excessive-agency/
+- LLM07:2025 System Prompt Leakage: https://genai.owasp.org/llmrisk/llm072025-system-prompt-leakage/
+- LLM08:2025 Vector and Embedding Weaknesses: https://genai.owasp.org/llmrisk/llm082025-vector-and-embedding-weaknesses/
+- LLM09:2025 Misinformation: https://genai.owasp.org/llmrisk/llm092025-misinformation/
+- LLM10:2025 Unbounded Consumption: https://genai.owasp.org/llmrisk/llm102025-unbounded-consumption/


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `llm-top-10`
**Skill path:** `skills/ai-security/llm-top-10/`

Closes #764.

### What Was Wrong

Section 9 still used retired OWASP GenAI risk-category slugs for LLM02, LLM03, and LLM05-LLM10. Those URLs now return HTTP 404. LLM01 and LLM04 still resolve, so this PR leaves them unchanged.

### What This PR Fixes

This PR updates the retired risk-category URLs to the official OWASP LLM Top 10 2025 slugs exposed by the current OWASP index:

- `llm022025-sensitive-information-disclosure`
- `llm032025-supply-chain`
- `llm052025-improper-output-handling`
- `llm062025-excessive-agency`
- `llm072025-system-prompt-leakage`
- `llm082025-vector-and-embedding-weaknesses`
- `llm092025-misinformation`
- `llm102025-unbounded-consumption`

### Evidence

**Before (skill misses this / false positive on this):**
```text
404 https://genai.owasp.org/llmrisk/llm02-sensitive-information-disclosure/
404 https://genai.owasp.org/llmrisk/llm03-supply-chain-vulnerabilities/
404 https://genai.owasp.org/llmrisk/llm05-improper-output-handling/
404 https://genai.owasp.org/llmrisk/llm06-excessive-agency/
404 https://genai.owasp.org/llmrisk/llm07-system-prompt-leakage/
404 https://genai.owasp.org/llmrisk/llm08-vector-and-embedding-weaknesses/
404 https://genai.owasp.org/llmrisk/llm09-misinformation/
404 https://genai.owasp.org/llmrisk/llm10-unbounded-consumption/
```

**After (now correctly handled):**
```text
200 https://genai.owasp.org/llmrisk/llm022025-sensitive-information-disclosure/
200 https://genai.owasp.org/llmrisk/llm032025-supply-chain/
200 https://genai.owasp.org/llmrisk/llm052025-improper-output-handling/
200 https://genai.owasp.org/llmrisk/llm062025-excessive-agency/
200 https://genai.owasp.org/llmrisk/llm072025-system-prompt-leakage/
200 https://genai.owasp.org/llmrisk/llm082025-vector-and-embedding-weaknesses/
200 https://genai.owasp.org/llmrisk/llm092025-misinformation/
200 https://genai.owasp.org/llmrisk/llm102025-unbounded-consumption/
```

Additional checks:
```text
git diff --check passed
Retired risk slugs are absent from skills/ai-security/llm-top-10/SKILL.md
Official OWASP LLM Top 10 index lists the replacement 2025 slugs
```

### Test Cases Added/Updated
- [ ] Added vulnerable test cases (`tests/vulnerable/`) - N/A, documentation reference update
- [ ] Added benign test cases (`tests/benign/`) - N/A, documentation reference update
- [x] Existing tests still pass - `git diff --check` passed and URL/source checks passed

### Bounty Tier
- [x] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [ ] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Can provide privately through the maintainer-approved channel after acceptance.
