### PR TITLE
Add SIEM late-event scheduling evidence

### DIFF
--- a/skills/secops/siem-rules/SKILL.md
+++ b/skills/secops/siem-rules/SKILL.md
@@ -12,7 +12,7 @@ phase: [operate]
 frameworks: [MITRE-ATT&CK-v16]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -56,6 +56,7 @@ Before beginning, gather or confirm:
 - [ ] **Environment baseline:** Normal volume and patterns for the data source (e.g., average daily failed logon count, typical admin logon hours).
 - [ ] **Alert priority and response:** Desired severity level and expected analyst response procedure.
 - [ ] **Performance constraints:** Query time window, maximum execution time, and scheduled frequency.
+- [ ] **Ingestion delay profile:** Expected source latency, platform scheduling delay, and late-event behavior for each log source.
 - [ ] **Existing rules:** Any current rules covering similar detections that may overlap or conflict.
 
 ---
@@ -443,6 +444,10 @@ index=wineventlog sourcetype="WinEventLog:Security" EventCode=4624 LogonType=3
 | `time window` | Aggregation period | `10m`, `1h`, `24h` |
 | `lookback period` | Historical data to evaluate | `ago(1h)`, `ago(24h)` |
 | `frequency` | How often the rule runs | Every 5m, 15m, 1h |
+| `ingestion delay` | Expected source latency before events become searchable | 5m, 20m, 2h |
+| `event/index time choice` | Whether scheduling is driven by event time, ingestion/index time, or both | `TimeGenerated`, `_time`, `_indextime` |
+| `deduplication key` | Entity key used to prevent overlap from creating duplicate incidents | user+ip+rule_window |
+| `backfill posture` | Whether late data is recovered by durable/backfill search | Sentinel delay, Splunk durable search |
 | `suppression window` | Cooldown after firing to prevent duplicate alerts | 1h, 4h, 24h |
 
 **KQL alert rule scheduling (Sentinel Analytics Rule):**
@@ -455,6 +460,33 @@ Event grouping:      Trigger alert for each event / Group all events
 Suppression:         Enabled, 1 hour
 Entity mapping:      Account -> UserPrincipalName, IP -> IPAddress, Host -> Computer
 ```
+
+#### Scheduling and Ingestion Delay Evidence
+
+Scheduled detections must prove they can see late-arriving events without flooding analysts with duplicates. For each scheduled rule, capture the timing evidence below before marking it production-ready:
+
+| Field | Evidence to Capture | Failure Mode |
+|---|---|---|
+| Query frequency | How often the rule runs | Frequency equals lookback while source latency is higher |
+| Lookback overlap | Event-time window queried on each run | No overlap for late-arriving cloud or SaaS logs |
+| Expected source latency | Connector, source, or platform delay by data source | One fast source assumption applied to all logs |
+| Platform delay | Built-in scheduling delay or durable-search setting | Default delay unknown or disabled |
+| Event time vs ingestion/index time | Sentinel `TimeGenerated`, Splunk `_time`, `_indextime`, or `_index_earliest` choice | Search filters only event time when data arrives late |
+| Deduplication / grouping key | Entity tuple, alert grouping, suppression, incident key | Wider lookback creates repeated alerts |
+| Backfill posture | Durable search, replay, manual backfill, or explicit no-backfill rationale | Missed events remain unrecovered after outage or lag |
+| Late-event validation | Synthetic or replayed event with old event time and new ingestion/index time | Only on-time true positives are tested |
+
+Sentinel guidance:
+
+- When connector latency is expected, use a query period longer than the frequency and account for the platform's scheduled-rule delay.
+- Preserve enough overlap to catch events generated in the previous window but ingested after the first run.
+- Pair widened lookback with entity grouping, suppression, or incident keys so overlap does not create duplicate alerts.
+
+Splunk guidance:
+
+- Decide whether the detection should reason over `_time`, `_indextime`, `_index_earliest`, or durable search configuration.
+- Use `_indextime` or durable search where completeness for late-arriving data is more important than pure event-time ordering.
+- Document lag time, schedule window, backfill behavior, and duplicate suppression for each correlation search.
 
 ### Step 5: Detection Rule Lifecycle Management
 
@@ -549,6 +581,17 @@ Produce SIEM rule deliverables in this structure:
 
 ### Validation
 - [How to test the rule produces a true positive]
+- [How to replay or simulate a late-arriving true positive whose event time is inside a prior window but whose ingestion/index time occurs after the first scheduled run]
+
+### Scheduling and Ingestion Delay
+| Field | Value | Rationale |
+|-------|-------|-----------|
+| Query frequency | [Xm/h] | [How often the rule runs] |
+| Lookback period | [Xm/h] | [Why this window covers late data] |
+| Expected source latency | [Xm/h by source] | [Connector/platform evidence] |
+| Event/index time mode | [event time / ingestion time / index time / durable] | [Why this mode is correct] |
+| Deduplication key | [entities + window] | [How overlap avoids duplicate incidents] |
+| Backfill posture | [durable search / replay / manual / none] | [How missed late data is recovered or why not] |
 ```
 
 ---
@@ -632,6 +675,10 @@ Deploying a rule without confirming it fires on known-malicious activity is depl
 
 A detection rule that fires every 5 minutes on the same ongoing activity (e.g., a brute force attack lasting 2 hours) floods the alert queue with duplicates. Configure alert suppression or deduplication to prevent the same incident from generating hundreds of identical alerts. Use suppression windows and entity-based grouping to consolidate related alerts.
 
+### Pitfall 6: Ignoring Late-Arriving Events
+
+A scheduled rule can be logically correct and still miss true positives when the source delivers events after the rule window closes. Cloud control-plane logs, SaaS audit logs, EDR telemetry, firewall batches, and summary indexes often arrive later than their event time. Validate schedule frequency, lookback overlap, ingestion/index-time handling, durable/backfill behavior, and duplicate suppression before calling a rule production-ready.
+
 ---
 
 ## 8. Prompt Injection Safety Notice
@@ -658,3 +705,15 @@ This skill processes user-supplied content that may include SIEM query drafts, l
 8. **MITRE ATT&CK Data Sources** -- https://attack.mitre.org/datasources/
 9. **Sentinel Entity Mapping** -- https://learn.microsoft.com/en-us/azure/sentinel/map-data-fields-to-entities
 10. **Splunk CIM (Common Information Model)** -- https://docs.splunk.com/Documentation/CIM/latest/User/Overview
+11. **Microsoft Sentinel Scheduled Analytics Rules and Ingestion Delay** -- https://learn.microsoft.com/en-us/azure/sentinel/scheduled-rules-overview
+12. **Splunk Durable Scheduled Reports** -- https://help.splunk.com/en/splunk-enterprise/create-dashboards-and-reports/reporting-manual/9.4/report-management/make-scheduled-reports-durable-to-prevent-event-loss
+13. **Splunk Time Modifiers (`_index_earliest`, `_index_latest`)** -- https://help.splunk.com/en/splunk-cloud-platform/search/search-reference/10.4.2604/time-format-variables-and-modifiers/time-modifiers
+
+---
+
+## 10. Version History
+
+| Version | Date | Changes |
+|---|---|---|
+| 1.0.1 | 2026-06-04 | Added scheduling and ingestion-delay evidence, late-event validation, Sentinel/Splunk timing guidance, and output fields. |
+| 1.0.0 | 2025-03-06 | Initial release |

--- a/skills/secops/siem-rules/SKILL.md
+++ b/skills/secops/siem-rules/SKILL.md
@@ -12,7 +12,7 @@ phase: [operate]
 frameworks: [MITRE-ATT&CK-v16]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.2"
+version: "1.0.3"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -589,9 +589,12 @@ Produce SIEM rule deliverables in this structure:
 | Query frequency | [Xm/h] | [How often the rule runs] |
 | Lookback period | [Xm/h] | [Why this window covers late data] |
 | Expected source latency | [Xm/h by source] | [Connector/platform evidence] |
+| Built-in platform delay | [Sentinel delay / Splunk lag / none] | [Scheduler behavior or saved-search setting] |
 | Event/index time mode | [event time / ingestion time / index time / durable] | [Why this mode is correct] |
 | Deduplication key | [entities + window] | [How overlap avoids duplicate incidents] |
 | Backfill posture | [durable search / replay / manual / none] | [How missed late data is recovered or why not] |
+| Late-event validation result | [pass / fail / not evaluated] | [Event ID, event time, ingestion/index time, run time, and alert result] |
+| Not-evaluable reason | [if applicable] | [Missing latency data, scheduler config, or safe replay method] |
 ```
 
 ---
@@ -715,6 +718,7 @@ This skill processes user-supplied content that may include SIEM query drafts, l
 
 | Version | Date | Changes |
 |---|---|---|
+| 1.0.3 | 2026-06-05 | Added explicit built-in platform delay, late-event validation result, and not-evaluable reason fields to the scheduling output template. |
 | 1.0.2 | 2026-06-05 | Added late-event scheduling fixtures for safe overlap/dedup handling, Sentinel connector latency gaps, and Splunk event-time-only searches. |
 | 1.0.1 | 2026-06-04 | Added scheduling and ingestion-delay evidence, late-event validation, Sentinel/Splunk timing guidance, and output fields. |
 | 1.0.0 | 2025-03-06 | Initial release |

--- a/skills/secops/siem-rules/SKILL.md
+++ b/skills/secops/siem-rules/SKILL.md
@@ -12,7 +12,7 @@ phase: [operate]
 frameworks: [MITRE-ATT&CK-v16]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.1"
+version: "1.0.2"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -715,5 +715,6 @@ This skill processes user-supplied content that may include SIEM query drafts, l
 
 | Version | Date | Changes |
 |---|---|---|
+| 1.0.2 | 2026-06-05 | Added late-event scheduling fixtures for safe overlap/dedup handling, Sentinel connector latency gaps, and Splunk event-time-only searches. |
 | 1.0.1 | 2026-06-04 | Added scheduling and ingestion-delay evidence, late-event validation, Sentinel/Splunk timing guidance, and output fields. |
 | 1.0.0 | 2025-03-06 | Initial release |

--- a/skills/secops/siem-rules/tests/benign/overlap-dedup-late-arrival.md
+++ b/skills/secops/siem-rules/tests/benign/overlap-dedup-late-arrival.md
@@ -1,0 +1,19 @@
+# Benign: Scheduled Rule Uses Overlap With Deduplication
+
+This fixture should pass because the scheduled detection accounts for expected connector latency and prevents duplicate incidents.
+
+```text
+platform: Microsoft Sentinel
+source: Entra ID SigninLogs
+query_frequency: 5m
+lookback_period: 30m
+expected_source_latency: p95 12m, p99 18m
+built_in_platform_delay: 5m
+event_time_field: TimeGenerated
+deduplication_key: IPAddress + ResultType + bin(TimeGenerated, 10m)
+suppression_window: 30m
+late_event_validation: synthetic sign-in event arrived 14m after event time and still matched on the second run
+owner: identity-detections
+```
+
+Expected result: pass. The frequency, lookback, latency evidence, platform delay, deduplication key, suppression window, and late-event validation are all recorded, so the overlap is deliberate rather than accidental duplicate noise.

--- a/skills/secops/siem-rules/tests/vulnerable/sentinel-equal-window-late-logs.md
+++ b/skills/secops/siem-rules/tests/vulnerable/sentinel-equal-window-late-logs.md
@@ -1,0 +1,23 @@
+# Vulnerable: Sentinel Rule Uses Frequency-Equal Lookback For Delayed Logs
+
+This fixture should fail because the rule only looks back as far as its run frequency while the data source commonly arrives later than that window.
+
+```text
+platform: Microsoft Sentinel
+source: Entra ID SigninLogs
+query_frequency: 5m
+lookback_period: 5m
+expected_source_latency: 6m to 20m for the connector
+built_in_platform_delay: not recorded
+deduplication_key: not recorded
+late_event_validation: not performed
+```
+
+```kql
+SigninLogs
+| where TimeGenerated between (ago(5m) .. now())
+| where ResultType != 0
+| summarize Attempts=count() by IPAddress, bin(TimeGenerated, 5m)
+```
+
+Expected result: fail. A true positive whose event time is inside the prior five-minute window but whose ingestion occurs after that run can be skipped, and there is no overlap, platform-delay evidence, or duplicate-suppression design.

--- a/skills/secops/siem-rules/tests/vulnerable/splunk-event-time-only-o365.md
+++ b/skills/secops/siem-rules/tests/vulnerable/splunk-event-time-only-o365.md
@@ -1,0 +1,23 @@
+# Vulnerable: Splunk Search Ignores Index-Time Lag For Batch Source
+
+This fixture should fail because a scheduled search uses only event time for a batch-delivered source without durable-search or index-time coverage.
+
+```text
+platform: Splunk Enterprise Security
+source: Microsoft 365 audit logs
+schedule: every 15m
+event_time_window: earliest=-15m latest=now
+index_time_window: not used
+durable_search: disabled
+lag_time: not configured
+deduplication_key: UserId + ClientIP + Operation
+late_event_validation: missing
+```
+
+```spl
+index=o365 sourcetype="o365:management:activity" earliest=-15m latest=now Operation=UserLoggedIn
+| stats count min(_time) as first_event max(_time) as last_event by UserId, ClientIP
+| where count > 5
+```
+
+Expected result: fail. The rule can miss events that are indexed after the scheduled event-time window closes. The review should require `_indextime` or durable-search evidence, lag-time reasoning, and a replayed late-arrival test before calling the rule production-ready.


### PR DESCRIPTION
Closes #438.

Summary:
- add scheduling and ingestion-delay evidence requirements for SIEM rules
- add Sentinel and Splunk late-event guidance for lookback, index/ingestion time, durable search, and deduplication
- add static fixtures for safe overlap/dedup handling, Sentinel equal-window late-log gaps, and Splunk event-time-only batch-source gaps
- add output fields, validation requirement, references, and version history
- clarify the output template with built-in platform delay, late-event validation result, and not-evaluable reason fields

Validation:
- `git diff --check origin/main...HEAD`
- changed-file conflict-marker scan
- markdown fence balance check for the skill and new fixtures
- targeted assertions for query frequency, lookback, source latency, built-in platform delay, deduplication, late-event validation, not-evaluable reason, durable search, lag time, and `_indextime`
- frontmatter required-key check for all 50 `SKILL.md` files
- index path existence check: 50 indexed file paths, 0 missing
- ASCII check for all changed files
- frontmatter/version check for `1.0.3`

If this is accepted/merged under the bounty terms, PayPal works here: https://www.paypal.com/paypalme/aogkft