### PR TITLE
Refresh AI security OWASP LLM references

### DIFF
--- a/skills/ai-security/ai-data-privacy/SKILL.md
+++ b/skills/ai-security/ai-data-privacy/SKILL.md
@@ -477,7 +477,7 @@ user input -> prompt assembly -> LLM API -> completion -> output -> logging/stor
 ## References
 
 - NIST AI Risk Management Framework 1.0 (January 2023) -- https://www.nist.gov/aiframework
-- OWASP Top 10 for LLM Applications (2025), LLM02: Sensitive Information Disclosure -- https://genai.owasp.org/llmrisk/llm02-sensitive-information-disclosure/
+- OWASP Top 10 for LLM Applications (2025), LLM02: Sensitive Information Disclosure -- https://genai.owasp.org/llmrisk/llm022025-sensitive-information-disclosure/
 - EU AI Act, Regulation (EU) 2024/1689 -- https://eur-lex.europa.eu/eli/reg/2024/1689
 - GDPR, Regulation (EU) 2016/679 -- https://eur-lex.europa.eu/eli/reg/2016/679
 - CCPA/CPRA, California Civil Code Sec. 1798.100-199 -- https://leginfo.legislature.ca.gov/

--- a/skills/ai-security/model-supply-chain/SKILL.md
+++ b/skills/ai-security/model-supply-chain/SKILL.md
@@ -445,7 +445,7 @@ Assess whether architectural and procedural controls exist to detect model backd
 
 ## References
 
-- OWASP Top 10 for LLM Applications (2025), LLM03: Supply Chain Vulnerabilities -- https://genai.owasp.org/llmrisk/llm03-supply-chain-vulnerabilities/ (Note: LLM03 in the 2025 edition covers supply chain; verify current numbering at https://genai.owasp.org)
+- OWASP Top 10 for LLM Applications (2025), LLM03: Supply Chain Vulnerabilities -- https://genai.owasp.org/llmrisk/llm032025-supply-chain/ (Note: LLM03 in the 2025 edition covers supply chain; verify current numbering at https://genai.owasp.org)
 - SLSA v1.0 Specification -- https://slsa.dev/spec/v1.0/
 - MITRE ATLAS -- https://atlas.mitre.org
 - Mithril Security. "PoisonGPT: How We Hid a Lobotomized LLM on Hugging Face to Spread Fake News" (2023) -- https://blog.mithrilsecurity.io/poisongpt-how-we-hid-a-lobotomized-llm-on-hugging-face-to-spread-fake-news/


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill names:** `ai-data-privacy`, `model-supply-chain`
**Skill paths:**
- `skills/ai-security/ai-data-privacy/SKILL.md`
- `skills/ai-security/model-supply-chain/SKILL.md`

Closes #768.

### What Was Wrong
Two AI-security skill references still used retired OWASP GenAI 2025 LLM risk slugs:

- `https://genai.owasp.org/llmrisk/llm02-sensitive-information-disclosure/` returns HTTP 404
- `https://genai.owasp.org/llmrisk/llm03-supply-chain-vulnerabilities/` returns HTTP 404

### What This PR Fixes
This PR replaces those stale references with the current official OWASP GenAI 2025 pages:

- `https://genai.owasp.org/llmrisk/llm022025-sensitive-information-disclosure/`
- `https://genai.owasp.org/llmrisk/llm032025-supply-chain/`

The patch is intentionally limited to the two dead reference URLs.

### Evidence
**Before:**
```text
404 https://genai.owasp.org/llmrisk/llm02-sensitive-information-disclosure/
404 https://genai.owasp.org/llmrisk/llm03-supply-chain-vulnerabilities/
```

**After:**
```text
200 https://genai.owasp.org/llmrisk/llm022025-sensitive-information-disclosure/
200 https://genai.owasp.org/llmrisk/llm032025-supply-chain/
```

Additional validation:
- `git diff --check` passed
- retired `llm02-sensitive-information-disclosure` / `llm03-supply-chain-vulnerabilities` slugs are absent from the touched files
- focused duplicate searches found no issue for this two-skill stale-reference scope; the only open PR hit for the old slugs is my separate `llm-top-10` reference-list PR #765

### Test Cases Added/Updated
- [ ] Added vulnerable test cases (`tests/vulnerable/`)
- [ ] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass / not applicable for a reference-only documentation update

### Bounty Tier
- [x] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [ ] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** can be provided privately after maintainer acceptance
