### PR TITLE
Add NuGet license evidence gates

### DIFF
--- a/skills/appsec/dependency-scanning/SKILL.md
+++ b/skills/appsec/dependency-scanning/SKILL.md
@@ -141,6 +141,17 @@ Not all CVEs carry equal operational risk. Use a three-signal triage model to pr
 4. **Dual-licensed commercial packages**: Some packages offer open-source licenses for non-commercial use and require a commercial license otherwise (e.g., certain database drivers, UI component libraries). Verify that the usage context matches the chosen license.
 5. **No-license dependencies**: Packages without a declared license default to full copyright protection. They cannot be legally redistributed. Replace or obtain explicit permission.
 
+### License Evidence Gates
+
+Before downgrading license risk, preserve the evidence source and decision record instead of relying on a single scanner label:
+
+- **Evidence source:** Record whether the license came from SPDX expression metadata, registry metadata, embedded package license file, SBOM component license, deprecated license URL, or scanner inference.
+- **Evidence status:** Mark each finding as verified, conflicting, URL-only, NOASSERTION, missing, or requires legal review.
+- **Usage context:** Record runtime, build-only, test-only, distributed binary, internal service, hosted SaaS, or embedded/client-side use because copyleft obligations can depend on deployment context.
+- **Dual-license decision:** For expressions such as `MIT OR Apache-2.0`, `GPL-2.0-only OR commercial`, or `AGPL-3.0-only OR commercial`, record the selected branch, entitlement or approval evidence, approver, and date.
+- **Conflict handling:** If registry metadata and embedded license files disagree, treat the result as conflicting until reviewed. Do not suppress the finding based only on the more permissive source.
+- **Fail closed:** Treat deprecated URL-only license metadata, `NOASSERTION`, missing license fields, and unstructured scanner output as unresolved evidence until a verified license source or legal decision record exists.
+
 ### Tooling
 
 - `licensed` (GitHub): Caches and verifies dependency licenses in CI.
@@ -201,9 +212,9 @@ When performing a dependency scan, produce findings in the following structure:
 
 ### License Findings
 
-| # | Package | Version | License | Risk Level | Action Required |
-|---|---------|---------|---------|------------|-----------------|
-| 1 | ...     | ...     | ...     | ...        | ...             |
+| # | Package | Version | License | Evidence Source | Evidence Status | Usage Context | Decision Record | Risk Level | Action Required |
+|---|---------|---------|---------|-----------------|-----------------|---------------|-----------------|------------|-----------------|
+| 1 | ...     | ...     | ...     | SPDX expression / registry / embedded file / SBOM / URL-only / scanner inference | verified / conflicting / NOASSERTION / missing / legal-review | runtime / build / test / SaaS / distributed | selected branch, entitlement, approver, date | ... | ... |
 
 ### Supply Chain Risk Indicators
 
@@ -224,7 +235,7 @@ When performing a dependency scan, produce findings in the following structure:
 2. **Inventory dependencies**: Read manifest files to enumerate direct dependencies and their declared version ranges.
 3. **Analyze lockfiles**: Read lockfiles to map the full transitive dependency tree with pinned versions.
 4. **Vulnerability scan**: Cross-reference packages and versions against known CVE databases. Apply the EPSS+CVSS+KEV triage model.
-5. **License audit**: Extract license declarations from lockfiles or registry metadata. Flag copyleft and unlicensed packages.
+5. **License audit**: Extract license declarations from lockfiles, registry metadata, package license files, and SBOM components. Preserve evidence source/status, usage context, and decision records before accepting dual-license or URL-only metadata.
 6. **Typosquatting check**: Review dependency names for patterns described in the detection section.
 7. **Supply chain assessment**: Evaluate SLSA posture -- lockfile presence, pinned versions, provenance availability.
 8. **Report**: Produce the assessment using the output template above, with prioritized remediation recommendations.

--- a/skills/appsec/dependency-scanning/csharp-dotnet.md
+++ b/skills/appsec/dependency-scanning/csharp-dotnet.md
@@ -337,6 +337,64 @@ NuGet packages declare licenses in two ways:
 - Dual-licensed packages (e.g., `MIT OR Apache-2.0`) require verifying which license applies to your usage.
 - Some packages embed a `LICENSE.md` file in the `.nupkg` — verify its contents match the declared expression.
 
+### NuGet License Evidence Gates
+
+For every NuGet package with license risk or ambiguous metadata, record these fields before closing the finding:
+
+| Field | Required evidence |
+|---|---|
+| Package identity | Package ID, version, source feed, direct/transitive scope, and project or solution path |
+| License evidence source | `PackageLicenseExpression`, embedded license file, `licenseUrl`, SBOM component license, or scanner inference |
+| License evidence status | Verified, conflicting, URL-only, `NOASSERTION`, missing, or legal-review required |
+| Usage context | Runtime, build-only, test-only, distributed binary, internal service, hosted SaaS/API, or client-side component |
+| Decision record | Selected license branch, commercial entitlement, legal/security approver, approval date, and review expiry |
+
+Benign dual-license example:
+
+```json
+{
+  "package": "Example.Library",
+  "version": "3.4.5",
+  "license": "MIT OR Apache-2.0",
+  "license_evidence_source": "PackageLicenseExpression",
+  "license_evidence_status": "verified",
+  "usage_context": "runtime",
+  "decision_record": {
+    "selected_license": "MIT",
+    "approved_by": "security@example.invalid",
+    "approved_at": "2026-06-05"
+  }
+}
+```
+
+Vulnerable or unresolved examples:
+
+```json
+{
+  "package": "Contoso.ReportEngine",
+  "version": "4.2.0",
+  "license": "AGPL-3.0-only",
+  "usage_context": "hosted SaaS/API",
+  "decision_record": null
+}
+```
+
+```json
+{
+  "package": "Acme.LegacyParser",
+  "version": "2.9.1",
+  "license": "NOASSERTION",
+  "license_evidence_source": "scanner inference",
+  "license_evidence_status": "NOASSERTION"
+}
+```
+
+```xml
+<licenseUrl>https://example.invalid/license</licenseUrl>
+```
+
+Treat deprecated `licenseUrl` metadata as URL-only evidence until the package license file or a verified SPDX expression is captured. If NuGet registry metadata and the embedded `.nupkg` license file conflict, keep the finding open for legal review instead of choosing the more permissive value.
+
 ## .NET-Specific Transitive Dependency Analysis
 
 ### Viewing the Full Dependency Tree
@@ -407,6 +465,10 @@ Add these to the supply chain risk indicators when scanning a .NET project:
 - [ ] Central Package Management enabled via `Directory.Packages.props` for multi-project solutions
 - [ ] `<NuGetAudit>true</NuGetAudit>` set in `Directory.Build.props` or individual project files
 - [ ] NuGet audit warnings (NU1901-NU1904) treated as errors in CI builds
+- [ ] NuGet license findings include evidence source, evidence status, usage context, and decision record fields
+- [ ] Deprecated `licenseUrl`, `NOASSERTION`, and missing license metadata remain unresolved until verified by package file, SPDX expression, SBOM component, or legal approval
+- [ ] Dual-license packages record the selected branch, entitlement or approver, approval date, and review expiry
+- [ ] AGPL or strong-copyleft runtime dependencies in hosted SaaS/API paths have legal approval or source-disclosure decision evidence
 - [ ] SDK version pinned in `global.json` with `rollForward` set to `latestPatch` or `disable`
 - [ ] `<clear />` present in `nuget.config` `<packageSources>` to prevent config inheritance
 - [ ] No `<EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>` in any project file


### PR DESCRIPTION
## Summary
- Add license evidence gates to dependency-scanning so license risk decisions preserve evidence source, evidence status, usage context, and decision records.
- Add NuGet-specific guidance for PackageLicenseExpression, deprecated licenseUrl, embedded license files, NOASSERTION, dual-license branch selection, and AGPL SaaS/API usage.
- Expand the license findings report template and .NET assessment checklist so unresolved or URL-only metadata stays open until verified.

Closes #686

## Validation
- `git diff --check`
- content assertions for License Evidence Gates, NuGet License Evidence Gates, PackageLicenseExpression, licenseUrl, NOASSERTION, usage context, decision record, hosted SaaS/API, AGPL-3.0-only, dual-license examples, evidence source, and evidence status
- skill/index metadata check for dependency-scanning
- markdown code fence balance check across touched files
- staged diff prompt-injection scan found no injected instruction patterns
