### PR TITLE
Improve dependency-scanning NuGet license evidence gates

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -67,7 +67,7 @@ skills:
 
   - id: dependency-scanning
     name: "Dependency Scanning & SBOM Analysis"
-    tags: [appsec, supply-chain, sbom, dependencies]
+    tags: [appsec, supply-chain, sbom, dependencies, license]
     role: [appsec-engineer, security-engineer]
     phase: [build, deploy]
     activity: [review, assess]

--- a/skills/appsec/dependency-scanning/SKILL.md
+++ b/skills/appsec/dependency-scanning/SKILL.md
@@ -6,7 +6,7 @@ description: >
   requirements.txt, go.mod, pom.xml, Cargo.toml) are shared or when discussing
   dependency security. Produces an SBOM assessment with CVE findings triaged
   by EPSS and CISA KEV, license compliance check, and supply chain risk rating.
-tags: [appsec, supply-chain, sbom, dependencies]
+tags: [appsec, supply-chain, sbom, dependencies, license]
 role: [appsec-engineer, security-engineer]
 phase: [build, deploy]
 frameworks: [SLSA-v1.0, CycloneDX, SPDX, CISA-KEV]
@@ -141,6 +141,24 @@ Not all CVEs carry equal operational risk. Use a three-signal triage model to pr
 4. **Dual-licensed commercial packages**: Some packages offer open-source licenses for non-commercial use and require a commercial license otherwise (e.g., certain database drivers, UI component libraries). Verify that the usage context matches the chosen license.
 5. **No-license dependencies**: Packages without a declared license default to full copyright protection. They cannot be legally redistributed. Replace or obtain explicit permission.
 
+### License Evidence Gates
+
+Do not downgrade license risk until the scan records the evidence source, evidence status, usage context, and any decision record needed to support the result.
+
+| Gate | Required evidence | Fail condition |
+|---|---|---|
+| Evidence source | SPDX expression, SBOM component license, registry metadata, embedded license file, or approved legal record | URL-only metadata, unstructured scanner text, or missing source |
+| Evidence status | `verified`, `legacy-url-only`, `conflict`, `noassertion`, `missing`, or `needs-legal-review` | Any status other than `verified` without a remediation action |
+| Usage context | Runtime, build-only, test-only, distributed client, SaaS/server, internal tool | AGPL/GPL/commercial packages without deployment and distribution context |
+| Decision record | Selected license branch, approver, approval date, entitlement reference, or source-disclosure decision | Dual-license, commercial, AGPL SaaS, or missing-license cases without an explicit decision |
+
+Apply these rules consistently:
+
+- Treat `NOASSERTION`, missing license data, and URL-only license metadata as unresolved evidence, not as verified permissive licenses.
+- If registry metadata conflicts with an embedded license file, classify the package as `needs-legal-review` until the conflict is resolved.
+- For dual-license expressions such as `MIT OR Apache-2.0` or `GPL-2.0-only OR commercial`, record the selected license branch and the decision record that makes that branch valid for the project.
+- For AGPL dependencies in SaaS or hosted API paths, require legal approval or a source-disclosure decision before marking the finding accepted.
+
 ### Tooling
 
 - `licensed` (GitHub): Caches and verifies dependency licenses in CI.
@@ -201,14 +219,15 @@ When performing a dependency scan, produce findings in the following structure:
 
 ### License Findings
 
-| # | Package | Version | License | Risk Level | Action Required |
-|---|---------|---------|---------|------------|-----------------|
-| 1 | ...     | ...     | ...     | ...        | ...             |
+| # | Package | Version | License | Evidence Source | Evidence Status | Usage Context | Decision Record | Risk Level | Action Required |
+|---|---------|---------|---------|-----------------|-----------------|---------------|-----------------|------------|-----------------|
+| 1 | ...     | ...     | ...     | ...             | ...             | ...           | ...             | ...        | ...             |
 
 ### Supply Chain Risk Indicators
 
 - [ ] Typosquatting risk detected
 - [ ] Packages with no license
+- [ ] Packages with `NOASSERTION`, URL-only, or conflicting license evidence
 - [ ] Packages with install scripts
 - [ ] Unmaintained packages (no release in 2+ years)
 - [ ] Dependency confusion risk (internal name collisions)
@@ -224,7 +243,7 @@ When performing a dependency scan, produce findings in the following structure:
 2. **Inventory dependencies**: Read manifest files to enumerate direct dependencies and their declared version ranges.
 3. **Analyze lockfiles**: Read lockfiles to map the full transitive dependency tree with pinned versions.
 4. **Vulnerability scan**: Cross-reference packages and versions against known CVE databases. Apply the EPSS+CVSS+KEV triage model.
-5. **License audit**: Extract license declarations from lockfiles or registry metadata. Flag copyleft and unlicensed packages.
+5. **License audit**: Extract license declarations from lockfiles, SBOMs, registry metadata, and embedded license files. Record evidence source/status, usage context, and decision records before downgrading risk. Flag copyleft, unlicensed, `NOASSERTION`, URL-only, conflicting, AGPL SaaS, and unresolved dual-license packages.
 6. **Typosquatting check**: Review dependency names for patterns described in the detection section.
 7. **Supply chain assessment**: Evaluate SLSA posture -- lockfile presence, pinned versions, provenance availability.
 8. **Report**: Produce the assessment using the output template above, with prioritized remediation recommendations.

--- a/skills/appsec/dependency-scanning/csharp-dotnet.md
+++ b/skills/appsec/dependency-scanning/csharp-dotnet.md
@@ -337,6 +337,38 @@ NuGet packages declare licenses in two ways:
 - Dual-licensed packages (e.g., `MIT OR Apache-2.0`) require verifying which license applies to your usage.
 - Some packages embed a `LICENSE.md` file in the `.nupkg` — verify its contents match the declared expression.
 
+### NuGet License Evidence Gates
+
+NuGet license reviews must preserve the source and quality of the license evidence before lowering risk. A license report should carry these fields for every direct and runtime transitive package:
+
+```json
+{
+  "package": "Example.Library",
+  "version": "3.4.5",
+  "license": "MIT OR Apache-2.0",
+  "license_evidence_source": "PackageLicenseExpression",
+  "license_evidence_status": "verified",
+  "usage_context": "runtime",
+  "decision_record": {
+    "selected_license": "MIT",
+    "approved_by": "legal@example.invalid",
+    "approved_date": "2026-06-04"
+  }
+}
+```
+
+| NuGet evidence case | Required handling |
+|---|---|
+| `<PackageLicenseExpression>` with a valid SPDX expression | Mark `license_evidence_source=PackageLicenseExpression`; verify the expression is still compatible with project usage. |
+| Legacy `<licenseUrl>` only | Mark `license_evidence_status=legacy-url-only`; do not treat it as verified until the license text is captured and reviewed. |
+| `NOASSERTION`, empty, or missing license data | Mark high risk with `license_evidence_status=noassertion` or `missing`; require replacement, vendor clarification, or legal approval. |
+| Embedded `.nupkg` license conflicts with registry metadata | Mark `license_evidence_status=conflict`; escalate for legal review before accepting. |
+| Dual-license expression using `OR` | Record the selected branch and decision record; do not automatically choose the most permissive branch. |
+| AGPL package used by a hosted API or SaaS service | Require legal approval or a source-disclosure decision before marking accepted. |
+| Commercial entitlement branch | Record an entitlement reference or approval record, but do not store secrets, license keys, or contract files in the report. |
+
+Scanner output that collapses these states into one unstructured `license` string is not enough to close the finding. Keep the raw scanner value, normalized SPDX expression, evidence status, and decision record side by side.
+
 ## .NET-Specific Transitive Dependency Analysis
 
 ### Viewing the Full Dependency Tree
@@ -411,6 +443,9 @@ Add these to the supply chain risk indicators when scanning a .NET project:
 - [ ] `<clear />` present in `nuget.config` `<packageSources>` to prevent config inheritance
 - [ ] No `<EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>` in any project file
 - [ ] NuGet prefix reservation claimed for internal package namespaces
+- [ ] License evidence source/status recorded for direct and runtime transitive packages
+- [ ] `licenseUrl`, `NOASSERTION`, missing, and conflicting license evidence triaged
+- [ ] Dual-license and commercial-entitlement decisions documented without secrets
 
 ## References
 


### PR DESCRIPTION
## Summary
- add license evidence gates to dependency-scanning before license risk can be downgraded
- expand the report template with evidence source/status, usage context, and decision record fields
- add NuGet-specific handling for `PackageLicenseExpression`, legacy `licenseUrl`, `NOASSERTION`, embedded license conflicts, dual-license choices, AGPL SaaS usage, and commercial entitlement branches

## Review issue
Addresses UnitOneAI/SecuritySkills#686.

## Validation
- `git diff --check`
- Markdown fence balance checked for `skills/appsec/dependency-scanning/SKILL.md` and `skills/appsec/dependency-scanning/csharp-dotnet.md`