### PR TITLE
Add SSRF final destination evidence gates

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -43,7 +43,7 @@ skills:
 
   - id: owasp-top-10-web
     name: "OWASP Top 10 Web Application Review"
-    tags: [appsec, web, owasp]
+    tags: [appsec, web, owasp, ssrf]
     role: [appsec-engineer, security-engineer]
     phase: [build, review]
     activity: [review, test]

--- a/skills/appsec/owasp-top-10-web/SKILL.md
+++ b/skills/appsec/owasp-top-10-web/SKILL.md
@@ -6,7 +6,7 @@ description: >
   when a user asks for a general security review of a web application. Produces
   structured findings mapped to A01-A10 with CWE references, severity ratings,
   and specific remediation guidance.
-tags: [appsec, web, owasp]
+tags: [appsec, web, owasp, ssrf]
 role: [appsec-engineer, security-engineer]
 phase: [build, review]
 frameworks: [OWASP-Top-10-2021]
@@ -589,6 +589,22 @@ url=|dest=|redirect=|uri=|callback=|src=.*http
 - Disable HTTP redirects in server-side HTTP clients, or re-validate the destination after each redirect.
 - Deploy network-level segmentation so the application server cannot reach internal services it does not need.
 - For webhook features, validate callback URLs at registration time and again at invocation time (DNS rebinding defense).
+
+**Effective Destination Evidence Gates:**
+
+Do not classify a server-side URL fetch as safe or unsafe from the sink call alone. Record evidence that the actual outbound request path constrains the effective destination at time of use.
+
+| Gate | Required evidence | Common failure |
+|------|-------------------|----------------|
+| Scheme and port | Explicit allowlist, usually `https` and approved ports only | Accepting any absolute URL or silently normalizing unsupported schemes |
+| Host allowlist | Exact host or tenant-specific allowlist checked on the same code path as the request | String contains/suffix checks, wildcard host patterns, or helper not invoked before the sink |
+| DNS/IP validation | All resolved addresses checked immediately before sending the request | Registration-time-only validation, single-address checks, or no DNS rebinding defense |
+| Restricted ranges | IPv4, IPv6, loopback, link-local, RFC1918, unique-local, and cloud metadata endpoints denied | IPv4-only checks that miss IPv6 or `169.254.169.254` equivalents |
+| Redirect handling | Redirects disabled, or every redirect target re-enters the same allowlist and DNS/IP validation | HTTP client follows redirects after only the initial URL was checked |
+| Invocation-time validation | Webhook/callback URLs revalidated when invoked, not only when registered | Stored URL passes once and later resolves to a restricted address |
+| Egress controls | Network policy, firewall, service mesh, or proxy rules block internal destinations from the app server | App-layer validation is the only control |
+
+Benign SSRF findings require positive evidence for these gates. Vulnerable findings should cite which gate is missing, not just that an HTTP client receives a URL-like value.
 
 ---
 

--- a/skills/appsec/owasp-top-10-web/csharp-dotnet.md
+++ b/skills/appsec/owasp-top-10-web/csharp-dotnet.md
@@ -1127,7 +1127,9 @@ public async Task<IActionResult> Fetch(
     if (!allowedHosts.Contains(uri.Host, StringComparer.OrdinalIgnoreCase))
         return BadRequest("Host not in allowlist");
 
-    var client = httpClientFactory.CreateClient("external");
+    // Use a named client whose primary handler disables automatic redirects,
+    // or re-run the same validation on every redirect target.
+    var client = httpClientFactory.CreateClient("external-no-redirects");
     var response = await client.GetStringAsync(uri);
     return Ok(response);
 }
@@ -1135,15 +1137,38 @@ public async Task<IActionResult> Fetch(
 private static bool IsPrivateOrReserved(IPAddress ip)
 {
     byte[] bytes = ip.GetAddressBytes();
-    return ip.IsIPv6LinkLocal
-        || ip.IsIPv6SiteLocal
-        || IPAddress.IsLoopback(ip)
-        || (bytes[0] == 10)                                          // 10.0.0.0/8
+    if (IPAddress.IsLoopback(ip) || ip.IsIPv6LinkLocal || ip.IsIPv6SiteLocal)
+        return true;
+
+    if (ip.AddressFamily == AddressFamily.InterNetworkV6)
+        return (bytes[0] & 0xfe) == 0xfc; // fc00::/7 unique local
+
+    return (bytes[0] == 10)                                          // 10.0.0.0/8
         || (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31)    // 172.16.0.0/12
         || (bytes[0] == 192 && bytes[1] == 168)                     // 192.168.0.0/16
         || (bytes[0] == 169 && bytes[1] == 254);                    // 169.254.0.0/16 (link-local / cloud metadata)
 }
 ```
+
+Configure the named client so redirects cannot bypass the allowlist:
+
+```csharp
+builder.Services.AddHttpClient("external-no-redirects")
+    .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
+    {
+        AllowAutoRedirect = false
+    });
+```
+
+**SSRF evidence checklist for .NET reviews:**
+
+- [ ] The sink uses the validated `Uri` object, not the original string.
+- [ ] Scheme, host, and port are allowlisted on the same path that sends the request.
+- [ ] `Dns.GetHostAddressesAsync` or equivalent runs at invocation time, including webhook delivery time.
+- [ ] Every resolved IPv4 and IPv6 address is checked for loopback, link-local, RFC1918, unique-local, and metadata-service ranges.
+- [ ] `HttpClientHandler` or `SocketsHttpHandler` disables automatic redirects, or each redirect target is revalidated before following it.
+- [ ] Network egress policy or firewall rules also block access to internal-only destinations.
+- [ ] A helper such as `safeFetch` or `ValidateUrl` is verified to be called immediately before `GetAsync`, `PostAsync`, `SendAsync`, or `GetStringAsync`.
 
 ---
 


### PR DESCRIPTION
## Summary
- add SSRF effective-destination evidence gates to the OWASP web review skill
- require evidence for scheme/host allowlists, DNS/IP checks at time of use, restricted ranges, redirect handling, invocation-time validation, and egress controls
- update the .NET SSRF example to use a no-redirect named client and add a .NET-specific evidence checklist

## Review issue
Addresses UnitOneAI/SecuritySkills#661.

## Validation
- `git diff --check`
- Markdown fence balance checked for `skills/appsec/owasp-top-10-web/SKILL.md` and `skills/appsec/owasp-top-10-web/csharp-dotnet.md`