### PR TITLE
Clarify pipeline GitHub token default permissions

### DIFF
--- a/skills/devsecops/pipeline-security/SKILL.md
+++ b/skills/devsecops/pipeline-security/SKILL.md
@@ -184,16 +184,20 @@ environment:
 
 **What to look for:**
 
-- Overly permissive `permissions` blocks in GitHub Actions (or absence of permissions, which defaults to read-write).
+- Overly permissive `permissions` blocks in GitHub Actions.
+- Missing `permissions` blocks when the enterprise, organization, or repository default workflow permission is unknown or set to read/write.
 - Use of `permissions: write-all` or top-level write permissions without scoping.
 - Shared service accounts across environments.
 - Missing `CODEOWNERS` file or broad ownership patterns.
-- Workflows that do not pin the `GITHUB_TOKEN` to minimum required permissions.
+- Workflows that do not scope the `GITHUB_TOKEN` to minimum required permissions.
+- `pull_request_target` workflows, where the `GITHUB_TOKEN` is granted read/write repository permission unless explicitly reduced.
 
 **Specific patterns in GitHub Actions:**
 
 ```yaml
-# BAD: No permissions block (defaults to read-write for everything)
+# RISKY: No permissions block. Effective permission inherits the enterprise,
+# organization, or repository default workflow permission, so the reviewer must
+# verify whether the default is read-only or read/write.
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -207,7 +211,17 @@ permissions:
   packages: write
 ```
 
-**Finding format:** Report the effective permission model, whether least-privilege is enforced, and whether identity controls (CODEOWNERS, required reviewers) are in place.
+**Default-permission evidence to record:**
+
+| Evidence | Pass / Fail / Not Evaluable |
+|---|---|
+| Top-level workflow `permissions` block present | Pass / Fail |
+| Job-level `permissions` blocks narrow broader workflow defaults | Pass / Fail / Not Evaluable |
+| Repository/organization default workflow permission verified as read-only | Pass / Fail / Not Evaluable |
+| `pull_request_target` workflows explicitly reduce permissions | Pass / Fail / Not Evaluable |
+| Write scopes map to the minimum job requirement | Pass / Fail / Not Evaluable |
+
+**Finding format:** Report the effective permission model, whether least-privilege is enforced, whether the platform default workflow permission was verified, and whether identity controls (CODEOWNERS, required reviewers) are in place. If the workflow has no `permissions` block and the platform default cannot be inspected from the supplied files, mark the effective token scope as `Not Evaluable from Config` instead of assuming read/write.
 
 ---
 
@@ -550,6 +564,7 @@ This skill processes user-supplied content including CI/CD configuration files, 
 - SLSA Build Track: https://slsa.dev/spec/v1.0/levels#build-track
 - OWASP Top 10 CI/CD Security Risks: https://owasp.org/www-project-top-10-ci-cd-security-risks/
 - GitHub Actions Security Hardening: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
+- GitHub Actions `GITHUB_TOKEN` permissions: https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token
 - Sigstore / Cosign: https://docs.sigstore.dev/
 - SLSA GitHub Generator: https://github.com/slsa-framework/slsa-github-generator
 

--- a/skills/devsecops/pipeline-security/tests/github-token-permissions-boundary.md
+++ b/skills/devsecops/pipeline-security/tests/github-token-permissions-boundary.md
@@ -1,0 +1,124 @@
+# GitHub Token Permission Boundary Fixtures
+
+These fixtures calibrate `pipeline-security` CICD-SEC-2 findings for GitHub
+Actions `GITHUB_TOKEN` permissions. Missing workflow `permissions` does not
+always prove read/write access; it inherits the enterprise, organization, or
+repository default workflow permission.
+
+## Vulnerable Fixture 1: Missing Permissions With Unknown Platform Default
+
+```yaml
+name: build
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm test
+```
+
+Evidence:
+
+```text
+repository_default_workflow_permission: unknown
+organization_default_workflow_permission: unknown
+```
+
+Expected assessment:
+
+- Do not assert "defaults to read-write for everything" from the YAML alone.
+- Mark effective `GITHUB_TOKEN` scope as `Not Evaluable from Config`.
+- Request repository or organization Actions settings, or require an explicit
+  least-privilege `permissions` block to remove ambiguity.
+
+## Vulnerable Fixture 2: Explicit Broad Write Scope
+
+```yaml
+name: release
+on: push
+permissions: write-all
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/publish.sh
+```
+
+Expected assessment:
+
+- Report CICD-SEC-2 because the workflow grants every available write scope.
+- Require job-level least-privilege scopes such as `contents: read` plus only
+  the write permissions that the publish job actually needs.
+
+## Vulnerable Fixture 3: `pull_request_target` Without Permission Reduction
+
+```yaml
+name: label
+on: pull_request_target
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh pr edit "$PR_URL" --add-label needs-triage
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+```
+
+Expected assessment:
+
+- Treat the workflow as high-risk until it explicitly scopes permissions.
+- Require a top-level or job-level block such as `permissions: { pull-requests:
+  write, contents: read }`, adjusted to the exact operation.
+- Continue checking for PR-controlled shell interpolation and checkout of
+  untrusted code in the CICD-SEC-4 path.
+
+## Benign Fixture 1: Missing Permissions With Verified Read-Only Default
+
+```yaml
+name: build
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm test
+```
+
+Evidence:
+
+```text
+repository_default_workflow_permission: read repository contents permission
+organization_default_workflow_permission: read repository contents permission
+```
+
+Expected assessment:
+
+- Do not report this as read/write default access.
+- Still recommend an explicit `permissions: contents: read` block for
+  self-documenting least privilege, but grade it separately from broad write
+  exposure.
+
+## Benign Fixture 2: Explicit Least-Privilege Build
+
+```yaml
+name: build
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm test
+```
+
+Expected assessment:
+
+- Pass CICD-SEC-2 for token scope if no job requires additional write access.
+- Continue assessing branch protection, dependency chain, and PPE controls in
+  their separate sections.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `pipeline-security`
**Skill path:** `skills/devsecops/pipeline-security/`

Closes #777.

### What Was Wrong

The skill said missing GitHub Actions `permissions` blocks default to read/write and showed a missing block as "BAD: No permissions block (defaults to read-write for everything)." GitHub's current documentation is more nuanced: the `GITHUB_TOKEN` starts from the enterprise, organization, or repository default workflow permission, and workflow/job `permissions` can then restrict or elevate it. `pull_request_target` is the special read/write case unless explicitly reduced.

This can create false positives in repositories whose workflow default is verified read-only, while still missing the need to record platform-default evidence when reviewing only YAML files.

### What This PR Fixes

- Replaces the blanket read/write default wording with enterprise/org/repo default inheritance.
- Adds `Not Evaluable from Config` handling when the platform default workflow permission is unknown.
- Adds evidence fields for top-level permissions, job-level permissions, repository/org default, `pull_request_target` reduction, and write-scope necessity.
- Keeps explicit broad scopes such as `permissions: write-all` as true findings.
- Adds focused fixtures for unknown default, explicit write-all, `pull_request_target`, verified read-only default, and explicit least privilege.
- Adds the GitHub `GITHUB_TOKEN` permissions reference.

### Evidence

**Before (skill can over-report this as read/write):**
```yaml
name: build
on: push
jobs:
  test:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - run: npm test
```

**After (now correctly handled):**
```text
repository_default_workflow_permission: unknown
organization_default_workflow_permission: unknown
```
Expected: mark effective token scope as `Not Evaluable from Config` and request platform settings or explicit `permissions`.

```text
repository_default_workflow_permission: read repository contents permission
organization_default_workflow_permission: read repository contents permission
```
Expected: do not report broad write exposure, but still recommend explicit `permissions: contents: read` for self-documenting least privilege.

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/` equivalent markdown fixtures under `skills/devsecops/pipeline-security/tests/`)
- [x] Added benign test cases (`tests/benign/` equivalent markdown fixtures under `skills/devsecops/pipeline-security/tests/`)
- [x] Existing tests still pass

Validation run:

- `git diff --check`
- required-frontmatter shell check from `.github/workflows/lint-skills.yml` logic
- prompt-injection scan logic from `.github/workflows/injection-scan.yml`
- changed skill frontmatter parses with Ruby/Psych
- content assertions for default workflow permission, `Not Evaluable from Config`, `pull_request_target`, `GITHUB_TOKEN`, and the GitHub docs reference

### Bounty Tier
- [ ] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** To be provided privately after acceptance
