### PR TITLE
Add firewall NAT and object expansion evidence

### DIFF
--- a/skills/network/firewall-review/SKILL.md
+++ b/skills/network/firewall-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [operate]
 frameworks: [CIS-Controls-v8, NIST-SP-800-41-Rev1]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -254,6 +254,34 @@ Egress filtering prevents compromised internal hosts from establishing unrestric
 
 ---
 
+#### 2.8 Object, Service Group, and NAT Expansion
+
+Firewall policies often reference aliases instead of concrete traffic criteria. Before making any exposure, default-deny, shadowing, or egress conclusion, expand address objects, nested address groups, service groups, application defaults, FQDN objects, dynamic objects, and NAT/VIP translations into the effective source, destination, protocol, and port set.
+
+**What to verify:**
+
+- Address objects and nested address groups are resolved to CIDRs, IP ranges, host addresses, or FQDN records before any/any and shadow analysis.
+- Service groups are expanded to explicit protocol/port tuples, including TCP, UDP, ICMP, ranges, and vendor-specific "application-default" or "any service" behavior.
+- DNAT, VIP, static NAT, and destination port translations are joined to the firewall policy so public exposure is evaluated in both pre-translation and post-translation views.
+- SNAT and source NAT pools are joined to egress rules so source identity, owner attribution, logging, and outbound allowlists are evaluated against the effective translated source.
+- Dynamic address groups, external dynamic lists, and FQDN objects include the membership source, last resolution timestamp, and evidence that the membership was current at assessment time.
+- Shadowed-rule analysis compares expanded CIDR and service sets, not only object names or comments.
+
+**Evidence codes to use in findings:**
+
+| Code | Missing Evidence | Risk |
+|------|------------------|------|
+| FW-EXPAND-01 | Address objects, address groups, or nested groups are not expanded before exposure or shadow analysis. | Alias names can hide broader networks, stale assets, or sensitive destinations. |
+| FW-EXPAND-02 | Service or application groups are not expanded to protocols, ports, ranges, or application defaults. | A rule that appears limited may allow additional protocols or high-risk ports. |
+| FW-NAT-01 | DNAT, VIP, static NAT, or destination port translations are not joined to the policy before exposure review. | Internet-facing access to internal services can be missed or misclassified. |
+| FW-NAT-02 | SNAT, NAT pools, or egress translations are not joined to outbound review. | Source attribution, owner mapping, and outbound allowlists may be wrong. |
+| FW-DYN-01 | FQDN, dynamic object, or external list membership lacks a timestamp and source. | Effective policy can change after the exported configuration was reviewed. |
+| FW-SHADOW-01 | Shadow analysis is performed on aliases instead of expanded CIDR and service sets. | Shadowed denies and duplicate permits can be missed. |
+
+**Finding classification:** Missing object or NAT expansion is **High** when it affects internet-facing rules, sensitive zones, management services, or default-deny/shadowing conclusions. It is **Medium** for internal-only rules with compensating segmentation evidence. Missing dynamic or FQDN freshness evidence is **Medium**, or **High** when the object controls public or privileged access.
+
+---
+
 ### Step 3: Compile Assessment Report
 
 Produce the final report using the following structure.
@@ -265,8 +293,8 @@ Produce the final report using the following structure.
 | Severity | Definition |
 |----------|-----------|
 | **Critical** | Missing default deny; any/any inbound rules. Immediate exploitation risk. |
-| **High** | Overly permissive outbound rules; shadowed deny rules; no logging on deny actions; missing anti-spoofing; unused rules to decommissioned resources. |
-| **Medium** | Shadowed permit rules; missing egress DNS restriction; unused rules (active resources); missing logging on sensitive permits; missing stealth rules. |
+| **High** | Overly permissive outbound rules; shadowed deny rules; no logging on deny actions; missing anti-spoofing; unused rules to decommissioned resources; missing NAT/object expansion for internet-facing or sensitive-zone conclusions. |
+| **Medium** | Shadowed permit rules; missing egress DNS restriction; unused rules (active resources); missing logging on sensitive permits; missing stealth rules; missing NAT/object expansion for internal-only rules; stale dynamic/FQDN object evidence. |
 | **Low** | Rule documentation gaps; suboptimal rule ordering with no current security impact; cosmetic rule base issues. |
 
 ---
@@ -298,6 +326,8 @@ Produce the final report using the following structure.
 - **Rule(s):** <rule number(s) or line(s)>
 - **Description:** <what was found>
 - **Evidence:** <specific rule text or configuration snippet>
+- **Expanded Evidence:** <resolved object/service/NAT view, or "not available">
+- **Confidence:** High / Medium / Low based on object, NAT, and runtime membership evidence
 - **Remediation:** <concrete fix with example>
 
 ### Default Deny Status
@@ -306,9 +336,14 @@ Produce the final report using the following structure.
 | Inbound   | Pass/Fail | <rule reference> |
 | Outbound  | Pass/Fail | <rule reference> |
 
+### Object and NAT Expansion Status
+| Rule/Policy | Objects Expanded | Service Groups Expanded | NAT/VIP Joined | Dynamic/FQDN Timestamp | Effective Source | Effective Destination | Effective Service | Confidence |
+|-------------|------------------|-------------------------|----------------|------------------------|------------------|-----------------------|-------------------|------------|
+| <rule id> | Yes/No/Partial | Yes/No/Partial | Yes/No/N/A | <timestamp/source or missing> | <expanded source> | <expanded destination> | <protocol/port set> | High/Medium/Low |
+
 ### Shadowed Rules Summary
-| Shadowed Rule | Position | Shadowing Rule | Position | Impact |
-|---------------|----------|----------------|----------|--------|
+| Shadowed Rule | Position | Shadowing Rule | Position | Expanded Criteria | Impact |
+|---------------|----------|----------------|----------|-------------------|--------|
 
 ### Egress Filtering Status
 | Protocol/Port | Restricted | Authorized Destinations |
@@ -361,6 +396,12 @@ Produce the final report using the following structure.
 
 5. **Conflating network ACLs with security groups in cloud environments.** In AWS, NACLs are stateless and operate at the subnet level; security groups are stateful and operate at the instance level. Both must be audited. A permissive NACL can undermine restrictive security group rules for responses.
 
+6. **Auditing aliases instead of expanded objects.** Object names such as `DMZ_WEB`, `Partner-Allow`, or `Web-Services` can hide broad CIDRs, nested groups, port ranges, or "any" service entries. Resolve them before deciding whether a rule is least-privilege or shadowed.
+
+7. **Checking only pre-NAT or only post-NAT addresses.** DNAT and VIP rules can expose internal services through public addresses, while SNAT can hide the real internal source. Join NAT rules with security policy before drawing exposure, ownership, or egress conclusions.
+
+8. **Treating FQDN and dynamic objects as static.** Dynamic groups, external lists, and FQDN objects can change without a full policy rewrite. Record the source and resolution timestamp so the finding reflects the effective policy at assessment time.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -381,9 +422,15 @@ This skill processes firewall configurations that may contain user-supplied comm
 - NIST SP 800-41 Rev 1, Guidelines on Firewalls and Firewall Policy: https://csrc.nist.gov/publications/detail/sp/800-41/rev-1/final
 - NIST SP 800-41 Rev 1 (PDF): https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-41r1.pdf
 - CIS Benchmarks (platform-specific firewall hardening): https://www.cisecurity.org/cis-benchmarks
+- Palo Alto Networks Policy Objects: https://docs.paloaltonetworks.com/network-security/security-policy/administration/objects
+- Palo Alto Networks Address Objects and FQDN References: https://docs.paloaltonetworks.com/network-security/security-policy/administration/objects/addresses/use-address-object-to-represent-ip-addresses
+- Palo Alto Networks Dynamic Address Groups: https://docs.paloaltonetworks.com/network-security/security-policy/administration/objects/address-groups
+- Palo Alto Networks NAT Policy Rules: https://docs.paloaltonetworks.com/ngfw/networking/nat/nat-policy-rules
+- Cisco Secure Firewall ASA Service Objects: https://ci.manage.security.cisco.com/content/docs/c_service-objects.html
 
 ---
 
 ## Changelog
 
+- **1.1.0** -- Added object, service group, dynamic/FQDN, and NAT/VIP expansion checks to reduce false exposure, shadowing, and egress conclusions.
 - **1.0.0** -- Initial release. Full coverage of CIS Controls v8 (4.4, 4.5) and NIST SP 800-41 Rev 1 firewall audit methodology.

--- a/skills/network/firewall-review/tests/benign/nat-object-expansion.md
+++ b/skills/network/firewall-review/tests/benign/nat-object-expansion.md
@@ -1,0 +1,33 @@
+# Benign NAT and Object Expansion Case
+
+Use this case to validate that `firewall-review` does not report an any/any, missing NAT, or stale-object finding when the effective traffic set is fully documented.
+
+## Partner CIDR and Fresh FQDN Evidence Are Fully Expanded
+
+**Configuration excerpt:**
+
+```text
+address group partner-api-sources:
+  198.51.100.0/24
+
+fqdn object api-prod.example.com:
+  resolved: 10.30.40.25
+  resolver: firewall-dns-cache
+  observed_at: 2026-06-04T18:15:00Z
+
+nat rule api-no-dnat:
+  original destination: api-prod.example.com
+  translation: none
+
+security rule partner-api:
+  source: partner-api-sources
+  destination: api-prod.example.com
+  service: tcp/443
+  action: allow
+```
+
+**Expected review behavior:**
+
+- Do not flag any/any or missing NAT expansion.
+- Record `Objects Expanded: Yes`, `Service Groups Expanded: Yes`, `NAT/VIP Joined: Yes`, and `Dynamic/FQDN Timestamp: 2026-06-04T18:15:00Z/firewall-dns-cache`.
+- Confidence may be **High** because the effective source, destination, service, and freshness evidence are present.

--- a/skills/network/firewall-review/tests/vulnerable/nat-object-expansion.md
+++ b/skills/network/firewall-review/tests/vulnerable/nat-object-expansion.md
@@ -1,0 +1,80 @@
+# Vulnerable NAT and Object Expansion Cases
+
+Use these cases to validate that `firewall-review` reaches conclusions from the effective traffic set, not from alias names alone.
+
+---
+
+## Case 1: Service Group Hides Additional Public Ports
+
+**Configuration excerpt:**
+
+```asa
+object-group network DMZ_WEB
+  network-object host 10.0.20.10
+  network-object host 10.0.20.11
+
+object-group service WEB-SVC tcp
+  port-object eq 80
+  port-object eq 443
+  port-object eq 8443
+
+access-list outside_in extended permit tcp any object-group DMZ_WEB object-group WEB-SVC
+```
+
+**Expected review behavior:**
+
+- Flag `FW-EXPAND-01` and `FW-EXPAND-02` if the report only says "`DMZ_WEB` allows web traffic."
+- Expanded evidence must show `any -> 10.0.20.10,10.0.20.11 tcp/80,443,8443`.
+- Classify as **High** if the rule is internet-facing because tcp/8443 may expose a management or alternate application port that was hidden by the service group name.
+
+---
+
+## Case 2: DNAT/VIP Exposure Missed When Only Internal Destination Is Reviewed
+
+**Configuration excerpt:**
+
+```text
+nat rule vip-web
+  original source zone: untrust
+  original destination: 203.0.113.10
+  original service: tcp/443
+  translated destination: 10.0.20.15
+  translated service: tcp/8443
+
+security rule allow-vip-web
+  source zone: untrust
+  destination zone: dmz
+  destination address: 10.0.20.15
+  service: tcp/8443
+  action: allow
+```
+
+**Expected review behavior:**
+
+- Flag `FW-NAT-01` if the review fails to join the public VIP to the internal security rule.
+- Expanded evidence must include both `203.0.113.10:443` pre-translation and `10.0.20.15:8443` post-translation.
+- The exposure conclusion should be based on the public listener, not only the internal object.
+
+---
+
+## Case 3: Nested Object Group Makes Shadowed Deny Visible
+
+**Configuration excerpt:**
+
+```asa
+object-group network APP_NETS
+  network-object 10.40.0.0 255.255.0.0
+  group-object APP_ADMIN_NETS
+
+object-group network APP_ADMIN_NETS
+  network-object 10.40.50.0 255.255.255.0
+
+access-list internal extended permit tcp object-group APP_NETS any eq 22
+access-list internal extended deny tcp 10.40.50.0 255.255.255.0 any eq 22
+```
+
+**Expected review behavior:**
+
+- Flag `FW-SHADOW-01` if shadow analysis compares `APP_NETS` and `10.40.50.0/24` as unrelated strings.
+- Expanded evidence must show that `10.40.50.0/24` is contained in `APP_NETS`.
+- Classify the shadowed deny as **High** because a security control intended to block SSH from the admin subnet is ineffective.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** firewall-review
**Skill path:** `skills/network/firewall-review/`

### Related Review
Addresses #789.

### What Was Wrong

`firewall-review` currently guides reviewers through default deny, any/any, shadowed rules, logging, and egress checks, but it does not require the reviewer to expand firewall aliases before making those conclusions. That leaves a gap for:

- address objects and nested address groups that hide broad CIDRs or sensitive destinations
- service groups that hide extra protocols, port ranges, or application-default behavior
- DNAT/VIP rules that expose internal services through public listeners
- SNAT/NAT pools that change source attribution for egress review
- FQDN, external list, and dynamic address group membership that can change after export
- shadow analysis performed on object names instead of effective CIDR/service sets

### What This PR Fixes

This PR adds a dedicated `2.8 Object, Service Group, and NAT Expansion` step to the skill, including evidence codes for missing expansion and NAT joins:

- `FW-EXPAND-01` for unresolved address/object groups
- `FW-EXPAND-02` for unresolved service/application groups
- `FW-NAT-01` for missing DNAT/VIP joins
- `FW-NAT-02` for missing SNAT/egress translation joins
- `FW-DYN-01` for stale or unproven dynamic/FQDN membership
- `FW-SHADOW-01` for alias-based shadow analysis

It also updates the output format with expanded evidence, confidence, an object/NAT expansion status table, and expanded criteria in the shadowed-rules table.

### Evidence

**Before (skill misses this / false positive on this):**
```text
nat rule vip-web
  original destination: 203.0.113.10
  original service: tcp/443
  translated destination: 10.0.20.15
  translated service: tcp/8443

security rule allow-vip-web
  destination address: 10.0.20.15
  service: tcp/8443
  action: allow
```

A review that only looks at the security rule destination can miss that the effective public listener is `203.0.113.10:443`.

**After (now correctly handled):**
```text
- **Expanded Evidence:** 203.0.113.10:443 pre-translation -> 10.0.20.15:8443 post-translation
- **Confidence:** High, because NAT/VIP and service expansion evidence are present
```

The new report schema requires both the raw rule and the effective traffic set before making the exposure conclusion.

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass

### Bounty Tier
- [ ] **Minor** ($50) -- Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) -- New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) -- Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** PayPal, details to be provided privately after acceptance

---

## Pull Request Checklist

- [x] Skill follows the format specification in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] At least one real framework is cited with correct control IDs
- [x] All framework references verified against primary sources (not blogs or AI output)
- [x] Prompt Injection Safety Notice section included
- [x] `injection-hardened: true` set in frontmatter
- [x] `allowed-tools` scoped to minimum necessary permissions
- [x] Tested with at least one AI coding agent (which one: Codex)
- [x] No prohibited patterns per [SECURITY.md](../SECURITY.md)
- [x] `index.yaml` updated with new skill entry (if adding a skill; not applicable, existing skill only)

## What This PR Does

Adds NAT, VIP, object group, service group, FQDN, and dynamic-object expansion requirements to `firewall-review`, then adds vulnerable and benign markdown test cases to prove the new review path.

## Framework References

- CIS Controls v8 4.4 and 4.5, already cited by the skill for firewall restriction and policy enforcement
- NIST SP 800-41 Rev. 1 Sections 4.2, 4.2.3, and 4.3 for firewall policy, least privilege, rule-base design, and rule-base management
- Palo Alto Networks Policy Objects, Address Objects/FQDNs, Dynamic Address Groups, and NAT Policy Rules for vendor-backed object and NAT semantics
- Cisco Secure Firewall ASA Service Objects for service-group and port-group behavior

## Testing

- `git diff --check`
- Frontmatter required-field scan from `.github/workflows/lint-skills.yml`
- Prompt-injection scan from `.github/workflows/injection-scan.yml`
- Markdown fence balance check on the changed skill and test files
- ASCII scan on the changed skill and test files
- Content assertions for `FW-NAT-01`, `FW-EXPAND-01`, `Dynamic/FQDN`, and `Object and NAT Expansion Status`

`index.yaml` is unchanged because this modifies an existing skill rather than adding a new skill entry.
