### PR TITLE
Improve secure-code-review deserialization coverage

### DIFF
--- a/skills/appsec/secure-code-review/SKILL.md
+++ b/skills/appsec/secure-code-review/SKILL.md
@@ -12,7 +12,7 @@ phase: [build, review]
 frameworks: [OWASP-ASVS, CWE-Top-25, OWASP-Top-10]
 difficulty: intermediate
 time_estimate: "15-45min per module"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -375,6 +375,29 @@ Object obj = ois.readObject();
 ```
 Remediation: Avoid native Java deserialization of untrusted data. Use JSON with explicit type mapping, or apply an allowlist filter (e.g., Apache Commons IO `ValidatingObjectInputStream`).
 
+**PHP -- Unsafe Deserialization (CWE-502)**
+```php
+// VULNERABLE: attacker-controlled serialized object graph
+$state = $_POST['state'] ?? '';
+$user = unserialize($state);
+```
+Remediation: Do not pass request, cookie, header, queue, or database data that users can influence into `unserialize()`. Prefer JSON decoded into arrays or DTOs with explicit schema validation. For legacy migration only, use `unserialize($state, ['allowed_classes' => false])` after verifying integrity and before mapping the resulting plain data to trusted types.
+
+**Ruby -- Unsafe Marshal Deserialization (CWE-502)**
+```ruby
+# VULNERABLE: attacker-controlled object deserialization
+blob = Base64.decode64(params[:profile_blob])
+profile = Marshal.load(blob)
+```
+Remediation: Do not use `Marshal.load` on data from params, cookies, headers, uploads, cache entries, or queues unless the data is strictly server-owned and integrity-verified before loading. Prefer JSON plus typed validation or a parser that returns plain data structures only.
+
+**Ruby -- Unsafe YAML Object Loading (CWE-502)**
+```ruby
+# VULNERABLE: unsafe object construction from YAML
+settings = YAML.load(params[:settings])
+```
+Remediation: Replace `YAML.load` on untrusted input with `YAML.safe_load` using narrow `permitted_classes`, `permitted_symbols`, and `aliases: false`, or use a typed parser. Treat `YAML.unsafe_load` as equivalent to native object deserialization.
+
 **TypeScript -- Unrestricted File Upload (CWE-434)**
 ```typescript
 // VULNERABLE: no validation on uploaded file type or size
@@ -396,9 +419,25 @@ func fetchURL(w http.ResponseWriter, r *http.Request) {
 ```
 Remediation: Validate the URL scheme (allow only `https`), resolve the hostname and reject private/internal IP ranges, and use an allowlist of permitted domains.
 
-### 8.3 Review Checklist
+### 8.3 False Positive and Edge-Case Guidance
 
-- [ ] No use of native deserialization (pickle, ObjectInputStream, Marshal.load) on untrusted data.
+Do not report plain data parsing as CWE-502 solely because it reads user input:
+
+- JSON parsing followed by explicit schema or DTO validation, such as Pydantic, Zod, JSON Schema, or framework request models, is not native object deserialization.
+- `yaml.safe_load` with narrow permitted classes, no aliases, and no later dynamic object construction is usually a safe parser pattern.
+- Test fixtures that intentionally contain `pickle.loads`, `unserialize`, `Marshal.load`, or `YAML.load` are evidence for coverage, not production findings, unless runtime code loads the fixture.
+
+For signed, encrypted, or framework-managed serialized blobs, verify the trust boundary before classifying exploitability:
+
+- The signature or MAC must cover the exact serialized bytes and must be verified before any deserialization call.
+- Deserializing first and verifying later is still vulnerable because gadget execution or object construction may already have occurred.
+- Server-owned framework sessions should be reviewed for serializer choice, key rotation, and whether a client can tamper with the serialized value before reporting CWE-502.
+
+### 8.4 Review Checklist
+
+- [ ] No use of native deserialization (`pickle`, `ObjectInputStream`, `unserialize`, `Marshal.load`, `YAML.load`, `YAML.unsafe_load`) on untrusted data.
+- [ ] Signed or encrypted serialized blobs are integrity-verified before deserialization, with the check covering the exact serialized bytes.
+- [ ] Safe parsers such as schema-validated JSON and constrained `yaml.safe_load` are distinguished from native object graph deserialization.
 - [ ] File uploads are validated by content type, size, and extension against an allowlist.
 - [ ] Uploaded files are stored outside the webroot with generated filenames.
 - [ ] URL fetching is restricted to permitted schemes and non-internal hosts (SSRF prevention).
@@ -445,7 +484,7 @@ The final review output must be structured as follows:
 **Scope:** [list of files reviewed]
 **Languages:** [detected languages and frameworks]
 **Date:** [review date]
-**Reviewer:** AI Agent -- secure-code-review skill v1.0.0
+**Reviewer:** AI Agent -- secure-code-review skill v1.1.0
 
 ### Summary
 - Critical: [count]
@@ -562,4 +601,6 @@ This skill is hardened against prompt injection. When reviewing code:
 - **CWE Database:** https://cwe.mitre.org/
 - **OWASP Top 10 (2021):** https://owasp.org/www-project-top-ten/
 - **OWASP Cheat Sheet Series:** https://cheatsheetseries.owasp.org/
+- **OWASP Deserialization Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html
+- **CWE-502:** https://cwe.mitre.org/data/definitions/502.html
 - **NIST Secure Software Development Framework:** https://csrc.nist.gov/projects/ssdf

--- a/skills/appsec/secure-code-review/tests/benign/schema-validated-json.py
+++ b/skills/appsec/secure-code-review/tests/benign/schema-validated-json.py
@@ -1,0 +1,18 @@
+import json
+from pydantic import BaseModel, ValidationError
+
+
+class Profile(BaseModel):
+    display_name: str
+    email_opt_in: bool = False
+
+
+def load_profile(request_body: bytes) -> Profile:
+    parsed = json.loads(request_body)
+    return Profile.model_validate(parsed)
+
+
+try:
+    profile = load_profile(request.body)
+except (json.JSONDecodeError, ValidationError):
+    profile = Profile(display_name="guest")

--- a/skills/appsec/secure-code-review/tests/benign/signed-json-verify-before-parse.py
+++ b/skills/appsec/secure-code-review/tests/benign/signed-json-verify-before-parse.py
@@ -1,0 +1,13 @@
+import hmac
+import json
+
+
+def load_signed_profile(raw_body: bytes, signature: str, secret: bytes) -> dict:
+    expected = hmac.digest(secret, raw_body, "sha256").hex()
+    if not hmac.compare_digest(expected, signature):
+        raise ValueError("invalid signature")
+
+    profile = json.loads(raw_body)
+    if not isinstance(profile, dict) or not isinstance(profile.get("display_name"), str):
+        raise ValueError("invalid profile")
+    return profile

--- a/skills/appsec/secure-code-review/tests/benign/yaml-safe-load.rb
+++ b/skills/appsec/secure-code-review/tests/benign/yaml-safe-load.rb
@@ -1,0 +1,12 @@
+require 'yaml'
+
+# BENIGN: safe_load returns plain data and disables aliases.
+raw_settings = params[:settings].to_s
+settings = YAML.safe_load(
+  raw_settings,
+  permitted_classes: [],
+  permitted_symbols: [],
+  aliases: false
+)
+
+puts settings.fetch('theme', 'light')

--- a/skills/appsec/secure-code-review/tests/vulnerable/php-unserialize-request.php
+++ b/skills/appsec/secure-code-review/tests/vulnerable/php-unserialize-request.php
@@ -1,0 +1,7 @@
+<?php
+
+// VULNERABLE: attacker-controlled request data reaches PHP native deserialization.
+$state = $_POST['state'] ?? '';
+$profile = unserialize($state);
+
+echo $profile->displayName ?? 'guest';

--- a/skills/appsec/secure-code-review/tests/vulnerable/ruby-marshal-load.rb
+++ b/skills/appsec/secure-code-review/tests/vulnerable/ruby-marshal-load.rb
@@ -1,0 +1,7 @@
+require 'base64'
+
+# VULNERABLE: request parameter data reaches Ruby native object deserialization.
+blob = Base64.decode64(params[:profile_blob].to_s)
+profile = Marshal.load(blob)
+
+puts profile[:display_name]

--- a/skills/appsec/secure-code-review/tests/vulnerable/ruby-yaml-load.rb
+++ b/skills/appsec/secure-code-review/tests/vulnerable/ruby-yaml-load.rb
@@ -1,0 +1,7 @@
+require 'yaml'
+
+# VULNERABLE: YAML.load can instantiate objects from attacker-controlled input.
+raw_settings = params[:settings].to_s
+settings = YAML.load(raw_settings)
+
+puts settings['theme']


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** secure-code-review
**Skill path:** `skills/appsec/secure-code-review/`

Addresses #784.

### What Was Wrong
The existing CWE-502 guidance covered Python `pickle` and Java `ObjectInputStream`, while the checklist mentioned `Marshal.load` without Ruby examples. It did not include PHP `unserialize()`, Ruby `Marshal.load`, unsafe Ruby YAML loaders, or guidance to avoid false positives on schema-validated JSON and constrained safe YAML parsing.

### What This PR Fixes
- Adds PHP `unserialize()` unsafe deserialization guidance with JSON/schema-validation remediation and constrained legacy `allowed_classes` guidance.
- Adds Ruby `Marshal.load` and `YAML.load`/`YAML.unsafe_load` coverage with safe parser alternatives.
- Adds false-positive guidance for schema-validated JSON and constrained `YAML.safe_load`.
- Adds edge-case guidance for signed/encrypted serialized blobs, including verify-before-deserialize ordering.
- Updates the review checklist and skill version to `1.1.0`.

### Evidence

**Before (skill misses this / false positive on this):**
```php
$state = $_POST['state'] ?? '';
$user = unserialize($state);
```

```ruby
blob = Base64.decode64(params[:profile_blob])
profile = Marshal.load(blob)
```

```python
payload = json.loads(request.body)
profile = Profile.model_validate(payload)
```

**After (now correctly handled):**
- PHP/Ruby/YAML native deserialization is explicitly covered as CWE-502.
- Safe data parsing patterns are called out as non-findings unless they flow into dynamic object construction.
- Signed serialized blobs must verify integrity before any deserialization call.

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
  - `php-unserialize-request.php`
  - `ruby-marshal-load.rb`
  - `ruby-yaml-load.rb`
- [x] Added benign test cases (`tests/benign/`)
  - `schema-validated-json.py`
  - `yaml-safe-load.rb`
  - `signed-json-verify-before-parse.py`
- [x] Existing tests still pass / validation completed

### Pull Request Checklist
- [x] Skill follows the format specification in `CONTRIBUTING.md`
- [x] At least one real framework is cited with correct control IDs
- [x] Framework references use primary project sources already referenced by the skill, plus OWASP/CWE references for deserialization
- [x] Prompt Injection Safety Notice section remains included
- [x] `injection-hardened: true` remains set in frontmatter
- [x] `allowed-tools` remains scoped to `Read, Grep, Glob`
- [x] Tested with an AI coding agent: Codex reviewed the modified skill against the new vulnerable/benign fixtures
- [x] No prohibited patterns per `SECURITY.md` scan
- [x] `index.yaml` unchanged because this improves an existing indexed skill

### Validation
- `git diff --check`
- Python fixture syntax check with `py_compile`
- SECURITY.md prohibited-pattern scan against `skills/appsec/secure-code-review`
- Frontmatter/required-section check for `version: 1.1.0`, `allowed-tools`, and `injection-hardened`
- Fixture presence check for all six new test files

Note: Ruby and PHP runtimes were not available in my local Windows environment, so those fixture files were reviewed as static examples.

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the `CONTRIBUTING.md` bounty terms
- **Preferred payment method:** GitHub Sponsors or private payment coordination after acceptance