### PR TITLE
Refresh vCISO OWASP agentic source

### DIFF
--- a/roles/vciso/SKILL.md
+++ b/roles/vciso/SKILL.md
@@ -144,7 +144,7 @@ llm-top-10 → agentic-top-10 → agent-security → prompt-injection
 | Step | Skill | Purpose |
 |------|-------|---------|
 | 1 | `llm-top-10` | Assess against the OWASP Top 10 for LLM Applications. Covers prompt injection, training data poisoning, model denial of service, supply chain vulnerabilities, and sensitive information disclosure. |
-| 2 | `agentic-top-10` | If the org uses agentic AI (agents that take actions, call tools, or chain outputs), assess against the OWASP Agentic AI Top 10. This covers excessive agency, trust boundary violations, and cascading hallucinations. |
+| 2 | `agentic-top-10` | If the org uses agentic AI (agents that take actions, call tools, or chain outputs), assess against the OWASP Top 10 for Agentic Applications 2026. This covers excessive agency, trust boundary violations, and cascading hallucinations. |
 | 3 | `agent-security` | Review the specific agent architecture: what tools are exposed, what permissions agents hold, how outputs are validated before execution, and whether human-in-the-loop gates exist. |
 | 4 | `prompt-injection` | Test for direct and indirect prompt injection across all user-facing and data-ingesting LLM surfaces. This is the most exploitable class of LLM vulnerability today. |
 
@@ -392,5 +392,5 @@ IMPORTANT: This role bundle is designed to be injection-hardened.
 - **ISO/IEC 27001:2022** — https://www.iso.org/standard/27001 — International ISMS standard. Used for organizations with global compliance requirements.
 - **CIS Controls v8** — https://www.cisecurity.org/controls — Implementation-focused control set. Useful for translating framework requirements into specific technical actions.
 - **OWASP Top 10 for LLM Applications** — https://owasp.org/www-project-top-10-for-large-language-model-applications/ — Primary reference for AI/LLM program reviews.
-- **OWASP Agentic AI Top 10** — https://owasp.org/www-project-agentic-ai-top-10/ — Covers risks specific to autonomous AI agents with tool access.
+- **OWASP Top 10 for Agentic Applications 2026** — https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/ — Covers risks specific to autonomous AI agents with tool access.
 - **FAIR (Factor Analysis of Information Risk)** — https://www.fairinstitute.org/ — Quantitative risk analysis methodology referenced in the risk-based prioritization principle.

--- a/roles/vciso/tests/benign/current-owasp-agentic-applications-source.md
+++ b/roles/vciso/tests/benign/current-owasp-agentic-applications-source.md
@@ -1,0 +1,23 @@
+# Benign: current OWASP Agentic Applications source
+
+This fixture documents the corrected vCISO source-reference pattern.
+
+## Evidence
+
+The vCISO AI/LLM program review records the current OWASP source:
+
+```text
+OWASP Top 10 for Agentic Applications 2026
+https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/
+Retrieved: 2026-06-04
+Status: current
+```
+
+The engagement output also records the agentic AI taxonomy version and agent
+scope before mapping findings to governance decisions.
+
+## Expected review result
+
+- Treat this as valid source-version evidence.
+- Continue with the `llm-top-10`, `agentic-top-10`, `agent-security`, and
+  `prompt-injection` sequence for in-scope AI/LLM program reviews.

--- a/roles/vciso/tests/vulnerable/stale-owasp-agentic-ai-source.md
+++ b/roles/vciso/tests/vulnerable/stale-owasp-agentic-ai-source.md
@@ -1,0 +1,21 @@
+# Vulnerable: stale OWASP Agentic AI source
+
+This fixture documents the stale vCISO source-reference pattern.
+
+## Finding
+
+The vCISO role cites the retired OWASP Agentic AI project URL:
+
+```text
+https://owasp.org/www-project-agentic-ai-top-10/
+```
+
+As of 2026-06-04, that URL returns HTTP 404. A vCISO AI governance report that
+uses it cannot prove which current OWASP agentic taxonomy was applied.
+
+## Expected review result
+
+- Mark the source as stale.
+- Do not use the dead URL as the source of truth for agentic AI governance.
+- Replace it with the current OWASP GenAI Agentic Applications source and record
+  the taxonomy version/date in the engagement source register.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** vciso role bundle
**Skill path:** `roles/vciso/`

### What Was Wrong
The vCISO AI/LLM program review referenced the retired OWASP Agentic AI project URL:

```text
https://owasp.org/www-project-agentic-ai-top-10/
```

As of 2026-06-04, that URL returns HTTP 404. The role also used the older taxonomy name, which makes source-version registers and board/customer-facing AI governance reports ambiguous.

Related review issue: #802

### What This PR Fixes
- Updates the AI/LLM engagement step to use `OWASP Top 10 for Agentic Applications 2026`.
- Replaces the dead OWASP project URL with the current OWASP GenAI resource: `https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/`.
- Adds stale/current fixtures under `roles/vciso/tests/` to document the broken-source and corrected-source cases.

### Evidence
**Before (stale source):**
```text
https://owasp.org/www-project-agentic-ai-top-10/ -> HTTP 404
```

**After (current source):**
```text
https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/ -> HTTP 200
```

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass

### Validation
- `git diff --cached --check`
- Required frontmatter field check for `roles/vciso/SKILL.md`
- Markdown fence balance check for touched files
- Prompt-injection/secrets scan of staged diff
- ASCII check for new fixture files
- Source URL checks: retired URL returns 404; replacement URL returns 200
- Content assertions: retired URL is absent from the production role file and only present in the vulnerable fixture
- Fresh duplicate search for exact retired and replacement URL work before submission

### Bounty Tier
- [x] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [ ] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** PayPal details can be provided privately after acceptance/merge.
