### PR TITLE
Improve soc2-gap backup recovery evidence gates

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -373,7 +373,7 @@ skills:
   # -- Compliance -----------------------------------------------------------
   - id: soc2-gap
     name: "SOC 2 Gap Analysis"
-    tags: [compliance, soc2, audit]
+    tags: [compliance, soc2, audit, availability, backup, disaster-recovery]
     role: [vciso, security-engineer]
     phase: [assess, operate]
     activity: [audit, assess]

--- a/skills/compliance/soc2-gap/SKILL.md
+++ b/skills/compliance/soc2-gap/SKILL.md
@@ -6,7 +6,7 @@ description: >
   or security program maturity. Walks through all Common Criteria (CC1-CC9) plus
   selected additional criteria, identifies gaps, and produces a remediation
   roadmap with evidence requirements and 90-day action plan.
-tags: [compliance, soc2, audit]
+tags: [compliance, soc2, audit, availability, backup, disaster-recovery]
 role: [vciso, security-engineer]
 phase: [assess, operate]
 frameworks: [AICPA-TSC, NIST-CSF-2.0]
@@ -42,6 +42,7 @@ Before beginning the gap analysis, ensure the following are available:
 - CI/CD pipeline configurations
 - Logging and monitoring configurations
 - Incident response documentation
+- Backup, restoration-test, disaster recovery, and business continuity evidence
 - Vendor and third-party service inventory
 
 ## Constraints
@@ -297,6 +298,58 @@ For detailed Trust Services Criteria evaluation questions, evidence requirements
 
 ---
 
+### Step 5: Availability Backup and Restore Evidence Gate
+
+If Availability is in scope, do not score CC7.5, A1.2, or A1.3 as audit-ready from policy-only or schedule-only backup evidence. Require auditor-verifiable proof that recovery controls can meet the system description, customer commitments, and stated RPO/RTO.
+
+#### 5.1 Backup Resilience Evidence Matrix
+
+Collect the following evidence for each in-scope critical system, datastore, queue, object store, and configuration source:
+
+| System / Data Set | TSC Criteria | Stated RPO | Stated RTO | Latest Backup Age | Failed-Job Monitoring | Retention / Immutability | Backup Admin Separation | Restore Drill Scope | Measured Restore Time | Integrity Validation | Residual Finding |
+|-------------------|--------------|------------|------------|-------------------|-----------------------|--------------------------|-------------------------|---------------------|-----------------------|---------------------|------------------|
+|                   | CC7.5 / A1.2 / A1.3 |            |            |                   |                       |                          |                         |                     |                       |                     |                  |
+
+#### 5.2 Required Evidence
+
+- **RPO/RTO linkage** -- Backup frequency, retention, replication, and restore-test results must be mapped to stated recovery commitments.
+- **Backup monitoring** -- Evidence must show failed-job alerting, escalation, ticket closure, and trend review; a green dashboard alone is not enough.
+- **Deletion resistance** -- Look for immutable backups, object/vault lock, retention lock, offline copies, MFA delete, separate backup accounts, or documented compensating controls.
+- **Blast-radius separation** -- Confirm backup administrators, break-glass access, encryption keys, and retention overrides are separated from ordinary production admin paths.
+- **Restore drill scope** -- Restore tests must cover production-like dependencies, representative data classes, infrastructure configuration, and customer-impacting services. Dev-only or single-table tests need residual-risk notation.
+- **Integrity validation** -- Restored data should be reconciled with checksums, record counts, application smoke tests, or other objective validation.
+- **Finding remediation** -- DR or restore-test failures must have tracked owners, due dates, retest evidence, and management acceptance when residual risk remains.
+
+#### 5.3 Findings to Raise
+
+BACKUP-RES-01: Backup policy exists, but no recent successful backup evidence for one or more in-scope systems
+
+BACKUP-RES-02: Backup failures are not monitored, alerted, escalated, or ticketed
+
+BACKUP-RES-03: Restore test is missing, stale, or limited to a non-production sample without residual-risk documentation
+
+BACKUP-RES-04: Measured restore duration or latest backup age does not meet stated RTO/RPO
+
+BACKUP-RES-05: Backups are mutable or deletable by the same admin path that controls production
+
+BACKUP-RES-06: Backup retention or immutability settings conflict with privacy/disposal obligations and lack documented scope or expiry
+
+BACKUP-RES-07: Restore test lacks integrity validation, application smoke testing, or business-owner sign-off
+
+BACKUP-RES-08: DR test findings are not remediated, retested, or formally risk-accepted
+
+BACKUP-RES-09: Configuration, secrets, IaC state, or dependency artifacts needed for recovery are excluded from backup/restore scope
+
+#### 5.4 Scoring Guardrails
+
+- Score **0-1** for A1.2/A1.3 when backups are undocumented, unmonitored, untested, or only asserted in policy.
+- Score **2** when backups and restore tests exist but scope, integrity checks, immutable retention, or RPO/RTO measurement is incomplete.
+- Score **3** when backup/restore controls are documented, monitored, and recently tested for critical systems, but evidence does not cover the full observation period or all dependencies.
+- Score **4** only when backup monitoring, deletion resistance, restore drills, measured RPO/RTO, integrity validation, and test-finding remediation evidence are all current and cover the audit period.
+- Use **Not Evaluable** when the system boundary, critical data sets, backup job evidence, or restore-test evidence is unavailable.
+
+---
+
 ### Step 6: Remediation Roadmap
 
 Prioritize remediation by audit readiness impact. Items that would result in examination exceptions or qualifications take highest priority.
@@ -330,13 +383,14 @@ Prioritize remediation by audit readiness impact. Items that would result in exa
 - [ ] Configure vulnerability scanning on a regular schedule (CC7.1, CC6.8)
 - [ ] Document system description and data flow diagrams (CC2.1)
 - [ ] Establish control monitoring and deficiency tracking (CC4.1, CC4.2)
-- [ ] Implement backup monitoring and conduct restoration test (A1.2, A1.3)
+- [ ] Implement backup monitoring, deletion-resistant retention, and restore testing for critical systems (CC7.5, A1.2, A1.3)
 - [ ] Complete vendor risk assessments for critical vendors (CC9.2)
 
 **Days 61-90: Maturation and Evidence Collection**
 - [ ] Conduct incident response tabletop exercise (CC7.4)
 - [ ] Perform second quarterly access review to establish pattern (CC6.1)
 - [ ] Complete business impact analysis (CC9.1)
+- [ ] Run production-like restore drill, measure RPO/RTO, validate restored data integrity, and close DR findings (CC7.5, A1.2, A1.3)
 - [ ] Establish annual policy review cycle with documented approvals (CC5.3)
 - [ ] Conduct fraud risk assessment (CC3.3)
 - [ ] Compile evidence binder for all in-scope criteria
@@ -352,7 +406,7 @@ Prioritize remediation by audit readiness impact. Items that would result in exa
 - Perform annual security awareness training refresh
 - Review and update policies annually
 - Collect vendor SOC 2 reports annually
-- Conduct annual DR test
+- Conduct annual DR test and at least annual representative restore test with integrity validation
 - Perform annual incident response tabletop exercise
 
 ---
@@ -366,8 +420,9 @@ When performing a SOC 2 gap analysis, produce the following deliverables:
 3. **Category Summary**: Average maturity score per category with narrative assessment.
 4. **Critical Findings**: List of all criteria scored 0 or 1, with specific gap descriptions and remediation recommendations.
 5. **Evidence Checklist**: Customized evidence requirements based on in-scope criteria, marking items as Exists / Partial / Missing.
-6. **90-Day Remediation Roadmap**: Prioritized action items with owners, deadlines, and dependencies.
-7. **Overall Readiness Assessment**: Go/no-go recommendation for engaging a SOC 2 auditor.
+6. **Backup Resilience Matrix**: For in-scope Availability, report RPO/RTO, backup age, failed-job monitoring, immutability, admin separation, restore drill scope, measured restore time, integrity validation, and residual findings.
+7. **90-Day Remediation Roadmap**: Prioritized action items with owners, deadlines, and dependencies.
+8. **Overall Readiness Assessment**: Go/no-go recommendation for engaging a SOC 2 auditor.
 
 ## Prompt Injection Safety Notice
 
@@ -386,6 +441,7 @@ This skill processes user-supplied content including compliance documentation, p
 - **NIST CSF 2.0 Mapping**: CC1-CC2 maps to Govern (GV), CC3 to Identify (ID), CC5-CC6 to Protect (PR), CC7 to Detect (DE) and Respond (RS), CC7.5 to Recover (RC).
 - **ISO 27001:2022**: CC6 maps to Annex A.8 (Technology Controls), CC8 maps to Annex A.8.32 (Change Management), CC9.2 maps to Annex A.5.19-5.22 (Supplier Relationships).
 - **CIS Controls v8**: CC6.1 maps to CIS Control 6 (Access Control Management), CC6.8 maps to CIS Control 10 (Malware Defenses), CC7.1 maps to CIS Control 7 (Continuous Vulnerability Management).
+- **Recovery Evidence**: CC7.5, A1.2, and A1.3 should be supported by backup monitoring, deletion-resistant retention, restore-test results, measured RPO/RTO, and DR finding remediation evidence.
 
 ## Limitations
 

--- a/skills/compliance/soc2-gap/SKILL.md
+++ b/skills/compliance/soc2-gap/SKILL.md
@@ -346,7 +346,7 @@ BACKUP-RES-09: Configuration, secrets, IaC state, or dependency artifacts needed
 - Score **2** when backups and restore tests exist but scope, integrity checks, immutable retention, or RPO/RTO measurement is incomplete.
 - Score **3** when backup/restore controls are documented, monitored, and recently tested for critical systems, but evidence does not cover the full observation period or all dependencies.
 - Score **4** only when backup monitoring, deletion resistance, restore drills, measured RPO/RTO, integrity validation, and test-finding remediation evidence are all current and cover the audit period.
-- Use **Not Evaluable** when the system boundary, critical data sets, backup job evidence, or restore-test evidence is unavailable.
+- Use **Not Evaluable** as an evidence-status flag only, not as the numeric criterion score. If the system boundary, critical data sets, backup job evidence, or restore-test evidence is unavailable, assign a numeric score of **0** when no control evidence exists or **1** when only policy/ownership claims exist, mark the evidence status `Not Evaluable`, and include that score in the aggregate readiness calculation.
 
 ---
 
@@ -420,7 +420,7 @@ When performing a SOC 2 gap analysis, produce the following deliverables:
 3. **Category Summary**: Average maturity score per category with narrative assessment.
 4. **Critical Findings**: List of all criteria scored 0 or 1, with specific gap descriptions and remediation recommendations.
 5. **Evidence Checklist**: Customized evidence requirements based on in-scope criteria, marking items as Exists / Partial / Missing.
-6. **Backup Resilience Matrix**: For in-scope Availability, report RPO/RTO, backup age, failed-job monitoring, immutability, admin separation, restore drill scope, measured restore time, integrity validation, and residual findings.
+6. **Backup Resilience Matrix**: For in-scope Availability, report RPO/RTO, backup age, failed-job monitoring, immutability, admin separation, restore drill scope, measured restore time, integrity validation, residual findings, numeric score, and evidence status.
 7. **90-Day Remediation Roadmap**: Prioritized action items with owners, deadlines, and dependencies.
 8. **Overall Readiness Assessment**: Go/no-go recommendation for engaging a SOC 2 auditor.
 

--- a/skills/compliance/soc2-gap/tsc-criteria.md
+++ b/skills/compliance/soc2-gap/tsc-criteria.md
@@ -397,7 +397,7 @@ When Availability is in scope, use this gate before scoring CC7.5, A1.2, or A1.3
 | Integrity validation | Checksums, record counts, application smoke tests, reconciliation, or business-owner sign-off | Marking a restore successful because data files were copied |
 | Finding remediation | DR findings, owners, due dates, retest evidence, and residual-risk acceptance | Leaving failed DR test findings open without management decision |
 
-Use `Not Evaluable` when the review lacks system-boundary, critical-data, backup-job, or restore-test evidence. Do not infer backup maturity from architecture claims, provider marketing pages, or policy text alone.
+Use `Not Evaluable` as an evidence-status flag when the review lacks system-boundary, critical-data, backup-job, or restore-test evidence. It is not a replacement for the 0-4 criterion score: assign **0** if no control evidence exists, assign **1** if only policy/ownership claims exist without operating evidence, and include that numeric score in the aggregate readiness calculation. Do not infer backup maturity from architecture claims, provider marketing pages, or policy text alone.
 
 ### Confidentiality Criteria (C1.1-C1.2)
 

--- a/skills/compliance/soc2-gap/tsc-criteria.md
+++ b/skills/compliance/soc2-gap/tsc-criteria.md
@@ -271,15 +271,22 @@ This file contains the detailed Trust Services Criteria evaluation questions, ev
   - Are recovery procedures documented?
   - Are backups tested for recoverability?
   - Are disaster recovery and business continuity plans in place?
+  - Are backup and restore controls mapped to stated RPO/RTO and customer commitments?
+  - Are backups protected from deletion or alteration by the same compromise path as production?
 - Evidence to look for:
   - Disaster recovery plan
   - Business continuity plan
   - Backup configuration and retention records
   - Backup restoration test records
+  - Failed-backup alert and ticket records
+  - Immutable retention, object/vault lock, offline-copy, or backup-account separation evidence
+  - Restore integrity checks and business-owner sign-off
 - Common gaps:
   - Backups exist but have never been tested for restoration
   - No documented disaster recovery plan
   - Recovery time objectives (RTO) and recovery point objectives (RPO) are undefined
+  - Restore tests are limited to dev-only samples or do not measure elapsed recovery time
+  - Backup administrators can delete backups through the same privileged path that controls production
 
 ---
 
@@ -360,14 +367,37 @@ Based on the scope determined in Step 1, evaluate the following additional crite
   - Backup configuration and monitoring records
   - Backup restoration test results (at least annual)
   - Redundancy configurations (multi-AZ, multi-region)
-- Common gaps: Backups are not monitored for success/failure; no restoration testing; single point of failure in architecture.
+  - Retention-lock, object-lock, vault-lock, offline-copy, or deletion-protection evidence
+  - Backup-job alert routing, escalation, and closure evidence
+  - Backup encryption-key custody and backup-admin separation records
+- Common gaps: Backups are not monitored for success/failure; no restoration testing; single point of failure in architecture; backup retention is mutable by production administrators; backup job failures have no ticketed escalation.
 
 **A1.3 -- The entity tests recovery plan procedures supporting system recovery to meet its objectives.**
 - Evidence to look for:
   - DR test plan and execution records
   - DR test results and findings
   - Remediation of issues found during DR testing
-- Common gaps: DR plan exists but has never been tested; DR tests do not cover all critical systems.
+  - Restore-drill scope showing production-like dependencies and representative data sets
+  - Measured restore duration and latest recoverable backup age compared to RTO/RPO
+  - Restored data integrity validation (checksums, record counts, application smoke tests, or reconciliation)
+  - Business-owner sign-off or management risk acceptance for unresolved recovery findings
+- Common gaps: DR plan exists but has never been tested; DR tests do not cover all critical systems; tests restore only a small dev sample; tests do not verify data integrity; failed DR test findings are not retested.
+
+#### Availability Backup Resilience Evidence Gate
+
+When Availability is in scope, use this gate before scoring CC7.5, A1.2, or A1.3 as Defined or Managed:
+
+| Evidence Area | Auditor-Verifiable Evidence | False Positive to Avoid |
+|---------------|-----------------------------|-------------------------|
+| RPO/RTO linkage | System-specific RPO/RTO mapped to backup frequency, backup age, restore duration, and customer commitments | Treating policy objectives as achieved outcomes |
+| Backup monitoring | Job success/failure history, alert rules, escalation tickets, and closure records | Relying on a green dashboard screenshot with no failure-handling evidence |
+| Deletion resistance | Immutable backup, object lock, vault lock, offline copy, retention lock, MFA delete, or documented compensating control | Accepting mutable snapshots controlled by the same production admin group |
+| Admin separation | Separate backup admin role, key custody, break-glass approval, and retention override logging | Allowing compromised production admins to erase recovery evidence |
+| Restore drill scope | Production-like dependency map, representative data sets, infrastructure/configuration restore, and known exclusions | Using a single dev-table restore to prove full service recovery |
+| Integrity validation | Checksums, record counts, application smoke tests, reconciliation, or business-owner sign-off | Marking a restore successful because data files were copied |
+| Finding remediation | DR findings, owners, due dates, retest evidence, and residual-risk acceptance | Leaving failed DR test findings open without management decision |
+
+Use `Not Evaluable` when the review lacks system-boundary, critical-data, backup-job, or restore-test evidence. Do not infer backup maturity from architecture claims, provider marketing pages, or policy text alone.
 
 ### Confidentiality Criteria (C1.1-C1.2)
 
@@ -550,13 +580,13 @@ After scoring, calculate:
 | CC7.2 | SIEM deployment evidence; log retention policy and compliance evidence; alert rules and escalation docs |
 | CC7.3 | Incident response plan; severity classification matrix; triage procedures |
 | CC7.4 | Tabletop exercise records; IR team roster; communication templates; post-incident review records |
-| CC7.5 | DR plan; BC plan; backup configs; backup restoration test records |
+| CC7.5 | DR plan; BC plan; backup configs; backup restoration test records; failed-backup alert tickets; immutable/deletion-resistant backup evidence; restore integrity validation |
 | CC8.1 | Change management policy; CI/CD pipeline configs with approval gates; PR review records; CAB minutes; segregation of duties evidence |
 | CC9.1 | Risk treatment plans; business impact analysis; risk acceptance sign-off records |
 | CC9.2 | Vendor management policy; vendor risk assessments; vendor SOC 2 review records; vendor inventory; DPAs/BAAs |
 | A1.1 | Capacity monitoring dashboards; auto-scaling configs; capacity planning documentation |
-| A1.2 | Backup policy with RPO/RTO; backup monitoring records; restoration test results; redundancy configs |
-| A1.3 | DR test plan; DR test execution records; DR test findings and remediation |
+| A1.2 | Backup policy with RPO/RTO; backup monitoring records; restoration test results; redundancy configs; backup retention/immutability evidence; backup-admin separation and encryption-key custody records |
+| A1.3 | DR test plan; DR test execution records; measured restore duration; latest recoverable backup age; restored data integrity validation; DR test findings, remediation, and retest evidence |
 | C1.1 | Data classification policy; confidential data inventory; classification labeling evidence |
 | C1.2 | Data retention and disposal policy; destruction certificates; automated lifecycle configs |
 | PI1.1-PI1.5 | Processing specifications; input validation rules; reconciliation procedures; output validation; storage integrity controls |


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `soc2-gap`
**Skill path:** `skills/compliance/soc2-gap/`

### What Was Wrong
Closes #806.

The SOC 2 gap analysis skill already asks for backup policy, monitoring records, restoration test results, and DR testing for CC7.5 / A1.2 / A1.3. However, it could still over-score Availability readiness from policy-only or schedule-only backup evidence. A backup job can be scheduled and a restore test can be documented while recovery remains ineffective because backups are mutable, failures are not ticketed, restore drills are too narrow, or measured restore outcomes do not meet RPO/RTO.

### What This PR Fixes

- Adds an Availability backup and restore evidence gate to `soc2-gap`.
- Adds a Backup Resilience Evidence Matrix covering RPO/RTO, latest backup age, failed-job monitoring, retention/immutability, admin separation, restore drill scope, measured restore time, integrity validation, and residual findings.
- Adds `BACKUP-RES-01` through `BACKUP-RES-09` findings for policy-only backups, stale restore tests, mutable backups, admin blast-radius issues, missed RPO/RTO, missing integrity validation, and unresolved DR findings.
- Expands CC7.5, A1.2, and A1.3 evidence requirements in `tsc-criteria.md`.
- Updates the 90-day remediation roadmap, ongoing activities, output format, evidence artifact reference, and index tags.

### Validation

- `git diff --check`
- Markdown fence balance check for touched SOC 2 files
- Markdown table smoke check for touched SOC 2 files
- `soc2-gap` frontmatter parse and required-key check
- `index.yaml` / frontmatter tag text sync check
- Content coverage assertions for backup resilience findings, RPO/RTO, `Not Evaluable`, restore-test, failed-job, and integrity evidence
- Old-email scan for `tanzehao@bytedance.com`
- Prompt phrase scope check confirming `ignore previous instructions` appears only in the existing Prompt Injection Safety Notice

Note: a full Ruby `YAML.load_file("index.yaml")` still fails on a pre-existing unquoted `ISO/IEC-27001:2022` scalar elsewhere in `index.yaml`; this PR does not touch that existing issue.

### Bounty

This is an Improver-tier contribution. I am requesting the Moderate tier (`$100`) for adding a first-class SOC 2 Availability backup/restore evidence gate.

Preferred payment method: PayPal `tzh476@gmail.com`
