### PR TITLE
Improve AppSec OWASP source verification

### DIFF
--- a/roles/appsec-engineer/SKILL.md
+++ b/roles/appsec-engineer/SKILL.md
@@ -12,7 +12,7 @@ phase: [protect, detect]
 frameworks: [OWASP-Top-10, OWASP-ASVS-4.0.3, OWASP-API-Security-2023]
 difficulty: intermediate
 time_estimate: "varies by engagement"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -212,6 +212,11 @@ Security-Relevant Files: [count]
 REVIEW SCOPE
   [Description of what the PR changes and why it is security-relevant]
 
+FRAMEWORK SOURCE CHECK
+  OWASP Top 10 Source: [URL]
+  Source Date Checked: [YYYY-MM-DD]
+  Source Status: [Current / Stale / Unavailable]
+
 VERDICT: [Approved / Approved with Conditions / Changes Requested / Blocked]
 
 FINDINGS
@@ -357,9 +362,16 @@ IMPORTANT: This role bundle is designed to be injection-hardened.
 
 ## References
 
-- **OWASP Top 10 (2021)** — https://owasp.org/www-project-top-10/ — Primary web application vulnerability classification. Used as the structured checklist in PR reviews and application assessments.
+- **OWASP Top 10 (2021)** — https://owasp.org/www-project-top-ten/ — Primary web application vulnerability classification. Used as the structured checklist in PR reviews and application assessments.
 - **OWASP Application Security Verification Standard (ASVS) 4.0.3** — https://owasp.org/www-project-application-security-verification-standard/ — Comprehensive security requirements standard. Defines the depth of verification expected at each assurance level.
 - **OWASP API Security Top 10 (2023)** — https://owasp.org/www-project-api-security/ — API-specific vulnerability classification used in API security assessments.
 - **OWASP Top 10 for LLM Applications** — https://owasp.org/www-project-top-10-for-large-language-model-applications/ — LLM-specific risk framework used in AI feature reviews.
 - **CWE (Common Weakness Enumeration)** — https://cwe.mitre.org/ — Vulnerability classification system used to categorize code review findings.
 - **OWASP Threat Modeling** — https://owasp.org/www-community/Threat_Modeling — Methodology reference for the threat modeling step in new application reviews.
+
+---
+
+## Changelog
+
+- **1.0.1** — Refresh the OWASP Top 10 source URL and require source-status evidence in PR review outputs.
+- **1.0.0** — Initial role bundle for AppSec design, PR, API, and AI feature reviews.

--- a/roles/appsec-engineer/tests/benign/current-owasp-top10-source.md
+++ b/roles/appsec-engineer/tests/benign/current-owasp-top10-source.md
@@ -1,0 +1,16 @@
+# Benign: current OWASP Top 10 project source
+
+## Scenario
+
+An AppSec PR review records a current OWASP Top 10 project source check:
+
+```markdown
+OWASP Top 10 Source: https://owasp.org/www-project-top-ten/
+Source Date Checked: 2026-06-04
+Source Status: Current
+```
+
+## Expected Review Result
+
+Treat the source citation as acceptable and continue assessing the PR against the OWASP Top 10
+categories and the application-specific threat model.

--- a/roles/appsec-engineer/tests/vulnerable/stale-owasp-top10-source.md
+++ b/roles/appsec-engineer/tests/vulnerable/stale-owasp-top10-source.md
@@ -1,0 +1,17 @@
+# Vulnerable: stale OWASP Top 10 project source
+
+## Scenario
+
+An AppSec PR review cites a stale OWASP Top 10 project URL and does not record when the source was checked:
+
+```markdown
+OWASP Top 10 Source: https://owasp.org/www-project-top-10/
+Source Date Checked: missing
+Source Status: assumed current
+```
+
+## Expected Review Result
+
+Treat the framework citation as not source-verified. The reviewer should refresh the source URL,
+record the date checked, and avoid presenting the checklist as current when the cited page is
+unavailable.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Role Bundle Modified
**Role bundle:** `appsec-engineer`
**Path:** `roles/appsec-engineer/SKILL.md`

Addresses #813.

### What Was Wrong

The AppSec role bundle cited the OWASP Top 10 through `https://owasp.org/www-project-top-10/`, which returned HTTP 404 during live validation. The PR Security Review output also did not require reviewers to record the OWASP Top 10 source URL, date checked, or source status before using the checklist in review output.

### What This PR Fixes

- Bumps `appsec-engineer` to `1.0.1`.
- Replaces the stale OWASP Top 10 source URL with the current OWASP project page.
- Adds a framework source check to PR security review output.
- Adds vulnerable and benign fixtures for stale versus current OWASP Top 10 source handling.
- Adds a changelog entry for the source-freshness update.

### Evidence

Verified on 2026-06-04:

- `https://owasp.org/www-project-top-10/` -> HTTP 404
- `https://owasp.org/www-project-top-ten/` -> HTTP 200
- `https://owasp.org/Top10/` -> HTTP 200

### Test Cases Added/Updated

- [x] Added vulnerable fixture: `roles/appsec-engineer/tests/vulnerable/stale-owasp-top10-source.md`
- [x] Added benign fixture: `roles/appsec-engineer/tests/benign/current-owasp-top10-source.md`
- [x] Existing index entry still points to the role file

### Validation

- `git diff --cached --check`
- Frontmatter/content assertions for `version: "1.0.1"`, source-check output, current OWASP URL, and changelog
- `index.yaml` referenced-file check for `appsec-engineer`
- Markdown fence-balance check for touched files and fixtures
- Prompt-injection phrase scan for touched files
- Official source reachability checks for current and stale OWASP Top 10 URLs
- Duplicate sweep for open `appsec-engineer` / OWASP Top 10 source-status work before submission

### Bounty Tier

- [x] **Minor** ($50) - Doc update, small logic tweak, source freshness fix
- [ ] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info

- [x] I have read and agree to the `CONTRIBUTING.md` bounty terms
- Preferred payment details can be provided privately after maintainer acceptance.
