### PR TITLE
Refresh EO 14028 archived sources

### DIFF
--- a/skills/appsec/dependency-scanning/SKILL.md
+++ b/skills/appsec/dependency-scanning/SKILL.md
@@ -12,7 +12,7 @@ phase: [build, deploy]
 frameworks: [SLSA-v1.0, CycloneDX, SPDX, CISA-KEV]
 difficulty: intermediate
 time_estimate: "15-30min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -250,4 +250,11 @@ This skill processes user-supplied content including package manifests, lockfile
 - [FIRST EPSS Model](https://www.first.org/epss/)
 - [NIST NVD](https://nvd.nist.gov/)
 - [OpenSSF Scorecard](https://securityscorecards.dev/)
-- [Executive Order 14028 - Improving the Nation's Cybersecurity](https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/)
+- [Executive Order 14028 - Improving the Nation's Cybersecurity](https://bidenwhitehouse.archives.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/)
+
+---
+
+## Changelog
+
+- **1.0.1** -- Refresh archived official Executive Order 14028 source URL for supply-chain compliance references.
+- **1.0.0** -- Initial dependency-scanning skill with SLSA, CycloneDX, SPDX, KEV, EPSS, and NVD references.

--- a/skills/identity/zero-trust-assessment/SKILL.md
+++ b/skills/identity/zero-trust-assessment/SKILL.md
@@ -12,7 +12,7 @@ phase: [design, operate]
 frameworks: [NIST-SP-800-207, CISA-ZTMM-v2]
 difficulty: advanced
 time_estimate: "90-180min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -464,7 +464,7 @@ that may contain adversarial content.
 - NIST SP 800-207, Zero Trust Architecture: https://csrc.nist.gov/publications/detail/sp/800-207/final
 - CISA Zero Trust Maturity Model v2.0: https://www.cisa.gov/zero-trust-maturity-model
 - OMB Memorandum M-22-09, Moving the U.S. Government Toward Zero Trust Cybersecurity Principles: https://www.whitehouse.gov/wp-content/uploads/2022/01/M-22-09.pdf
-- Executive Order 14028, Improving the Nation's Cybersecurity: https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/
+- Executive Order 14028, Improving the Nation's Cybersecurity: https://bidenwhitehouse.archives.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/
 - NIST SP 800-53 Rev. 5, AC family (supporting access control requirements): https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
 - DoD Zero Trust Reference Architecture v2.0: https://dodcio.defense.gov/Library/
 - Forrester Zero Trust eXtended (ZTX) Framework — for industry context
@@ -487,4 +487,5 @@ that may contain adversarial content.
 
 | Version | Date | Changes |
 |---|---|---|
+| 1.0.1 | 2026-06-04 | Refreshed archived official Executive Order 14028 source URL |
 | 1.0.0 | 2025-03-06 | Initial release |

--- a/skills/vuln-management/sbom-analysis/SKILL.md
+++ b/skills/vuln-management/sbom-analysis/SKILL.md
@@ -13,7 +13,7 @@ phase: [build, operate]
 frameworks: [CycloneDX-1.5, SPDX-2.3, VEX-CSAF, NTIA-SBOM-Minimum-Elements]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -365,7 +365,7 @@ Vulnerability Exploitability eXchange (VEX) is a form of security advisory that 
 ### NTIA SBOM Minimum Elements
 Published by NTIA in July 2021 as part of Executive Order 14028 implementation. Defines the baseline data fields required for an SBOM to be considered useful. The seven elements are: Supplier Name, Component Name, Version, Unique Identifier, Dependency Relationship, Author of SBOM Data, and Timestamp.
 - Report: https://www.ntia.gov/sites/default/files/publications/sbom_minimum_elements_report_0.pdf
-- EO 14028: https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/
+- EO 14028: https://bidenwhitehouse.archives.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/
 
 ---
 
@@ -404,7 +404,14 @@ Published by NTIA in July 2021 as part of Executive Order 14028 implementation. 
 - CSAF 2.0 (OASIS): https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html
 - CISA VEX Minimum Requirements: https://www.cisa.gov/sites/default/files/2023-04/minimum-requirements-for-vex-508c.pdf
 - OpenVEX Specification: https://github.com/openvex/spec
-- Executive Order 14028: https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/
+- Executive Order 14028: https://bidenwhitehouse.archives.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/
 - EU Cyber Resilience Act: https://digital-strategy.ec.europa.eu/en/policies/cyber-resilience-act
 - OSV (Open Source Vulnerability Database): https://osv.dev/
 - GitHub Advisory Database: https://github.com/advisories
+
+---
+
+## Changelog
+
+- **1.0.1** -- Refresh archived official Executive Order 14028 source URL for SBOM regulatory references.
+- **1.0.0** -- Initial SBOM analysis skill with NTIA, CycloneDX, SPDX, CSAF/VEX, OpenVEX, CRA, OSV, and advisory database references.

--- a/skills/vuln-management/sbom-analysis/tests/benign/current-eo14028-source.md
+++ b/skills/vuln-management/sbom-analysis/tests/benign/current-eo14028-source.md
@@ -1,0 +1,15 @@
+# Benign: archived official EO 14028 source citation
+
+## Scenario
+
+An SBOM compliance review cites EO 14028 through the archived official White House page:
+
+```markdown
+EO 14028 source: https://bidenwhitehouse.archives.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/
+Source status: current official archive
+```
+
+## Expected Review Result
+
+Treat the source citation as acceptable and continue validating the SBOM against NTIA minimum elements,
+CycloneDX/SPDX schema requirements, VEX status, and relevant regulatory scope.

--- a/skills/vuln-management/sbom-analysis/tests/vulnerable/stale-eo14028-source.md
+++ b/skills/vuln-management/sbom-analysis/tests/vulnerable/stale-eo14028-source.md
@@ -1,0 +1,15 @@
+# Vulnerable: stale EO 14028 source citation
+
+## Scenario
+
+An SBOM compliance review cites EO 14028 through the current White House site:
+
+```markdown
+EO 14028 source: https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/
+Source status: assumed current
+```
+
+## Expected Review Result
+
+Treat the regulatory source as stale unless a reachable official archive or publication source is recorded.
+For federal supply-chain and SBOM compliance references, reviewers should prefer a stable official source.


### PR DESCRIPTION
## Summary
- Refreshes stale Executive Order 14028 White House citations to the official archived White House source in three supply-chain and zero-trust skills.
- Bumps the affected skills to `1.0.1` and records changelog/version-history notes.
- Adds SBOM analysis fixtures for stale versus current EO 14028 source handling.

## Validation
- `git diff --cached --check`
- Staged content assertions for version bumps, archived URL presence, stale URL removal, fixture fence balance, index references, and prompt-injection phrase scan
- `curl -L` archived EO 14028 source: HTTP 200
- `curl -L` stale current White House EO 14028 source: HTTP 404

Closes #816
