### PR TITLE
Add AWS organization scope evidence guidance

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -99,7 +99,68 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
-### Step 7: Compile Assessment Report
+### Step 7: AWS Organization Coverage and Scope Calibration
+
+Before assigning organization-wide pass/fail conclusions, determine whether the
+available evidence proves account-local posture, delegated-administrator scope,
+or full AWS Organizations coverage.
+
+Record the following when AWS Organizations, delegated administrators, Security
+Hub, Access Analyzer, CloudTrail organization trails, AWS Config aggregators, or
+SCPs appear in scope:
+
+- Organization ID, management account, delegated administrator account(s), and
+  evidence source date.
+- Accounts, OUs, and Regions reviewed, including the coverage denominator when
+  known (for example, `17/19 active accounts`, `4/5 enabled Regions`).
+- Excluded, suspended, self-managed, newly created, or unavailable accounts/OUs.
+- Whether CloudTrail, Security Hub, Access Analyzer, AWS Config, and related
+  exports are account-local, delegated-admin, organization-wide, sampled, or
+  unknown scope.
+- Whether local IAM/resource-policy findings have SCP, permission boundary,
+  session policy, delegated-admin, or resource-policy evidence that changes the
+  effective blast radius.
+
+Use these scope outcomes consistently:
+
+- **Organization-wide:** Evidence identifies the organization/account/OU/Region
+  coverage and proves the control across the stated denominator.
+- **Delegated-admin scoped:** Evidence comes from a delegated administrator or
+  aggregator and must state home Region, linked Regions, target accounts/OUs,
+  and self-managed exceptions.
+- **Account-local:** Evidence proves only the reviewed account or module. Do not
+  extrapolate to the organization.
+- **Sampled/partial:** Evidence covers only selected accounts, OUs, Regions, or
+  files. State the sample and remaining unknowns.
+- **Not Evaluable from Single Account:** A control requires organization-wide
+  evidence, but only member-account or single-account evidence is available.
+- **Not Evaluable from IaC Only:** The source files do not include live account,
+  delegated-admin, aggregator, Region, or account inventory evidence needed to
+  prove the control.
+
+Specific checks to add to the CIS evaluation:
+
+- **CloudTrail organization trails:** Separate member-account trails from
+  `is_organization_trail` evidence. Record owning account, management/delegated
+  admin status, covered accounts/OUs, all-Region status, excluded Regions, log
+  file validation, KMS/log bucket evidence, and delivery health.
+- **IAM Access Analyzer:** Distinguish `ACCOUNT` analyzers from `ORGANIZATION`
+  analyzers. Record delegated administrator evidence and Region coverage before
+  treating external-access coverage as organization-wide.
+- **Security Hub CSPM central configuration:** Record home Region, linked
+  Regions, central configuration policies, target account/OU associations, and
+  centrally managed vs self-managed targets.
+- **AWS Config aggregators:** Record aggregator account, source accounts/OUs,
+  Region list, excluded accounts, and last successful aggregation time.
+- **SCP and effective-access qualifiers:** SCPs set maximum permissions; they do
+  not grant permissions and do not automatically make a broad local allow safe.
+  If SCPs, permission boundaries, session policies, or delegated-admin
+  boundaries reduce blast radius, cite that evidence and lower confidence when
+  it is incomplete.
+
+---
+
+### Step 8: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
 
@@ -128,6 +189,16 @@ Produce the final report using the structure defined in the Output Format sectio
 - Framework: CIS Amazon Web Services Foundations Benchmark v3.0.0
 - Files reviewed: <list of IaC files>
 
+### AWS Organization Coverage
+- Organization ID: <org id or Not Evaluable>
+- Management account: <account id/name or unknown>
+- Delegated administrators reviewed: <service -> account/Region/scope>
+- Accounts/OUs reviewed: <count/list and denominator>
+- Regions reviewed: <enabled Regions, linked Regions, excluded Regions>
+- Evidence source/date: <IaC, CLI export, Security Hub, Config aggregator, CloudTrail, Access Analyzer>
+- Coverage status: Organization-wide / Delegated-admin scoped / Account-local / Sampled / Not Evaluable
+- Exclusions and limitations: <suspended accounts, self-managed targets, missing Regions, unavailable exports>
+
 ### Executive Summary
 - Total CIS recommendations evaluated: <N>/62
 - Passed: <N>
@@ -154,6 +225,12 @@ Produce the final report using the structure defined in the Output Format sectio
 - **CIS Profile:** Level 1 / Level 2
 - **File:** <path to relevant config>
 - **Line(s):** <line numbers if applicable>
+- **Evidence Scope:** Organization-wide / Delegated-admin scoped / Account-local / Sampled / IaC-only / Unknown
+- **Account / OU / Region:** <covered account, OU, Region, or denominator>
+- **Delegated Admin Evidence:** <service, delegated admin account, home/linked Regions, or none>
+- **Coverage Denominator:** <covered accounts/Regions over known total, or Not Evaluable>
+- **Effective Access Qualifiers:** <SCP, permission boundary, session policy, resource policy, or none>
+- **Not Evaluable Reason:** Single-account-only evidence / IaC-only evidence / missing Region inventory / missing account denominator / stale aggregator export / missing delegated-admin evidence / not applicable
 - **Description:** <what was found>
 - **Evidence:** <specific configuration or code snippet>
 - **Remediation:** <specific fix with code example>
@@ -196,10 +273,13 @@ Produce the final report using the structure defined in the Output Format sectio
 
 1. **Checking only Terraform state, not all resource definitions.** Security groups and IAM policies may be defined across dozens of files. Always use Glob to find all `.tf` files before evaluating.
 2. **Missing account-level vs. bucket-level S3 public access blocks.** CIS 2.1.4 requires both. An account-level block can override permissive bucket settings, but the bucket-level block should also be set.
-3. **Confusing CloudTrail multi-region with organization trail.** CIS 3.1 requires multi-region, not necessarily an organization trail. Both are valid, but the control checks `is_multi_region_trail`.
-4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
-5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
-6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
+3. **Confusing account-local evidence with organization-wide coverage.** A member-account trail, analyzer, Security Hub export, or Config snapshot proves only the stated account/Region unless the evidence includes organization ID, delegated administrator, account/OU denominator, and Region coverage.
+4. **Confusing CloudTrail multi-region with organization trail.** CIS 3.1 requires multi-region, not necessarily an organization trail. Both are valid, but the control checks `is_multi_region_trail`; organization-wide conclusions also require `is_organization_trail`, owning account, account/OU coverage, and delivery evidence.
+5. **Treating Security Hub or Config aggregation as complete by default.** Security Hub central configuration and AWS Config aggregators can exclude accounts, OUs, linked Regions, or self-managed targets. Record target associations and last aggregation time before marking controls organization-wide.
+6. **Treating SCPs as proof of safety.** SCPs set permission ceilings but do not grant or fully explain effective access. Do not downgrade broad IAM/resource-policy findings unless SCPs, permission boundaries, session policies, and resource policies are all evidenced for the affected principal and account scope.
+7. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
+8. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
+9. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass." Use `Not Evaluable from Single Account` or `Not Evaluable from IaC Only` when organization or live-export evidence is required.
 
 ---
 
@@ -223,7 +303,13 @@ Produce the final report using the structure defined in the Output Format sectio
 - AWS Security Best Practices: https://docs.aws.amazon.com/security/
 - AWS IAM Best Practices: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 - AWS CloudTrail Documentation: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/
+- AWS CloudTrail Organization Trails: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-trail-organization.html
+- AWS Organizations CloudTrail Integration: https://docs.aws.amazon.com/organizations/latest/userguide/services-that-can-integrate-cloudtrail.html
+- IAM Access Analyzer Delegated Administrator: https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-delegated-administrator.html
+- IAM Access Analyzer Overview: https://docs.aws.amazon.com/IAM/latest/UserGuide/what-is-access-analyzer.html
 - AWS Security Hub: https://docs.aws.amazon.com/securityhub/latest/userguide/
+- AWS Security Hub Central Configuration: https://docs.aws.amazon.com/securityhub/latest/userguide/start-central-configuration.html
+- Security Hub Central vs Self-Managed Targets: https://docs.aws.amazon.com/securityhub/latest/userguide/central-configuration-management-type.html
 - AWS VPC Security: https://docs.aws.amazon.com/vpc/latest/userguide/security.html
 - Terraform AWS Provider Documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 
@@ -231,4 +317,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Added AWS organization coverage calibration, delegated administrator scope fields, organization-wide evidence source handling, and Not Evaluable reason codes for single-account or IaC-only evidence.
 - **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 (62 recommendations).


### PR DESCRIPTION
## Summary
- Adds an AWS organization coverage calibration step to `aws-review`.
- Adds output fields for delegated administrators, account/OU/Region scope, coverage denominator, effective-access qualifiers, and Not Evaluable reasons.
- Expands pitfalls and references for CloudTrail organization trails, Access Analyzer organization scope, Security Hub central configuration, AWS Config aggregators, and SCP boundaries.

## Testing
- Documentation-only skill update; verified the edited Markdown has balanced fences and ASCII-only content.
- Reviewed the diff to confirm it touches only `skills/cloud/aws-review/SKILL.md`.

Addresses #190

## Bounty
Preferred payout: crypto
EVM wallet: 0xD23dcD5F6582a6C46CcA93E8b971e403dA3cD401