### PR TITLE
Quote ISO framework IDs for YAML parsing

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -389,7 +389,7 @@ skills:
     role: [vciso, security-engineer]
     phase: [assess, operate]
     activity: [audit, assess]
-    frameworks: [ISO/IEC-27001:2022, ISO/IEC-27002:2022]
+    frameworks: ["ISO/IEC-27001:2022", "ISO/IEC-27002:2022"]
     difficulty: intermediate
     time_estimate: "90-180min"
     file: skills/compliance/iso27001-gap/SKILL.md

--- a/skills/compliance/iso27001-gap/SKILL.md
+++ b/skills/compliance/iso27001-gap/SKILL.md
@@ -10,7 +10,7 @@ description: >
 tags: [compliance, iso27001, isms]
 role: [vciso, security-engineer]
 phase: [assess, operate]
-frameworks: [ISO/IEC-27001:2022, ISO/IEC-27002:2022]
+frameworks: ["ISO/IEC-27001:2022", "ISO/IEC-27002:2022"]
 difficulty: intermediate
 time_estimate: "90-180min"
 version: "1.0.0"


### PR DESCRIPTION
## Summary

- quotes the ISO/IEC framework IDs in `index.yaml` so standard YAML parsers can load the skill catalog
- applies the same quoting to the `iso27001-gap` skill frontmatter, which uses the same ISO/IEC identifiers

Closes #627.

## Validation

- `git diff --check`
- `ruby -ryaml -e 'data = YAML.load_file("index.yaml"); puts data.fetch("skills").find { |s| s["id"] == "iso27001-gap" }.fetch("frameworks").join(",")'`\n- `ruby -ryaml -e 'text = File.read("skills/compliance/iso27001-gap/SKILL.md"); fm = text.split("---", 3)[1]; data = YAML.safe_load(fm); puts data.fetch("frameworks").join(",")'`\n- all `skills/**/SKILL.md` and `roles/**/SKILL.md` frontmatter parsed with Ruby YAML\n- all `index.yaml` `file:` entries resolve on disk\n\n## Bounty Info\n\n- I have read and agree to the `CONTRIBUTING.md` bounty terms.\n- Payment details can be provided privately after maintainer acceptance/merge.