### PR TITLE
Improve azure-review authentication strength evidence

### DIFF
--- a/skills/cloud/azure-review/SKILL.md
+++ b/skills/cloud/azure-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-Azure-v2.1.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -152,6 +152,9 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration or code snippet>
+- **Authentication Strength Evidence:** <required for Section 1 MFA findings; CA grant control, strength, method policy scope, and admin/guest coverage>
+- **External MFA Trust Evidence:** <required when guests or partner tenants are in scope; inbound trust settings, accepted methods, and resource-tenant fallback>
+- **Exception Evidence:** <break-glass, service account, service principal, or emergency-access exclusions with owner, monitoring, vaulting, and test cadence>
 - **Remediation:** <specific fix with code example>
 
 ### Prioritized Remediation Plan
@@ -175,7 +178,7 @@ Produce the final report using the structure defined in the Output Format sectio
 
 | Section | Domain | Key Focus Areas |
 |---------|--------|-----------------|
-| 1 | Identity and Access Management | Entra ID security defaults, MFA enforcement, Conditional Access policies, guest user management, PIM configuration |
+| 1 | Identity and Access Management | Entra ID security defaults, MFA enforcement, authentication strength, Conditional Access policies, external MFA trust, guest user management, PIM configuration |
 | 2 | Microsoft Defender for Cloud | Defender plan enablement (Servers, App Service, SQL, Storage, Containers, Key Vault, DNS, ARM), security contacts, auto-provisioning |
 | 3 | Storage Accounts | HTTPS enforcement, infrastructure encryption, public access, network rules, soft delete, CMK encryption, TLS version |
 | 4 | Database Services | SQL auditing, firewall rules, threat detection, SSL enforcement, TDE, Entra ID admin, Cosmos DB public access |
@@ -200,6 +203,10 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **NSG rules using service tags.** A rule with `source_address_prefix = "Internet"` is equivalent to `0.0.0.0/0`. Both must be flagged for CIS 6.1 and 6.2.
 5. **Key Vault purge protection is irreversible.** CIS 8.5 requires `purge_protection_enabled = true`. Note this cannot be disabled once enabled -- flag this for awareness during remediation.
 6. **App Service TLS version on both Linux and Windows.** Check `azurerm_linux_web_app` and `azurerm_windows_web_app` resources separately.
+7. **Treating all MFA controls as equivalent.** `built_in_controls = ["mfa"]`, legacy per-user MFA, and `require_mfa: true` prove ordinary MFA, not phishing-resistant authentication strength for privileged roles or sensitive apps.
+8. **Passing Conditional Access from policy names alone.** A policy named "Require MFA" is not enough. Verify enabled state, include/exclude scope, grant controls, authentication method policy scope, and whether included users can register methods that satisfy the required strength.
+9. **Assuming home-tenant MFA is always acceptable for external users.** Cross-tenant MFA trust, partner tenant scope, accepted method combinations, and resource-tenant fallback must be evidenced before passing guest access to sensitive resources.
+10. **Flagging documented break-glass exclusions as failures.** Emergency access accounts should normally be excluded from broad Conditional Access lockout risks, but they need separate owner approval, monitoring, vaulting, and periodic test evidence.
 
 ---
 
@@ -222,6 +229,10 @@ Produce the final report using the structure defined in the Output Format sectio
 - CIS Microsoft Azure Foundations Benchmark v2.1.0: https://www.cisecurity.org/benchmark/azure
 - Microsoft Defender for Cloud Documentation: https://learn.microsoft.com/en-us/azure/defender-for-cloud/
 - Microsoft Entra ID Security: https://learn.microsoft.com/en-us/entra/identity/
+- Conditional Access authentication strengths: https://learn.microsoft.com/en-us/entra/identity/authentication/concept-authentication-strengths
+- Phishing-resistant MFA for administrator roles: https://learn.microsoft.com/en-us/entra/identity/conditional-access/policy-admin-phish-resistant-mfa
+- Authentication strength for external users: https://learn.microsoft.com/en-us/entra/identity/conditional-access/policy-guests-mfa-strength
+- Emergency access accounts in Microsoft Entra ID: https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/security-emergency-access
 - Azure Storage Security: https://learn.microsoft.com/en-us/azure/storage/common/storage-security-guide
 - Azure Key Vault Best Practices: https://learn.microsoft.com/en-us/azure/key-vault/general/best-practices
 - Azure App Service Security: https://learn.microsoft.com/en-us/azure/app-service/overview-security
@@ -231,4 +242,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Added authentication strength, external MFA trust, and break-glass evidence gates for Section 1 identity findings.
 - **1.0.0** -- Initial release. Full coverage of CIS Microsoft Azure Foundations Benchmark v2.1.0 sections 1 through 9.

--- a/skills/cloud/azure-review/benchmark-checklist.md
+++ b/skills/cloud/azure-review/benchmark-checklist.md
@@ -21,6 +21,22 @@ resource "azuread_authentication_strength_policy" { ... }
 
 **Note:** Security Defaults should be disabled ONLY when Conditional Access policies provide equivalent or stronger controls.
 
+When Security Defaults are disabled, do not treat the setting as an automatic
+failure. Require evidence that Conditional Access provides the intended control:
+
+| Evidence | Pass condition | Finding trigger |
+|----------|----------------|-----------------|
+| Policy state | Relevant policies are `enabled` for enforcement | Policy is `disabled`, `reportOnly`, or only present as a draft/template |
+| Scope | Policies cover the required users, directory roles, user risks, apps, and resources | Privileged roles, sensitive apps, guests, or all-user scope are omitted without documented rationale |
+| Grant control | Policy uses `Require authentication strength` with the required built-in or custom strength, or generic MFA only where the review objective permits it | Generic `mfa` is counted as phishing-resistant MFA, or the grant control is missing |
+| Authentication methods | Method policies enable the methods needed by the included users/groups | Users in scope cannot register any method that satisfies the required strength |
+| Exceptions | Break-glass and service-principal exclusions have owner, monitoring, vaulting, and test evidence | Broad user/group exclusions, stale exception groups, or no break-glass monitoring evidence |
+
+If these artifacts are absent, mark the control **Not Evaluable** rather than
+passing based on a policy name such as "Require MFA." Mark it **Fail** when the
+available configuration proves that the relevant users/resources are not
+covered.
+
 #### CIS 1.1.2 -- Ensure that Multi-Factor Authentication is enabled for all privileged users
 
 Check for Conditional Access policies requiring MFA for admin roles:
@@ -38,13 +54,83 @@ resource "azuread_conditional_access_policy" {
 }
 ```
 
+Authentication strength gate for privileged roles:
+
+- For Global Administrator, Privileged Role Administrator, Conditional Access
+  Administrator, Security Administrator, Privileged Authentication
+  Administrator, Application Administrator, Cloud Application Administrator,
+  Exchange Administrator, SharePoint Administrator, User Administrator,
+  Authentication Administrator, Password Administrator, Billing Administrator,
+  and Helpdesk Administrator, record whether the enforcing policy uses
+  phishing-resistant MFA strength or only generic MFA.
+- Treat `built_in_controls = ["mfa"]`, `require_mfa: true`, legacy per-user
+  MFA, or a policy named "MFA" as ordinary MFA evidence, not as
+  phishing-resistant evidence.
+- Require authentication method policy evidence for the included admins:
+  FIDO2/passkeys, Windows Hello for Business or platform credentials, and
+  multifactor certificate-based authentication for phishing-resistant
+  strength; SMS, voice, push, and OATH methods alone do not satisfy that
+  stronger gate.
+- Confirm included admin roles are not bypassed through nested groups,
+  administrative unit-scoped/custom roles, stale exclusions, named-location
+  exclusions, device-platform exclusions, or report-only policy state.
+- Verify break-glass exclusions separately: at least two emergency accounts
+  where possible, owner approval, monitored use/change alerts, credential or
+  key vaulting evidence, and a periodic test cadence. Do not flag the exclusion
+  itself when this evidence exists.
+
+Use this finding calibration:
+
+| Scenario | Expected status |
+|----------|-----------------|
+| Security Defaults disabled, enabled CA policy covers privileged roles, grant control requires phishing-resistant MFA strength, admins can register allowed methods, and break-glass exclusions are documented | Pass |
+| Enabled CA policy covers privileged roles but only grants generic MFA while admin method policy allows SMS/voice/push only | Fail for phishing-resistant privileged-role evidence |
+| CA policy is report-only or excludes broad admin groups without owner/ticket/expiry | Fail |
+| Policy and method data are missing from the repository/export | Not Evaluable |
+
 #### CIS 1.1.3 -- Ensure that Multi-Factor Authentication is enabled for all non-privileged users
 
-Verify MFA requirement extends to all users, not just admins.
+Verify MFA requirement extends to all users, not just admins. For sensitive
+apps, high-risk users, finance/admin portals, and privileged operations,
+distinguish the configured authentication strength from the broad MFA grant
+control. Generic MFA can be acceptable for normal users when the policy/risk
+model says so, but should not silently downgrade a resource that requires
+passwordless or phishing-resistant strength.
 
 #### CIS 1.1.4 -- Ensure that 'Allow users to remember multi-factor authentication on devices they trust' is Disabled
 
 Check for MFA trust settings that weaken the control.
+
+For guests and external users, evaluate Conditional Access and cross-tenant
+access settings together:
+
+- Identify policies that include `Guest or external users`, B2B collaboration
+  users, direct-connect users, partner tenant groups, or sensitive apps exposed
+  to external identities.
+- Record whether the resource tenant requires generic MFA, passwordless MFA, a
+  built-in phishing-resistant MFA strength, or a custom authentication
+  strength.
+- Check inbound cross-tenant access settings for MFA trust. If the resource
+  tenant trusts MFA from the home tenant, require evidence of the trusted
+  partner tenant IDs, default vs partner-specific settings, accepted method
+  combinations, owner approval, review date, and whether the home-tenant claim
+  can satisfy the resource-tenant strength.
+- Do not pass external access based only on `require_mfa: true` when the
+  accepted home-tenant methods are unknown, all tenants are trusted by default,
+  or the sensitive app requires phishing-resistant authentication strength.
+- If external authentication methods, email OTP, SAML/WS-Fed, or Google
+  federation are in use, note whether authentication strength applies; where it
+  does not, evaluate the generic MFA grant control and residual risk instead.
+
+Suggested external-user evidence fields:
+
+| Field | Evidence to capture |
+|-------|---------------------|
+| External user scope | Included guest/external user types, partner tenant IDs, and sensitive apps/resources |
+| Resource-tenant CA grant | Generic MFA, passwordless MFA strength, phishing-resistant MFA strength, or custom strength |
+| Cross-tenant MFA trust | Default and partner-specific inbound trust settings, review date, and owner/ticket |
+| Method compatibility | Whether home-tenant or resource-tenant methods can satisfy the required strength |
+| Fallback path | Resource-tenant registration or challenge path when MFA trust is disabled or insufficient |
 
 ### CIS 1.2 -- Conditional Access Policies
 

--- a/skills/cloud/azure-review/benchmark-checklist.md
+++ b/skills/cloud/azure-review/benchmark-checklist.md
@@ -65,12 +65,15 @@ Authentication strength gate for privileged roles:
   phishing-resistant MFA strength or only generic MFA.
 - Treat `built_in_controls = ["mfa"]`, `require_mfa: true`, legacy per-user
   MFA, or a policy named "MFA" as ordinary MFA evidence, not as
-  phishing-resistant evidence.
+  phishing-resistant evidence. These controls can satisfy the CIS 1.1.2 MFA
+  requirement when scoped correctly, but should be reported separately as a
+  phishing-resistant authentication-strength gap when privileged-role risk,
+  organizational policy, or sensitive-resource scope requires stronger methods.
 - Require authentication method policy evidence for the included admins:
   FIDO2/passkeys, Windows Hello for Business or platform credentials, and
   multifactor certificate-based authentication for phishing-resistant
   strength; SMS, voice, push, and OATH methods alone do not satisfy that
-  stronger gate.
+  stronger gate, but do not fail the CIS MFA control solely for that reason.
 - Confirm included admin roles are not bypassed through nested groups,
   administrative unit-scoped/custom roles, stale exclusions, named-location
   exclusions, device-platform exclusions, or report-only policy state.
@@ -84,7 +87,7 @@ Use this finding calibration:
 | Scenario | Expected status |
 |----------|-----------------|
 | Security Defaults disabled, enabled CA policy covers privileged roles, grant control requires phishing-resistant MFA strength, admins can register allowed methods, and break-glass exclusions are documented | Pass |
-| Enabled CA policy covers privileged roles but only grants generic MFA while admin method policy allows SMS/voice/push only | Fail for phishing-resistant privileged-role evidence |
+| Enabled CA policy covers privileged roles with generic MFA while admin method policy allows SMS/voice/push only | Pass CIS 1.1.2 MFA coverage; add supplemental phishing-resistant MFA gap for privileged roles |
 | CA policy is report-only or excludes broad admin groups without owner/ticket/expiry | Fail |
 | Policy and method data are missing from the repository/export | Not Evaluable |
 

--- a/skills/cloud/azure-review/tests/benign/conditional-access-phishing-resistant-admins.yaml
+++ b/skills/cloud/azure-review/tests/benign/conditional-access-phishing-resistant-admins.yaml
@@ -1,0 +1,72 @@
+case: conditional_access_phishing_resistant_admins
+expected: should_not_trigger
+description: >
+  Security Defaults are intentionally disabled because enabled Conditional
+  Access policies enforce phishing-resistant MFA strength for privileged roles
+  and document break-glass exclusions.
+
+security_defaults:
+  enabled: false
+  disabled_reason: Conditional Access provides stronger scoped controls.
+
+conditional_access:
+  policies:
+    - name: require-phishing-resistant-mfa-for-admins
+      state: enabled
+      include_roles:
+        - Global Administrator
+        - Privileged Role Administrator
+        - Conditional Access Administrator
+        - Security Administrator
+        - Privileged Authentication Administrator
+      include_resources:
+        - all_cloud_apps
+      grant_controls:
+        require_authentication_strength:
+          display_name: Phishing-resistant MFA
+          policy_type: builtIn
+          allowed_combinations:
+            - fido2_security_key
+            - windows_hello_for_business
+            - certificate_based_authentication_multifactor
+      exclude_users:
+        - breakglass-admin-1
+        - breakglass-admin-2
+      report_only: false
+
+authentication_methods:
+  fido2_security_key:
+    enabled: true
+    include_groups:
+      - privileged-admins
+  windows_hello_for_business:
+    enabled: true
+    include_groups:
+      - privileged-admins
+  certificate_based_authentication:
+    enabled: true
+    include_groups:
+      - privileged-admins
+  sms:
+    enabled: false
+    include_groups: []
+  voice:
+    enabled: false
+    include_groups: []
+
+break_glass:
+  accounts:
+    - breakglass-admin-1
+    - breakglass-admin-2
+  owner: identity-security
+  monitoring_alert: Emergency access account sign-in or credential change
+  credential_vaulting: offline hardware security key custody record
+  test_cadence: quarterly
+  last_tested_at: "<last-quarter RFC3339>"
+
+review_expectation:
+  status: Pass
+  reason: >
+    The review should not flag Security Defaults disabled when enabled
+    Conditional Access policies provide stronger phishing-resistant controls
+    and documented emergency-access exceptions.

--- a/skills/cloud/azure-review/tests/benign/external-mfa-trust-scoped.yaml
+++ b/skills/cloud/azure-review/tests/benign/external-mfa-trust-scoped.yaml
@@ -1,0 +1,47 @@
+case: external_mfa_trust_scoped
+expected: should_not_trigger
+description: >
+  Guest access to a sensitive app uses a resource-tenant authentication
+  strength policy and partner-specific inbound MFA trust with reviewed method
+  evidence.
+
+external_user_access:
+  sensitive_app: finance-portal
+  included_external_user_types:
+    - b2b_collaboration_guest
+  conditional_access:
+    policy_name: require-phishing-resistant-mfa-for-finance-guests
+    state: enabled
+    include_resources:
+      - finance-portal
+    grant_controls:
+      require_authentication_strength:
+        display_name: Phishing-resistant MFA
+        policy_type: builtIn
+        allowed_combinations:
+          - fido2_security_key
+          - certificate_based_authentication_multifactor
+    exclude_users:
+      - finance-breakglass-guest-admin
+  cross_tenant_access_settings:
+    inbound_trust:
+      default_trust_mfa_from_home_tenant: false
+      partner_tenants:
+        - tenant_id: "11111111-2222-3333-4444-555555555555"
+          name: approved-auditor-tenant
+          trust_mfa_from_home_tenant: true
+          accepted_home_tenant_methods:
+            - fido2_security_key
+            - certificate_based_authentication_multifactor
+          owner: vendor-risk
+          ticket: VR-2026-042
+          reviewed_at: "<last-review RFC3339>"
+  fallback_path:
+    resource_tenant_registration_required_when_home_strength_missing: true
+    guest_registration_group: finance-portal-guest-strong-auth
+
+review_expectation:
+  status: Pass
+  reason: >
+    The reviewer can connect the sensitive app policy, partner-specific MFA
+    trust, accepted methods, owner review, and resource-tenant fallback path.

--- a/skills/cloud/azure-review/tests/vulnerable/admin-mfa-without-authentication-strength.yaml
+++ b/skills/cloud/azure-review/tests/vulnerable/admin-mfa-without-authentication-strength.yaml
@@ -1,0 +1,54 @@
+case: admin_mfa_without_authentication_strength
+expected: should_trigger
+description: >
+  Privileged roles have an enabled Conditional Access policy that requires
+  ordinary MFA, but admins are not enabled for any phishing-resistant method.
+
+security_defaults:
+  enabled: false
+
+conditional_access:
+  policies:
+    - name: require-mfa-for-admins
+      state: enabled
+      include_roles:
+        - Global Administrator
+        - Privileged Role Administrator
+        - Security Administrator
+      include_resources:
+        - all_cloud_apps
+      grant_controls:
+        built_in_controls:
+          - mfa
+      exclude_users:
+        - breakglass-admin-1
+
+authentication_methods:
+  allowed_for_admins:
+    sms:
+      enabled: true
+    voice:
+      enabled: true
+    push_notification:
+      enabled: true
+  phishing_resistant_methods:
+    fido2_security_key:
+      enabled_for_admins: false
+    windows_hello_for_business:
+      enabled_for_admins: false
+    certificate_based_authentication:
+      enabled_for_admins: false
+
+break_glass:
+  accounts:
+    - breakglass-admin-1
+  monitoring_alert: null
+  credential_vaulting: null
+  test_cadence: null
+
+review_expectation:
+  status: Fail
+  severity: High
+  reason: >
+    Generic MFA and phishable methods should not satisfy the
+    phishing-resistant MFA evidence gate for privileged roles.

--- a/skills/cloud/azure-review/tests/vulnerable/admin-mfa-without-authentication-strength.yaml
+++ b/skills/cloud/azure-review/tests/vulnerable/admin-mfa-without-authentication-strength.yaml
@@ -47,8 +47,9 @@ break_glass:
   test_cadence: null
 
 review_expectation:
-  status: Fail
+  status: Supplemental Finding
   severity: High
   reason: >
-    Generic MFA and phishable methods should not satisfy the
-    phishing-resistant MFA evidence gate for privileged roles.
+    Generic MFA can satisfy CIS 1.1.2 when scoped to privileged roles, but
+    phishable methods should still be reported as a separate privileged-role
+    phishing-resistant authentication-strength gap.

--- a/skills/cloud/azure-review/tests/vulnerable/external-mfa-trust-unverified.yaml
+++ b/skills/cloud/azure-review/tests/vulnerable/external-mfa-trust-unverified.yaml
@@ -1,0 +1,40 @@
+case: external_mfa_trust_unverified
+expected: should_trigger
+description: >
+  A sensitive application accepts external users with generic MFA and broad
+  home-tenant MFA trust, but lacks evidence that the home-tenant method
+  satisfies the resource-tenant requirement.
+
+external_user_access:
+  sensitive_app: finance-portal
+  included_external_user_types:
+    - b2b_collaboration_guest
+    - b2b_direct_connect_user
+  conditional_access:
+    policy_name: require-mfa-for-finance-guests
+    state: enabled
+    include_resources:
+      - finance-portal
+    grant_controls:
+      built_in_controls:
+        - mfa
+  cross_tenant_access_settings:
+    inbound_trust:
+      default_trust_mfa_from_home_tenant: true
+      partner_tenants: all
+      accepted_home_tenant_methods: unknown
+      owner: null
+      reviewed_at: null
+  missing_evidence:
+    - resource_tenant_authentication_strength
+    - accepted_home_tenant_methods
+    - partner_tenant_allowlist
+    - resource_tenant_registration_or_challenge_path
+
+review_expectation:
+  status: Fail
+  severity: High
+  reason: >
+    The reviewer should not pass sensitive external access from a broad
+    require-MFA policy when cross-tenant trust and method-strength evidence are
+    unknown.


### PR DESCRIPTION
Closes #838.

## Summary
- add Section 1 evidence gates that distinguish Security Defaults, generic MFA, authentication strength, method policy scope, and documented break-glass exclusions
- add external-user MFA trust checks covering cross-tenant inbound trust, partner scope, accepted methods, and resource-tenant fallback paths
- add benign/vulnerable calibration fixtures for privileged-role phishing-resistant MFA and external MFA trust edge cases

## Bounty
- Requesting Moderate implementation bounty: $100
- Preferred payment: PayPal `tzh476@gmail.com`

## Validation
- `git diff --check`
- `git diff --cached --check`
- `ruby -e 'require "yaml"; Dir["skills/cloud/azure-review/tests/**/*.yaml"].sort.each { |f| YAML.load_file(f); puts "OK #{f}" }'`
- frontmatter required-key smoke check
- keyword coverage check for authentication strength, phishing-resistant MFA, cross-tenant MFA trust, and break-glass evidence
- Microsoft Learn reference URL checks returned HTTP 200
- staged diff scan found no `tanzehao`, `bytedance.com`, or unrelated CLA command text
