### PR TITLE
Add Azure authentication strength review evidence

### DIFF
--- a/skills/cloud/azure-review/SKILL.md
+++ b/skills/cloud/azure-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-Azure-v2.1.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -27,7 +27,7 @@ argument-hint: "[target-file-or-directory]"
 
 This skill performs a structured security assessment of Azure environments against the **CIS Microsoft Azure Foundations Benchmark v2.1.0**. The benchmark is organized into nine sections covering identity management, security center, storage, database services, logging and monitoring, networking, virtual machines, Key Vault, and App Service. Each recommendation is evaluated by inspecting infrastructure-as-code definitions (Terraform, Bicep, ARM templates), Azure CLI output, or configuration files available in the repository.
 
-The CIS Azure Foundations Benchmark v2.1.0 provides prescriptive guidance across nine domains. This skill evaluates each applicable control and produces a findings report with CIS recommendation IDs, severity ratings, and actionable remediation steps.
+The CIS Azure Foundations Benchmark v2.1.0 provides prescriptive guidance across nine domains. This skill evaluates each applicable control and produces a findings report with CIS recommendation IDs, severity ratings, and actionable remediation steps. Identity findings must treat MFA as evidence-driven rather than binary: verify Security Defaults versus Conditional Access, authentication strength for privileged roles and sensitive apps, external-user MFA trust, break-glass exclusions, and workload-identity coverage before marking a control pass or fail.
 
 ---
 
@@ -86,6 +86,8 @@ Evaluate all Azure configurations against CIS Azure v2.1.0 Sections 1 through 9,
 
 For detailed CIS benchmark checklist items with specific Terraform patterns, Bicep examples, and configuration checks for all nine sections, see [benchmark-checklist.md](benchmark-checklist.md) in this skill directory.
 
+For identity controls, do not treat "MFA enabled" as a single boolean. Review Conditional Access policy state, grant controls, authentication strength references, authentication method policy scope, external-user MFA trust, emergency access exclusions, and workload identity controls where applicable.
+
 ---
 
 
@@ -102,7 +104,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | Severity | Definition | Examples |
 |----------|-----------|----------|
 | **Critical** | Immediate risk of data breach or unauthorized access | NSGs open to 0.0.0.0/0 on RDP/SSH, SQL databases publicly accessible, Defender for Cloud disabled |
-| **High** | Significant security gap that materially weakens posture | Missing MFA enforcement, storage accounts with public access, Key Vault without purge protection |
+| **High** | Significant security gap that materially weakens posture | Missing MFA enforcement, privileged roles without phishing-resistant authentication strength, storage accounts with public access, Key Vault without purge protection |
 | **Medium** | Control gap that should be addressed in normal cycle | Missing activity log alerts, soft delete not enabled, TLS below 1.2 |
 | **Low** | Hardening recommendation or defense-in-depth measure | HTTP/2 not enabled, FTP not fully disabled, missing CMK on non-sensitive storage |
 | **Informational** | Best practice observation, no direct security impact | Naming conventions, tag policies, documentation gaps |
@@ -119,6 +121,16 @@ Produce the final report using the structure defined in the Output Format sectio
 - Date: <assessment date>
 - Framework: CIS Microsoft Azure Foundations Benchmark v2.1.0
 - Files reviewed: <list of IaC files>
+
+### Identity Assurance Evidence
+- Security Defaults state: <enabled/disabled/not observed>
+- Conditional Access MFA policies: <policy names, state, scope, grant controls>
+- Privileged-role authentication strength: <phishing-resistant/passwordless/standard MFA/not observed>
+- Sensitive-app authentication strength: <policy names and covered apps>
+- Authentication method policy scope: <FIDO2, Windows Hello for Business, certificate-based auth, SMS/voice/push scope>
+- External-user access: <cross-tenant MFA trust, resource-tenant strength, guest method path>
+- Emergency access accounts: <excluded accounts, monitoring, vaulting, validation cadence>
+- Workload identities: <service principal policies, report-only/enforced state, risk/location controls>
 
 ### Executive Summary
 - Total CIS recommendations evaluated: <N>
@@ -175,7 +187,7 @@ Produce the final report using the structure defined in the Output Format sectio
 
 | Section | Domain | Key Focus Areas |
 |---------|--------|-----------------|
-| 1 | Identity and Access Management | Entra ID security defaults, MFA enforcement, Conditional Access policies, guest user management, PIM configuration |
+| 1 | Identity and Access Management | Entra ID security defaults, MFA enforcement, authentication strength, external-user MFA trust, workload identities, guest user management, PIM configuration |
 | 2 | Microsoft Defender for Cloud | Defender plan enablement (Servers, App Service, SQL, Storage, Containers, Key Vault, DNS, ARM), security contacts, auto-provisioning |
 | 3 | Storage Accounts | HTTPS enforcement, infrastructure encryption, public access, network rules, soft delete, CMK encryption, TLS version |
 | 4 | Database Services | SQL auditing, firewall rules, threat detection, SSL enforcement, TDE, Entra ID admin, Cosmos DB public access |
@@ -194,12 +206,15 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Common Pitfalls
 
-1. **Confusing Entra ID Security Defaults with Conditional Access.** CIS 1.1.1 accepts either, but if Conditional Access is used, Security Defaults must be disabled. Do not flag this as a failure if equivalent CA policies exist.
+1. **Confusing Entra ID Security Defaults with Conditional Access.** CIS 1.1.1 accepts either, but if Conditional Access is used, Security Defaults must be disabled. Do not flag this as a failure if equivalent CA policies exist and they are enabled, scoped, and backed by authentication method evidence.
 2. **Missing Defender for Cloud plan coverage.** Each resource type (Servers, SQL, Storage, etc.) requires its own Defender plan enablement. A single `azurerm_security_center_subscription_pricing` resource only covers one type.
 3. **Overlooking `allow_nested_items_to_be_public` on storage accounts.** CIS 3.7 checks the account-level setting, not individual container access levels. The account setting must be `false` to prevent any container from being public.
 4. **NSG rules using service tags.** A rule with `source_address_prefix = "Internet"` is equivalent to `0.0.0.0/0`. Both must be flagged for CIS 6.1 and 6.2.
 5. **Key Vault purge protection is irreversible.** CIS 8.5 requires `purge_protection_enabled = true`. Note this cannot be disabled once enabled -- flag this for awareness during remediation.
 6. **App Service TLS version on both Linux and Windows.** Check `azurerm_linux_web_app` and `azurerm_windows_web_app` resources separately.
+7. **Treating MFA as method-agnostic.** `Require multifactor authentication` is not the same evidence as `Require authentication strength` with phishing-resistant methods for privileged roles or sensitive apps.
+8. **Ignoring external-user trust path.** Guest access can satisfy MFA in the home tenant or resource tenant depending on cross-tenant MFA trust and the authentication methods that satisfy the resource tenant's required strength.
+9. **Applying user MFA logic to workload identities.** Service principals cannot perform MFA; evaluate Conditional Access for workload identities, risk/location controls, and service principal sign-in evidence instead.
 
 ---
 
@@ -222,6 +237,11 @@ Produce the final report using the structure defined in the Output Format sectio
 - CIS Microsoft Azure Foundations Benchmark v2.1.0: https://www.cisecurity.org/benchmark/azure
 - Microsoft Defender for Cloud Documentation: https://learn.microsoft.com/en-us/azure/defender-for-cloud/
 - Microsoft Entra ID Security: https://learn.microsoft.com/en-us/entra/identity/
+- Microsoft Entra Conditional Access authentication strengths: https://learn.microsoft.com/en-us/entra/identity/authentication/concept-authentication-strengths
+- Microsoft Entra authentication strengths for external users: https://learn.microsoft.com/en-us/entra/identity/authentication/concept-authentication-strength-external-users
+- Microsoft Entra security defaults: https://learn.microsoft.com/en-us/entra/fundamentals/security-defaults
+- Microsoft Entra emergency access admin accounts: https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/security-emergency-access
+- Microsoft Entra Conditional Access for workload identities: https://learn.microsoft.com/en-us/entra/identity/conditional-access/workload-identity
 - Azure Storage Security: https://learn.microsoft.com/en-us/azure/storage/common/storage-security-guide
 - Azure Key Vault Best Practices: https://learn.microsoft.com/en-us/azure/key-vault/general/best-practices
 - Azure App Service Security: https://learn.microsoft.com/en-us/azure/app-service/overview-security
@@ -231,4 +251,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.1.0** -- Added authentication strength, external-user MFA trust, emergency access, and workload-identity evidence gates for identity reviews.
 - **1.0.0** -- Initial release. Full coverage of CIS Microsoft Azure Foundations Benchmark v2.1.0 sections 1 through 9.

--- a/skills/cloud/azure-review/benchmark-checklist.md
+++ b/skills/cloud/azure-review/benchmark-checklist.md
@@ -21,9 +21,11 @@ resource "azuread_authentication_strength_policy" { ... }
 
 **Note:** Security Defaults should be disabled ONLY when Conditional Access policies provide equivalent or stronger controls.
 
+Do not fail a tenant solely because Security Defaults are disabled. Microsoft requires Security Defaults to be disabled when an organization implements replacement Conditional Access policies, and Conditional Access is the expected path for tenants that need granular control, exclusions, authentication strength, risk-based policy, or app-specific requirements. Instead, collect evidence that replacement policies are enabled, scoped to the relevant users/apps/roles, and enforce equivalent or stronger controls.
+
 #### CIS 1.1.2 -- Ensure that Multi-Factor Authentication is enabled for all privileged users
 
-Check for Conditional Access policies requiring MFA for admin roles:
+Check for Conditional Access policies requiring MFA or authentication strength for admin roles:
 
 ```hcl
 resource "azuread_conditional_access_policy" {
@@ -38,6 +40,36 @@ resource "azuread_conditional_access_policy" {
 }
 ```
 
+**Authentication strength evidence for privileged roles and sensitive apps:**
+
+`built_in_controls = ["mfa"]` proves that a policy requires MFA, but it does not prove that privileged access requires phishing-resistant MFA. Microsoft Entra authentication strength is a separate Conditional Access grant control that specifies which authentication method combinations can satisfy access. For privileged roles and sensitive applications, collect the policy evidence below before marking the control as pass, fail, or not evaluable.
+
+| Evidence | What to Verify | Failure Pattern |
+|---|---|---|
+| Conditional Access policy state | Policy is `enabled`, not disabled or report-only, for privileged roles or sensitive apps | Report-only policy counted as enforcement |
+| Role/app scope | Global Administrator, Privileged Role Administrator, Security Administrator, Conditional Access Administrator, and other high-risk roles are included, or a documented equivalent privileged group is included | MFA policy only covers all users except admins, or misses privileged roles |
+| Grant control | Policy uses `Require authentication strength` for privileged roles/sensitive apps when phishing-resistant MFA is required | Plain `Require MFA` accepted as phishing-resistant |
+| Authentication strength | Built-in or custom strength allows phishing-resistant methods such as FIDO2 security keys, Windows Hello for Business/platform credentials, or certificate-based authentication | SMS, voice, or push-only methods allowed for highest-risk roles |
+| Authentication method policy | Users/groups in scope are enabled to register at least one allowed method in the authentication methods policy | CA policy requires a strength that users cannot satisfy |
+| Break-glass exclusion | Emergency accounts are intentionally excluded from lockout-prone CA policies and have separate monitoring, vaulting, and validation evidence | Break-glass accounts excluded with no owner, alerts, or test cadence |
+
+**Authentication strength checks to add to findings:**
+
+```text
+AZ-ID-STR-01: Privileged role policy requires generic MFA but not phishing-resistant authentication strength
+AZ-ID-STR-02: Authentication strength exists but authentication method policy does not enable any allowed method for scoped admins
+AZ-ID-STR-03: Conditional Access policy is report-only/disabled but counted as active MFA enforcement
+AZ-ID-STR-04: Sensitive app requires MFA but allows phishable methods where phishing-resistant strength is required
+AZ-ID-STR-05: Break-glass account exclusion lacks owner, vaulting, sign-in alerting, or periodic validation
+```
+
+**Provider/export patterns to review:**
+
+- Microsoft Graph Conditional Access exports with `grantControls.authenticationStrength` or `builtInControls`.
+- Terraform AzureAD provider resources such as `azuread_conditional_access_policy` and `azuread_authentication_strength_policy`.
+- Authentication methods policy exports showing FIDO2, Windows Hello for Business/platform credential, certificate-based authentication, Temporary Access Pass bootstrap, SMS, voice, and push scope.
+- Conditional Access policy state fields such as `enabled`, `disabled`, or `enabledForReportingButNotEnforced`.
+
 #### CIS 1.1.3 -- Ensure that Multi-Factor Authentication is enabled for all non-privileged users
 
 Verify MFA requirement extends to all users, not just admins.
@@ -45,6 +77,35 @@ Verify MFA requirement extends to all users, not just admins.
 #### CIS 1.1.4 -- Ensure that 'Allow users to remember multi-factor authentication on devices they trust' is Disabled
 
 Check for MFA trust settings that weaken the control.
+
+**External-user MFA trust and authentication strength:**
+
+For guests, partners, and B2B direct connect users, a simple "require MFA" policy does not prove that the resource tenant receives the expected authentication strength. Microsoft Entra evaluates Conditional Access authentication strength for external users together with cross-tenant MFA trust settings.
+
+| Evidence | What to Verify | Failure Pattern |
+|---|---|---|
+| Cross-tenant access settings | Whether inbound MFA trust is enabled for the external tenant or default settings | Reviewer assumes home-tenant MFA is always trusted |
+| Resource tenant CA policy | Sensitive apps require the intended authentication strength for external users | Guest access only has generic MFA or no app-specific strength |
+| Home-tenant method compatibility | Trusted home-tenant claim satisfies the resource tenant's required strength | Home tenant uses methods not accepted by the strength |
+| Resource-tenant registration path | If MFA trust is disabled, external users can satisfy MFA in the resource tenant using allowed methods | User is challenged but has no usable method registration path |
+| External-user exceptions | Exclusions are approved, time-bounded, and monitored | Broad guest exclusions bypass MFA without owner or expiry |
+
+```text
+AZ-ID-EXT-01: External users access sensitive app with generic MFA but no authentication strength evidence
+AZ-ID-EXT-02: Cross-tenant MFA trust enabled without evidence that trusted methods satisfy resource-tenant strength
+AZ-ID-EXT-03: MFA trust disabled but resource-tenant registration path for external users is missing
+AZ-ID-EXT-04: Guest or partner exclusion bypasses MFA/authentication strength without owner, expiry, or monitoring
+```
+
+**Workload identity edge case:**
+
+Workload identities and service principals cannot perform MFA and should not be evaluated as if they were users. Review Conditional Access for workload identities separately when service principals access sensitive resources.
+
+```text
+AZ-ID-WID-01: Service principal or workload identity has sensitive access but no workload identity Conditional Access, risk, location, or lifecycle evidence
+AZ-ID-WID-02: User-scoped MFA policy is incorrectly treated as covering service principals
+AZ-ID-WID-03: Workload identity policy is report-only and counted as enforcement
+```
 
 ### CIS 1.2 -- Conditional Access Policies
 


### PR DESCRIPTION
/claim #838

## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `azure-review`
**Skill path:** `skills/cloud/azure-review/`

### What Was Wrong

The Azure review skill treated MFA evidence too broadly:

- The main skill and checklist could treat MFA as a binary control without asking whether privileged roles or sensitive apps require an appropriate authentication strength.
- `built_in_controls = ["mfa"]` could be accepted even when the tenant allows phishable methods such as SMS, voice, or push for high-risk roles.
- Security Defaults being disabled could look suspicious even when Microsoft expects replacement Conditional Access policies for tenants needing granular controls.
- External users, cross-tenant MFA trust, break-glass exclusions, and workload identities were not explicitly handled.

This can create both false positives and false assurance in mature Entra tenants.

### What This PR Fixes

- Bumps `azure-review` to version `1.1.0`.
- Adds an identity assurance evidence section to the report template.
- Adds checklist gates for Conditional Access policy state, role/app scope, authentication strength, authentication method policy scope, and break-glass evidence.
- Distinguishes generic `Require MFA` from `Require authentication strength` for phishing-resistant methods.
- Adds external-user MFA trust and resource-tenant authentication strength evidence.
- Adds workload identity findings so service principals are not evaluated as user-MFA-covered identities.
- Adds Microsoft Learn references for authentication strengths, external users, security defaults, emergency access accounts, and workload identity Conditional Access.

### Evidence

**Before (false positive / false assurance risk):**
```hcl
resource "azuread_conditional_access_policy" "admins" {
  grant_controls {
    built_in_controls = ["mfa"]
  }
}
```

The previous guidance could count this as privileged-user MFA coverage without checking whether the policy was enabled, whether privileged roles were actually scoped, whether phishing-resistant authentication strength was required, or whether users could register the allowed methods.

**After (now correctly handled):**
```text
Identity evidence gates:
- Conditional Access policy state is enabled, not report-only
- Privileged role/app scope is covered
- Grant control distinguishes generic MFA from authentication strength
- Authentication method policy enables allowed phishing-resistant methods
- External users are checked against cross-tenant MFA trust and resource-tenant strength
- Break-glass accounts and workload identities are assessed through their own evidence paths
```

### Test Cases Added/Updated
- [ ] Added vulnerable test cases (`tests/vulnerable/`) - not applicable; this skill is markdown/checklist guidance and has no fixture directory.
- [ ] Added benign test cases (`tests/benign/`) - not applicable; false-positive and false-assurance examples are documented directly in the checklist guidance and linked issue.
- [x] Existing validation checks pass

Validation performed:

- `git diff --check`
- YAML frontmatter parsed successfully with `version: "1.1.0"`
- Content assertions confirmed the new identity assurance section and `AZ-ID-STR`, `AZ-ID-EXT`, and `AZ-ID-WID` finding families are present.
- Content assertions confirmed the generic MFA versus authentication-strength distinction is present.
- Prohibited-pattern scan reviewed; matches were limited to repository `SECURITY.md` policy text, not the Azure review changes.

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Details will be provided privately after maintainer acceptance.

## Pull Request Checklist

- [x] Skill follows the format specification in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] At least one real framework is cited with correct control IDs
- [x] All framework references verified against primary sources (not blogs or AI output)
- [x] Prompt Injection Safety Notice section included
- [x] `injection-hardened: true` set in frontmatter
- [x] `allowed-tools` scoped to minimum necessary permissions
- [x] Tested with at least one AI coding agent (which one: Codex)
- [x] No prohibited patterns per [SECURITY.md](../SECURITY.md)
- [x] `index.yaml` updated with new skill entry (if adding a skill) - not applicable; existing skill improvement

## What This PR Does

Adds authentication-strength-aware MFA review guidance for Azure/Entra assessments, including privileged roles, sensitive apps, external users, emergency access accounts, and workload identities.

## Framework References

- CIS Microsoft Azure Foundations Benchmark v2.1.0 Section 1 identity controls
- Microsoft Entra Conditional Access authentication strengths
- Microsoft Entra cross-tenant MFA trust for external users
- Microsoft Entra Security Defaults and emergency access account guidance
- Microsoft Entra Conditional Access for workload identities

Primary sources checked:

- https://learn.microsoft.com/en-us/entra/identity/authentication/concept-authentication-strengths
- https://learn.microsoft.com/en-us/entra/identity/authentication/concept-authentication-strength-external-users
- https://learn.microsoft.com/en-us/entra/fundamentals/security-defaults
- https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/security-emergency-access
- https://learn.microsoft.com/en-us/entra/identity/conditional-access/workload-identity

## Testing

Tested with Codex against `skills/cloud/azure-review/SKILL.md` and `skills/cloud/azure-review/benchmark-checklist.md`. Validation was limited to markdown/frontmatter/content checks because this skill does not include executable tests or fixture directories.
