### PR TITLE
Add CSRF credential transport gates

### DIFF
--- a/skills/appsec/owasp-top-10-web/SKILL.md
+++ b/skills/appsec/owasp-top-10-web/SKILL.md
@@ -161,6 +161,8 @@ app.post("/transfer", cookieSession, async (req, res) => {
 
 `SameSite=Lax` alone is not enough for high-impact unsafe methods. Require a request-bound CSRF token or strong Origin/Referer enforcement in addition to secure cookie attributes.
 
+Use the calibration fixtures under `tests/benign/` and `tests/vulnerable/` to verify the distinction between bearer-token false positives, valid cross-site identity callbacks, high-value cookie POSTs, and refresh-cookie CSRF exposure.
+
 ---
 
 ### A02:2021 — Cryptographic Failures

--- a/skills/appsec/owasp-top-10-web/SKILL.md
+++ b/skills/appsec/owasp-top-10-web/SKILL.md
@@ -12,7 +12,7 @@ phase: [build, review]
 frameworks: [OWASP-Top-10-2021]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.1"
+version: "1.0.2"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -118,9 +118,48 @@ Access-Control-Allow-Origin.*\*|cors\(\{.*origin.*true
 - Enforce authorization server-side on every request using middleware or decorators; adopt deny-by-default.
 - Validate resource ownership — confirm the authenticated user owns or has explicit permission to the requested resource.
 - Use indirect references or opaque tokens instead of sequential database IDs.
-- Enable CSRF protection framework-wide; use `SameSite` cookie attributes.
+- Gate CSRF findings on credential transport: cookie/session-authenticated unsafe requests need CSRF controls, while bearer-token-only APIs that reject ambient cookies should not be flagged for missing CSRF tokens by default.
+- Use `SameSite` cookie attributes as defense-in-depth, not as the only control for high-value unsafe methods.
 - Restrict CORS to an explicit allowlist of origins; never reflect arbitrary `Origin` values.
 - Constrain file paths with canonicalization and chroot/jail patterns; reject `..` sequences.
+
+**CSRF and SameSite Decision Gate:**
+
+Before reporting missing CSRF protection, identify whether the browser automatically sends credentials to the endpoint:
+
+| Credential pattern | CSRF assessment |
+|--------------------|-----------------|
+| Session cookie or refresh-token cookie accepted on unsafe methods | Require a synchronizer token, double-submit token, signed state parameter, or strict Origin/Referer validation. |
+| Explicit `Authorization: Bearer ...` only, with cookies rejected or ignored | Do not report a missing CSRF token by default; review token storage, CORS, and XSS exposure instead. |
+| Hybrid access-token header plus refresh cookie | Review refresh/logout/session-extension endpoints as cookie-authenticated flows even if normal API calls use bearer tokens. |
+| OIDC/SAML callback, embedded app, or federated logout requiring cross-site cookies | `SameSite=None; Secure` can be valid when paired with `state`/`nonce`, CSRF tokens, or Origin/Referer checks. |
+
+Benign bearer-token API example:
+
+```javascript
+app.post("/api/profile", rejectCookies, requireBearerToken, express.json(), async (req, res) => {
+  await updateProfile(req.user.id, req.body);
+  res.sendStatus(204);
+});
+
+function rejectCookies(req, res, next) {
+  if (req.headers.cookie) return res.sendStatus(400);
+  next();
+}
+```
+
+This should not be reported as missing CSRF protection solely because there is no CSRF middleware; the browser does not automatically attach the accepted credential.
+
+Vulnerable high-value cookie flow example:
+
+```javascript
+app.post("/transfer", cookieSession, async (req, res) => {
+  await transferMoney(req.user.id, req.body.to, req.body.amount);
+  res.redirect("/done");
+});
+```
+
+`SameSite=Lax` alone is not enough for high-impact unsafe methods. Require a request-bound CSRF token or strong Origin/Referer enforcement in addition to secure cookie attributes.
 
 ---
 

--- a/skills/appsec/owasp-top-10-web/csharp-dotnet.md
+++ b/skills/appsec/owasp-top-10-web/csharp-dotnet.md
@@ -167,6 +167,43 @@ builder.Services.AddControllersWithViews(options =>
 });
 ```
 
+**CSRF Credential Transport Gate:**
+
+Treat unsafe Razor/MVC, minimal API, logout, refresh-token, and session-extension
+routes as CSRF-sensitive when authentication is carried by cookies or other
+browser-attached credentials. Require anti-forgery validation or strict
+Origin/Referer enforcement for those routes, even when `SameSite=Lax` or
+`SameSite=Strict` is configured.
+
+Do not report missing anti-forgery validation solely because an endpoint accepts
+unsafe methods when the route is authenticated only with an explicit
+`Authorization: Bearer` header and rejects or ignores ambient cookies. For
+hybrid apps, evaluate refresh-cookie endpoints separately from bearer-only API
+routes.
+
+```csharp
+// VULNERABLE - cookie-authenticated unsafe action without CSRF validation
+[HttpPost]
+public IActionResult TransferFunds(TransferModel model)
+{
+    _bankService.Transfer(model.FromAccount, model.ToAccount, model.Amount);
+    return RedirectToAction("Success");
+}
+
+// BENIGN FOR CSRF - bearer-only API route that does not trust cookies
+app.MapPost("/api/profile", (ProfileUpdate update) => Results.NoContent())
+   .RequireAuthorization(new AuthorizeAttribute
+   {
+       AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme
+   });
+```
+
+`SameSite=None; Secure` can be legitimate for OIDC/SAML callbacks, federated
+logout, embedded widgets, and cross-site enterprise flows, but those paths still
+need state/nonce binding and explicit origin controls. Treat `SameSite` as
+defense-in-depth rather than a replacement for CSRF validation on high-value
+cookie-authenticated state changes.
+
 ---
 
 ### A02:2021 — Cryptographic Failures

--- a/skills/appsec/owasp-top-10-web/tests/benign/bearer-token-api-no-csrf.js
+++ b/skills/appsec/owasp-top-10-web/tests/benign/bearer-token-api-no-csrf.js
@@ -1,0 +1,25 @@
+import express from "express";
+
+const app = express();
+
+function rejectAmbientCredentials(req, res, next) {
+  if (req.headers.cookie) {
+    return res.status(400).json({ error: "cookies are not accepted" });
+  }
+  return next();
+}
+
+function requireBearerToken(req, res, next) {
+  const header = req.get("Authorization") || "";
+  if (!header.startsWith("Bearer ")) {
+    return res.sendStatus(401);
+  }
+  req.user = { id: "user-123" };
+  return next();
+}
+
+app.post("/api/profile", rejectAmbientCredentials, requireBearerToken, express.json(), async (req, res) => {
+  res.status(204).end();
+});
+
+export { app };

--- a/skills/appsec/owasp-top-10-web/tests/benign/samesite-none-oidc-callback.js
+++ b/skills/appsec/owasp-top-10-web/tests/benign/samesite-none-oidc-callback.js
@@ -1,0 +1,28 @@
+import express from "express";
+
+const app = express();
+const expectedStates = new Set(["state-123"]);
+
+function requireTrustedOrigin(req, res, next) {
+  const origin = req.get("Origin");
+  if (origin && origin !== "https://idp.example.test") {
+    return res.sendStatus(403);
+  }
+  return next();
+}
+
+app.post("/auth/oidc/callback", requireTrustedOrigin, express.urlencoded({ extended: false }), (req, res) => {
+  const { state, nonce } = req.body;
+  if (!expectedStates.has(state) || typeof nonce !== "string" || nonce.length < 16) {
+    return res.sendStatus(400);
+  }
+
+  res.cookie("session", "opaque", {
+    httpOnly: true,
+    secure: true,
+    sameSite: "none",
+  });
+  return res.redirect("/dashboard");
+});
+
+export { app };

--- a/skills/appsec/owasp-top-10-web/tests/vulnerable/cookie-post-origin-missing.js
+++ b/skills/appsec/owasp-top-10-web/tests/vulnerable/cookie-post-origin-missing.js
@@ -1,0 +1,14 @@
+import express from "express";
+
+const app = express();
+
+function cookieSession(req, res, next) {
+  req.user = { id: "user-123" };
+  return next();
+}
+
+app.post("/settings/email", cookieSession, express.json(), (req, res) => {
+  return res.json({ userId: req.user.id, email: req.body.email });
+});
+
+export { app };

--- a/skills/appsec/owasp-top-10-web/tests/vulnerable/lax-cookie-high-value-post.js
+++ b/skills/appsec/owasp-top-10-web/tests/vulnerable/lax-cookie-high-value-post.js
@@ -1,0 +1,28 @@
+import express from "express";
+
+const app = express();
+
+function cookieSession(req, res, next) {
+  req.user = { id: "user-123" };
+  return next();
+}
+
+app.use((req, res, next) => {
+  res.cookie("session", "opaque", {
+    httpOnly: true,
+    secure: true,
+    sameSite: "lax",
+  });
+  return next();
+});
+
+app.post("/transfer", cookieSession, express.urlencoded({ extended: false }), async (req, res) => {
+  await transferMoney(req.user.id, req.body.to, req.body.amount);
+  return res.redirect("/done");
+});
+
+async function transferMoney(fromUserId, toAccount, amount) {
+  return { fromUserId, toAccount, amount };
+}
+
+export { app };

--- a/skills/appsec/owasp-top-10-web/tests/vulnerable/refresh-cookie-csrf-risk.js
+++ b/skills/appsec/owasp-top-10-web/tests/vulnerable/refresh-cookie-csrf-risk.js
@@ -1,0 +1,14 @@
+import express from "express";
+
+const app = express();
+
+app.post("/auth/refresh", (req, res) => {
+  const refreshToken = req.cookies?.refresh_token;
+  if (!refreshToken) {
+    return res.sendStatus(401);
+  }
+
+  return res.json({ accessToken: "new-access-token" });
+});
+
+export { app };


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** owasp-top-10-web
**Skill path:** `skills/appsec/owasp-top-10-web/`

### What Was Wrong
Issue #843 points out that the current CSRF guidance is too broad: it can flag bearer-token APIs that reject ambient cookies, while also treating SameSite guidance too simplistically for high-value cookie-authenticated unsafe methods and legitimate cross-site identity flows.

### What This PR Fixes
- Adds a credential-transport decision gate before reporting missing CSRF protection.
- Distinguishes cookie/session-authenticated unsafe requests from bearer-token-only APIs that reject cookies.
- Calls out hybrid refresh-cookie flows as still needing CSRF review on refresh/logout/session-extension endpoints.
- Treats `SameSite=None; Secure` as valid for OIDC/SAML, embedded-app, and federated logout flows when paired with state/nonce, CSRF tokens, or Origin/Referer checks.
- Clarifies that `SameSite=Lax` is defense-in-depth, not a standalone control for high-impact unsafe methods.
- Bumps the skill version to `1.0.2`.

### Evidence

**Before (false positive risk):**
```javascript
app.post("/api/profile", requireBearerToken, express.json(), async (req, res) => {
  await updateProfile(req.user.id, req.body);
  res.sendStatus(204);
});
```
A bearer-token-only API could be reported for missing CSRF middleware even when cookies are rejected or ignored.

**After (now correctly handled):**
```javascript
app.post("/api/profile", rejectCookies, requireBearerToken, express.json(), async (req, res) => {
  await updateProfile(req.user.id, req.body);
  res.sendStatus(204);
});
```
The skill now directs reviewers not to report missing CSRF tokens by default for explicit bearer-token-only APIs where the browser does not automatically attach the accepted credential.

**Before (missed/under-framed risk):**
```javascript
app.post("/transfer", cookieSession, async (req, res) => {
  await transferMoney(req.user.id, req.body.to, req.body.amount);
  res.redirect("/done");
});
```
Cookie-authenticated high-value unsafe methods could be under-evaluated if SameSite was treated as sufficient.

**After (now correctly handled):**
The skill now requires request-bound CSRF tokens or strong Origin/Referer enforcement for cookie/session-authenticated unsafe methods, with SameSite treated only as defense-in-depth.

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass / validation completed

Validation completed:
- `git diff --check`
- frontmatter required-field check for `SKILL.md`
- markdown fence-balance check for `SKILL.md`
- content assertions for bearer-token false-positive handling, high-value cookie flow, hybrid refresh-cookie flow, and OIDC/SAML `SameSite=None; Secure` exception

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** PayPal - details can be provided privately after maintainer acceptance

Closes #843.


