### PR TITLE
Improve OWASP CSRF credential triage

### DIFF
--- a/skills/appsec/owasp-top-10-web/SKILL.md
+++ b/skills/appsec/owasp-top-10-web/SKILL.md
@@ -12,7 +12,7 @@ phase: [build, review]
 frameworks: [OWASP-Top-10-2021]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.1"
+version: "1.0.2"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -81,6 +81,7 @@ Before including any finding in the report, apply the following verification gat
 - Direct object references (IDOR) where user-supplied IDs are used to fetch records without ownership validation.
 - Endpoints that rely solely on client-side enforcement (hidden UI elements) rather than server-side checks.
 - CORS misconfigurations that permit arbitrary origins or reflect the `Origin` header without validation.
+- CSRF gaps on browser-reachable state-changing routes that accept ambient credentials such as cookies, Basic/Digest auth, or client certificates.
 - Missing HTTP method restrictions (e.g., a route that accepts PUT/DELETE but only intended for GET).
 - JWT or session tokens that contain role claims without server-side verification against a trusted source.
 - Path traversal in file-serving endpoints.
@@ -113,12 +114,25 @@ Access-Control-Allow-Origin.*\*|cors\(\{.*origin.*true
 \.\.\/|\.\.\\|path\.join.*req\.|sendFile.*req\.
 ```
 
+**Credential-Aware CSRF Gate:**
+
+Before reporting missing CSRF protection, identify how the endpoint authenticates the browser request:
+
+1. **Ambient credentials accepted:** Report CSRF risk only when a state-changing endpoint can be authenticated by browser-managed credentials, such as session cookies, remember-me cookies, Basic/Digest auth, client certificates, or refresh cookies.
+2. **Explicit bearer-token-only APIs:** Do not report a missing CSRF token by default when the endpoint rejects cookies and requires an `Authorization: Bearer ...` header or another explicit non-ambient credential that a cross-site form/image request cannot attach.
+3. **Hybrid designs:** Split the finding by credential type. A JSON API may be bearer-only while the refresh, logout, password-change, or account-linking route still accepts a cookie and needs CSRF, state, or Origin/Referer validation.
+4. **SameSite is contextual:** Treat `SameSite=None; Secure` as valid for documented cross-site identity or embedded-app flows when it is paired with CSRF tokens, OAuth/OIDC `state`, or strict Origin/Referer checks. Treat SameSite as defense-in-depth, not as a full replacement for CSRF validation on high-value actions.
+5. **Evidence field:** Include `ambient_credentials_accepted: yes/no/unclear` in CSRF findings so reviewers can see why the issue was or was not reported.
+
+See `csrf-credential-fixtures.md` for benign and vulnerable examples that should guide this gate.
+
 **Mitigations:**
 
 - Enforce authorization server-side on every request using middleware or decorators; adopt deny-by-default.
 - Validate resource ownership — confirm the authenticated user owns or has explicit permission to the requested resource.
 - Use indirect references or opaque tokens instead of sequential database IDs.
-- Enable CSRF protection framework-wide; use `SameSite` cookie attributes.
+- Enable CSRF protection on browser-authenticated state-changing routes; combine synchronizer tokens or double-submit tokens with `SameSite` cookie attributes and Origin/Referer checks for high-value actions.
+- For bearer-token-only APIs, reject cookie/session credentials on the route so the CSRF decision remains explicit and auditable.
 - Restrict CORS to an explicit allowlist of origins; never reflect arbitrary `Origin` values.
 - Constrain file paths with canonicalization and chroot/jail patterns; reject `..` sequences.
 
@@ -635,6 +649,7 @@ Present findings in this structure:
 - **Location:** [file:line or file:function]
 - **Description:** [Clear explanation of the vulnerability, including how it could be exploited]
 - **Evidence:** [Code snippet or configuration excerpt]
+- **Ambient Credentials Accepted:** [yes/no/unclear; required for CSRF-related findings]
 - **Remediation:** [Specific, actionable fix with code example where applicable]
 - **Verification:** [How to confirm the fix is effective]
 
@@ -685,7 +700,9 @@ Present findings in this structure:
 
 4. **Reporting deprecated algorithms without context.** MD5 used for non-security checksums (e.g., cache busting, ETags) is not a cryptographic failure. Only flag weak algorithms when they protect sensitive data, passwords, or integrity-critical operations. State the security impact clearly.
 
-5. **Ignoring transitive dependencies.** A project may have zero direct vulnerable dependencies but inherit critical CVEs through transitive dependencies. Always analyze the full dependency tree, not just top-level declarations.
+5. **Reporting CSRF without credential transport context.** CSRF depends on the browser automatically attaching credentials. A route that only accepts an explicit bearer token and rejects cookies is different from a cookie-authenticated form post, refresh-cookie endpoint, or account settings route.
+
+6. **Ignoring transitive dependencies.** A project may have zero direct vulnerable dependencies but inherit critical CVEs through transitive dependencies. Always analyze the full dependency tree, not just top-level declarations.
 
 ## Prompt Injection Safety Notice
 

--- a/skills/appsec/owasp-top-10-web/csharp-dotnet.md
+++ b/skills/appsec/owasp-top-10-web/csharp-dotnet.md
@@ -22,7 +22,7 @@ Language-specific supplement for `owasp-top-10-web` covering ASP.NET Core, Entit
 # IDOR — user-supplied ID without ownership check
 FromRoute.*id|FromQuery.*id
 
-# Missing anti-forgery token validation
+# Missing anti-forgery token validation on cookie-authenticated MVC/Razor writes
 \[HttpPost\](?!.*\[ValidateAntiForgeryToken\])
 
 # AllowAnonymous on sensitive endpoints
@@ -166,6 +166,58 @@ builder.Services.AddControllersWithViews(options =>
     options.Filters.Add(new AutoValidateAntiforgeryTokenAttribute());
 });
 ```
+
+**5. Bearer-token API should not be flagged as CSRF by default**
+
+```csharp
+// BENIGN FOR CSRF - explicit Authorization header only; no browser-managed cookie auth accepted
+[ApiController]
+[Route("api/profile")]
+[Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+public class ProfileController : ControllerBase
+{
+    [HttpPost]
+    public async Task<IActionResult> Update([FromBody] UpdateProfileRequest request)
+    {
+        await _profileService.UpdateAsync(User, request);
+        return NoContent();
+    }
+}
+```
+
+Review guidance:
+
+- Record `ambient_credentials_accepted: no` when the route is bearer-token-only.
+- Confirm cookie authentication is not registered as a fallback for this endpoint.
+- Do not report missing `[ValidateAntiForgeryToken]` unless the route also accepts cookies or another ambient credential.
+
+**6. Cross-site identity flows need paired controls, not blanket SameSite findings**
+
+```csharp
+// CONTEXTUAL - OIDC often requires SameSite=None, but must keep Secure and state validation
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
+})
+.AddCookie(options =>
+{
+    options.Cookie.HttpOnly = true;
+    options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+    options.Cookie.SameSite = SameSiteMode.None;
+})
+.AddOpenIdConnect(options =>
+{
+    options.ResponseType = OpenIdConnectResponseType.Code;
+    options.UsePkce = true;
+});
+```
+
+Review guidance:
+
+- Treat `SameSite=None; Secure` as valid when a documented OIDC/SAML or embedded-app flow requires cross-site cookies.
+- Verify the identity middleware preserves state/nonce validation and that application state-changing routes still use anti-forgery or Origin/Referer checks.
+- Record `ambient_credentials_accepted: yes` because cookies are browser-managed.
 
 ---
 

--- a/skills/appsec/owasp-top-10-web/csrf-credential-fixtures.md
+++ b/skills/appsec/owasp-top-10-web/csrf-credential-fixtures.md
@@ -1,0 +1,81 @@
+# CSRF Credential Transport Fixtures
+
+Use these fixtures when reviewing CSRF and SameSite findings in `owasp-top-10-web`. The goal is to avoid noisy "missing CSRF token" findings on endpoints that do not accept browser-managed credentials while still catching cookie-authenticated high-value actions.
+
+## Benign: Explicit Bearer Token API
+
+```javascript
+app.post("/api/profile", requireBearerToken, express.json(), async (req, res) => {
+  await updateProfile(req.user.id, req.body);
+  res.sendStatus(204);
+});
+
+function requireBearerToken(req, res, next) {
+  const header = req.get("Authorization");
+  if (!header?.startsWith("Bearer ")) return res.sendStatus(401);
+  req.user = verifyAccessToken(header.slice("Bearer ".length));
+  next();
+}
+```
+
+Expected review outcome:
+
+- Do not report missing CSRF token by default.
+- Record `ambient_credentials_accepted: no`.
+- Confirm the route does not also accept session cookies, refresh cookies, or fallback Basic/Digest credentials.
+
+## Vulnerable: Cookie-Authenticated High-Value Action
+
+```javascript
+app.post("/account/email", requireSessionCookie, express.urlencoded({ extended: false }), async (req, res) => {
+  await changeEmail(req.session.userId, req.body.email);
+  res.redirect("/account");
+});
+```
+
+Expected review outcome:
+
+- Report CSRF if no synchronizer token, double-submit token, strict Origin/Referer validation, or equivalent framework protection is enforced.
+- Record `ambient_credentials_accepted: yes`.
+- Treat `SameSite=Lax` as helpful defense-in-depth, not a complete replacement for CSRF validation on this high-value mutation.
+
+## Contextual: OIDC Callback or Embedded Cross-Site Flow
+
+```http
+Set-Cookie: session=abc123; Path=/; HttpOnly; Secure; SameSite=None
+```
+
+```yaml
+documented_cross_site_use:
+  - oidc_login_callback
+  - saml_assertion_consumer_service
+  - embedded_partner_app
+required_controls:
+  - secure_cookie: true
+  - csrf_token_or_oidc_state: present
+  - origin_or_referer_check: present_for_state_changing_routes
+  - callback_destination_allowlist: present
+```
+
+Expected review outcome:
+
+- Do not flag `SameSite=None` by itself when `Secure` is present and the cross-site flow is documented.
+- Flag missing CSRF/OIDC `state` or missing Origin/Referer validation when the route changes account state.
+- Record `ambient_credentials_accepted: yes` because cookies are browser-managed.
+
+## Hybrid: Bearer Access Token plus Refresh Cookie
+
+```yaml
+access_api:
+  auth: Authorization Bearer access token
+  accepts_cookies: false
+refresh_endpoint:
+  auth: HttpOnly refresh cookie
+  method: POST
+  csrf_token: missing
+```
+
+Expected review outcome:
+
+- Do not report CSRF on the bearer-only access API.
+- Review the refresh endpoint separately and report CSRF if the cookie-authenticated refresh action lacks token/state or strict Origin/Referer validation.


### PR DESCRIPTION
## Skill Modified
**Skill name:** `owasp-top-10-web`
**Skill path:** `skills/appsec/owasp-top-10-web/`

## What Was Wrong
The current CSRF guidance could produce false positives for stateless APIs that authenticate only with explicit `Authorization: Bearer ...` headers and reject browser-managed credentials. It also treated SameSite guidance too broadly for legitimate cross-site identity and embedded-app flows.

## What This PR Fixes
- Adds a credential-aware CSRF gate that requires reviewers to identify whether ambient browser credentials are accepted before reporting CSRF.
- Distinguishes bearer-token-only APIs from cookie-authenticated mutating endpoints and hybrid access-token plus refresh-cookie designs.
- Treats `SameSite=None; Secure` as valid when required by documented OIDC/SAML or embedded-app flows and paired with state/CSRF/Origin controls.
- Adds an `Ambient Credentials Accepted` evidence field for CSRF findings.
- Adds dedicated CSRF credential transport fixtures and .NET-specific examples for bearer-only APIs and OIDC cookie flows.

## Evidence
**Before (false positive risk):**
```javascript
app.post(/api/profile, requireBearerToken, express.json(), async (req, res) => {
  await updateProfile(req.user.id, req.body);
  res.sendStatus(204);
});
```
A reviewer could flag missing CSRF even though a cross-site request cannot attach the required bearer token.

**After (now correctly handled):**
The skill records `ambient_credentials_accepted: no`, confirms cookies are not accepted as fallback auth, and does not report missing CSRF by default for this bearer-only route. Cookie-authenticated high-value actions and refresh-cookie endpoints remain reportable.

## Test Cases Added/Updated
- [x] Added benign CSRF fixture for explicit bearer-token APIs
- [x] Added vulnerable CSRF fixture for cookie-authenticated high-value actions
- [x] Added contextual SameSite/OIDC and hybrid refresh-cookie fixtures
- [x] Updated .NET examples for bearer-only APIs and OIDC cross-site cookie flows
- [x] Existing frontmatter checks still pass

## Validation
- `git diff --check`
- Local frontmatter field check for all `skills/**/SKILL.md` and `roles/**/SKILL.md`

## Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

## Bounty Info
- [x] I have read and agree to the CONTRIBUTING.md bounty terms
- **Preferred payment method:** PayPal - details can be provided privately after maintainer acceptance

Addresses #843