### PR TITLE
Add DNS rebinding evidence gates

### DIFF
--- a/skills/network/dns-security/SKILL.md
+++ b/skills/network/dns-security/SKILL.md
@@ -6,14 +6,14 @@ description: >
   -- Use DNS Filtering Services). Auto-invoked when reviewing DNS configurations,
   DNSSEC deployment, or investigating DNS-based exfiltration and tunneling
   indicators. Produces a DNS security assessment covering DNSSEC validation,
-  protective DNS, and exfiltration detection patterns.
-tags: [network, dns, dnssec, exfiltration]
+  protective DNS, DNS rebinding protection, and exfiltration detection patterns.
+tags: [network, dns, dnssec, rebinding, exfiltration]
 role: [security-engineer]
 phase: [operate]
 frameworks: [NIST-SP-800-81-Rev2, CIS-Controls-v8]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -23,7 +23,7 @@ argument-hint: "[target-file-or-directory]"
 
 # DNS Security Review
 
-A structured, repeatable process for evaluating DNS security posture against NIST SP 800-81 Rev 2 (Secure Domain Name System Deployment Guide) and CIS Controls v8 Control 9.2 (Use DNS Filtering Services). This skill covers DNSSEC deployment, encrypted DNS transport, Response Policy Zones, DNS exfiltration detection, and protective DNS services. All findings are mapped to framework controls with severity ratings and actionable remediation.
+A structured, repeatable process for evaluating DNS security posture against NIST SP 800-81 Rev 2 (Secure Domain Name System Deployment Guide) and CIS Controls v8 Control 9.2 (Use DNS Filtering Services). This skill covers DNSSEC deployment, encrypted DNS transport, Response Policy Zones, DNS rebinding protection, DNS exfiltration detection, and protective DNS services. All findings are mapped to framework controls with severity ratings and actionable remediation.
 
 ---
 
@@ -34,6 +34,7 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 - DNS infrastructure security review as part of network security assessment.
 - DNSSEC deployment readiness evaluation or post-deployment validation.
 - Investigation of suspected DNS-based data exfiltration or command-and-control.
+- Assessment of DNS rebinding controls for browser, SSRF, or internal-service exposure.
 - Compliance audits requiring NIST SP 800-81 alignment.
 - Protective DNS service evaluation or deployment planning.
 - Incident response when DNS tunneling is suspected.
@@ -42,7 +43,7 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 
 ## Context
 
-DNS is a foundational protocol that is often under-secured. NIST SP 800-81 Rev 2 Section 2 identifies three primary DNS threat categories: DNS cache poisoning, DNS-based denial of service, and unauthorized zone data modification. DNSSEC addresses data integrity but not confidentiality. CIS Controls v8 Control 9.2 requires the use of DNS filtering services to block access to known malicious domains. Beyond these baseline controls, DNS is increasingly exploited as a covert data exfiltration channel because port 53 is almost universally permitted through firewalls. Detecting DNS tunneling and exfiltration requires analysis of query patterns, payload sizes, and entropy -- not just domain reputation.
+DNS is a foundational protocol that is often under-secured. NIST SP 800-81 Rev 2 Section 2 identifies three primary DNS threat categories: DNS cache poisoning, DNS-based denial of service, and unauthorized zone data modification. DNSSEC addresses data integrity but not confidentiality, and it does not prevent DNS rebinding when an attacker controls an otherwise valid domain. CIS Controls v8 Control 9.2 requires the use of DNS filtering services to block access to known malicious domains. Beyond these baseline controls, DNS is increasingly exploited as a covert data exfiltration channel because port 53 is almost universally permitted through firewalls. Detecting DNS tunneling and exfiltration requires analysis of query patterns, payload sizes, and entropy -- not just domain reputation.
 
 ---
 
@@ -80,10 +81,11 @@ Use Glob and Grep to locate DNS server configurations, resolver settings, and re
 **/adguard*
 **/*.rpz
 **/rpz*
+**/dnsmasq*
+**/unbound*
 
 # Application-level DNS settings
 **/dnsconfig*
-**/unbound*
 ```
 
 Categorize discovered configurations:
@@ -237,11 +239,81 @@ If a cloud-based protective DNS service is used (Cisco Umbrella, Cloudflare Gate
 
 ---
 
-### Step 5: DNS Exfiltration and Tunneling Detection Patterns
+### Step 5: DNS Rebinding Protection Review
+
+DNS rebinding abuses attacker-controlled DNS responses to make public hostnames resolve to private, loopback, link-local, unique-local, or metadata-service addresses after a victim client or service has already trusted the hostname. This matters for browsers, webhook fetchers, SSRF defenses, package scanners, preview renderers, and any service that fetches user-provided URLs.
+
+#### 5.1 Resolver and Protective DNS Controls
+
+For each recursive resolver, protective DNS service, and local DNS forwarder, verify:
+
+- **Private address blocking:** Public domains are not allowed to resolve to internal address space by default.
+- **IPv4 coverage:** RFC1918, loopback, link-local, carrier-grade NAT, benchmark, multicast, and metadata-service ranges are blocked or sinkholed when returned by public names.
+- **IPv6 coverage:** Loopback, link-local, unique local, multicast, and IPv4-mapped private ranges are covered.
+- **Split-horizon exceptions:** Internal domains that intentionally resolve to private addresses are explicitly allowlisted, owned, justified, and scoped.
+- **Low-TTL behavior:** Monitoring detects public-to-private answer changes, especially answers with short TTL values.
+- **Application consistency:** Application SSRF protections perform DNS resolution and IP range checks at connect time, not only at initial URL parsing.
+
+**Unbound evidence patterns:**
+
+```
+server:
+  # Block public DNS answers that point to private or local networks.
+  private-address: 10.0.0.0/8
+  private-address: 172.16.0.0/12
+  private-address: 192.168.0.0/16
+  private-address: 127.0.0.0/8
+  private-address: 169.254.0.0/16
+  private-address: 100.64.0.0/10
+  private-address: ::1/128
+  private-address: fc00::/7
+  private-address: fe80::/10
+
+  # Only trusted split-horizon zones should bypass private-address blocking.
+  private-domain: "corp.example"
+```
+
+**dnsmasq / Pi-hole evidence patterns:**
+
+```
+# dnsmasq
+stop-dns-rebind
+rebind-domain-ok=/corp.example/
+
+# Pi-hole FTL may report warnings when upstream answers are blocked as rebinds.
+```
+
+#### 5.2 Exception Review
+
+Every rebinding exception must include:
+
+- Domain or zone name.
+- Business owner and approving security owner.
+- Exact private ranges allowed.
+- Justification for split-horizon behavior.
+- Expiration or review date.
+- Evidence that the exception is not applied globally to all public domains.
+
+Flag exceptions such as `rebind-domain-ok=/*/`, broad `private-domain` entries for public suffixes, or wildcard allowlists for third-party domains as high risk.
+
+#### 5.3 Detection and Validation
+
+Where logs are available, verify alerts for:
+
+- Public domain responses returning private, loopback, link-local, unique-local, multicast, or metadata-service addresses.
+- Public domain A/AAAA answers that shift from public ranges to private ranges within a short time window.
+- Repeated low-TTL answers from the same domain or authoritative nameserver.
+- Resolver warnings such as `possible DNS-rebind attack detected`.
+
+**Finding classification:** No DNS rebinding protection on recursive or protective resolvers is **High** when browsers, SSRF-exposed services, or URL fetchers rely on those resolvers; otherwise **Medium**. Public domains broadly allowed to return private ranges are **High**. Split-horizon exceptions without owner, scope, or review date are **Medium**.
+
+---
+
+### Step 6: DNS Exfiltration and Tunneling Detection Patterns
 
 DNS tunneling encodes data in DNS query names or TXT record responses to create a covert communication channel. Detection requires pattern analysis, not just domain reputation.
 
-#### 5.1 Exfiltration Indicators
+#### 6.1 Exfiltration Indicators
 
 | Indicator | Normal | Suspicious | Detection Method |
 |-----------|--------|-----------|-----------------|
@@ -252,7 +324,7 @@ DNS tunneling encodes data in DNS query names or TXT record responses to create 
 | **Query volume per domain** | < 100/hr to a single domain | > 1000/hr to single obscure domain | Volumetric per-domain threshold |
 | **Response size** | < 512 bytes | TXT responses > 512 bytes, multiple TXT records | Monitor response payload sizes |
 
-#### 5.2 Tunneling Tool Signatures
+#### 6.2 Tunneling Tool Signatures
 
 Common DNS tunneling tools produce distinctive query patterns:
 
@@ -270,7 +342,7 @@ abcdef0123456789.dnscat.example.com TXT
 0001.<encoded>.d.example.com KEY
 ```
 
-#### 5.3 Detection Configuration
+#### 6.3 Detection Configuration
 
 **Where to implement detection:**
 
@@ -286,7 +358,7 @@ abcdef0123456789.dnscat.example.com TXT
 
 ---
 
-### Step 6: Domain Categorization and Newly Registered Domain (NRD) Blocking
+### Step 7: Domain Categorization and Newly Registered Domain (NRD) Blocking
 
 - **NRD blocking:** Domains registered within the past 30 days are disproportionately associated with phishing and malware. CIS Control 9.2 supports blocking or flagging NRDs.
 - **DGA detection:** Domain Generation Algorithms produce random-appearing domain names. Detection relies on entropy analysis and machine learning classifiers integrated into protective DNS services.
@@ -299,8 +371,8 @@ abcdef0123456789.dnscat.example.com TXT
 | Severity | Definition |
 |----------|-----------|
 | **Critical** | Broken DNSSEC chain of trust (missing DS record in parent); authoritative zones serving invalid signatures. |
-| **High** | DNSSEC validation disabled on resolvers; no DNS filtering/RPZ; unsigned public authoritative zones; DNS bypass paths around protective DNS; no DNS query logging; weak signing algorithms. |
-| **Medium** | Plaintext DNS forwarding over untrusted networks; stale RPZ feeds; undocumented NTAs; no NRD blocking; no exfiltration detection; DoH bypass not controlled. |
+| **High** | DNSSEC validation disabled on resolvers; no DNS filtering/RPZ; unsigned public authoritative zones; DNS bypass paths around protective DNS; no DNS query logging; weak signing algorithms; no rebinding protection where browsers or URL fetchers rely on DNS controls; broad public-domain private-address allowlists. |
+| **Medium** | Plaintext DNS forwarding over untrusted networks; stale RPZ feeds; undocumented NTAs; no NRD blocking; no exfiltration detection; DoH bypass not controlled; unowned or stale split-horizon rebinding exceptions. |
 | **Low** | Missing documentation of DNS architecture; resolver software not at latest version; cosmetic configuration issues. |
 
 ---
@@ -324,9 +396,9 @@ abcdef0123456789.dnscat.example.com TXT
 
 ### Resolver Security
 
-| Resolver | DNSSEC Validation | Encrypted Transport | RPZ/Filtering | Query Logging |
-|----------|-------------------|--------------------|--------------|--------------|
-| ns1      | Enabled/Disabled  | DoT/DoH/Plaintext  | Yes/No       | Yes/No       |
+| Resolver | DNSSEC Validation | Encrypted Transport | RPZ/Filtering | Rebinding Protection | Query Logging |
+|----------|-------------------|--------------------|--------------|----------------------|--------------|
+| ns1      | Enabled/Disabled  | DoT/DoH/Plaintext  | Yes/No       | Enabled/Disabled     | Yes/No       |
 
 ### Findings
 
@@ -343,6 +415,12 @@ abcdef0123456789.dnscat.example.com TXT
 - Entropy-based detection: <Deployed / Not deployed>
 - Volumetric thresholds: <Configured / Not configured>
 - SIEM integration: <Yes / No>
+
+### DNS Rebinding Readiness
+- Private address blocking: <Enabled / Disabled>
+- IPv6 private/local coverage: <Complete / Partial / Missing>
+- Split-horizon exceptions: <Owned / Unowned / Not present>
+- Low-TTL public-to-private alerting: <Configured / Not configured>
 
 ### Prioritized Remediation Plan
 1. **[Critical]** <action item with control reference>
@@ -384,6 +462,8 @@ abcdef0123456789.dnscat.example.com TXT
 
 4. **Ignoring DNS over TCP.** DNS is not UDP-only. DNS over TCP (port 53) supports large responses and is required for zone transfers. Some tunneling tools prefer TCP for reliability. Firewall rules and monitoring must cover both UDP and TCP port 53.
 
+5. **Assuming DNSSEC prevents DNS rebinding.** DNSSEC validates that a DNS answer is authentic for the zone, not that the returned IP address is safe for the caller. Attacker-owned signed domains can still return private, loopback, or link-local addresses unless resolver or application policy blocks those answers.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -408,9 +488,14 @@ This skill processes DNS configuration files that may contain user-supplied zone
 - RFC 7719 -- DNS Terminology: https://datatracker.ietf.org/doc/html/rfc7719
 - ISC Response Policy Zones (RPZ): https://www.isc.org/rpz/
 - CISA Protective DNS: https://www.cisa.gov/protective-dns
+- OWASP Top 10 2021 A10 -- Server-Side Request Forgery (SSRF): https://owasp.org/Top10/2021/A10_2021-Server-Side_Request_Forgery_%28SSRF%29/
+- OWASP SSRF Prevention Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html
+- Unbound configuration manual -- private-address and private-domain: https://unbound.docs.nlnetlabs.nl/en/latest/manpages/unbound.conf.html
+- Pi-hole dnsmasq warnings -- DNS-rebind attack detected: https://docs.pi-hole.net/ftldns/dnsmasq_warn/
 
 ---
 
 ## Changelog
 
+- **1.0.1** -- Added DNS rebinding protection review, private-address evidence gates, split-horizon exception checks, detection guidance, output fields, and OWASP/Unbound/Pi-hole references.
 - **1.0.0** -- Initial release. Full coverage of NIST SP 800-81 Rev 2 and CIS Controls v8 Control 9.2 for DNS security review.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** dns-security
**Skill path:** `skills/network/dns-security/`

### What Was Wrong
The skill covered DNSSEC, protective DNS/RPZ, encrypted transport, and DNS exfiltration, but did not include DNS rebinding evidence gates. That leaves an important gap for browser-facing environments, SSRF-exposed URL fetchers, webhooks, preview renderers, and other services that rely on resolver policy to prevent public hostnames from resolving to private, loopback, link-local, unique-local, or metadata-service addresses.

Addresses #860.

### What This PR Fixes
- Adds a dedicated DNS Rebinding Protection Review section.
- Adds Unbound `private-address` / `private-domain` evidence patterns.
- Adds dnsmasq / Pi-hole `stop-dns-rebind` and scoped exception examples.
- Adds split-horizon exception review requirements with owner, scope, justification, and review date.
- Adds detection guidance for public-to-private A/AAAA answer changes, low TTLs, and resolver rebinding warnings.
- Updates severity guidance, report output fields, common pitfalls, references, and the changelog.

### Evidence

**Before (skill misses this / false positive on this):**
```
Public domains returning 10.0.0.0/8, 127.0.0.0/8, 169.254.0.0/16, fc00::/7, or fe80::/10 answers were not called out as a DNS rebinding review gate.
DNSSEC could be enabled while attacker-controlled signed domains still returned private addresses.
Split-horizon exceptions were not required to be owned, scoped, justified, or periodically reviewed.
```

**After (now correctly handled):**
```
The skill now requires private-address blocking review, IPv4/IPv6 private/local coverage, scoped split-horizon exceptions, low-TTL public-to-private monitoring, and application connect-time DNS/IP range consistency for SSRF-prone fetchers.
```

### Test Cases Added/Updated
- [ ] Added vulnerable test cases (`tests/vulnerable/`)
- [ ] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass

No standalone test fixture directory exists for this documentation skill; validation focused on the skill file and repository format checks.

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** PayPal

## Pull Request Checklist

- [x] Skill follows the format specification in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] At least one real framework is cited with correct control IDs
- [x] All framework references verified against primary sources (not blogs or AI output)
- [x] Prompt Injection Safety Notice section included
- [x] `injection-hardened: true` set in frontmatter
- [x] `allowed-tools` scoped to minimum necessary permissions
- [x] Tested with at least one AI coding agent (which one: GPT-5 Codex)
- [x] No prohibited patterns per [SECURITY.md](../SECURITY.md)
- [x] `index.yaml` updated with new skill entry (if adding a skill; not applicable)

## Framework References

- NIST SP 800-81 Rev 2, Sections 2, 3, 4, 5, and 6
- CIS Controls v8 Control 9.2
- OWASP Top 10 2021 A10 SSRF
- OWASP SSRF Prevention Cheat Sheet
- Unbound `private-address` / `private-domain`
- Pi-hole dnsmasq DNS-rebind warning documentation

## Testing

- `git diff --check`
- Frontmatter field validation for `skills/**/SKILL.md`
- Content presence check for the new rebinding section, evidence patterns, output fields, references, and version bump