### PR TITLE
Fix prompt-injection PISmith citation

### DIFF
--- a/skills/ai-security/prompt-injection/SKILL.md
+++ b/skills/ai-security/prompt-injection/SKILL.md
@@ -13,7 +13,7 @@ phase: [build, review, operate]
 frameworks: [OWASP-LLM01-2025, MITRE-ATLAS]
 difficulty: advanced
 time_estimate: "30-60min"
-version: "1.0.2"
+version: "1.0.3"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -194,13 +194,24 @@ Evaluate which of the following mitigations are implemented and how effectively.
 
 ### 5.7 Adaptive Attack Resilience
 
-> **Warning:** Static prompt injection defenses (hardcoded system prompts, simple keyword filtering) are demonstrably insufficient against adaptive attackers. PISmith (Yin et al. 2026) achieved highest attack success rates across 13 benchmarks using RL-optimized adaptive black-box attacks.
+> **Warning:** Static prompt injection defenses (hardcoded system prompts, simple keyword filtering) are demonstrably insufficient against adaptive attackers. PISmith (Yin et al. 2026), published as "PISmith: Reinforcement Learning-based Red Teaming for Prompt Injection Defenses," reports the highest attack success rates across 13 benchmarks using reinforcement-learning-based adaptive red teaming in a practical black-box setting.
 
 - **Continuous red-team evaluation:** Prompt injection defenses must be evaluated continuously, not as a one-time test. Adaptive attackers iteratively refine their payloads against deployed defenses. Schedule recurring red-team assessments using automated adversarial tooling alongside manual expert testing.
 - **Agentic benchmark suites:** For applications where LLMs invoke tools or take autonomous actions, standard prompt injection benchmarks are insufficient. Use agentic-specific benchmark suites that test injection in the context of tool use and multi-step workflows:
   - **InjecAgent** -- Tests indirect prompt injection in agentic settings where the LLM processes external content and has tool access.
   - **AgentDojo** -- Evaluates agent robustness against injection attacks across diverse tool-use scenarios with realistic adversarial content.
   - **fabraix/playground** (https://github.com/fabraix/playground) -- Open-source library of AI agent exploit PoCs that can serve as a test harness for validating direct and indirect injection defenses against published attack patterns.
+
+### 5.8 Research Source Integrity
+
+Prompt-injection research changes quickly, and assessment reports often copy references directly from this skill. Before using a research paper as evidence for adaptive-attack resilience or benchmark coverage, verify:
+
+- The source identifier resolves to the cited paper (`arXiv:<id>`, DOI, or official URL).
+- The reference list preserves the exact paper title; descriptive shorthand belongs in prose, not in citation metadata.
+- The report records the source status as `verified`, `title-mismatch`, `unresolved`, or `supporting-only`.
+- The report records `date_checked` for fast-moving research references used in customer-facing findings.
+
+If a source is unresolved or title-mismatched, do not cite it as primary evidence until the citation is corrected.
 
 ---
 
@@ -284,5 +295,5 @@ Each finding should be assigned a severity based on potential impact:
 - Perez, F. & Ribeiro, I. (2022). "Ignore Previous Prompt: Attack Techniques For Language Models." arXiv:2211.09527.
 - Greshake, K. et al. (2023). "Not What You've Signed Up For: Compromising Real-World LLM-Integrated Applications with Indirect Prompt Injection." arXiv:2302.12173.
 - Willison, S. Prompt Injection taxonomy and ongoing research — https://simonwillison.net
-- Yin, X. et al. "PISmith: RL-Optimized Adaptive Black-Box Prompt Injection Attacks" (2026) -- arXiv:2603.13026
+- Yin, X. et al. (2026). "PISmith: Reinforcement Learning-based Red Teaming for Prompt Injection Defenses." arXiv:2603.13026. Source title verified from arXiv on 2026-06-05.
 - fabraix/playground — Open-source AI agent exploit library for testing injection defenses — https://github.com/fabraix/playground


### PR DESCRIPTION
Fixes #874

## Summary
- update the PISmith reference to the exact arXiv title
- rephrase the adaptive-attack warning around the paper's red-teaming framing
- add a short research source-integrity gate for fast-moving prompt-injection references
- bump `prompt-injection` to version 1.0.3

## Bounty request
Improver minor: $50 if accepted. Payment details can be provided privately after maintainer acceptance.

## Validation
- verified arXiv:2603.13026 on the official arXiv page
- `git diff --check`
- frontmatter/content assertions for `prompt-injection`
- markdown fence balance check
- content assertions for exact PISmith title, arXiv ID, `date_checked`, and `title-mismatch`
