### PR TITLE
Add container runtime profile evidence gates

### DIFF
--- a/skills/cloud/container-security/SKILL.md
+++ b/skills/cloud/container-security/SKILL.md
@@ -13,7 +13,7 @@ phase: [build, deploy, operate]
 frameworks: [CIS-Docker-v1.6.0, CIS-Kubernetes-v1.9.0, NIST-SP-800-190]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -127,8 +127,8 @@ Produce the final report using the structure defined in the Output Format sectio
 | Severity | Definition | Examples |
 |----------|-----------|----------|
 | **Critical** | Container escape, cluster compromise, or credential exposure | Privileged containers, Docker socket mounts, cluster-admin bound to application SA, secrets in plaintext manifests, `hostPID`/`hostNetwork` on app pods |
-| **High** | Significant security gap enabling lateral movement or privilege escalation | Running as root, missing network policies, wildcard RBAC, `allowPrivilegeEscalation: true`, host path mounts to sensitive directories |
-| **Medium** | Missing hardening that weakens defense-in-depth | No resource limits, mutable image tags, missing seccomp profile, read-write root filesystem, secrets as env vars |
+| **High** | Significant security gap enabling lateral movement or privilege escalation | Running as root, missing network policies, wildcard RBAC, `allowPrivilegeEscalation: true`, host path mounts to sensitive directories, unconfined seccomp/AppArmor on application workloads |
+| **Medium** | Missing hardening that weakens defense-in-depth | No resource limits, mutable image tags, missing effective seccomp evidence, read-write root filesystem, secrets as env vars |
 | **Low** | Best-practice deviation with limited immediate risk | No HEALTHCHECK in Dockerfile, ADD instead of COPY, missing liveness/readiness probes, using default namespace |
 | **Informational** | Observation with no direct security impact | Image size optimization, multi-stage build suggestions, label recommendations |
 
@@ -184,6 +184,13 @@ Produce the final report using the structure defined in the Output Format sectio
 |----------|-----------|-----------|------------|
 | deploy/app | production | Baseline (not Restricted) | runAsRoot, no seccomp |
 | deploy/worker | production | Privileged | privileged: true |
+
+### Runtime Profile Effective-State Matrix
+
+| Workload | Container Type | Container | seccomp Effective State | AppArmor Effective State | Capabilities | Evidence |
+|----------|----------------|-----------|-------------------------|--------------------------|--------------|----------|
+| deploy/app | app | api | RuntimeDefault | RuntimeDefault | drop ALL | manifest + namespace PSA |
+| job/migrate | init | migrate | Unset / unknown | Unset / unknown | adds SYS_ADMIN | manifest |
 
 ### Prioritized Remediation Plan
 
@@ -244,7 +251,8 @@ Produce the final report using the structure defined in the Output Format sectio
 | Volumes | No hostPath | Restricted volume types only |
 | allowPrivilegeEscalation | -- | Must be false |
 | runAsNonRoot | -- | Must be true |
-| seccompProfile | -- | RuntimeDefault or Localhost |
+| seccompProfile | -- | RuntimeDefault or Localhost, proven at pod or container level |
+| AppArmor | RuntimeDefault unless explicitly overridden | RuntimeDefault or Localhost, not Unconfined |
 
 ---
 
@@ -257,6 +265,8 @@ Produce the final report using the structure defined in the Output Format sectio
 5. **`readOnlyRootFilesystem` breaks many applications.** When recommending this control, also recommend adding writable `emptyDir` volume mounts for directories the application needs to write to (e.g., `/tmp`, `/var/cache`).
 6. **Network policies are additive, not subtractive.** A default-deny policy must be explicitly created. Without it, all pod-to-pod traffic is allowed regardless of other NetworkPolicy resources.
 7. **Distroless images have no shell.** While this is excellent for security, note that debugging requires ephemeral containers (`kubectl debug`). Flag this as a consideration, not a problem.
+8. **Unset seccomp is not always RuntimeDefault.** If manifests omit `seccompProfile`, confirm kubelet `seccompDefault` or admission policy evidence before marking the workload as effectively confined. Otherwise record the effective state as unknown or unconfined.
+9. **Pod-level settings can be overridden per container.** Check `containers`, `initContainers`, and `ephemeralContainers`; a hardened pod-level `securityContext` does not prove every container keeps the same effective seccomp, AppArmor, or capability state.
 
 ---
 
@@ -283,8 +293,14 @@ Produce the final report using the structure defined in the Output Format sectio
 - NIST SP 800-190 Application Container Security Guide: https://csrc.nist.gov/publications/detail/sp/800-190/final
 - Kubernetes Pod Security Standards: https://kubernetes.io/docs/concepts/security/pod-security-standards/
 - Kubernetes Pod Security Admission: https://kubernetes.io/docs/concepts/security/pod-security-admission/
+- Kubernetes seccomp tutorial: https://kubernetes.io/docs/tutorials/security/seccomp/
+- Kubernetes seccomp reference: https://kubernetes.io/docs/reference/node/seccomp/
+- Kubernetes security context docs: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+- Kubernetes AppArmor tutorial: https://kubernetes.io/docs/tutorials/security/apparmor/
 - Kubernetes Network Policies: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 - Kubernetes RBAC: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Docker seccomp security profiles: https://docs.docker.com/engine/security/seccomp/
+- Docker runtime privilege and Linux capabilities: https://docs.docker.com/engine/containers/run/
 - Docker Security Best Practices: https://docs.docker.com/develop/security-best-practices/
 - Dockerfile Best Practices: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
 - NSA/CISA Kubernetes Hardening Guide: https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF
@@ -293,4 +309,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Added runtime-profile effective-state evidence for seccomp, AppArmor, Linux capabilities, init/ephemeral containers, kubelet `seccompDefault`, report output, references, and fixtures.
 - **1.0.0** -- Initial release. Full coverage of CIS Docker Benchmark v1.6.0 Section 4-5, CIS Kubernetes Benchmark v1.9.0 Sections 1-5, and NIST SP 800-190 countermeasures across all five risk categories.

--- a/skills/cloud/container-security/cis-benchmarks.md
+++ b/skills/cloud/container-security/cis-benchmarks.md
@@ -379,6 +379,80 @@ securityContext:
     add: ["NET_BIND_SERVICE"]  # Only if needed for ports < 1024
 ```
 
+#### Runtime Profile Effective-State Evidence Gate
+
+Do not treat a workload as Restricted-compatible until the effective runtime profile is proven for every container class:
+
+- `spec.containers[*]`
+- `spec.initContainers[*]`
+- `spec.ephemeralContainers[*]`
+
+Review both pod-level and per-container security contexts. A pod-level `seccompProfile` can provide the default for all containers, but a container-level field may override it. If the manifest omits `seccompProfile`, require independent evidence that kubelet `seccompDefault` or an admission policy applies `RuntimeDefault`; otherwise record the effective state as unknown or unconfined.
+
+**Seccomp evidence:**
+
+```yaml
+# GOOD: pod-level default applies unless a container overrides it.
+spec:
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  initContainers:
+    - name: migrate
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+  containers:
+    - name: app
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+
+# HIGH: explicit unconfined profile on an application container.
+securityContext:
+  seccompProfile:
+    type: Unconfined
+```
+
+**AppArmor evidence:**
+
+```yaml
+# GOOD: explicit runtime/default AppArmor profile where supported.
+securityContext:
+  appArmorProfile:
+    type: RuntimeDefault
+
+# HIGH: AppArmor disabled for an application workload.
+securityContext:
+  appArmorProfile:
+    type: Unconfined
+```
+
+**Capability evidence:**
+
+```yaml
+# Restricted-compatible default.
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+    add: ["NET_BIND_SERVICE"] # only when justified
+
+# HIGH or CRITICAL depending on workload sensitivity.
+securityContext:
+  capabilities:
+    add: ["SYS_ADMIN", "NET_ADMIN"]
+```
+
+**Finding classification:**
+
+- **Critical:** `privileged: true`, Docker socket mount, or `SYS_ADMIN` added on an application workload with host namespace or hostPath exposure.
+- **High:** `seccompProfile.type: Unconfined`, `appArmorProfile.type: Unconfined`, `allowPrivilegeEscalation: true`, or added `SYS_ADMIN`/`NET_ADMIN`/`SYS_PTRACE` without system-workload justification.
+- **Medium:** `seccompProfile` omitted without kubelet `seccompDefault` evidence; `capabilities.drop` does not include `ALL`; `readOnlyRootFilesystem` omitted for workloads that can support it.
+- **Low:** Runtime profile owner, exception reason, or review date missing while technical controls are otherwise present.
+
 #### CIS 5.2.11 -- Minimize the admission of Windows HostProcess containers
 
 Check for `windowsOptions.hostProcess: true`.

--- a/skills/cloud/container-security/tests/benign/restricted-runtime-profiles.yaml
+++ b/skills/cloud/container-security/tests/benign/restricted-runtime-profiles.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: restricted-runtime-profile
+spec:
+  selector:
+    matchLabels:
+      app: restricted-runtime-profile
+  template:
+    metadata:
+      labels:
+        app: restricted-runtime-profile
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: migrate
+          image: busybox:1.36
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+      containers:
+        - name: app
+          image: nginx:1.25
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+              add: ["NET_BIND_SERVICE"]
+            appArmorProfile:
+              type: RuntimeDefault

--- a/skills/cloud/container-security/tests/vulnerable/unconfined-runtime-profiles.yaml
+++ b/skills/cloud/container-security/tests/vulnerable/unconfined-runtime-profiles.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vulnerable-runtime-profile
+spec:
+  selector:
+    matchLabels:
+      app: vulnerable-runtime-profile
+  template:
+    metadata:
+      labels:
+        app: vulnerable-runtime-profile
+    spec:
+      initContainers:
+        - name: migrate
+          image: busybox:1.36
+          securityContext:
+            seccompProfile:
+              type: Unconfined
+            capabilities:
+              add: ["SYS_ADMIN"]
+      containers:
+        - name: app
+          image: nginx:1.25
+          securityContext:
+            allowPrivilegeEscalation: true
+            appArmorProfile:
+              type: Unconfined
+            capabilities:
+              add: ["NET_ADMIN"]


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** container-security
**Skill path:** `skills/cloud/container-security/`

### What Was Wrong
The skill referenced Pod Security Standards and listed seccomp/capabilities in quick-reference guidance, but it did not require reviewers to prove the effective runtime profile for every container class. That can miss init or ephemeral containers, container-level overrides, omitted seccomp fields that depend on kubelet `seccompDefault`, and unconfined AppArmor/seccomp profiles.

Addresses #883.

### What This PR Fixes
- Adds runtime-profile effective-state gates for seccomp, AppArmor, Linux capabilities, `allowPrivilegeEscalation`, and `readOnlyRootFilesystem`.
- Requires checking `containers`, `initContainers`, and `ephemeralContainers`.
- Distinguishes declared manifest settings from effective runtime state when kubelet `seccompDefault` or admission policy evidence is needed.
- Adds report output fields for effective seccomp/AppArmor/capabilities evidence.
- Adds vulnerable and benign Kubernetes fixture manifests.
- Adds official Kubernetes and Docker references plus changelog update.

### Evidence

**Before (skill misses this / false positive on this):**
```
A pod-level securityContext looked hardened, but an initContainer or app container could set seccompProfile: Unconfined, appArmorProfile: Unconfined, allowPrivilegeEscalation: true, or add SYS_ADMIN/NET_ADMIN without a dedicated effective-state check.
```

**After (now correctly handled):**
```
The skill now requires effective runtime-profile evidence across regular, init, and ephemeral containers, and classifies unconfined seccomp/AppArmor or dangerous capabilities by severity.
```

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass

Fixtures added:
- `tests/vulnerable/unconfined-runtime-profiles.yaml`
- `tests/benign/restricted-runtime-profiles.yaml`

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** PayPal

## Pull Request Checklist

- [x] Skill follows the format specification in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] At least one real framework is cited with correct control IDs
- [x] All framework references verified against primary sources (not blogs or AI output)
- [x] Prompt Injection Safety Notice section included
- [x] `injection-hardened: true` set in frontmatter
- [x] `allowed-tools` scoped to minimum necessary permissions
- [x] Tested with at least one AI coding agent (which one: GPT-5 Codex)
- [x] No prohibited patterns per [SECURITY.md](../SECURITY.md)
- [x] `index.yaml` updated with new skill entry (if adding a skill; not applicable)

## Framework References

- CIS Docker Benchmark v1.6.0 Section 5
- CIS Kubernetes Benchmark v1.9.0 Section 5.2
- NIST SP 800-190 container risk countermeasures
- Kubernetes Pod Security Standards
- Kubernetes seccomp tutorial/reference
- Kubernetes security context and AppArmor docs
- Docker seccomp and Linux capabilities docs

## Testing

- `git diff --check`
- Frontmatter field validation for `skills/**/SKILL.md`
- Content presence check for runtime-profile effective-state matrix, evidence gate, `seccompDefault`, `appArmorProfile`, `ephemeralContainers`, fixtures, and version bump