### PR TITLE
Add role bundle argument hints

### DIFF
--- a/roles/appsec-engineer/SKILL.md
+++ b/roles/appsec-engineer/SKILL.md
@@ -18,6 +18,7 @@ license: MIT
 allowed-tools: Read, Grep, Glob
 injection-hardened: true
 disable-model-invocation: true
+argument-hint: "[target-file-or-directory]"
 ---
 
 # AppSec Engineer Role Bundle

--- a/roles/cloud-security-engineer/SKILL.md
+++ b/roles/cloud-security-engineer/SKILL.md
@@ -18,6 +18,7 @@ license: MIT
 allowed-tools: Read, Grep, Glob
 injection-hardened: true
 disable-model-invocation: true
+argument-hint: "[target-file-or-directory]"
 ---
 
 # Cloud Security Engineer Role Bundle

--- a/roles/security-engineer/SKILL.md
+++ b/roles/security-engineer/SKILL.md
@@ -18,6 +18,7 @@ license: MIT
 allowed-tools: Read, Grep, Glob
 injection-hardened: true
 disable-model-invocation: true
+argument-hint: "[target-file-or-directory]"
 ---
 
 # Security Engineer Role Bundle

--- a/roles/soc-analyst/SKILL.md
+++ b/roles/soc-analyst/SKILL.md
@@ -18,6 +18,7 @@ license: MIT
 allowed-tools: Read, Grep, Glob
 injection-hardened: true
 disable-model-invocation: true
+argument-hint: "[alert-id-log-source-or-target]"
 ---
 
 # SOC Analyst Role Bundle (Tier 1-3)

--- a/roles/vciso/SKILL.md
+++ b/roles/vciso/SKILL.md
@@ -18,6 +18,7 @@ license: MIT
 allowed-tools: Read, Grep, Glob
 injection-hardened: true
 disable-model-invocation: true
+argument-hint: "[scope-description]"
 ---
 
 # Virtual CISO Role Bundle


### PR DESCRIPTION
## Summary
- add concise `argument-hint` frontmatter metadata to all five role bundles under `roles/**/SKILL.md`
- use role-specific hints for engineering targets, SOC alert/log inputs, and vCISO scope descriptions
- keep the change scoped to the missing metadata field only

## Review issue
Addresses UnitOneAI/SecuritySkills#904.

## Validation
- `git diff --check`
- Verified all `roles/**/SKILL.md` files include an `argument-hint` frontmatter value