### PR TITLE
Add role argument-hint metadata

### DIFF
--- a/roles/appsec-engineer/SKILL.md
+++ b/roles/appsec-engineer/SKILL.md
@@ -18,6 +18,7 @@ license: MIT
 allowed-tools: Read, Grep, Glob
 injection-hardened: true
 disable-model-invocation: true
+argument-hint: "[application-or-pr-context]"
 ---
 
 # AppSec Engineer Role Bundle

--- a/roles/cloud-security-engineer/SKILL.md
+++ b/roles/cloud-security-engineer/SKILL.md
@@ -18,6 +18,7 @@ license: MIT
 allowed-tools: Read, Grep, Glob
 injection-hardened: true
 disable-model-invocation: true
+argument-hint: "[cloud-environment-or-iac-context]"
 ---
 
 # Cloud Security Engineer Role Bundle

--- a/roles/security-engineer/SKILL.md
+++ b/roles/security-engineer/SKILL.md
@@ -18,6 +18,7 @@ license: MIT
 allowed-tools: Read, Grep, Glob
 injection-hardened: true
 disable-model-invocation: true
+argument-hint: "[security-engagement-context]"
 ---
 
 # Security Engineer Role Bundle

--- a/roles/soc-analyst/SKILL.md
+++ b/roles/soc-analyst/SKILL.md
@@ -18,6 +18,7 @@ license: MIT
 allowed-tools: Read, Grep, Glob
 injection-hardened: true
 disable-model-invocation: true
+argument-hint: "[alert-incident-or-hunt-context]"
 ---
 
 # SOC Analyst Role Bundle (Tier 1-3)

--- a/roles/vciso/SKILL.md
+++ b/roles/vciso/SKILL.md
@@ -18,6 +18,7 @@ license: MIT
 allowed-tools: Read, Grep, Glob
 injection-hardened: true
 disable-model-invocation: true
+argument-hint: "[security-program-or-compliance-context]"
 ---
 
 # Virtual CISO Role Bundle


### PR DESCRIPTION
## Summary
- Adds role-specific `argument-hint` frontmatter metadata to all five role bundles under `roles/`.
- Keeps the role SKILL.md metadata aligned with the strict metadata contract already used by skill bundles.
- Addresses #904.

## Evidence before / after
- Before: a strict frontmatter check over `skills/**/SKILL.md` and `roles/**/SKILL.md` reported every role bundle missing `argument-hint`.
- After: the same check passes across both `skills/` and `roles/`.

## Validation
- `git diff --check`
- Strict frontmatter validation for required keys across `skills/**/SKILL.md` and `roles/**/SKILL.md`
- Presence check for `argument-hint:` in all five changed role files

## Bounty
- Suggested tier: Minor ($50)
- Payment method: PayPal