### PR TITLE
Add DNS split horizon evidence gates

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -507,7 +507,7 @@ skills:
 
   - id: dns-security
     name: "DNS Security Review"
-    tags: [network, dns, dnssec, exfiltration]
+    tags: [network, dns, dnssec, exfiltration, split-horizon, protective-dns]
     role: [security-engineer]
     phase: [operate]
     activity: [review, audit]

--- a/skills/network/dns-security/SKILL.md
+++ b/skills/network/dns-security/SKILL.md
@@ -6,14 +6,15 @@ description: >
   -- Use DNS Filtering Services). Auto-invoked when reviewing DNS configurations,
   DNSSEC deployment, or investigating DNS-based exfiltration and tunneling
   indicators. Produces a DNS security assessment covering DNSSEC validation,
-  protective DNS, and exfiltration detection patterns.
-tags: [network, dns, dnssec, exfiltration]
+  split-horizon/private DNS classification, conditional forwarders, protective
+  DNS, and exfiltration detection patterns.
+tags: [network, dns, dnssec, exfiltration, split-horizon, protective-dns]
 role: [security-engineer]
 phase: [operate]
 frameworks: [NIST-SP-800-81-Rev2, CIS-Controls-v8]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -23,7 +24,7 @@ argument-hint: "[target-file-or-directory]"
 
 # DNS Security Review
 
-A structured, repeatable process for evaluating DNS security posture against NIST SP 800-81 Rev 2 (Secure Domain Name System Deployment Guide) and CIS Controls v8 Control 9.2 (Use DNS Filtering Services). This skill covers DNSSEC deployment, encrypted DNS transport, Response Policy Zones, DNS exfiltration detection, and protective DNS services. All findings are mapped to framework controls with severity ratings and actionable remediation.
+A structured, repeatable process for evaluating DNS security posture against NIST SP 800-81 Rev 2 (Secure Domain Name System Deployment Guide) and CIS Controls v8 Control 9.2 (Use DNS Filtering Services). This skill covers DNSSEC deployment, split-horizon/private DNS classification, conditional forwarders, encrypted DNS transport, Response Policy Zones, DNS exfiltration detection, and protective DNS services. All findings are mapped to framework controls with severity ratings and actionable remediation.
 
 ---
 
@@ -36,6 +37,7 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 - Investigation of suspected DNS-based data exfiltration or command-and-control.
 - Compliance audits requiring NIST SP 800-81 alignment.
 - Protective DNS service evaluation or deployment planning.
+- Split-horizon, private hosted zone, VPN DNS routing, or conditional-forwarder review.
 - Incident response when DNS tunneling is suspected.
 
 ---
@@ -67,9 +69,12 @@ Use Glob and Grep to locate DNS server configurations, resolver settings, and re
 **/resolvconf/**
 
 # Cloud DNS
-**/*.tf           # Terraform (aws_route53_zone, google_dns_managed_zone, azurerm_dns_zone)
+**/*.tf           # Terraform (aws_route53_zone, google_dns_managed_zone, azurerm_dns_zone, private DNS zones)
 **/dns*
 **/route53*
+**/*private_dns*
+**/*privatedns*
+**/*dns-zone*
 
 # CoreDNS (Kubernetes)
 **/Corefile
@@ -88,17 +93,98 @@ Use Glob and Grep to locate DNS server configurations, resolver settings, and re
 
 Categorize discovered configurations:
 - **Authoritative servers:** BIND, PowerDNS, Route53 hosted zones, Cloud DNS zones.
+- **Public authoritative zones:** Internet-delegated zones and parent DS records.
+- **Private hosted zones / split-horizon views:** BIND views, cloud private zones, internal-only zones, shadowed names.
 - **Recursive resolvers:** Unbound, BIND (recursion enabled), CoreDNS, systemd-resolved.
+- **Conditional forwarders and resolver routes:** BIND/Unbound forward zones, CoreDNS `forward` or `stubDomains`, VPN resolver routes.
 - **Protective DNS / filtering:** RPZ, Pi-hole, Cisco Umbrella, Cloudflare Gateway, Quad9.
-- **Client settings:** resolv.conf, DHCP-distributed resolver addresses.
+- **Client settings:** resolv.conf, DHCP-distributed resolver addresses, VPN DNS suffix search lists.
 
 ---
 
-### Step 2: DNSSEC Deployment Review (NIST SP 800-81 Rev 2, Sections 4 and 5)
+### Step 2: Split-Horizon and Resolver Path Classification
+
+Before scoring DNSSEC, exposure, or protective DNS bypass findings, classify the DNS view and resolver path for each high-value zone or name. Private, non-delegated zones may intentionally be unsigned and invisible from public resolvers; treat them differently from public authoritative zones.
+
+#### 2.1 Split-Horizon Inventory Gate
+
+Build an inventory of public and private DNS sources:
+
+| Evidence Source | What to Capture | Risk Signal |
+|-----------------|-----------------|-------------|
+| Public authoritative zones | Internet-delegated zones, parent DS records, public NS set | Unsigned or broken chain of trust for public/delegated names |
+| Private hosted zones | Route 53 private hosted zones, Google Cloud private zones, Azure Private DNS zones | Private zone shadows public name without owner or association record |
+| Resolver views | BIND `view`, `match-clients`, PowerDNS views, Unbound access controls | Internal and external answers diverge without documentation |
+| Conditional forwarders | Forwarded suffix, target resolver, source resolver, transport, logging | Internal names sent to public or untrusted resolvers |
+| Client/VPN DNS routing | DHCP resolvers, VPN pushed DNS servers, suffix search list, split-tunnel routes | VPN or endpoint path bypasses corporate resolver controls |
+
+**Patterns to check:**
+
+```
+# BIND split-horizon and forwarding
+view "
+match-clients
+zone "
+forwarders
+forward only
+
+# Unbound forward zones
+forward-zone:
+forward-addr:
+
+# CoreDNS forwarding and split behavior
+forward .
+forward corp.example.com
+stubDomains
+fallthrough
+
+# Cloud private DNS resources
+aws_route53_zone
+vpc
+google_dns_managed_zone
+visibility = "private"
+azurerm_private_dns_zone
+
+# Client and VPN resolver routes
+dhcp-option DNS
+dhcp-option DOMAIN
+DNS Server
+search-domain
+split-dns
+```
+
+#### 2.2 Resolver Vantage Evidence
+
+For high-value names, query from multiple vantage points and document expected divergence instead of assuming inconsistent answers are automatically findings.
+
+| Name | Public Resolver Answer | Corporate Resolver Answer | VPN/Client Resolver Answer | Expected Owner/Service | TTL | Divergence Documented | Finding |
+|------|------------------------|---------------------------|----------------------------|------------------------|-----|-----------------------|---------|
+| api.example.com | CNAME api-prod.example.net | A 10.24.8.15 | A 10.24.8.15 | Payments API | 300/86400 | Yes/No | Pass/Fail |
+
+**Interpretation rules:**
+
+- Public `NXDOMAIN` plus internal `A` or `CNAME` can be expected for private services if the zone owner, resolver scope, TTL, and access path are documented.
+- Internal `NXDOMAIN` plus public `A` or `CNAME` may indicate VPN suffix routing drift, stale split-horizon configuration, or endpoint resolver bypass.
+- Unsigned private zones are **Informational** or **Not Applicable** for DNSSEC unless they are delegated, externally reachable, used as a trust boundary, or expected to participate in a DNSSEC chain of trust.
+- Undocumented split-horizon drift for authentication, payment, administration, certificate, or production API names is **Medium** or **High** depending on blast radius and exploitability.
+
+#### 2.3 Conditional Forwarder Gates
+
+Review resolver-to-resolver paths, not only endpoint-to-resolver paths. Conditional forwarders can bypass protective DNS and leak internal names even when client DNS policy appears enforced.
+
+| Source Resolver | Zone/Suffix | Forwarder Target | Target Type | Logging Retained | Filtering Retained | Internal-Name Leakage Risk | Rationale |
+|-----------------|-------------|------------------|-------------|------------------|--------------------|----------------------------|-----------|
+| branch-recursive-01 | corp.example.com | 8.8.8.8 | Public resolver | No | No | High | Missing enterprise exception |
+
+**Finding classification:** Conditional forwarder to a public or untrusted resolver for an internal suffix without documented approval, logging, and filtering is **High**. Conditional forwarding that intentionally bypasses filtering but retains logging and has a business-approved exception is **Medium**. Documented internal forwarding to an enterprise resolver with retained logging/filtering is **Pass**.
+
+---
+
+### Step 3: DNSSEC Deployment Review (NIST SP 800-81 Rev 2, Sections 4 and 5)
 
 NIST SP 800-81 Rev 2 Section 4 covers DNSSEC for authoritative servers (zone signing) and Section 5 covers DNSSEC for recursive resolvers (validation).
 
-#### 2.1 Authoritative Zone Signing (Section 4)
+#### 3.1 Authoritative Zone Signing (Section 4)
 
 For each authoritative zone, verify:
 
@@ -126,11 +212,11 @@ auto-dnssec maintain
 inline-signing yes
 ```
 
-**Finding classification:** Unsigned authoritative zones for public-facing domains are **High**. Weak signing algorithms (RSA < 2048-bit, SHA-1) are **High**. Missing DS record in parent (broken chain of trust) is **Critical**.
+**Finding classification:** Unsigned authoritative zones for public-facing or delegated domains are **High**. Weak signing algorithms (RSA < 2048-bit, SHA-1) are **High**. Missing DS record in parent for a signed public/delegated zone (broken chain of trust) is **Critical**. Unsigned non-delegated private zones are **Informational** or **Not Applicable** unless they cross a trust boundary or are externally reachable.
 
 ---
 
-#### 2.2 Recursive Resolver DNSSEC Validation (Section 5)
+#### 3.2 Recursive Resolver DNSSEC Validation (Section 5)
 
 For each recursive resolver, verify:
 
@@ -156,11 +242,11 @@ dnssec
 
 ---
 
-### Step 3: Encrypted DNS Transport Review
+### Step 4: Encrypted DNS Transport Review
 
 Evaluate whether DNS queries are protected in transit.
 
-#### 3.1 DNS over HTTPS (DoH) and DNS over TLS (DoT)
+#### 4.1 DNS over HTTPS (DoH) and DNS over TLS (DoT)
 
 | Transport | Port | Standard | Use Case |
 |-----------|------|----------|----------|
@@ -194,11 +280,11 @@ forwarders { 1.1.1.1; };  # Plaintext -- flag as finding
 
 ---
 
-### Step 4: Response Policy Zones (RPZ) and Protective DNS (CIS Control 9.2)
+### Step 5: Response Policy Zones (RPZ) and Protective DNS (CIS Control 9.2)
 
 CIS Control 9.2 requires the use of DNS filtering services to block access to known malicious domains. RPZ (Response Policy Zones, defined by ISC) is the standard mechanism for DNS-based filtering on recursive resolvers.
 
-#### 4.1 RPZ Configuration
+#### 5.1 RPZ Configuration
 
 **Verify RPZ is deployed and configured:**
 
@@ -223,25 +309,27 @@ rpz:
 - Update frequency is at least daily.
 - Logging of RPZ-blocked queries is enabled for incident detection.
 
-#### 4.2 Protective DNS Service Evaluation
+#### 5.2 Protective DNS Service Evaluation
 
 If a cloud-based protective DNS service is used (Cisco Umbrella, Cloudflare Gateway, Quad9, CISA Protective DNS), verify:
 
 - All clients and recursive resolvers forward to the protective DNS service.
 - No DNS resolution paths bypass the protective DNS (direct queries to 8.8.8.8, 1.1.1.1 from endpoints).
+- Conditional forwarders, branch resolvers, CoreDNS forward plugins, VPN resolvers, and resolver-to-resolver routes preserve protective DNS logging/filtering or have documented risk-approved exceptions.
+- Internal suffixes are not forwarded to public resolvers unless the owner has accepted internal-name leakage and loss of filtering visibility.
 - Domain categorization covers: malware C2, phishing, newly registered domains (NRDs < 30 days), DGA-generated domains.
 - Block pages or NXDOMAIN responses are returned for blocked categories.
 - Logs are forwarded to SIEM.
 
-**Finding classification:** No DNS filtering/RPZ deployed is **High**. RPZ feeds not automatically updated is **Medium**. DNS resolution paths that bypass protective DNS is **High**.
+**Finding classification:** No DNS filtering/RPZ deployed is **High**. RPZ feeds not automatically updated is **Medium**. DNS resolution paths that bypass protective DNS are **High**. Conditional forwarders that leak internal names or bypass filtering/logging are **High** unless explicitly documented and risk accepted.
 
 ---
 
-### Step 5: DNS Exfiltration and Tunneling Detection Patterns
+### Step 6: DNS Exfiltration and Tunneling Detection Patterns
 
 DNS tunneling encodes data in DNS query names or TXT record responses to create a covert communication channel. Detection requires pattern analysis, not just domain reputation.
 
-#### 5.1 Exfiltration Indicators
+#### 6.1 Exfiltration Indicators
 
 | Indicator | Normal | Suspicious | Detection Method |
 |-----------|--------|-----------|-----------------|
@@ -252,7 +340,7 @@ DNS tunneling encodes data in DNS query names or TXT record responses to create 
 | **Query volume per domain** | < 100/hr to a single domain | > 1000/hr to single obscure domain | Volumetric per-domain threshold |
 | **Response size** | < 512 bytes | TXT responses > 512 bytes, multiple TXT records | Monitor response payload sizes |
 
-#### 5.2 Tunneling Tool Signatures
+#### 6.2 Tunneling Tool Signatures
 
 Common DNS tunneling tools produce distinctive query patterns:
 
@@ -270,7 +358,7 @@ abcdef0123456789.dnscat.example.com TXT
 0001.<encoded>.d.example.com KEY
 ```
 
-#### 5.3 Detection Configuration
+#### 6.3 Detection Configuration
 
 **Where to implement detection:**
 
@@ -286,7 +374,7 @@ abcdef0123456789.dnscat.example.com TXT
 
 ---
 
-### Step 6: Domain Categorization and Newly Registered Domain (NRD) Blocking
+### Step 7: Domain Categorization and Newly Registered Domain (NRD) Blocking
 
 - **NRD blocking:** Domains registered within the past 30 days are disproportionately associated with phishing and malware. CIS Control 9.2 supports blocking or flagging NRDs.
 - **DGA detection:** Domain Generation Algorithms produce random-appearing domain names. Detection relies on entropy analysis and machine learning classifiers integrated into protective DNS services.
@@ -299,8 +387,8 @@ abcdef0123456789.dnscat.example.com TXT
 | Severity | Definition |
 |----------|-----------|
 | **Critical** | Broken DNSSEC chain of trust (missing DS record in parent); authoritative zones serving invalid signatures. |
-| **High** | DNSSEC validation disabled on resolvers; no DNS filtering/RPZ; unsigned public authoritative zones; DNS bypass paths around protective DNS; no DNS query logging; weak signing algorithms. |
-| **Medium** | Plaintext DNS forwarding over untrusted networks; stale RPZ feeds; undocumented NTAs; no NRD blocking; no exfiltration detection; DoH bypass not controlled. |
+| **High** | DNSSEC validation disabled on resolvers; no DNS filtering/RPZ; unsigned public authoritative zones; DNS bypass paths around protective DNS; conditional forwarders leaking internal names; no DNS query logging; weak signing algorithms. |
+| **Medium** | Plaintext DNS forwarding over untrusted networks; stale RPZ feeds; undocumented NTAs; undocumented split-horizon drift; risk-accepted filtering bypass; no NRD blocking; no exfiltration detection; DoH bypass not controlled. |
 | **Low** | Missing documentation of DNS architecture; resolver software not at latest version; cosmetic configuration issues. |
 
 ---
@@ -321,6 +409,18 @@ abcdef0123456789.dnscat.example.com TXT
 | Zone | Signed | Algorithm | Key Sizes | DS in Parent | NSEC Version | Status |
 |------|--------|-----------|-----------|--------------|-------------|--------|
 | example.com | Yes/No | 13/8/15 | KSK:2048/ZSK:1024 | Yes/No | NSEC3 | Pass/Fail |
+
+### Split-Horizon and Resolver Vantage Evidence
+
+| Name | Public Resolver Answer | Corporate Resolver Answer | VPN/Client Resolver Answer | Expected Owner/Service | TTL | Divergence Documented | Status |
+|------|------------------------|---------------------------|----------------------------|------------------------|-----|-----------------------|--------|
+| api.example.com | CNAME api-prod.example.net | A 10.24.8.15 | A 10.24.8.15 | Payments API | 300/86400 | Yes/No | Pass/Fail |
+
+### Conditional Forwarder Review
+
+| Source Resolver | Zone/Suffix | Forwarder Target | Target Type | Logging Retained | Filtering Retained | Internal-Name Leakage Risk | Status |
+|-----------------|-------------|------------------|-------------|------------------|--------------------|----------------------------|--------|
+| branch-recursive-01 | corp.example.com | enterprise-resolver.internal | Enterprise resolver | Yes/No | Yes/No | Low/Medium/High | Pass/Fail |
 
 ### Resolver Security
 
@@ -384,6 +484,10 @@ abcdef0123456789.dnscat.example.com TXT
 
 4. **Ignoring DNS over TCP.** DNS is not UDP-only. DNS over TCP (port 53) supports large responses and is required for zone transfers. Some tunneling tools prefer TCP for reliability. Firewall rules and monitoring must cover both UDP and TCP port 53.
 
+5. **Scoring private split-horizon zones as public DNSSEC failures.** Non-delegated private zones may be intentionally unsigned and unreachable from public resolvers. Classify resolver views and delegation status before assigning High or Critical DNSSEC findings.
+
+6. **Checking endpoint resolver policy but missing conditional forwarders.** A client can use the corporate resolver while a branch resolver forwards internal suffixes to public resolvers. Review resolver-to-resolver forwarding, logging retention, and filtering retention for every internal suffix.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -408,9 +512,14 @@ This skill processes DNS configuration files that may contain user-supplied zone
 - RFC 7719 -- DNS Terminology: https://datatracker.ietf.org/doc/html/rfc7719
 - ISC Response Policy Zones (RPZ): https://www.isc.org/rpz/
 - CISA Protective DNS: https://www.cisa.gov/protective-dns
+- CoreDNS forward plugin: https://coredns.io/plugins/forward/
+- AWS Route 53 private hosted zones: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-private.html
+- Google Cloud DNS zones: https://cloud.google.com/dns/docs/zones
+- Azure Private DNS overview: https://learn.microsoft.com/en-us/azure/dns/private-dns-overview
 
 ---
 
 ## Changelog
 
+- **1.1.0** -- Added split-horizon/private DNS classification, resolver vantage evidence, conditional-forwarder gates, and cloud private DNS search patterns.
 - **1.0.0** -- Initial release. Full coverage of NIST SP 800-81 Rev 2 and CIS Controls v8 Control 9.2 for DNS security review.


### PR DESCRIPTION
## Summary
- add split-horizon/private DNS classification before DNSSEC and public exposure scoring
- add resolver-vantage and conditional-forwarder evidence tables for high-value names
- add cloud private DNS/CoreDNS search patterns and false-positive guidance for non-delegated private zones

## Validation
- `git diff --check`
- verified fenced code block balance
- verified required split-horizon, conditional-forwarder, cloud private DNS, CoreDNS, and Not Applicable guidance strings are present
- verified added reference links return HTTP 200