### PR TITLE
Add firewall cloud and IPv6 evidence gates

### DIFF
--- a/skills/network/firewall-review/SKILL.md
+++ b/skills/network/firewall-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [operate]
 frameworks: [CIS-Controls-v8, NIST-SP-800-41-Rev1]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -80,6 +80,8 @@ Record all discovered files. Categorize each by:
 - **Platform:** iptables, nftables, pf, cloud security groups, Kubernetes NetworkPolicy, vendor-specific (Palo Alto, Fortinet, Cisco ASA).
 - **Direction:** Perimeter (north-south) vs. internal (east-west).
 - **Scope:** Server, endpoint, network segment.
+- **Address family:** IPv4, IPv6, dual-stack, or evidence that IPv6 is disabled at the platform/interface level.
+- **Cloud effective-policy context:** Explicit rules, platform default/implicit rules, priority/order model, and association scope.
 
 ---
 
@@ -89,13 +91,22 @@ NIST SP 800-41 Rev 1 Section 4 defines core firewall policy principles. Evaluate
 
 #### 2.1 Default Deny Verification (NIST SP 800-41, Section 4.2)
 
-The rule base MUST terminate with an explicit deny-all rule. Every traffic flow that is not explicitly permitted must be dropped.
+Default deny means every traffic flow that is not explicitly permitted is dropped. The evidence required depends on the firewall platform:
+
+- Traditional ordered firewalls (iptables, nftables, pf, ASA, perimeter appliances) SHOULD terminate each chain/policy with an explicit deny/drop or enforce a default DROP/DENY policy.
+- AWS Security Groups are stateful allow-lists. They do not support explicit deny rules; unmatched traffic is implicitly denied. Evaluate the effective allow set, default outbound allow rules, attached ENIs/instances/load balancers, and IPv4/IPv6 CIDRs instead of failing solely because no explicit deny exists.
+- AWS Network ACLs are stateless, ordered subnet controls that support allow and deny entries. Evaluate rule number precedence in both ingress and egress directions, including ephemeral return-port behavior.
+- Azure NSGs are stateful and use priority-ordered user rules plus default security rules. Evaluate effective security rules, including default rules such as `AllowVnetInBound`, `AllowAzureLoadBalancerInBound`, `DenyAllInBound`, `AllowVnetOutBound`, `AllowInternetOutBound`, and `DenyAllOutBound`.
+- GCP VPC firewall rules are stateful and priority-based. Evaluate implied allow egress and implied deny ingress rules, plus hierarchical firewall policies and target scope.
+- If only IaC is available and runtime effective rules, associations, or IPv6 enablement cannot be proven, mark the relevant item `Not Evaluable` instead of forcing Pass/Fail.
 
 **What to verify:**
 
-- The last rule in every chain/policy is an explicit `deny all` or `drop all`.
-- No implicit allow rules override the default deny (e.g., cloud security groups that default to allow outbound).
+- For ordered firewalls, the last rule in every chain/policy is an explicit `deny all` or `drop all`, or the chain default policy is DROP/DENY.
+- For cloud firewalls, the platform's effective policy combines explicit rules, default/implicit behavior, priority/order, and resource associations.
+- No implied or default allow rules create unrestricted inbound or outbound exposure.
 - Both inbound AND outbound directions enforce default deny.
+- Default-deny evidence distinguishes explicit terminal deny, implicit deny, implied allow, unsupported deny semantics, and `Not Evaluable` cases.
 
 **Patterns to check:**
 
@@ -107,12 +118,13 @@ The rule base MUST terminate with an explicit deny-all rule. Every traffic flow 
 
 # Cloud security groups -- verify no 0.0.0.0/0 allow-all egress
 egress: 0.0.0.0/0 allow all
+ipv6_cidr_blocks: ["::/0"]
 
 # Terraform
 default_action = "Allow"    # BAD -- should be "Deny"
 ```
 
-**Finding classification:** Absence of explicit default deny is **Critical**.
+**Finding classification:** Missing default deny on ordered firewalls is **Critical**. Cloud effective policy that exposes management planes or sensitive services to the internet is **Critical**. Cloud policies that cannot be evaluated from available evidence should be marked `Not Evaluable` with confidence and missing evidence, not reported as Pass.
 
 ---
 
@@ -254,6 +266,74 @@ Egress filtering prevents compromised internal hosts from establishing unrestric
 
 ---
 
+#### 2.8 Cloud Platform Effective Policy Evaluation
+
+For each discovered cloud firewall resource, compute the effective policy from explicit rules plus provider behavior, resource associations, and priority/order. Do not evaluate cloud firewalls with a traditional "last explicit deny" test alone.
+
+**Record the effective-policy properties:**
+
+| Property | Required evidence |
+|----------|-------------------|
+| Platform | AWS, Azure, GCP, Kubernetes, or on-premises/vendor platform |
+| Firewall type | Security Group, Network ACL, NSG, VPC firewall, hierarchical firewall policy, or host firewall |
+| Stateful/stateless | Platform behavior that determines return traffic handling |
+| Explicit deny supported | Yes/No/N/A with platform rationale |
+| Ordered or priority rules | Rule numbers, priorities, or statement that ordering is not used |
+| Platform implicit/default rules | Ingress/egress default permits and denies |
+| Association scope | Attached ENIs, instances, load balancers, subnets, NICs, VPCs, projects, folders, organizations, tags, or service accounts |
+| IPv4 reviewed | Yes/No with source evidence |
+| IPv6 reviewed | Yes/No with source evidence |
+| IPv6 disabled evidence | Platform/interface proof, not merely absence of IPv6 IaC |
+| Source of effective rules | IaC only, runtime export, cloud API/CLI, console export, or mixed |
+| Confidence | High, Medium, Low, or Not Evaluable |
+
+**AWS Security Groups:**
+
+- Treat security groups as stateful allow-lists with no explicit deny rule support.
+- Enumerate inbound and outbound rules, including `0.0.0.0/0`, `::/0`, prefix lists, and security group references.
+- Check whether default outbound allow-all rules remain present.
+- Verify attachments to ENIs, EC2 instances, load balancers, RDS resources, and other supported targets.
+- Mark outbound default-deny status as Fail if an effective allow-all egress rule exists without a documented control.
+
+**AWS Network ACLs:**
+
+- Treat NACLs as stateless, ordered rules that can allow or deny traffic.
+- Evaluate ingress and egress rule-number precedence, terminal `*` behavior, and subnet associations.
+- Check that ephemeral return-port ranges are intentionally handled and not accidentally opened to `0.0.0.0/0` or `::/0`.
+
+**Azure NSGs:**
+
+- Evaluate user rules by priority and include default security rules in the final decision.
+- Explicitly review `AllowVnetInBound`, `AllowAzureLoadBalancerInBound`, `DenyAllInBound`, `AllowVnetOutBound`, `AllowInternetOutBound`, and `DenyAllOutBound`.
+- Verify NSG association to subnet, NIC, or both; unassociated NSGs do not enforce traffic.
+- Use effective security rules when available. If only IaC is available, mark runtime association and effective-rule questions with lower confidence or `Not Evaluable`.
+- Review IPv6 prefixes and service tags separately from IPv4 CIDRs.
+
+**GCP VPC firewall rules:**
+
+- Include implied allow egress and implied deny ingress in the effective policy.
+- Evaluate rule priority, action, direction, network, source/destination ranges, target tags, and target service accounts.
+- Review hierarchical firewall policies at organization and folder scope before concluding VPC-level exposure.
+- Review IPv6 ranges independently from IPv4 ranges when the VPC or subnet is dual-stack.
+
+---
+
+#### 2.9 IPv4/IPv6 Dual-Stack Exposure Review
+
+Evaluate IPv4 and IPv6 exposure as separate attack surfaces. Do not assume IPv4 restrictions protect IPv6 traffic.
+
+**What to verify:**
+
+- For every inbound and outbound rule, record the address family and compare IPv4 CIDRs with IPv6 CIDRs.
+- Treat `::/0` as global IPv6 exposure and evaluate it separately from `0.0.0.0/0`.
+- Confirm that sensitive services (SSH, RDP, database ports, admin consoles, Kubernetes API, metadata proxies) are not exposed through IPv6 when IPv4 is restricted.
+- If IPv6 appears absent from IaC, require platform or interface evidence that IPv6 is disabled. Absence of IPv6 configuration alone is not sufficient evidence.
+- If IPv6 enablement cannot be proven or disproven from available inputs, mark IPv6 coverage `Not Evaluable` and list the missing evidence.
+
+**Finding classification:** Global IPv6 inbound exposure to sensitive services is **Critical**. Unreviewed IPv6 coverage in a dual-stack environment is **High**. IPv6 status that cannot be determined from IaC-only evidence is `Not Evaluable`.
+
+---
+
 ### Step 3: Compile Assessment Report
 
 Produce the final report using the following structure.
@@ -264,8 +344,8 @@ Produce the final report using the following structure.
 
 | Severity | Definition |
 |----------|-----------|
-| **Critical** | Missing default deny; any/any inbound rules. Immediate exploitation risk. |
-| **High** | Overly permissive outbound rules; shadowed deny rules; no logging on deny actions; missing anti-spoofing; unused rules to decommissioned resources. |
+| **Critical** | Missing default deny on ordered firewalls; any/any inbound rules; unrestricted inbound IPv6 `::/0` to sensitive services; cloud effective policy exposing management planes or sensitive services to the internet. |
+| **High** | Overly permissive outbound rules; implied allow egress without compensating controls; shadowed deny rules; no logging on deny actions; missing anti-spoofing; unused rules to decommissioned resources; unknown cloud association scope on production resources; IPv6 unreviewed on dual-stack assets. |
 | **Medium** | Shadowed permit rules; missing egress DNS restriction; unused rules (active resources); missing logging on sensitive permits; missing stealth rules. |
 | **Low** | Rule documentation gaps; suboptimal rule ordering with no current security impact; cosmetic rule base issues. |
 
@@ -296,15 +376,21 @@ Produce the final report using the following structure.
 - **Control Reference:** CIS 4.4 / NIST SP 800-41 Section X.X
 - **File:** <path to config file>
 - **Rule(s):** <rule number(s) or line(s)>
+- **Confidence:** High / Medium / Low / Not Evaluable
 - **Description:** <what was found>
 - **Evidence:** <specific rule text or configuration snippet>
 - **Remediation:** <concrete fix with example>
 
+### Platform Effective Policy Summary
+| Platform | Firewall Type | Stateful/Stateless | Explicit Deny Supported | Ordered/Priority Rules | Platform Implicit/Default Rules | Association Scope | IPv4 Reviewed | IPv6 Reviewed | IPv6 Disabled Evidence | Source of Effective Rules | Confidence |
+|----------|---------------|--------------------|-------------------------|------------------------|---------------------------------|-------------------|---------------|---------------|------------------------|---------------------------|------------|
+| <AWS/Azure/GCP/etc.> | <SG/NSG/NACL/VPC FW/etc.> | <stateful/stateless> | <Yes/No/N/A> | <Yes/No/N/A> | <rules in effect> | <attachments/scope> | <Yes/No> | <Yes/No> | <evidence/Unknown> | <IaC/runtime/both> | <High/Medium/Low/Not Evaluable> |
+
 ### Default Deny Status
-| Direction | Status | Evidence |
-|-----------|--------|----------|
-| Inbound   | Pass/Fail | <rule reference> |
-| Outbound  | Pass/Fail | <rule reference> |
+| Direction | Explicit Terminal Deny | Implicit Deny | Implied Allow | Platform Status | Confidence | Evidence |
+|-----------|------------------------|---------------|---------------|-----------------|------------|----------|
+| Inbound   | Found/Absent/N/A | Present/Absent/N/A | Present/Absent | Pass/Fail/Not Evaluable | High/Medium/Low/Not Evaluable | <rule or platform reference> |
+| Outbound  | Found/Absent/N/A | Present/Absent/N/A | Present/Absent | Pass/Fail/Not Evaluable | High/Medium/Low/Not Evaluable | <rule or platform reference> |
 
 ### Shadowed Rules Summary
 | Shadowed Rule | Position | Shadowing Rule | Position | Impact |
@@ -316,6 +402,14 @@ Produce the final report using the following structure.
 | DNS (53)      | Yes/No    | <resolver IPs>         |
 | SMTP (25)     | Yes/No    | <mail server IPs>      |
 | HTTPS (443)   | Yes/No    | <proxy or direct>      |
+
+### IPv4/IPv6 Exposure Matrix
+| Direction | Address Family | Most Permissive CIDR | Overly Permissive Rules | Effective Exposure | Evidence |
+|-----------|----------------|----------------------|--------------------------|--------------------|----------|
+| Inbound   | IPv4 | 0.0.0.0/0 / restricted / none | <count> | Open/Restricted/Not Evaluable | <rule references> |
+| Inbound   | IPv6 | ::/0 / restricted / disabled / unknown | <count> | Open/Restricted/Disabled/Not Evaluable | <rule references or disabled evidence> |
+| Outbound  | IPv4 | 0.0.0.0/0 / restricted / none | <count> | Open/Restricted/Not Evaluable | <rule references> |
+| Outbound  | IPv6 | ::/0 / restricted / disabled / unknown | <count> | Open/Restricted/Disabled/Not Evaluable | <rule references or disabled evidence> |
 
 ### Prioritized Remediation Plan
 1. **[Critical]** <action item with control reference>
@@ -353,13 +447,15 @@ Produce the final report using the following structure.
 
 1. **Auditing inbound only and ignoring egress.** NIST SP 800-41 Section 4.2 explicitly requires both directions. Unrestricted egress is the primary enabler of data exfiltration and C2 communication. Always evaluate outbound rules with equal rigor.
 
-2. **Treating cloud security groups like traditional firewalls.** Cloud security groups are stateful and often default to allow-all egress. Each cloud provider has different implicit behaviors (AWS security groups allow all outbound by default; Azure NSGs do not). Document the platform's default behavior before auditing rules.
+2. **Treating cloud security groups like traditional firewalls.** Cloud controls may be stateful allow-lists, stateless ordered ACLs, or priority-based policy engines. Compute effective policy from explicit rules, platform implicit/default rules, association scope, and priority/order before assigning Pass/Fail.
 
-3. **Ignoring IPv6 rules.** Many environments have parallel IPv4 and IPv6 rule bases (ip6tables, IPv6 security group rules). If IPv6 is not explicitly disabled at the interface level, an unmanaged IPv6 rule base can bypass all IPv4 firewall controls.
+3. **Ignoring IPv6 rules.** Many environments have parallel IPv4 and IPv6 rule bases (ip6tables, IPv6 security group rules). If IPv6 is not explicitly disabled at the platform or interface level, an unmanaged IPv6 rule base can bypass all IPv4 firewall controls. Absence of IPv6 IaC is not evidence that IPv6 is disabled.
 
 4. **Assuming hit count of zero means the rule is unused.** Hit counters reset on firewall reload or failover. Verify the counter baseline timestamp before recommending rule removal. Cross-reference with SIEM/flow data where available.
 
 5. **Conflating network ACLs with security groups in cloud environments.** In AWS, NACLs are stateless and operate at the subnet level; security groups are stateful and operate at the instance level. Both must be audited. A permissive NACL can undermine restrictive security group rules for responses.
+
+6. **Overclaiming from IaC only.** Source files often lack runtime attachments, effective security rules, hit counters, flow logs, and IPv6 enablement state. Use `Not Evaluable` and confidence levels when evidence is unavailable instead of inventing a Pass/Fail outcome.
 
 ---
 
@@ -381,9 +477,13 @@ This skill processes firewall configurations that may contain user-supplied comm
 - NIST SP 800-41 Rev 1, Guidelines on Firewalls and Firewall Policy: https://csrc.nist.gov/publications/detail/sp/800-41/rev-1/final
 - NIST SP 800-41 Rev 1 (PDF): https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-41r1.pdf
 - CIS Benchmarks (platform-specific firewall hardening): https://www.cisecurity.org/cis-benchmarks
+- AWS Security group rules: https://docs.aws.amazon.com/vpc/latest/userguide/security-group-rules.html
+- Azure Network security groups overview: https://learn.microsoft.com/en-us/azure/virtual-network/network-security-groups-overview
+- Google Cloud VPC firewall rules: https://cloud.google.com/firewall/docs/firewalls
 
 ---
 
 ## Changelog
 
+- **1.0.1** -- Added cloud effective-policy, IPv4/IPv6 exposure, and Not Evaluable evidence gates for firewall reviews.
 - **1.0.0** -- Initial release. Full coverage of CIS Controls v8 (4.4, 4.5) and NIST SP 800-41 Rev 1 firewall audit methodology.


### PR DESCRIPTION
## Summary
- Adds platform-aware default-deny guidance for ordered firewalls, AWS Security Groups, AWS Network ACLs, Azure NSGs, and GCP VPC firewalls.
- Adds structured cloud effective-policy evaluation covering default/implicit rules, association scope, stateful/stateless behavior, IPv4/IPv6 review, source evidence, and confidence.
- Expands the report template with Platform Effective Policy Summary, richer Default Deny Status, IPv4/IPv6 Exposure Matrix, and Not Evaluable confidence outcomes.

## Validation
- git diff --check
- Verified required #220 terms are present in `skills/network/firewall-review/SKILL.md`

Closes #220