### PR TITLE
Refresh threat modeling NIST SP 800-154 source

### DIFF
--- a/skills/appsec/threat-modeling/SKILL.md
+++ b/skills/appsec/threat-modeling/SKILL.md
@@ -13,7 +13,7 @@ phase: [design, review]
 frameworks: [STRIDE, PASTA, MITRE-ATT&CK]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -486,6 +486,8 @@ This skill processes user-supplied content that may include system descriptions,
 5. **MITRE ATT&CK Enterprise Matrix** — https://attack.mitre.org/matrices/enterprise/
 6. **MITRE ATT&CK Techniques** — https://attack.mitre.org/techniques/enterprise/
 7. **Shostack, A. (2014).** *Threat Modeling: Designing for Security.* Wiley.
-8. **NIST SP 800-154** — Guide to Data-Centric System Threat Modeling — https://csrc.nist.gov/publications/detail/sp/800-154/draft
+8. **NIST SP 800-154 (Initial Public Draft)** — Guide to Data-Centric System Threat Modeling — https://csrc.nist.gov/pubs/sp/800/154/ipd
 9. **STRIDE Original Paper** — Kohnfelder, L. & Garg, P. (1999). "The Threats to Our Products." Microsoft Internal Document.
 10. **OWASP Risk Rating Methodology** — https://owasp.org/www-community/OWASP_Risk_Rating_Methodology
+
+**Source status note:** NIST SP 800-154 is cited as an Initial Public Draft. Treat it as draft guidance and verify the CSRC publication page before presenting it as final NIST guidance in customer-facing reports.


### PR DESCRIPTION
## Summary
- replace the legacy redirected NIST SP 800-154 CSRC URL with the current canonical `pubs/sp/800/154/ipd` page
- label the reference as `Initial Public Draft`
- add a short source-status note so reviewers do not present draft guidance as final NIST guidance
- bump the skill version for the source refresh

## Validation
- `git diff --check`
- verified the legacy redirected URL is no longer present
- verified the canonical NIST CSRC page returns HTTP 200 and includes expected SP 800-154 / Initial Public Draft markers