### PR TITLE
Refresh Azure benchmark scope for CIS v6

### DIFF
--- a/skills/cloud/azure-review/SKILL.md
+++ b/skills/cloud/azure-review/SKILL.md
@@ -2,18 +2,18 @@
 name: azure-review
 description: >
   Performs an Azure security posture review against the CIS Microsoft Azure
-  Foundations Benchmark v2.1.0. Auto-invoked when reviewing Azure infrastructure,
-  Entra ID configurations, NSG rules, Defender for Cloud settings, or Key Vault
-  access policies. Walks through all nine benchmark sections, evaluates each
-  recommendation, and produces a prioritized findings report with remediation
-  guidance mapped to specific CIS control IDs.
+  Foundations Benchmark v6.0.0 by default, with legacy v2.1.0 support when
+  explicitly scoped. Auto-invoked when reviewing Azure infrastructure, NSG
+  rules, Defender for Cloud settings, Storage, Key Vault, App Service, or
+  Entra ID configuration exports. Produces a prioritized findings report with
+  benchmark version metadata, Entra scope handling, and remediation guidance.
 tags: [cloud, azure, cis-benchmark]
 role: [cloud-security-engineer, security-engineer]
 phase: [assess, operate]
-frameworks: [CIS-Azure-v2.1.0]
+frameworks: [CIS-Azure-v6.0.0, CIS-Azure-v2.1.0-legacy, CIS-Microsoft-365-Foundations-entra]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "2.0.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -25,9 +25,9 @@ argument-hint: "[target-file-or-directory]"
 
 ## Overview
 
-This skill performs a structured security assessment of Azure environments against the **CIS Microsoft Azure Foundations Benchmark v2.1.0**. The benchmark is organized into nine sections covering identity management, security center, storage, database services, logging and monitoring, networking, virtual machines, Key Vault, and App Service. Each recommendation is evaluated by inspecting infrastructure-as-code definitions (Terraform, Bicep, ARM templates), Azure CLI output, or configuration files available in the repository.
+This skill performs a structured security assessment of Azure environments against the **CIS Microsoft Azure Foundations Benchmark v6.0.0** by default. CIS published v6.0.0 in May 2026 and migrated Entra ID recommendations out of Azure Foundations into CIS Microsoft 365 Foundations. Each recommendation is evaluated by inspecting infrastructure-as-code definitions (Terraform, Bicep, ARM templates), Azure CLI output, or configuration files available in the repository.
 
-The CIS Azure Foundations Benchmark v2.1.0 provides prescriptive guidance across nine domains. This skill evaluates each applicable control and produces a findings report with CIS recommendation IDs, severity ratings, and actionable remediation steps.
+The legacy v2.1.0 checklist remains available for historical audits only. Current Azure Foundations reports must record the benchmark version, benchmark source date, legacy-baseline status, Entra scope handling, and whether exact v6.0.0 recommendation IDs were verified from the CIS benchmark source.
 
 ---
 
@@ -38,26 +38,41 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 - Reviewing Azure infrastructure-as-code before deployment
 - Assessing an existing Azure environment's security posture against CIS benchmarks
 - Preparing for a CIS benchmark audit or compliance assessment
-- Evaluating Entra ID configurations, NSG rules, Defender for Cloud, Storage account security, or Key Vault access policies
+- Evaluating NSG rules, Defender for Cloud, Storage account security, Key Vault access policies, or App Service settings
+- Routing Entra ID configuration findings to a Microsoft 365/Entra scope when those exports are provided
 - Onboarding a new Azure subscription into a security program
 
 ---
 
 ## Context
 
-The CIS Microsoft Azure Foundations Benchmark v2.1.0 is a consensus-driven security configuration guide developed by the Center for Internet Security. Organizations use it as the foundation for Azure security assessments, compliance programs, and continuous monitoring. Microsoft Defender for Cloud natively supports CIS benchmark assessments, making this benchmark the de facto standard for Azure security posture evaluation.
+The CIS Microsoft Azure Foundations Benchmark is a consensus-driven security configuration guide developed by the Center for Internet Security. Organizations use it as the foundation for Azure security assessments, compliance programs, and continuous monitoring. Because CIS benchmark versions change recommendation IDs, section scope, and scoring, compliance percentages must be calculated only against the selected benchmark version and must not be compared across versions without a mapping.
 
 ### Prerequisites
 
 - Access to Azure infrastructure-as-code files (Terraform `.tf`, Bicep `.bicep`, ARM templates `.json`)
 - Azure CLI output or configuration exports (if reviewing a live environment)
-- Entra ID (Azure AD) configuration files or policy documents
+- Optional Entra ID configuration files or policy documents, if a separate Microsoft 365/Entra scope is requested
 - NSG and firewall rule definitions
 - Key Vault access policies and RBAC assignments
 
 ---
 
 ## Process
+
+### Step 0: Determine Benchmark Version and Scope
+
+Before discovering resources, determine and record the benchmark context:
+
+1. Check the user's request for an explicit CIS Azure benchmark version.
+2. Default to **CIS Microsoft Azure Foundations Benchmark v6.0.0** for current assessments.
+3. If `v2.1.0`, `legacy`, or a historical audit period is explicitly requested, set `legacy_baseline = true` and use the legacy v2.1.0 checklist.
+4. Determine `entra_scope_handling`:
+   - `excluded`: Default for current Azure Foundations v6.0.0 reports. Entra ID controls are out of current Azure Foundations scope.
+   - `included-as-m365`: Evaluate Entra findings separately against CIS Microsoft 365 / Entra scope when the user provides identity exports and requests identity review.
+   - `legacy_v2.1.0`: Include Entra ID controls only when the assessment is explicitly scoped to CIS Azure v2.1.0.
+5. Record `benchmark_version`, `benchmark_source_date`, `legacy_baseline`, `entra_scope_handling`, and whether exact recommendation IDs were verified from the CIS source.
+6. If the v6.0.0 PDF/DOCX is unavailable, mark exact v6 recommendation IDs as `Not Evaluable -- benchmark source unavailable` rather than reusing v2.1.0 IDs.
 
 ### Step 1: Discovery -- Locate Azure Configuration Files
 
@@ -80,11 +95,15 @@ Record all discovered files. If no Azure configurations are found, report that f
 
 ---
 
-### Step 2 through Step 10: CIS Benchmark Evaluation (Sections 1-9)
+### Step 2 through Step 10: CIS Benchmark Evaluation
 
-Evaluate all Azure configurations against CIS Azure v2.1.0 Sections 1 through 9, covering Identity and Access Management, Microsoft Defender for Cloud, Storage Accounts, Database Services, Logging and Monitoring, Networking, Virtual Machines, Key Vault, and App Service.
+Evaluate Azure configurations against the selected CIS Azure benchmark version.
 
-For detailed CIS benchmark checklist items with specific Terraform patterns, Bicep examples, and configuration checks for all nine sections, see [benchmark-checklist.md](benchmark-checklist.md) in this skill directory.
+- For current v6.0.0 assessments, exclude Entra ID / identity-only recommendations from the Azure Foundations score unless they are explicitly handled as `included-as-m365`.
+- For legacy v2.1.0 assessments, the existing checklist can be used, but the report must clearly state that it is a legacy baseline.
+- For exact v6.0.0 recommendation IDs and scoring, use the CIS v6.0.0 benchmark source. If unavailable, assess control themes from evidence and mark CIS ID mapping confidence as Low / Not Evaluable.
+
+For detailed legacy v2.1.0 checklist items with specific Terraform patterns, Bicep examples, and configuration checks, see [benchmark-checklist.md](benchmark-checklist.md) in this skill directory.
 
 ---
 
@@ -117,7 +136,12 @@ Produce the final report using the structure defined in the Output Format sectio
 ### Environment
 - Subscription/Repository: <identifier>
 - Date: <assessment date>
-- Framework: CIS Microsoft Azure Foundations Benchmark v2.1.0
+- Framework: CIS Microsoft Azure Foundations Benchmark
+- Benchmark Version: v6.0.0 / v2.1.0-legacy / <explicit version>
+- Benchmark Source Date: 2026-05 / <source date> / Not Evaluable
+- Legacy Baseline: false / true
+- Entra Scope Handling: excluded / included-as-m365 / legacy_v2.1.0
+- Exact CIS IDs Verified From Source: Yes / No / Not Evaluable
 - Files reviewed: <list of IaC files>
 
 ### Executive Summary
@@ -130,17 +154,17 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ### Section Scores
 
-| Section | Description | Passed | Failed | N/A | Compliance |
-|---------|-------------|--------|--------|-----|------------|
-| 1 | Identity and Access Management | X | Y | Z | nn% |
-| 2 | Microsoft Defender for Cloud | X | Y | Z | nn% |
-| 3 | Storage Accounts | X | Y | Z | nn% |
-| 4 | Database Services | X | Y | Z | nn% |
-| 5 | Logging and Monitoring | X | Y | Z | nn% |
-| 6 | Networking | X | Y | Z | nn% |
-| 7 | Virtual Machines | X | Y | Z | nn% |
-| 8 | Key Vault | X | Y | Z | nn% |
-| 9 | App Service | X | Y | Z | nn% |
+| Section | Description | Scope Handling | Passed | Failed | N/A | Compliance |
+|---------|-------------|----------------|--------|--------|-----|------------|
+| Entra/M365 | Identity and Access Management | excluded / included-as-m365 / legacy_v2.1.0 | X | Y | Z | nn% / N/A |
+| 2 | Microsoft Defender for Cloud | Azure Foundations | X | Y | Z | nn% |
+| 3 | Storage Accounts | Azure Foundations | X | Y | Z | nn% |
+| 4 | Database Services | Azure Foundations | X | Y | Z | nn% |
+| 5 | Logging and Monitoring | Azure Foundations | X | Y | Z | nn% |
+| 6 | Networking | Azure Foundations | X | Y | Z | nn% |
+| 7 | Virtual Machines | Azure Foundations | X | Y | Z | nn% |
+| 8 | Key Vault | Azure Foundations | X | Y | Z | nn% |
+| 9 | App Service | Azure Foundations | X | Y | Z | nn% |
 
 ### Detailed Findings
 
@@ -148,6 +172,9 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Status:** Pass / Fail / Not Evaluable
 - **Severity:** Critical / High / Medium / Low
 - **CIS Profile:** Level 1 / Level 2
+- **Benchmark Version:** v6.0.0 / v2.1.0-legacy / <explicit version>
+- **CIS ID Mapping Confidence:** High / Medium / Low / Not Evaluable
+- **Scope Classification:** Azure Foundations / Microsoft 365-Entra / Legacy Azure v2.1.0 / Out of Scope
 - **File:** <path to relevant config>
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
@@ -171,11 +198,20 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Framework Reference
 
-### CIS Azure Foundations Benchmark v2.1.0 -- Section Map
+### CIS Azure Foundations Benchmark v6.0.0 -- Scope Model
+
+CIS Azure Foundations v6.0.0 is the default current benchmark. CIS' May 2026 update states that Entra ID recommendations were migrated to CIS Microsoft 365 Foundations. Therefore:
+
+- Azure resource controls remain in the Azure Foundations report.
+- Entra ID identity controls are excluded from the default Azure Foundations score.
+- Entra findings can be reported in a separate Microsoft 365/Entra section when requested.
+- Legacy v2.1.0 identity controls can be used only when `legacy_baseline = true`.
+
+### Legacy CIS Azure Foundations Benchmark v2.1.0 -- Section Map
 
 | Section | Domain | Key Focus Areas |
 |---------|--------|-----------------|
-| 1 | Identity and Access Management | Entra ID security defaults, MFA enforcement, Conditional Access policies, guest user management, PIM configuration |
+| 1 | Identity and Access Management | Legacy only. Entra ID security defaults, MFA enforcement, Conditional Access policies, guest user management, PIM configuration |
 | 2 | Microsoft Defender for Cloud | Defender plan enablement (Servers, App Service, SQL, Storage, Containers, Key Vault, DNS, ARM), security contacts, auto-provisioning |
 | 3 | Storage Accounts | HTTPS enforcement, infrastructure encryption, public access, network rules, soft delete, CMK encryption, TLS version |
 | 4 | Database Services | SQL auditing, firewall rules, threat detection, SSL enforcement, TDE, Entra ID admin, Cosmos DB public access |
@@ -194,12 +230,13 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Common Pitfalls
 
-1. **Confusing Entra ID Security Defaults with Conditional Access.** CIS 1.1.1 accepts either, but if Conditional Access is used, Security Defaults must be disabled. Do not flag this as a failure if equivalent CA policies exist.
+1. **Scoring Entra ID controls inside current Azure Foundations.** CIS Azure v6.0.0 migrated Entra ID recommendations to CIS Microsoft 365 Foundations. Do not include Entra ID controls in the current Azure Foundations compliance percentage unless the report is explicitly legacy v2.1.0.
 2. **Missing Defender for Cloud plan coverage.** Each resource type (Servers, SQL, Storage, etc.) requires its own Defender plan enablement. A single `azurerm_security_center_subscription_pricing` resource only covers one type.
 3. **Overlooking `allow_nested_items_to_be_public` on storage accounts.** CIS 3.7 checks the account-level setting, not individual container access levels. The account setting must be `false` to prevent any container from being public.
 4. **NSG rules using service tags.** A rule with `source_address_prefix = "Internet"` is equivalent to `0.0.0.0/0`. Both must be flagged for CIS 6.1 and 6.2.
 5. **Key Vault purge protection is irreversible.** CIS 8.5 requires `purge_protection_enabled = true`. Note this cannot be disabled once enabled -- flag this for awareness during remediation.
 6. **App Service TLS version on both Linux and Windows.** Check `azurerm_linux_web_app` and `azurerm_windows_web_app` resources separately.
+7. **Reusing v2.1.0 IDs for v6.0.0 findings.** If the current CIS v6.0.0 source is unavailable, mark exact recommendation IDs as Not Evaluable instead of copying legacy IDs.
 
 ---
 
@@ -219,7 +256,9 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## References
 
-- CIS Microsoft Azure Foundations Benchmark v2.1.0: https://www.cisecurity.org/benchmark/azure
+- CIS Microsoft Azure Foundations Benchmark: https://www.cisecurity.org/benchmark/azure
+- CIS Benchmarks May 2026 Update: https://www.cisecurity.org/insights/blog/cis-benchmarks-may-2026-update
+- NIST NCP checklist entry for CIS Microsoft Azure Foundations Benchmark: https://ncp.nist.gov/checklist/1278
 - Microsoft Defender for Cloud Documentation: https://learn.microsoft.com/en-us/azure/defender-for-cloud/
 - Microsoft Entra ID Security: https://learn.microsoft.com/en-us/entra/identity/
 - Azure Storage Security: https://learn.microsoft.com/en-us/azure/storage/common/storage-security-guide
@@ -231,4 +270,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **2.0.0** -- Added CIS Azure v6.0.0 default scope, legacy v2.1.0 mode, Entra/Microsoft 365 scope handling, benchmark metadata fields, and guardrails against reusing stale v2.1.0 IDs for current assessments.
 - **1.0.0** -- Initial release. Full coverage of CIS Microsoft Azure Foundations Benchmark v2.1.0 sections 1 through 9.

--- a/skills/cloud/azure-review/benchmark-checklist.md
+++ b/skills/cloud/azure-review/benchmark-checklist.md
@@ -1,12 +1,21 @@
-# CIS Azure Foundations Benchmark v2.1.0 -- Detailed Checklist
+# Legacy CIS Azure Foundations Benchmark v2.1.0 -- Detailed Checklist
 
-This file contains the detailed CIS benchmark checklist items for the Azure Security Posture Review skill. See [SKILL.md](SKILL.md) for the main skill definition, process overview, and output format.
+This file contains the detailed CIS benchmark checklist items for historical or explicitly legacy Azure Security Posture Review runs. See [SKILL.md](SKILL.md) for the main skill definition, current benchmark scope, process overview, and output format.
+
+> Current benchmark warning: Do not use this checklist to score CIS Azure v6.0.0 assessments. v6.0.0 must be scored from its own CIS benchmark source, and Entra ID findings are out of the default Azure Foundations scope unless they are reported separately as CIS Microsoft 365 / Entra findings.
+
+## Scope Guardrails
+
+- Use this checklist only when `legacy_baseline = true` or the user explicitly asks for CIS Microsoft Azure Foundations Benchmark v2.1.0.
+- Do not copy v2.1.0 recommendation IDs into current v6.0.0 reports unless the exact v6.0.0 CIS source confirms the mapping.
+- Mark v6.0.0 exact IDs as `Not Evaluable -- benchmark source unavailable` when the current CIS benchmark source is unavailable.
+- Treat Section 1 Entra ID controls as legacy-only Azure v2.1.0 controls. For current assessments, route Entra evidence to the Microsoft 365 / Entra scope described in `SKILL.md`.
 
 ---
 
 ## Section 1 -- Identity and Access Management
 
-Evaluate Entra ID and IAM configurations against CIS Azure v2.1.0 Section 1 recommendations.
+Evaluate Entra ID and IAM configurations against CIS Azure v2.1.0 Section 1 recommendations only when a legacy v2.1.0 assessment is explicitly requested.
 
 ### CIS 1.1 -- Security Defaults and Conditional Access
 
@@ -675,7 +684,7 @@ resource "azurerm_linux_web_app" {
 
 ### CIS 9.5 -- Ensure that Register with Entra ID is enabled on App Service
 
-Check for identity configuration:
+Check for App Service managed identity configuration. This is Azure App Service resource evidence, not a replacement for current Microsoft 365 / Entra tenant-policy review.
 
 ```hcl
 resource "azurerm_linux_web_app" {


### PR DESCRIPTION
## Summary
- Default azure-review to CIS Microsoft Azure Foundations Benchmark v6.0.0 while keeping v2.1.0 as an explicit legacy mode.
- Add benchmark version/source metadata, Entra scope handling, and CIS ID mapping confidence fields to the review output.
- Mark the existing checklist as legacy v2.1.0 only so stale recommendation IDs are not reused for current v6 scoring.

## Validation
- git diff --check
- Required #209 CIS v6 / Entra scope terms present in azure-review SKILL.md and benchmark-checklist.md
- Markdown fence balance check
- Official CIS May 2026 update spot-check: https://www.cisecurity.org/insights/blog/cis-benchmarks-may-2026-update

Closes #209