### PR TITLE
Refresh GCP benchmark scope for CIS v5

### DIFF
--- a/skills/cloud/gcp-review/SKILL.md
+++ b/skills/cloud/gcp-review/SKILL.md
@@ -2,18 +2,18 @@
 name: gcp-review
 description: >
   Performs a GCP security posture review against the CIS Google Cloud Platform
-  Foundation Benchmark v2.0.0. Auto-invoked when reviewing GCP infrastructure,
-  IAM bindings, VPC firewall rules, Cloud Audit Logs, or GCS bucket security.
-  Walks through all seven benchmark sections, evaluates each recommendation,
-  and produces a prioritized findings report with remediation guidance mapped
-  to specific CIS control IDs.
+  Foundation Benchmark v5.0.0 by default, with legacy v2.0.0 support when
+  explicitly scoped. Auto-invoked when reviewing GCP infrastructure, IAM
+  bindings, org policies, VPC firewall rules, Cloud Audit Logs, or GCS bucket
+  security. Produces a prioritized findings report with benchmark source
+  metadata, project/organization scope handling, and remediation guidance.
 tags: [cloud, gcp, cis-benchmark]
 role: [cloud-security-engineer, security-engineer]
 phase: [assess, operate]
-frameworks: [CIS-GCP-v2.0.0]
+frameworks: [CIS-GCP-v5.0.0, CIS-GCP-v2.0.0-legacy]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "2.0.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -25,9 +25,9 @@ argument-hint: "[target-file-or-directory]"
 
 ## Overview
 
-This skill performs a structured security assessment of Google Cloud Platform environments against the **CIS Google Cloud Platform Foundation Benchmark v2.0.0**. The benchmark is organized into seven sections covering identity and access management, logging and monitoring, networking, virtual machines, storage, Cloud SQL, and BigQuery. Each recommendation is evaluated by inspecting infrastructure-as-code definitions (Terraform, Deployment Manager), gcloud CLI output, or configuration files available in the repository.
+This skill performs a structured security assessment of Google Cloud Platform environments against the **CIS Google Cloud Platform Foundation Benchmark v5.0.0** by default. NIST NCP checklist #1282 lists v5.0.0 with an original publication date of 2026-05-09 and notes that most recommendations in this release cover individual project-level security considerations rather than organization-level controls. Each recommendation is evaluated by inspecting infrastructure-as-code definitions (Terraform, Deployment Manager), gcloud CLI output, or configuration files available in the repository.
 
-The CIS GCP Foundation Benchmark v2.0.0 provides prescriptive guidance for hardening GCP projects and organizations. This skill evaluates each applicable control and produces a findings report with CIS recommendation IDs, severity ratings, and actionable remediation steps.
+The legacy v2.0.0 checklist remains available for historical audits only. Current GCP Foundation reports must record the benchmark version, benchmark source date, legacy-baseline status, scope level, scope evidence, and whether exact v5.0.0 recommendation IDs were verified from the CIS benchmark source.
 
 ---
 
@@ -45,19 +45,33 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 
 ## Context
 
-The CIS Google Cloud Platform Foundation Benchmark v2.0.0 is a consensus-driven security configuration guide developed by the Center for Internet Security. It provides prescriptive guidance for configuring GCP projects and organizations to a hardened baseline. Google Cloud's Security Command Center can assess many of these controls natively, making this benchmark the standard for GCP security posture evaluation.
+The CIS Google Cloud Platform Foundation Benchmark is a consensus-driven security configuration guide developed by the Center for Internet Security. It provides prescriptive guidance for configuring GCP environments to a hardened baseline. Because benchmark versions change recommendation IDs, scope, service coverage, and scoring, compliance percentages must be calculated only against the selected benchmark version and must not be compared across versions without a verified mapping.
 
 ### Prerequisites
 
 - Access to GCP infrastructure-as-code files (Terraform `.tf`, Deployment Manager `.yaml`/`.jinja`)
 - gcloud CLI output or configuration exports (if reviewing a live environment)
-- IAM policy bindings and org policy definitions
+- IAM policy bindings and org policy definitions, separated by project and organization scope where possible
 - VPC and firewall rule definitions
 - Cloud Audit Logs configuration
 
 ---
 
 ## Process
+
+### Step 0: Determine Benchmark Version and Scope
+
+Before discovering resources, determine and record the benchmark context:
+
+1. Check the user's request for an explicit CIS GCP benchmark version.
+2. Default to **CIS Google Cloud Platform Foundation Benchmark v5.0.0** for current assessments.
+3. If `v2.0.0`, `legacy`, or a historical audit period is explicitly requested, set `legacy_baseline = true` and use the legacy v2.0.0 checklist.
+4. Determine `scope_level`:
+   - `project`: Most current v5.0.0 recommendations apply at individual GCP project level.
+   - `organization`: Organization policy, folder, or org-level IAM evidence is available and requested.
+   - `mixed`: Both project-level and organization-level evidence are available.
+5. Record `benchmark_version`, `benchmark_source_date`, `legacy_baseline`, `scope_level`, `scope_evidence`, and whether exact recommendation IDs were verified from the CIS source.
+6. If the v5.0.0 PDF/DOCX is unavailable, mark exact v5 recommendation IDs as `Not Evaluable -- benchmark source unavailable` rather than reusing v2.0.0 IDs.
 
 ### Step 1: Discovery -- Locate GCP Configuration Files
 
@@ -80,11 +94,15 @@ Record all discovered files. If no GCP configurations are found, report that fin
 
 ---
 
-### Step 2 through Step 8: CIS Benchmark Evaluation (Sections 1-7)
+### Step 2 through Step 8: CIS Benchmark Evaluation
 
-Evaluate all GCP configurations against CIS GCP v2.0.0 Sections 1 through 7, covering Identity and Access Management, Logging and Monitoring, Networking, Virtual Machines, Storage, Cloud SQL, and BigQuery.
+Evaluate GCP configurations against the selected CIS GCP benchmark version.
 
-For detailed CIS benchmark checklist items with specific Terraform patterns, grep patterns, and configuration examples for all seven sections, see [benchmark-checklist.md](benchmark-checklist.md) in this skill directory.
+- For current v5.0.0 assessments, track project-level and organization-level evidence separately and calculate compliance only from evaluable controls in the selected scope.
+- For legacy v2.0.0 assessments, the existing checklist can be used, but the report must clearly state that it is a legacy baseline.
+- For exact v5.0.0 recommendation IDs and scoring, use the CIS v5.0.0 benchmark source. If unavailable, assess control themes from evidence and mark CIS ID mapping confidence as Low / Not Evaluable.
+
+For detailed legacy v2.0.0 checklist items with specific Terraform patterns, grep patterns, and configuration examples, see [benchmark-checklist.md](benchmark-checklist.md) in this skill directory.
 
 ---
 
@@ -113,10 +131,21 @@ Produce the final report using the structure defined in the Output Format sectio
 ## GCP Security Posture Assessment Report
 
 ### Environment
-- Project/Organization: <identifier>
+- Project ID: <identifier>
+- Organization ID: <identifier if available>
 - Date: <assessment date>
-- Framework: CIS Google Cloud Platform Foundation Benchmark v2.0.0
+- Framework: CIS Google Cloud Platform Foundation Benchmark
+- Benchmark Version: v5.0.0 / v2.0.0-legacy / <explicit version>
+- Benchmark Source Date: 2026-05-09 / <source date> / Not Evaluable
+- Legacy Baseline: false / true
+- Scope Level: project / organization / mixed
+- Exact CIS IDs Verified From Source: Yes / No / Not Evaluable
 - Files reviewed: <list of IaC files>
+
+### Scope Evidence
+- Project-level controls evaluated: <list>
+- Organization-level controls evaluated: <list>
+- Not evaluable from available evidence: <list>
 
 ### Executive Summary
 - Total CIS recommendations evaluated: <N>
@@ -124,19 +153,27 @@ Produce the final report using the structure defined in the Output Format sectio
 - Failed: <N>
 - Not Applicable: <N>
 - Not Evaluable (insufficient data): <N>
-- Overall compliance: <percentage>
+- Overall compliance: <percentage of evaluable controls only>
+
+### Scope Scores
+
+| Scope | Controls Evaluated | Passed | Failed | N/A | Not Evaluable | Compliance |
+|-------|--------------------|--------|--------|-----|---------------|------------|
+| Project-level | N | X | Y | Z | N | nn% |
+| Organization-level | N | X | Y | Z | N | nn% / N/A |
+| Mixed total (evaluable only) | N | X | Y | Z | N | nn% |
 
 ### Section Scores
 
-| Section | Description | Passed | Failed | N/A | Compliance |
-|---------|-------------|--------|--------|-----|------------|
-| 1 | Identity and Access Management | X | Y | Z | nn% |
-| 2 | Logging and Monitoring | X | Y | Z | nn% |
-| 3 | Networking | X | Y | Z | nn% |
-| 4 | Virtual Machines | X | Y | Z | nn% |
-| 5 | Storage | X | Y | Z | nn% |
-| 6 | Cloud SQL | X | Y | Z | nn% |
-| 7 | BigQuery | X | Y | Z | nn% |
+| Section | Description | Scope Level | Passed | Failed | N/A | Compliance |
+|---------|-------------|-------------|--------|--------|-----|------------|
+| 1 | Identity and Access Management | project / organization / mixed | X | Y | Z | nn% |
+| 2 | Logging and Monitoring | project / organization / mixed | X | Y | Z | nn% |
+| 3 | Networking | project / organization / mixed | X | Y | Z | nn% |
+| 4 | Virtual Machines | project | X | Y | Z | nn% |
+| 5 | Storage | project / organization / mixed | X | Y | Z | nn% |
+| 6 | Cloud SQL | project | X | Y | Z | nn% |
+| 7 | BigQuery | project | X | Y | Z | nn% |
 
 ### Detailed Findings
 
@@ -144,6 +181,10 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Status:** Pass / Fail / Not Evaluable
 - **Severity:** Critical / High / Medium / Low
 - **CIS Profile:** Level 1 / Level 2
+- **Benchmark Version:** v5.0.0 / v2.0.0-legacy / <explicit version>
+- **CIS ID Mapping Confidence:** High / Medium / Low / Not Evaluable
+- **Scope Level:** Project / Organization / Mixed / Not Evaluable
+- **Applicable Services:** <GCP services checked>
 - **File:** <path to relevant config>
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
@@ -167,7 +208,16 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Framework Reference
 
-### CIS GCP Foundation Benchmark v2.0.0 -- Section Map
+### CIS GCP Foundation Benchmark v5.0.0 -- Scope Model
+
+CIS GCP Foundation Benchmark v5.0.0 is the default current benchmark. NIST NCP checklist #1282 lists v5.0.0 with original publication date 2026-05-09 and summarizes the release as focused mostly on individual project-level security considerations rather than organization-level controls. Therefore:
+
+- Project-level evidence is the default scoring unit for current assessments.
+- Organization-level policies and IAM bindings must be tracked separately from project-level evidence.
+- Controls that require unavailable organization, folder, Cloud Identity, or Workspace evidence must be marked Not Evaluable instead of being counted as pass.
+- Legacy v2.0.0 controls can be used only when `legacy_baseline = true`.
+
+### Legacy CIS GCP Foundation Benchmark v2.0.0 -- Section Map
 
 | Section | Domain | Key Focus Areas |
 |---------|--------|-----------------|
@@ -188,12 +238,13 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Common Pitfalls
 
-1. **Missing org-level policy checks.** Many CIS controls (e.g., 3.1 default network, 5.1 public access) can be enforced via org policies. Check both resource-level configuration and org policy constraints.
+1. **Conflating project and organization scope.** CIS GCP v5.0.0 focuses mostly on individual project-level recommendations. Track organization-level policies and IAM separately, and mark unavailable org evidence as Not Evaluable.
 2. **Confusing GCP-managed vs. user-managed service account keys.** CIS 1.4 only flags user-managed keys (created via `google_service_account_key`). Keys automatically managed by GCP services are acceptable.
 3. **VPC flow logs must be per-subnet.** CIS 3.8 requires flow logs on every subnet, not just the VPC. Each `google_compute_subnetwork` must have a `log_config` block.
 4. **Cloud SQL authorized_networks vs. private IP.** CIS 6.5 flags `0.0.0.0/0` in authorized networks, but CIS 6.6 goes further and recommends disabling public IP entirely in favor of private networking.
 5. **BigQuery dataset-level vs. table-level CMEK.** CIS 7.2 checks table-level encryption, while CIS 7.3 checks the dataset default. Both should be evaluated independently.
 6. **Default compute service account identification.** The default SA follows the pattern `PROJECT_NUMBER-compute@developer.gserviceaccount.com`. Grep for this pattern, not just the string "default."
+7. **Reusing v2.0.0 IDs for v5.0.0 findings.** If the current CIS v5.0.0 source is unavailable, mark exact recommendation IDs as Not Evaluable instead of copying legacy IDs.
 
 ---
 
@@ -213,7 +264,9 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## References
 
-- CIS Google Cloud Platform Foundation Benchmark v2.0.0: https://www.cisecurity.org/benchmark/google_cloud_computing_platform
+- CIS Google Cloud Platform Foundation Benchmark: https://www.cisecurity.org/benchmark/google_cloud_computing_platform
+- NIST NCP Checklist #1282 -- CIS Google Cloud Platform Foundation Benchmark v5.0.0: https://ncp.nist.gov/checklist/revision/7289
+- Google Cloud CIS Compliance: https://cloud.google.com/security/compliance/cis
 - Google Cloud Security Best Practices: https://cloud.google.com/security/best-practices
 - Google Cloud IAM Documentation: https://cloud.google.com/iam/docs
 - Google Cloud Audit Logs: https://cloud.google.com/logging/docs/audit
@@ -225,4 +278,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **2.0.0** -- Added CIS GCP v5.0.0 default scope, legacy v2.0.0 mode, project/organization scope evidence fields, benchmark metadata, and guardrails against reusing stale v2.0.0 IDs for current assessments.
 - **1.0.0** -- Initial release. Full coverage of CIS Google Cloud Platform Foundation Benchmark v2.0.0 sections 1 through 7.

--- a/skills/cloud/gcp-review/benchmark-checklist.md
+++ b/skills/cloud/gcp-review/benchmark-checklist.md
@@ -1,12 +1,21 @@
-# CIS GCP Foundation Benchmark v2.0.0 -- Detailed Checklist
+# Legacy CIS GCP Foundation Benchmark v2.0.0 -- Detailed Checklist
 
-This file contains the detailed CIS benchmark checklist items for the GCP Security Posture Review skill. See [SKILL.md](SKILL.md) for the main skill definition, process overview, and output format.
+This file contains the detailed CIS benchmark checklist items for historical or explicitly legacy GCP Security Posture Review runs. See [SKILL.md](SKILL.md) for the main skill definition, current benchmark scope, process overview, and output format.
+
+> Current benchmark warning: Do not use this checklist to score CIS GCP v5.0.0 assessments. v5.0.0 must be scored from its own CIS benchmark source, project-level and organization-level evidence must be tracked separately, and legacy v2.0.0 recommendation IDs must not be reused as current v5.0.0 IDs without source verification.
+
+## Scope Guardrails
+
+- Use this checklist only when `legacy_baseline = true` or the user explicitly asks for CIS Google Cloud Platform Foundation Benchmark v2.0.0.
+- Do not copy v2.0.0 recommendation IDs into current v5.0.0 reports unless the exact v5.0.0 CIS source confirms the mapping.
+- Mark v5.0.0 exact IDs as `Not Evaluable -- benchmark source unavailable` when the current CIS benchmark source is unavailable.
+- Track project-level and organization-level evidence separately. Do not treat an organization policy as project-level evidence, and do not score unavailable organization context as pass.
 
 ---
 
 ## Section 1 -- Identity and Access Management
 
-Evaluate IAM configurations against CIS GCP v2.0.0 Section 1 recommendations.
+Evaluate IAM configurations against CIS GCP v2.0.0 Section 1 recommendations only when a legacy v2.0.0 assessment is explicitly requested.
 
 ### CIS 1.1 -- Ensure that Corporate Login Credentials are Used
 
@@ -737,7 +746,7 @@ resource "google_sql_database_instance" {
 
 ## Section 7 -- BigQuery
 
-Evaluate BigQuery configurations against CIS GCP v2.0.0 Section 7 recommendations.
+Evaluate BigQuery configurations against CIS GCP v2.0.0 Section 7 recommendations only when a legacy v2.0.0 assessment is explicitly requested.
 
 ### CIS 7.1 -- Ensure that BigQuery Datasets Are Not Anonymously or Publicly Accessible
 


### PR DESCRIPTION
## Summary
- Default gcp-review to CIS Google Cloud Platform Foundation Benchmark v5.0.0 while keeping v2.0.0 as an explicit legacy mode.
- Add benchmark source/date fields, project vs organization scope handling, scope evidence, and CIS ID mapping confidence to the report output.
- Mark the existing checklist as legacy v2.0.0 only so stale control IDs are not reused for current v5 scoring.

## Validation
- git diff --check
- Required #211 CIS GCP v5 / source / scope terms present in gcp-review SKILL.md and benchmark-checklist.md
- Markdown fence balance check
- Official source spot-checks: NIST NCP checklist #1282 and CIS Google Cloud Platform benchmark page

Closes #211