### PR TITLE
Correct GitHub token permission guidance

### DIFF
--- a/skills/devsecops/pipeline-security/SKILL.md
+++ b/skills/devsecops/pipeline-security/SKILL.md
@@ -185,7 +185,7 @@ environment:
 **What to look for:**
 
 - Overly permissive `permissions` blocks in GitHub Actions.
-- Absence of a workflow or job `permissions` block when the repository, organization, or enterprise default workflow permission is unknown.
+- Absence of a workflow or job `permissions` block when the repository, organization, or enterprise default workflow permission is unknown or verified as read/write.
 - Use of `permissions: write-all` or top-level write permissions without scoping.
 - Shared service accounts across environments.
 - Missing `CODEOWNERS` file or broad ownership patterns.
@@ -205,6 +205,13 @@ jobs:
 
 # BAD: Overly broad permissions
 permissions: write-all
+
+# BAD: No permissions block with a verified read/write platform default
+# Effective token scope inherits that broad default until the workflow or job
+# explicitly narrows it.
+jobs:
+  release:
+    runs-on: ubuntu-latest
 
 # BAD: pull_request_target without explicit token reduction
 on: pull_request_target
@@ -233,7 +240,7 @@ permissions:
 | Job-level `permissions` | Each job has only the scopes it needs | Job expands to broad write scopes without need | Missing and inherited effective scope is unknown |
 | `pull_request_target` permission reduction | Trigger is absent, or token is explicitly reduced to minimum required scopes | Trigger is present and no explicit `permissions` block reduces the read/write default | Trigger is present but effective job token scope cannot be determined |
 
-**Important nuance:** A missing `permissions` block is a least-privilege hygiene gap, but it is not always proof of read/write exposure. GitHub calculates the `GITHUB_TOKEN` permissions from enterprise, organization, or repository defaults, then applies workflow and job-level `permissions`. Treat missing YAML permissions as "Not Evaluable from Config" unless platform defaults are known. Keep `permissions: write-all`, unnecessary write scopes, and unscoped `pull_request_target` workflows as true findings.
+**Important nuance:** A missing `permissions` block is a least-privilege hygiene gap, but it is not always proof of read/write exposure. GitHub calculates the `GITHUB_TOKEN` permissions from enterprise, organization, or repository defaults, then applies workflow and job-level `permissions`. Treat missing YAML permissions as "Not Evaluable from Config" unless platform defaults are known. If the platform default is verified as read/write, report the missing block as a real broad-token finding. When a workflow or job declares `permissions`, unspecified permissions are set to no access except for required metadata access, so evaluate the declared scopes rather than assuming every scope remains inherited. Keep `permissions: write-all`, unnecessary write scopes, and unscoped `pull_request_target` workflows as true findings.
 
 **Finding format:** Report the effective permission model, the evidence source for platform defaults, whether least-privilege is enforced, whether unknown values are "Not Evaluable from Config," and whether identity controls (CODEOWNERS, required reviewers) are in place.
 

--- a/skills/devsecops/pipeline-security/SKILL.md
+++ b/skills/devsecops/pipeline-security/SKILL.md
@@ -184,16 +184,21 @@ environment:
 
 **What to look for:**
 
-- Overly permissive `permissions` blocks in GitHub Actions (or absence of permissions, which defaults to read-write).
+- Overly permissive `permissions` blocks in GitHub Actions.
+- Absence of a workflow or job `permissions` block when the repository, organization, or enterprise default workflow permission is unknown.
 - Use of `permissions: write-all` or top-level write permissions without scoping.
 - Shared service accounts across environments.
 - Missing `CODEOWNERS` file or broad ownership patterns.
 - Workflows that do not pin the `GITHUB_TOKEN` to minimum required permissions.
+- `pull_request_target` workflows that do not explicitly reduce `GITHUB_TOKEN` permissions.
 
 **Specific patterns in GitHub Actions:**
 
 ```yaml
-# BAD: No permissions block (defaults to read-write for everything)
+# NOT EVALUABLE FROM CONFIG: No permissions block.
+# Effective token scope inherits enterprise, organization, or repository default
+# workflow permissions. Request platform settings evidence before reporting a
+# definite read/write token exposure.
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -201,13 +206,36 @@ jobs:
 # BAD: Overly broad permissions
 permissions: write-all
 
+# BAD: pull_request_target without explicit token reduction
+on: pull_request_target
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh pr edit "$PR_URL" --add-label needs-triage
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+
 # GOOD: Least-privilege permissions
 permissions:
   contents: read
   packages: write
 ```
 
-**Finding format:** Report the effective permission model, whether least-privilege is enforced, and whether identity controls (CODEOWNERS, required reviewers) are in place.
+**GitHub Actions permission evidence table:** For every GitHub Actions review, report these fields before deciding whether CICD-SEC-2 is a pass, fail, partial, or not evaluable finding.
+
+| Evidence field | Pass | Fail | Not Evaluable from Config |
+|----------------|------|------|---------------------------|
+| Platform default workflow permission | Repository, organization, or enterprise default is verified as read-only | Default is verified as read/write | Platform default was not provided or cannot be inferred from workflow YAML |
+| Top-level workflow `permissions` | Explicitly scoped to least privilege | `write-all` or broad write scopes without need | Missing and platform default is unknown |
+| Job-level `permissions` | Each job has only the scopes it needs | Job expands to broad write scopes without need | Missing and inherited effective scope is unknown |
+| `pull_request_target` permission reduction | Trigger is absent, or token is explicitly reduced to minimum required scopes | Trigger is present and no explicit `permissions` block reduces the read/write default | Trigger is present but effective job token scope cannot be determined |
+
+**Important nuance:** A missing `permissions` block is a least-privilege hygiene gap, but it is not always proof of read/write exposure. GitHub calculates the `GITHUB_TOKEN` permissions from enterprise, organization, or repository defaults, then applies workflow and job-level `permissions`. Treat missing YAML permissions as "Not Evaluable from Config" unless platform defaults are known. Keep `permissions: write-all`, unnecessary write scopes, and unscoped `pull_request_target` workflows as true findings.
+
+**Finding format:** Report the effective permission model, the evidence source for platform defaults, whether least-privilege is enforced, whether unknown values are "Not Evaluable from Config," and whether identity controls (CODEOWNERS, required reviewers) are in place.
 
 ---
 
@@ -550,6 +578,8 @@ This skill processes user-supplied content including CI/CD configuration files, 
 - SLSA Build Track: https://slsa.dev/spec/v1.0/levels#build-track
 - OWASP Top 10 CI/CD Security Risks: https://owasp.org/www-project-top-10-ci-cd-security-risks/
 - GitHub Actions Security Hardening: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
+- GitHub Actions Workflow Syntax -- Permissions: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions
+- GitHub Actions Events -- `pull_request_target`: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target
 - Sigstore / Cosign: https://docs.sigstore.dev/
 - SLSA GitHub Generator: https://github.com/slsa-framework/slsa-github-generator
 
@@ -557,4 +587,5 @@ This skill processes user-supplied content including CI/CD configuration files, 
 
 ## Changelog
 
+- **1.0.1** -- Corrected GitHub Actions `GITHUB_TOKEN` default-permission guidance. Missing workflow `permissions` is now treated as platform-default dependent, unknown defaults are "Not Evaluable from Config," explicit broad write scopes remain true findings, and `pull_request_target` requires explicit token reduction evidence.
 - **1.0.0** -- Initial release. Full coverage of SLSA v1.0 build track and OWASP Top 10 CI/CD Security Risks (CICD-SEC-1 through CICD-SEC-10).

--- a/skills/devsecops/pipeline-security/tests/github-token-permissions.md
+++ b/skills/devsecops/pipeline-security/tests/github-token-permissions.md
@@ -56,7 +56,34 @@ Expected classification:
 - Severity: Informational hygiene recommendation
 - Rationale: Effective default is read-only, but explicit job-level least privilege is still clearer.
 
-## Fixture 3: Explicit write-all
+## Fixture 3: Missing permissions with verified read/write default
+
+```yaml
+name: release
+on: push
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/publish.sh
+```
+
+Platform evidence:
+
+```text
+repository_default_workflow_permission: read and write permissions
+organization_default_workflow_permission: read and write permissions
+enterprise_default_workflow_permission: read and write permissions
+```
+
+Expected classification:
+
+- CICD-SEC-2 status: `Fail`
+- Severity: High unless the workflow is explicitly narrowed before privileged steps run
+- Rationale: Missing YAML `permissions` inherits a verified read/write platform default, so this is no longer merely "Not Evaluable from Config."
+
+## Fixture 4: Explicit write-all
 
 ```yaml
 name: release
@@ -76,7 +103,7 @@ Expected classification:
 - Severity: High unless every write scope is justified
 - Rationale: `write-all` grants every available write scope and should be replaced with job-level least privilege.
 
-## Fixture 4: pull_request_target without explicit token reduction
+## Fixture 5: pull_request_target without explicit token reduction
 
 ```yaml
 name: label
@@ -97,7 +124,7 @@ Expected classification:
 - Severity: High
 - Rationale: `pull_request_target` receives read/write repository permission unless the workflow reduces the token with `permissions`.
 
-## Fixture 5: pull_request_target with reduced token
+## Fixture 6: pull_request_target with reduced token
 
 ```yaml
 name: label
@@ -120,4 +147,3 @@ Expected classification:
 - CICD-SEC-2 status: `Pass` or `Partial`
 - Severity: Low if the write scope is required and PR code is not checked out or executed
 - Rationale: The workflow uses the risky trigger but explicitly narrows token scope to the operation it performs.
-

--- a/skills/devsecops/pipeline-security/tests/github-token-permissions.md
+++ b/skills/devsecops/pipeline-security/tests/github-token-permissions.md
@@ -1,0 +1,123 @@
+# GitHub token permission fixtures
+
+These fixtures cover CICD-SEC-2 classification for GitHub Actions `GITHUB_TOKEN` permissions. They are intended as regression examples for avoiding false positives while preserving true broad-scope findings.
+
+## Fixture 1: Missing permissions with unknown platform default
+
+```yaml
+name: build
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm test
+```
+
+Platform evidence:
+
+```text
+repository_default_workflow_permission: unknown
+organization_default_workflow_permission: unknown
+enterprise_default_workflow_permission: unknown
+```
+
+Expected classification:
+
+- CICD-SEC-2 status: `Not Evaluable from Config`
+- Severity: Low hygiene gap unless other evidence proves write exposure
+- Rationale: Missing YAML `permissions` inherits platform defaults, which are not present in the workflow file.
+
+## Fixture 2: Missing permissions with verified read-only default
+
+```yaml
+name: build
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm test
+```
+
+Platform evidence:
+
+```text
+repository_default_workflow_permission: read repository contents permission
+organization_default_workflow_permission: read repository contents permission
+enterprise_default_workflow_permission: read repository contents permission
+```
+
+Expected classification:
+
+- CICD-SEC-2 status: `Pass` or `Partial`
+- Severity: Informational hygiene recommendation
+- Rationale: Effective default is read-only, but explicit job-level least privilege is still clearer.
+
+## Fixture 3: Explicit write-all
+
+```yaml
+name: release
+on: push
+permissions: write-all
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/publish.sh
+```
+
+Expected classification:
+
+- CICD-SEC-2 status: `Fail`
+- Severity: High unless every write scope is justified
+- Rationale: `write-all` grants every available write scope and should be replaced with job-level least privilege.
+
+## Fixture 4: pull_request_target without explicit token reduction
+
+```yaml
+name: label
+on: pull_request_target
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh pr edit "$PR_URL" --add-label needs-triage
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+```
+
+Expected classification:
+
+- CICD-SEC-2 status: `Fail`
+- Severity: High
+- Rationale: `pull_request_target` receives read/write repository permission unless the workflow reduces the token with `permissions`.
+
+## Fixture 5: pull_request_target with reduced token
+
+```yaml
+name: label
+on: pull_request_target
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh pr edit "$PR_URL" --add-label needs-triage
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+```
+
+Expected classification:
+
+- CICD-SEC-2 status: `Pass` or `Partial`
+- Severity: Low if the write scope is required and PR code is not checked out or executed
+- Rationale: The workflow uses the risky trigger but explicitly narrows token scope to the operation it performs.
+


### PR DESCRIPTION
# Correct GitHub token permission guidance

Resolves #777.

## Skill Improvement ($50-150 Bounty)

### Skill Modified

**Skill name:** `pipeline-security`  
**Skill path:** `skills/devsecops/pipeline-security/`

### What Was Wrong

The CICD-SEC-2 GitHub Actions guidance treated a missing `permissions` block as definite broad read/write token exposure. That creates false positives because GitHub calculates `GITHUB_TOKEN` permissions from enterprise, organization, or repository defaults before workflow/job-level YAML is applied, so a config-only review cannot prove broad write access from the workflow file alone.

The skill also needed sharper handling for `pull_request_target`, where the default repository token exposure is still a high-risk case unless the workflow explicitly reduces permissions.

### What This PR Fixes

- Reframes missing `permissions` as `Not Evaluable from Config` unless platform defaults are known.
- Adds a GitHub Actions permission evidence table covering platform defaults, workflow-level permissions, job-level permissions, `write-all`, and `pull_request_target`.
- Preserves true findings for `permissions: write-all`, unnecessary write scopes, and unscoped `pull_request_target` workflows.
- Adds regression fixtures for unknown defaults, verified read-only defaults, explicit `write-all`, and `pull_request_target` with/without explicit token reduction.

### Evidence

**Before (skill false positive on this):**

```yaml
name: ci
on: [push]
jobs:
  test:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
```

The previous text implied missing `permissions` defaulted to read/write, even when repository defaults might be read-only.

**After (now correctly handled):**

```text
No workflow/job permissions block + unknown enterprise/org/repo default = Not Evaluable from Config.
No workflow/job permissions block + verified read-only repository default = no broad-write finding.
pull_request_target without explicit reduced permissions = High risk.
permissions: write-all = High risk.
```

References used in the skill update:

- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions
- https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target
- https://docs.github.com/en/actions/tutorials/authenticate-with-github_token

### Test Cases Added/Updated

- [x] Added vulnerable test cases (`skills/devsecops/pipeline-security/tests/github-token-permissions.md`)
- [x] Added benign test cases (`skills/devsecops/pipeline-security/tests/github-token-permissions.md`)
- [x] Existing tests still pass (`git diff --check`; targeted `rg` verification; no repo-level automated runner found for this skill content)

### Bounty Tier

- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info

- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Crypto. Payment details can be provided privately after acceptance.

### Verification

```bash
git diff --check
rg -n "defaults to read-write|No permissions block \\(defaults|write-all|Not Evaluable from Config|pull_request_target" skills/devsecops/pipeline-security
```
