### PR TITLE
Add container runtime profile applicability gates

### DIFF
--- a/skills/cloud/container-security/SKILL.md
+++ b/skills/cloud/container-security/SKILL.md
@@ -13,7 +13,7 @@ phase: [build, deploy, operate]
 frameworks: [CIS-Docker-v1.6.0, CIS-Kubernetes-v1.9.0, NIST-SP-800-190]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -113,6 +113,8 @@ Evaluate all container and Kubernetes configurations against CIS Docker Benchmar
 
 For detailed CIS benchmark checklist items, NIST SP 800-190 countermeasure tables, and comprehensive security context evaluation criteria, see [cis-benchmarks.md](cis-benchmarks.md) in this skill directory.
 
+During runtime hardening review, build an effective Linux security module profile inventory for each workload. Capture pod-level and container-level `seccompProfile`, structured `appArmorProfile`, legacy `container.apparmor.security.beta.kubernetes.io/*` annotations, and whether each app, init, sidecar, and ephemeral container overrides the pod default. Treat `RuntimeDefault` as the normal baseline. Treat `Localhost` as acceptable only when the report includes node/profile distribution evidence, scheduling constraints, runtime/OS applicability, and a fallback plan if the profile is unavailable. Treat missing node evidence, unsupported OS/runtime combinations, or incomplete container coverage as `Not Evaluable`, not as a pass.
+
 ---
 
 ### Step 7: Compile Assessment Report
@@ -127,8 +129,8 @@ Produce the final report using the structure defined in the Output Format sectio
 | Severity | Definition | Examples |
 |----------|-----------|----------|
 | **Critical** | Container escape, cluster compromise, or credential exposure | Privileged containers, Docker socket mounts, cluster-admin bound to application SA, secrets in plaintext manifests, `hostPID`/`hostNetwork` on app pods |
-| **High** | Significant security gap enabling lateral movement or privilege escalation | Running as root, missing network policies, wildcard RBAC, `allowPrivilegeEscalation: true`, host path mounts to sensitive directories |
-| **Medium** | Missing hardening that weakens defense-in-depth | No resource limits, mutable image tags, missing seccomp profile, read-write root filesystem, secrets as env vars |
+| **High** | Significant security gap enabling lateral movement or privilege escalation | Running as root, missing network policies, wildcard RBAC, `allowPrivilegeEscalation: true`, host path mounts to sensitive directories, application/init/ephemeral container explicitly set to `Unconfined` |
+| **Medium** | Missing hardening that weakens defense-in-depth | No resource limits, mutable image tags, missing seccomp profile, `Localhost` profile without node evidence, read-write root filesystem, secrets as env vars |
 | **Low** | Best-practice deviation with limited immediate risk | No HEALTHCHECK in Dockerfile, ADD instead of COPY, missing liveness/readiness probes, using default namespace |
 | **Informational** | Observation with no direct security impact | Image size optimization, multi-stage build suggestions, label recommendations |
 
@@ -184,6 +186,14 @@ Produce the final report using the structure defined in the Output Format sectio
 |----------|-----------|-----------|------------|
 | deploy/app | production | Baseline (not Restricted) | runAsRoot, no seccomp |
 | deploy/worker | production | Privileged | privileged: true |
+
+### Effective Seccomp and AppArmor Profile Matrix
+
+| Workload | Container Type | Container | OS | Seccomp Effective Type | Seccomp Source | AppArmor Effective Type | AppArmor Source | Localhost Profile Evidence | Status |
+|----------|----------------|-----------|----|------------------------|----------------|-------------------------|-----------------|----------------------------|--------|
+| deploy/payments-api | app | api | linux | Localhost | pod | RuntimeDefault | annotation | profile deployed to restricted node pool, selector present | Pass |
+| deploy/mixed-profiles | sidecar | legacy-sidecar | linux | Unconfined | container override | Not set | n/a | n/a | Fail |
+| job/windows-worker | app | worker | windows | Not Applicable | OS | Not Applicable | OS | n/a | Not Evaluable |
 
 ### Prioritized Remediation Plan
 
@@ -245,6 +255,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | allowPrivilegeEscalation | -- | Must be false |
 | runAsNonRoot | -- | Must be true |
 | seccompProfile | -- | RuntimeDefault or Localhost |
+| appArmorProfile | Must not be Unconfined | RuntimeDefault or validated Localhost where supported |
 
 ---
 
@@ -257,6 +268,9 @@ Produce the final report using the structure defined in the Output Format sectio
 5. **`readOnlyRootFilesystem` breaks many applications.** When recommending this control, also recommend adding writable `emptyDir` volume mounts for directories the application needs to write to (e.g., `/tmp`, `/var/cache`).
 6. **Network policies are additive, not subtractive.** A default-deny policy must be explicitly created. Without it, all pod-to-pod traffic is allowed regardless of other NetworkPolicy resources.
 7. **Distroless images have no shell.** While this is excellent for security, note that debugging requires ephemeral containers (`kubectl debug`). Flag this as a consideration, not a problem.
+8. **Pod-level runtime profiles can be overridden.** A pod-level `RuntimeDefault` seccomp profile does not prove every container is hardened if an app, init, or ephemeral container sets `Unconfined`.
+9. **`Localhost` profiles need node evidence.** A custom seccomp or AppArmor profile is only meaningful when it is loaded on the nodes where the workload can run and the scheduling policy constrains the workload to those nodes.
+10. **AppArmor syntax varies by Kubernetes version.** Check both structured `securityContext.appArmorProfile` fields and legacy `container.apparmor.security.beta.kubernetes.io/*` annotations before scoring effective AppArmor status.
 
 ---
 
@@ -283,6 +297,8 @@ Produce the final report using the structure defined in the Output Format sectio
 - NIST SP 800-190 Application Container Security Guide: https://csrc.nist.gov/publications/detail/sp/800-190/final
 - Kubernetes Pod Security Standards: https://kubernetes.io/docs/concepts/security/pod-security-standards/
 - Kubernetes Pod Security Admission: https://kubernetes.io/docs/concepts/security/pod-security-admission/
+- Kubernetes seccomp profiles: https://kubernetes.io/docs/reference/node/seccomp/
+- Kubernetes AppArmor: https://kubernetes.io/docs/tutorials/security/apparmor/
 - Kubernetes Network Policies: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 - Kubernetes RBAC: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 - Docker Security Best Practices: https://docs.docker.com/develop/security-best-practices/
@@ -293,4 +309,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Add effective seccomp/AppArmor profile review guidance, including `Localhost` node-evidence requirements, per-container override handling, AppArmor structured-field and annotation checks, and `Not Evaluable` status for unsupported or unverifiable profile applicability.
 - **1.0.0** -- Initial release. Full coverage of CIS Docker Benchmark v1.6.0 Section 4-5, CIS Kubernetes Benchmark v1.9.0 Sections 1-5, and NIST SP 800-190 countermeasures across all five risk categories.

--- a/skills/cloud/container-security/cis-benchmarks.md
+++ b/skills/cloud/container-security/cis-benchmarks.md
@@ -406,6 +406,153 @@ ports:
     hostPort: 8080  # FAIL: binds directly to host
 ```
 
+### Pod Security Runtime Profiles -- seccomp and AppArmor Applicability
+
+Do not score runtime hardening from a single pod-level field. Build an effective profile matrix for every app container, sidecar, init container, and ephemeral/debug container.
+
+**Discovery patterns:**
+
+```
+seccompProfile:
+localhostProfile:
+appArmorProfile:
+container.apparmor.security.beta.kubernetes.io/
+initContainers:
+ephemeralContainers:
+nodeSelector:
+affinity:
+runtimeClassName:
+kubernetes.io/os:
+```
+
+**Effective profile precedence:**
+
+1. Container-level `securityContext.seccompProfile` overrides pod-level `spec.securityContext.seccompProfile`.
+2. Structured `securityContext.appArmorProfile` should be captured when present.
+3. Legacy AppArmor annotations such as `container.apparmor.security.beta.kubernetes.io/<container-name>` apply to the named container and must be mapped to the same effective-profile matrix.
+4. Pod-level runtime defaults do not cover a container that explicitly declares `Unconfined`.
+5. Linux and Windows workloads have different seccomp/AppArmor applicability; record OS before assigning pass/fail status.
+
+**Effective profile matrix fields:**
+
+| Field | Required Evidence |
+|-------|-------------------|
+| Workload and namespace | Deployment/StatefulSet/DaemonSet/Job/CronJob and namespace |
+| Container scope | app container, sidecar, init container, or ephemeral container |
+| OS and runtime class | `kubernetes.io/os`, `runtimeClassName`, node pool, or cluster evidence |
+| Seccomp effective type | `RuntimeDefault`, `Localhost`, `Unconfined`, missing, or Not Applicable |
+| Seccomp source level | pod default, container override, policy mutation, or unknown |
+| Seccomp localhost profile | profile path/name and kubelet seccomp-root distribution evidence |
+| AppArmor effective type | `RuntimeDefault`, `Localhost`, `Unconfined`, missing, or Not Applicable |
+| AppArmor source level | structured field, legacy annotation, policy mutation, or unknown |
+| AppArmor localhost profile | profile name/path and node distribution evidence |
+| Scheduling constraint | node selector, affinity, taint/toleration, runtime class, or admission policy tying workload to prepared nodes |
+| Evidence status | Pass, Fail, Partial, Not Applicable, or Not Evaluable |
+
+**Safe `RuntimeDefault` baseline:**
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: runtime-default-worker
+spec:
+  template:
+    metadata:
+      labels:
+        app: runtime-default-worker
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: worker
+          image: ghcr.io/example/worker@sha256:1111111111111111111111111111111111111111111111111111111111111111
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+```
+
+**Acceptable `Localhost` profile only with node evidence:**
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: custom-profile-worker
+spec:
+  template:
+    spec:
+      nodeSelector:
+        security.example.com/seccomp-profile-worker: "true"
+      securityContext:
+        seccompProfile:
+          type: Localhost
+          localhostProfile: profiles/seccomp/worker.json
+      containers:
+        - name: worker
+          image: ghcr.io/example/worker@sha256:2222222222222222222222222222222222222222222222222222222222222222
+          securityContext:
+            appArmorProfile:
+              type: Localhost
+              localhostProfile: profiles/apparmor/worker-deny-write
+```
+
+Evidence required before this is a pass:
+
+- Profile file or profile name exists on every schedulable Linux node for the workload.
+- Profile rollout method is documented, such as image bake, DaemonSet distribution, node bootstrap, or managed node-pool configuration.
+- Workload scheduling is constrained to nodes with the profile.
+- Admission or policy checks prevent accidental scheduling where the profile is absent.
+- Runtime and Kubernetes version support the selected seccomp/AppArmor field.
+
+**Failing container-level override despite pod default:**
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mixed-profiles
+spec:
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: app
+      image: ghcr.io/example/app@sha256:3333333333333333333333333333333333333333333333333333333333333333
+    - name: legacy-sidecar
+      image: ghcr.io/example/legacy@sha256:4444444444444444444444444444444444444444444444444444444444444444
+      securityContext:
+        seccompProfile:
+          type: Unconfined
+```
+
+The sidecar is a finding even though the pod default is `RuntimeDefault`.
+
+**Legacy AppArmor annotation mapping:**
+
+```yaml
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/uploader: runtime/default
+spec:
+  containers:
+    - name: uploader
+      securityContext:
+        allowPrivilegeEscalation: false
+```
+
+Map the annotation to the `uploader` container in the effective profile matrix. If both structured fields and annotations are present, report the conflict or precedence assumption instead of silently choosing one.
+
+**Severity guidance:**
+
+- **High:** Application, sidecar, init, or ephemeral container explicitly sets seccomp/AppArmor to `Unconfined`, especially with elevated capabilities, host namespaces, privileged mode, or writable host mounts.
+- **Medium:** `Localhost` profile is declared but profile distribution, node support, or scheduling constraint evidence is missing.
+- **Low/Informational:** Workload uses `RuntimeDefault` and no AppArmor profile is set, but the platform does not enforce AppArmor or the control is documented as out of scope.
+- **Not Evaluable:** OS/runtime/Kubernetes version, node evidence, profile rollout path, or effective container mapping is unavailable.
+
 ### CIS 5.3 -- Network Policies and CNI
 
 #### CIS 5.3.1 -- Ensure that the CNI in use supports NetworkPolicies
@@ -614,7 +761,7 @@ Evaluate container runtime configurations against NIST SP 800-190 countermeasure
 | **CM-12:** Use read-only root filesystem | `readOnlyRootFilesystem: true` |
 | **CM-13:** Drop all capabilities | `capabilities.drop: ["ALL"]` |
 | **CM-14:** Set resource limits | CPU and memory limits set on all containers |
-| **CM-15:** Use seccomp profiles | `seccompProfile.type: RuntimeDefault` or custom |
+| **CM-15:** Use seccomp profiles | `seccompProfile.type: RuntimeDefault` or validated `Localhost`; flag `Unconfined` overrides |
 
 **Resource limits check:**
 
@@ -644,6 +791,17 @@ securityContext:
     type: RuntimeDefault
 ```
 
+**Validated Localhost seccomp profile:**
+
+```yaml
+securityContext:
+  seccompProfile:
+    type: Localhost
+    localhostProfile: profiles/seccomp/payments-api.json
+```
+
+Only score this as pass when the report includes profile distribution, node scheduling, and OS/runtime applicability evidence. Otherwise mark it `Not Evaluable` or `Medium` depending on risk.
+
 ---
 
 ## Comprehensive Security Context Evaluation
@@ -670,6 +828,8 @@ spec:
           drop: ["ALL"]
         seccompProfile:
           type: RuntimeDefault
+        appArmorProfile:
+          type: RuntimeDefault
       resources:
         limits:
           memory: "256Mi"
@@ -689,4 +849,13 @@ spec:
 - `hostPort` in container ports
 - Capabilities beyond the allowed set (only `NET_BIND_SERVICE` is permitted)
 - `procMount` other than `Default`
-- `appArmorProfile` of `unconfined`
+- `seccompProfile.type: Unconfined` at pod, app container, init container, sidecar, or ephemeral container scope
+- `appArmorProfile.type: Unconfined` at app container, init container, sidecar, or ephemeral container scope
+- Legacy AppArmor annotations set to `unconfined`
+
+**Runtime profile validation notes:**
+
+- `RuntimeDefault` at pod scope is inherited only by containers that do not declare a container-level seccomp profile.
+- `Localhost` seccomp/AppArmor profiles require node-local profile availability evidence and scheduling constraints before they can be counted as hardened.
+- `initContainers` and `ephemeralContainers` must be included in the same effective-profile matrix as regular app containers.
+- Windows pods should record seccomp/AppArmor as Not Applicable, not Fail, unless the manifest is intended for Linux nodes.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `container-security`
**Skill path:** `skills/cloud/container-security/`

### What Was Wrong
The existing guidance treated `RuntimeDefault` as the normal good path but did not fully model effective seccomp/AppArmor state per container. That could create both false positives and misses:

- A tested `Localhost` seccomp/AppArmor profile could be over-reported as unsafe even when it is stronger than `RuntimeDefault`.
- A pod-level `RuntimeDefault` could hide an app, sidecar, init, or ephemeral container that overrides seccomp to `Unconfined`.
- Review logic could miss structured `securityContext.appArmorProfile` fields or legacy AppArmor annotations.
- `Localhost` profiles could be counted as hardened without node/profile distribution, scheduling, OS/runtime, or policy evidence.

### What This PR Fixes
- Adds an effective seccomp/AppArmor profile inventory to the main skill process.
- Adds an output matrix for app, sidecar, init, and ephemeral containers.
- Adds benchmark guidance for profile precedence, structured AppArmor fields, legacy annotations, OS applicability, and `Localhost` node evidence.
- Updates severity guidance so `Unconfined` container overrides are High risk and missing `Localhost` node evidence is Medium or Not Evaluable depending on context.
- Adds official Kubernetes seccomp/AppArmor references and bumps the skill version to `1.0.1`.

### Evidence
**Before (skill misses this / false positive on this):**

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: mixed-profiles
spec:
  securityContext:
    seccompProfile:
      type: RuntimeDefault
  containers:
    - name: app
      image: ghcr.io/example/app@sha256:3333333333333333333333333333333333333333333333333333333333333333
    - name: legacy-sidecar
      image: ghcr.io/example/legacy@sha256:4444444444444444444444444444444444444444444444444444444444444444
      securityContext:
        seccompProfile:
          type: Unconfined
```

A report that only records the pod-level profile can incorrectly treat the pod as hardened.

**After (now correctly handled):**

The new effective-profile matrix requires the `legacy-sidecar` container to be listed separately and scored as Fail/High because its container-level `Unconfined` profile overrides the pod-level `RuntimeDefault`. The same matrix lets a `Localhost` profile pass only when node rollout, scheduling constraints, and OS/runtime evidence are present.

### Test Cases Added/Updated
- [ ] Added vulnerable test cases (`tests/vulnerable/`)
- [ ] Added benign test cases (`tests/benign/`)
- [x] Existing changed-file validations pass

This repository's current `container-security` skill is markdown/checklist based rather than test-directory based, so the before/after examples were added directly to `cis-benchmarks.md` as review fixtures.

### Bounty Tier
- [ ] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the CONTRIBUTING.md bounty terms
- **Preferred payment method:** Payment details can be provided privately after maintainer acceptance.

### Validation
- `git diff --check`
- Changed `SKILL.md` frontmatter parses and reports version `1.0.1`
- Markdown code-fence balance checked for both changed files
- Content assertions verified the new effective-profile matrix, `Localhost` evidence gate, container override handling, AppArmor structured field, legacy annotation handling, ephemeral container coverage, `Unconfined` severity, and `Not Evaluable` guidance
- Official Kubernetes seccomp, security context, AppArmor, and Pod Security Standards references returned HTTP 200

Addresses #949.