### PR TITLE
Add Azure Container Apps and workload identity evidence gates

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -153,13 +153,13 @@ skills:
 
   - id: azure-review
     name: "Azure Security Posture Review"
-    tags: [cloud, azure, cis-benchmark]
+    tags: [cloud, azure, cis-benchmark, container-apps, workload-identity]
     role: [cloud-security-engineer, security-engineer]
     phase: [assess, operate]
     activity: [audit, review]
     frameworks: [CIS-Azure-v2.1.0]
     difficulty: intermediate
-    time_estimate: "60-90min"
+    time_estimate: "75-120min"
     file: skills/cloud/azure-review/SKILL.md
     compatible_tools: [claude-code, gemini-cli, cursor, codex-cli, openclaw, kiro]
 

--- a/skills/cloud/azure-review/SKILL.md
+++ b/skills/cloud/azure-review/SKILL.md
@@ -4,16 +4,17 @@ description: >
   Performs an Azure security posture review against the CIS Microsoft Azure
   Foundations Benchmark v2.1.0. Auto-invoked when reviewing Azure infrastructure,
   Entra ID configurations, NSG rules, Defender for Cloud settings, or Key Vault
-  access policies. Walks through all nine benchmark sections, evaluates each
-  recommendation, and produces a prioritized findings report with remediation
-  guidance mapped to specific CIS control IDs.
-tags: [cloud, azure, cis-benchmark]
+  access policies. Walks through all nine benchmark sections, evaluates
+  supplemental Azure Container Apps and workload identity federation evidence,
+  and produces a prioritized findings report with remediation guidance mapped to
+  specific CIS control IDs or Azure workload evidence gates.
+tags: [cloud, azure, cis-benchmark, container-apps, workload-identity]
 role: [cloud-security-engineer, security-engineer]
 phase: [assess, operate]
 frameworks: [CIS-Azure-v2.1.0]
 difficulty: intermediate
-time_estimate: "60-90min"
-version: "1.0.0"
+time_estimate: "75-120min"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -27,6 +28,8 @@ argument-hint: "[target-file-or-directory]"
 
 This skill performs a structured security assessment of Azure environments against the **CIS Microsoft Azure Foundations Benchmark v2.1.0**. The benchmark is organized into nine sections covering identity management, security center, storage, database services, logging and monitoring, networking, virtual machines, Key Vault, and App Service. Each recommendation is evaluated by inspecting infrastructure-as-code definitions (Terraform, Bicep, ARM templates), Azure CLI output, or configuration files available in the repository.
 
+The skill also records supplemental Azure workload evidence for Azure Container Apps and Microsoft Entra workload identity federation. These checks are not a replacement for the CIS section score; they prevent reviewers from missing public Container Apps ingress, direct Container Apps secret values, unmanaged Key Vault secret references, or broad OIDC federation that can deploy to Azure without a long-lived client secret.
+
 The CIS Azure Foundations Benchmark v2.1.0 provides prescriptive guidance across nine domains. This skill evaluates each applicable control and produces a findings report with CIS recommendation IDs, severity ratings, and actionable remediation steps.
 
 ---
@@ -39,6 +42,8 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 - Assessing an existing Azure environment's security posture against CIS benchmarks
 - Preparing for a CIS benchmark audit or compliance assessment
 - Evaluating Entra ID configurations, NSG rules, Defender for Cloud, Storage account security, or Key Vault access policies
+- Reviewing Azure Container Apps secrets, ingress exposure, managed identity, Key Vault references, or scale-rule secrets
+- Reviewing Microsoft Entra workload identity federation for CI/CD systems such as GitHub Actions, GitLab, Terraform Cloud, or custom OIDC issuers
 - Onboarding a new Azure subscription into a security program
 
 ---
@@ -54,6 +59,8 @@ The CIS Microsoft Azure Foundations Benchmark v2.1.0 is a consensus-driven secur
 - Entra ID (Azure AD) configuration files or policy documents
 - NSG and firewall rule definitions
 - Key Vault access policies and RBAC assignments
+- Azure Container Apps Terraform/Bicep/ARM definitions and Container Apps Environment configuration
+- Entra application/service principal federated identity credential definitions and Azure RBAC assignments
 
 ---
 
@@ -88,6 +95,45 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, Bic
 
 ---
 
+### Step 10A: Supplemental Azure Workload Evidence Gates
+
+Evaluate Azure Container Apps and workload identity federation configurations that are not fully represented by the CIS v2.1.0 App Service checklist.
+
+**Azure Container Apps evidence to collect:**
+
+- Workload name, resource type, environment, revision mode, and data classification.
+- Ingress mode: external vs. internal, HTTPS-only behavior, insecure-connection setting, client certificate mode, private endpoint or internal Container Apps Environment evidence, and upstream authentication/authorization evidence.
+- Secret source: direct Container Apps secret value, Key Vault reference, environment `secretRef`/Terraform `secret_name`, volume secret, scale-rule secret reference, or missing secret definition.
+- Runtime identity: system-assigned or user-assigned managed identity used for Key Vault secret retrieval, with the exact Key Vault scope and role assignment.
+- Key Vault reference details: version pinned vs. latest, secret URI, vault RBAC mode, private endpoint/logging evidence, and whether production secrets are directly embedded in IaC.
+
+**Workload identity federation evidence to collect:**
+
+- Federated credential issuer, audience, subject, and provider type.
+- CI/CD identity constraints: repository, organization, branch, tag, pull request, workflow, environment, project, or workspace.
+- Azure application/service principal and reachable Azure RBAC assignments, including scope and role definition.
+- Evidence that long-lived client secrets or certificates have been removed or justified.
+- Confidence level: strong, partial, docs-only, or not evaluable with the missing artifact named.
+
+**Supplemental findings to look for:**
+
+```
+AZ-ACA-01: Production Container Apps secret uses a direct plaintext value in Terraform, Bicep, ARM, or CLI output
+AZ-ACA-02: Container Apps Key Vault secret reference has no runtime identity or missing Key Vault Secrets User-equivalent scope
+AZ-ACA-03: Container Apps secret reference is unversioned without rotation, rollback, or change-control evidence
+AZ-ACA-04: Container Apps env, volume, or scale-rule secret reference points to a missing or direct-value secret definition
+AZ-ACA-05: External Container Apps ingress lacks authentication, authorization, private endpoint/internal environment, or data-classification evidence
+AZ-ACA-06: Container Apps ingress allows insecure connections or lacks HTTPS-only enforcement evidence
+AZ-WIF-01: Federated identity credential issuer, audience, or subject is wildcarded beyond the intended repository, branch, tag, environment, or workspace
+AZ-WIF-02: Federated CI/CD principal has Azure RBAC broader than the deployment target or business purpose
+AZ-WIF-03: Workload identity federation exists but long-lived client secrets/certificates for the same deployment principal remain active
+```
+
+**False-positive guards:**
+
+- Do not report a plaintext secret finding solely because an environment variable name contains `KEY`, `TOKEN`, or `SECRET` when the value is supplied through a Container Apps `secretRef`/Terraform `secret_name` backed by Key Vault and a scoped managed identity.
+- Do not fail a public Container Apps endpoint solely for `external_enabled = true`; calibrate severity by authentication, authorization, HTTPS-only behavior, private endpoint/internal environment design, allowed origins, and workload/data classification.
+- Treat unpinned Key Vault secret versions as an evidence item, not an automatic high-severity failure, when rotation and rollback controls are documented.
 
 ---
 
@@ -102,8 +148,8 @@ Produce the final report using the structure defined in the Output Format sectio
 | Severity | Definition | Examples |
 |----------|-----------|----------|
 | **Critical** | Immediate risk of data breach or unauthorized access | NSGs open to 0.0.0.0/0 on RDP/SSH, SQL databases publicly accessible, Defender for Cloud disabled |
-| **High** | Significant security gap that materially weakens posture | Missing MFA enforcement, storage accounts with public access, Key Vault without purge protection |
-| **Medium** | Control gap that should be addressed in normal cycle | Missing activity log alerts, soft delete not enabled, TLS below 1.2 |
+| **High** | Significant security gap that materially weakens posture | Missing MFA enforcement, storage accounts with public access, Key Vault without purge protection, public Container Apps admin API without auth evidence |
+| **Medium** | Control gap that should be addressed in normal cycle | Missing activity log alerts, soft delete not enabled, TLS below 1.2, broad workload identity federation subject |
 | **Low** | Hardening recommendation or defense-in-depth measure | HTTP/2 not enabled, FTP not fully disabled, missing CMK on non-sensitive storage |
 | **Informational** | Best practice observation, no direct security impact | Naming conventions, tag policies, documentation gaps |
 
@@ -119,6 +165,7 @@ Produce the final report using the structure defined in the Output Format sectio
 - Date: <assessment date>
 - Framework: CIS Microsoft Azure Foundations Benchmark v2.1.0
 - Files reviewed: <list of IaC files>
+- Supplemental workload gates reviewed: <Azure Container Apps / workload identity federation / none>
 
 ### Executive Summary
 - Total CIS recommendations evaluated: <N>
@@ -141,6 +188,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | 7 | Virtual Machines | X | Y | Z | nn% |
 | 8 | Key Vault | X | Y | Z | nn% |
 | 9 | App Service | X | Y | Z | nn% |
+| Supplemental | Container Apps and Workload Identity | X | Y | Z | nn% |
 
 ### Detailed Findings
 
@@ -148,10 +196,12 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Status:** Pass / Fail / Not Evaluable
 - **Severity:** Critical / High / Medium / Low
 - **CIS Profile:** Level 1 / Level 2
+- **Evidence Gate:** CIS X.Y.Z / AZ-ACA-NN / AZ-WIF-NN
 - **File:** <path to relevant config>
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration or code snippet>
+- **Azure Workload Context:** workload type, ingress exposure, secret reference type, runtime identity, Key Vault scope, federated issuer/audience/subject, Azure RBAC scope, and confidence when applicable
 - **Remediation:** <specific fix with code example>
 
 ### Prioritized Remediation Plan
@@ -184,6 +234,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | 7 | Virtual Machines | Azure Bastion, managed disks, disk encryption with CMK, approved extensions, endpoint protection |
 | 8 | Key Vault | Key/secret expiration, soft delete, purge protection, RBAC authorization, private endpoints |
 | 9 | App Service | Authentication, HTTPS redirect, TLS version, client certificates, Entra ID registration, HTTP/2, FTP disabled |
+| Supplemental | Container Apps and Workload Identity | Container Apps secrets, ingress, managed identity, Key Vault references, Entra workload identity federation, Azure RBAC scope |
 
 ### CIS Profile Levels
 
@@ -200,6 +251,9 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **NSG rules using service tags.** A rule with `source_address_prefix = "Internet"` is equivalent to `0.0.0.0/0`. Both must be flagged for CIS 6.1 and 6.2.
 5. **Key Vault purge protection is irreversible.** CIS 8.5 requires `purge_protection_enabled = true`. Note this cannot be disabled once enabled -- flag this for awareness during remediation.
 6. **App Service TLS version on both Linux and Windows.** Check `azurerm_linux_web_app` and `azurerm_windows_web_app` resources separately.
+7. **Container Apps secrets are not App Service settings.** Check `azurerm_container_app.secret`, ARM/Bicep `configuration.secrets`, env `secretRef`, volume secrets, and scale-rule secret references separately from App Service app settings.
+8. **Key Vault references still need identity proof.** A Key Vault URI is not enough; record the managed identity used by the Container App and the exact Key Vault RBAC/access-policy scope.
+9. **Federation removes one secret but can widen blast radius.** OIDC workload identity is safer than a stored client secret only when issuer, audience, subject, environment/branch constraints, and Azure RBAC scope are tight.
 
 ---
 
@@ -225,10 +279,16 @@ Produce the final report using the structure defined in the Output Format sectio
 - Azure Storage Security: https://learn.microsoft.com/en-us/azure/storage/common/storage-security-guide
 - Azure Key Vault Best Practices: https://learn.microsoft.com/en-us/azure/key-vault/general/best-practices
 - Azure App Service Security: https://learn.microsoft.com/en-us/azure/app-service/overview-security
+- Azure Container Apps secrets: https://learn.microsoft.com/en-us/azure/container-apps/manage-secrets
+- Azure Container Apps managed identities: https://learn.microsoft.com/en-us/azure/container-apps/managed-identity
+- Microsoft Entra workload identity federation: https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation
 - Terraform AzureRM Provider Documentation: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
+- Terraform AzureRM Container App resource: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_app
+- Terraform AzureAD federated identity credential resource: https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_federated_identity_credential
 
 ---
 
 ## Changelog
 
+- **1.0.1** -- Added Azure Container Apps secret/ingress and workload identity federation evidence gates.
 - **1.0.0** -- Initial release. Full coverage of CIS Microsoft Azure Foundations Benchmark v2.1.0 sections 1 through 9.

--- a/skills/cloud/azure-review/benchmark-checklist.md
+++ b/skills/cloud/azure-review/benchmark-checklist.md
@@ -781,9 +781,13 @@ Record these fields for each Key Vault-backed secret:
 | Secret version | pinned version, latest version, or not evaluable |
 | Vault controls | purge protection, RBAC authorization, private endpoint/logging where available |
 
-Flag findings when the identity is missing, the vault access is broader than needed, the URI is not a Key Vault reference for production secrets, or the secret version/rotation evidence is not documented.
+Flag `AZ-ACA-02` when the runtime identity is missing, the vault access is broader than needed, or the URI is not a Key Vault reference for production secrets.
 
-### AZ-ACA-03 -- Verify env, volume, and scale-rule secret references resolve to controlled secrets
+### AZ-ACA-03 -- Record Key Vault secret version and rotation evidence
+
+Flag `AZ-ACA-03` when a production Container Apps Key Vault reference uses the latest secret version without documented rotation, rollback, change-control, or deployment-revision evidence. Treat an unpinned secret version as an evidence item rather than an automatic high-severity failure when rotation and rollback controls are documented.
+
+### AZ-ACA-04 -- Verify env, volume, and scale-rule secret references resolve to controlled secrets
 
 Environment variables and scale rules can safely reference Container Apps secrets, but the referenced secret must exist and be backed by the appropriate source:
 
@@ -807,9 +811,9 @@ template {
 }
 ```
 
-Do not flag an environment variable solely because its name contains `KEY`, `TOKEN`, or `SECRET`. Flag it when `secret_name`, `secretRef`, volume secret, or scale-rule secret references a missing secret, a direct production value, or a secret whose Key Vault identity/access evidence is missing.
+Do not flag an environment variable solely because its name contains `KEY`, `TOKEN`, or `SECRET`. Flag `AZ-ACA-04` when `secret_name`, `secretRef`, volume secret, or scale-rule secret references a missing secret, a direct production value, or a secret whose Key Vault identity/access evidence is missing.
 
-### AZ-ACA-04 -- Review external Container Apps ingress and insecure transport separately from VM/NSG exposure
+### AZ-ACA-05 and AZ-ACA-06 -- Review external Container Apps ingress and insecure transport separately from VM/NSG exposure
 
 Container Apps can expose HTTP endpoints without a VM public IP or obvious NSG rule. Review `ingress` and Container Apps Environment evidence:
 
@@ -834,7 +838,7 @@ For each external endpoint, collect:
 | Workload context | public API, admin API, webhook, internal service, health endpoint |
 | Data classification | public, internal, confidential, regulated, unknown |
 
-`external_enabled = true` is not automatically a finding for a public API. Assign severity based on authentication, authorization, transport security, private endpoint/internal environment design, allowed origins, and workload/data classification.
+`external_enabled = true` is not automatically a finding for a public API. Flag `AZ-ACA-05` when external ingress lacks authentication, authorization, private endpoint/internal environment, or data-classification evidence. Flag `AZ-ACA-06` when insecure connections are allowed or HTTPS-only enforcement evidence is missing. Assign severity based on authentication, authorization, transport security, private endpoint/internal environment design, allowed origins, and workload/data classification.
 
 ### AZ-WIF-01 -- Verify federated identity credential issuer, audience, and subject precision
 

--- a/skills/cloud/azure-review/benchmark-checklist.md
+++ b/skills/cloud/azure-review/benchmark-checklist.md
@@ -704,3 +704,186 @@ resource "azurerm_linux_web_app" {
   }
 }
 ```
+
+---
+
+## Supplemental -- Azure Container Apps and Workload Identity Federation
+
+These evidence gates are CIS-adjacent Azure workload checks. They do not replace the CIS v2.1.0 section score, but they prevent App Service, Key Vault, and Entra ID checks from missing Container Apps-specific secret, ingress, and federated identity risk.
+
+### AZ-ACA-01 -- Ensure production Container Apps secrets are not direct plaintext values
+
+Flag direct secret values in Terraform, Bicep, ARM, CLI exports, or checked-in configuration for production workloads:
+
+```hcl
+resource "azurerm_container_app" "webhook" {
+  secret {
+    name  = "stripe-webhook-secret"
+    value = "whsec_plaintext_value" # Finding: direct production secret value
+  }
+}
+```
+
+```json
+{
+  "type": "Microsoft.App/containerApps",
+  "properties": {
+    "configuration": {
+      "secrets": [
+        { "name": "payment-api-key", "value": "plain-secret" }
+      ]
+    }
+  }
+}
+```
+
+Benign calibration: local examples or non-production demos may include placeholder values, but production assessments should record environment, data classification, owner, and a migration plan to Key Vault references or managed identity.
+
+### AZ-ACA-02 -- Verify Key Vault-backed Container Apps secrets have runtime identity and scoped vault access
+
+A Key Vault reference is acceptable only when the Container App identity used for retrieval is explicit and has narrow Key Vault access:
+
+```hcl
+resource "azurerm_user_assigned_identity" "aca_runtime" {
+  name                = "checkout-runtime"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+}
+
+resource "azurerm_role_assignment" "runtime_can_read_secrets" {
+  scope                = azurerm_key_vault.app.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = azurerm_user_assigned_identity.aca_runtime.principal_id
+}
+
+resource "azurerm_container_app" "checkout_api" {
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.aca_runtime.id]
+  }
+
+  secret {
+    name                = "payment-api-key"
+    key_vault_secret_id = "${azurerm_key_vault.app.vault_uri}secrets/payment-api-key/0a1b2c3d4e5f"
+    identity            = azurerm_user_assigned_identity.aca_runtime.id
+  }
+}
+```
+
+Record these fields for each Key Vault-backed secret:
+
+| Field | Evidence |
+|---|---|
+| Secret reference type | direct value, Key Vault versioned URI, Key Vault latest-version URI |
+| Runtime identity | system-assigned, user-assigned, missing, or not evaluable |
+| Vault access scope | vault, resource group, subscription, management group, or unknown |
+| Vault permission | `Key Vault Secrets User`, access policy `get/list`, broader contributor/owner, or unknown |
+| Secret version | pinned version, latest version, or not evaluable |
+| Vault controls | purge protection, RBAC authorization, private endpoint/logging where available |
+
+Flag findings when the identity is missing, the vault access is broader than needed, the URI is not a Key Vault reference for production secrets, or the secret version/rotation evidence is not documented.
+
+### AZ-ACA-03 -- Verify env, volume, and scale-rule secret references resolve to controlled secrets
+
+Environment variables and scale rules can safely reference Container Apps secrets, but the referenced secret must exist and be backed by the appropriate source:
+
+```hcl
+template {
+  container {
+    env {
+      name        = "PAYMENT_API_KEY"
+      secret_name = "payment-api-key" # Benign when payment-api-key is Key Vault-backed
+    }
+  }
+
+  scale_rule {
+    name             = "queue"
+    custom_rule_type = "azure-queue"
+    authentication {
+      secret_name       = "queue-connection"
+      trigger_parameter = "connection"
+    }
+  }
+}
+```
+
+Do not flag an environment variable solely because its name contains `KEY`, `TOKEN`, or `SECRET`. Flag it when `secret_name`, `secretRef`, volume secret, or scale-rule secret references a missing secret, a direct production value, or a secret whose Key Vault identity/access evidence is missing.
+
+### AZ-ACA-04 -- Review external Container Apps ingress and insecure transport separately from VM/NSG exposure
+
+Container Apps can expose HTTP endpoints without a VM public IP or obvious NSG rule. Review `ingress` and Container Apps Environment evidence:
+
+```hcl
+resource "azurerm_container_app" "admin_api" {
+  ingress {
+    external_enabled           = true
+    target_port                = 8080
+    allow_insecure_connections = true # Finding unless explicitly justified and protected
+  }
+}
+```
+
+For each external endpoint, collect:
+
+| Field | Evidence |
+|---|---|
+| Ingress exposure | external, internal, private endpoint, or not evaluable |
+| Transport | HTTPS-only, `allow_insecure_connections`, TLS termination evidence |
+| Authentication | Entra auth, app gateway/front door auth, API gateway, mTLS/client certificate, or application auth evidence |
+| Authorization | role/tenant checks, backend authorization policy, API gateway policy, or not evaluable |
+| Workload context | public API, admin API, webhook, internal service, health endpoint |
+| Data classification | public, internal, confidential, regulated, unknown |
+
+`external_enabled = true` is not automatically a finding for a public API. Assign severity based on authentication, authorization, transport security, private endpoint/internal environment design, allowed origins, and workload/data classification.
+
+### AZ-WIF-01 -- Verify federated identity credential issuer, audience, and subject precision
+
+Workload identity federation is preferred over long-lived client secrets, but wildcarded trust can over-authorize CI/CD:
+
+```hcl
+resource "azuread_application_federated_identity_credential" "github" {
+  application_id = azuread_application.deploy.id
+  display_name   = "github-main"
+  issuer         = "https://token.actions.githubusercontent.com"
+  audiences      = ["api://AzureADTokenExchange"]
+  subject        = "repo:example-org/example-repo:*" # Finding: wildcard subject
+}
+```
+
+Record issuer-specific constraints:
+
+| Provider | Evidence to require |
+|---|---|
+| GitHub Actions | org/repo, branch/tag/environment, workflow or reusable workflow boundary where applicable, audience |
+| GitLab | project path, ref type, ref, environment, audience |
+| Terraform Cloud | organization, workspace, run phase, audience |
+| Custom OIDC | issuer URL, signing/key trust, subject format, audience, claim mapping |
+
+Flag findings for wildcard subjects such as `repo:org/repo:*`, unbounded branch/tag patterns, wrong audience, issuer mismatch, missing environment constraints for production deploys, or missing provider documentation.
+
+### AZ-WIF-02 -- Verify Azure RBAC scope reached by the federated principal
+
+Federated identity safety depends on both token claims and Azure permissions. For each federated service principal, map role assignments:
+
+```hcl
+resource "azurerm_role_assignment" "deploy" {
+  scope                = azurerm_subscription.primary.id
+  role_definition_name = "Owner" # Finding for a narrow app deploy workflow
+  principal_id         = azuread_service_principal.deploy.object_id
+}
+```
+
+Prefer resource group, app, or environment-specific roles over subscription-wide `Owner`, `Contributor`, `User Access Administrator`, or broad Key Vault permissions. Record scope, role name, principal ID, environment, owner, and business purpose.
+
+### AZ-WIF-03 -- Check for leftover long-lived credentials after federation
+
+If workload identity federation is implemented, verify that long-lived deployment credentials are removed or justified:
+
+```hcl
+resource "azuread_application_password" "deploy_secret" {
+  application_id = azuread_application.deploy.id
+  display_name   = "legacy-ci-secret" # Finding if still active without exception evidence
+}
+```
+
+Not Evaluable reasons include missing Entra application export, missing service principal credentials export, missing Azure RBAC assignments, missing CI/CD OIDC configuration, or provider-specific subject/audience evidence unavailable.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `azure-review`
**Skill path:** `skills/cloud/azure-review/`

### What Was Wrong
Addresses #966.

The Azure review skill covered CIS Azure v2.1.0, Key Vault, App Service, Entra ID, networking, and Defender for Cloud, but it did not model Azure Container Apps or workload identity federation as first-class evidence gates.

That leaves two practical gaps:

- A Container App can expose an HTTP endpoint or embed direct production secrets without showing up as a VM public IP, NSG rule, or App Service finding.
- Workload identity federation can replace long-lived CI secrets, but broad issuer/audience/subject patterns or subscription-wide Azure RBAC can still make the deployment principal over-privileged.

### What This PR Fixes
- Adds Azure Container Apps and workload identity federation to `azure-review` metadata, usage guidance, prerequisites, and output fields.
- Adds supplemental `AZ-ACA-01` through `AZ-ACA-06` findings for direct Container Apps secret values, Key Vault-backed secret identity/scope evidence, unversioned secret references, missing env/volume/scale-rule secret definitions, public ingress authorization evidence, and insecure ingress.
- Adds supplemental `AZ-WIF-01` through `AZ-WIF-03` findings for wildcarded federated credential issuer/audience/subject patterns, over-broad Azure RBAC scope, and leftover long-lived credentials after federation.
- Extends `benchmark-checklist.md` with concrete Terraform and ARM patterns for `azurerm_container_app`, `configuration.secrets`, `secret_name`, scale-rule secret auth, external ingress, `azuread_application_federated_identity_credential`, RBAC role assignments, and leftover application passwords.
- Adds false-positive guards so Key Vault-backed Container Apps secret references and intentional public APIs are calibrated by identity, scope, auth, transport, data classification, and rotation evidence instead of string-name heuristics.

### Evidence

**Before (skill can miss this):**
```hcl
resource "azurerm_container_app" "admin_api" {
  secret {
    name  = "stripe-webhook-secret"
    value = "whsec_plaintext_value"
  }

  ingress {
    external_enabled           = true
    target_port                = 8080
    allow_insecure_connections = true
  }
}
```

**After (now requires evidence):**
```hcl
resource "azurerm_container_app" "checkout_api" {
  identity {
    type         = "UserAssigned"
    identity_ids = [azurerm_user_assigned_identity.aca_runtime.id]
  }

  secret {
    name                = "payment-api-key"
    key_vault_secret_id = "${azurerm_key_vault.app.vault_uri}secrets/payment-api-key/0a1b2c3d4e5f"
    identity            = azurerm_user_assigned_identity.aca_runtime.id
  }

  template {
    container {
      env {
        name        = "PAYMENT_API_KEY"
        secret_name = "payment-api-key"
      }
    }
  }
}
```

### Test Cases Added/Updated
- [x] Added vulnerable/benign Terraform and ARM calibration examples inline because this existing skill does not have a `tests/` directory
- [x] Existing skill frontmatter still parses
- [x] Index entry still points to the existing skill file and includes the new Container Apps / workload identity metadata

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** PayPal; I can provide payment details privately through the maintainer-requested channel.

## Validation

- `git diff --check`
- Ruby frontmatter parse for `skills/cloud/azure-review/SKILL.md`
- Markdown fence balance checks for `skills/cloud/azure-review/SKILL.md` and `skills/cloud/azure-review/benchmark-checklist.md`
- Content assertions for `AZ-ACA-01`, `AZ-ACA-06`, `AZ-WIF-01`, `AZ-WIF-03`, `Container Apps and Workload Identity`, `secret_name`, `azuread_application_federated_identity_credential`, and `False-positive guards`
- Old email scan for touched files
- Official Microsoft Learn and Terraform reference URL checks returned HTTP 200

---

## Withdrawal

Withdrawing this PR from bounty consideration. After opening it, I rechecked the issue timeline and saw that another contributor had already posted an attempt comment for issue #966 before this PR was opened. To avoid duplicate review noise, please do not consider #968 for payout.