### PR TITLE
Add Azure Container Apps evidence gates

### DIFF
--- a/skills/cloud/azure-review/SKILL.md
+++ b/skills/cloud/azure-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-Azure-v2.1.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -54,6 +54,7 @@ The CIS Microsoft Azure Foundations Benchmark v2.1.0 is a consensus-driven secur
 - Entra ID (Azure AD) configuration files or policy documents
 - NSG and firewall rule definitions
 - Key Vault access policies and RBAC assignments
+- Azure Container Apps definitions and workload identity federation evidence where serverless container workloads or external CI/CD deployment identities are in scope
 
 ---
 
@@ -91,7 +92,48 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, Bic
 
 ---
 
-### Step 11: Compile Assessment Report
+### Step 11: Azure Container Apps and Workload Identity Evidence
+
+**Objective:** Validate Azure Container Apps secrets, ingress, managed identity, and external workload identity federation evidence that is not covered by App Service-only checks.
+
+Review `azurerm_container_app`, ARM/Bicep `Microsoft.App/containerApps`, managed identities, Key Vault role assignments, and Entra federated identity credentials. Distinguish production direct secret values from Key Vault-backed references, and distinguish well-scoped OIDC federation from broad CI trust.
+
+**What to look for:**
+
+```
+AZ-ACA-01: Container Apps secret uses direct `value` in production IaC instead of Key Vault reference
+AZ-ACA-02: Container Apps Key Vault secret reference lacks managed identity evidence or Key Vault Secrets User-equivalent scope
+AZ-ACA-03: Container Apps secret reference is unversioned where change control requires a pinned secret version
+AZ-ACA-04: External ingress enabled without HTTPS-only behavior, authentication, authorization, or private/internal environment evidence
+AZ-ACA-05: Insecure Container Apps ingress connections allowed without documented exception
+AZ-ACA-06: Secret references used by env vars, volumes, or scale rules are not classified by source and sensitivity
+AZ-WIF-01: Federated identity credential uses wildcard issuer, subject, repository, branch, environment, or audience pattern
+AZ-WIF-02: External CI/CD federated principal has broad subscription/resource-group role assignment beyond deployment need
+AZ-WIF-03: Workload identity federation trust lacks evidence linking issuer, audience, subject, environment, and Azure role scope
+AZ-WIF-04: Long-lived client secret is retained where workload identity federation is available and expected
+```
+
+Record these fields in findings or supplemental evidence when applicable:
+
+| Field | Description |
+|---|---|
+| **workload_type** | Container App, job, revision, scale rule, or external CI/CD identity |
+| **ingress_public** | `true`/`false`, internal environment, private endpoint, and HTTPS/insecure setting |
+| **secret_reference_type** | Direct value, Key Vault reference, secret env ref, volume ref, scale-rule secret ref |
+| **secret_version_pinned** | Pinned Key Vault secret version, latest version, or not applicable |
+| **runtime_identity** | System-assigned or user-assigned managed identity used by the Container App |
+| **key_vault_access_scope** | Key Vault role/access policy scope and permissions granted to the runtime identity |
+| **external_oidc_federation** | Issuer, audience, subject pattern, branch/environment constraints, and linked Azure role scope |
+
+**Severity calibration:**
+
+- **High/Critical:** production direct secret values in IaC, public admin/API ingress without auth or HTTPS enforcement, or wildcard CI federation with broad Azure RBAC.
+- **Medium:** Key Vault reference lacks version/control evidence, managed identity scope is broader than needed, or ingress auth evidence is incomplete.
+- **Low/Informational:** well-scoped Key Vault-backed secret references or OIDC federation with missing documentation but no unsafe effective access.
+
+---
+
+### Step 12: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
 
@@ -102,8 +144,8 @@ Produce the final report using the structure defined in the Output Format sectio
 | Severity | Definition | Examples |
 |----------|-----------|----------|
 | **Critical** | Immediate risk of data breach or unauthorized access | NSGs open to 0.0.0.0/0 on RDP/SSH, SQL databases publicly accessible, Defender for Cloud disabled |
-| **High** | Significant security gap that materially weakens posture | Missing MFA enforcement, storage accounts with public access, Key Vault without purge protection |
-| **Medium** | Control gap that should be addressed in normal cycle | Missing activity log alerts, soft delete not enabled, TLS below 1.2 |
+| **High** | Significant security gap that materially weakens posture | Missing MFA enforcement, storage accounts with public access, Key Vault without purge protection, Container App direct production secret values in IaC |
+| **Medium** | Control gap that should be addressed in normal cycle | Missing activity log alerts, soft delete not enabled, TLS below 1.2, Container App Key Vault reference without runtime identity or version evidence |
 | **Low** | Hardening recommendation or defense-in-depth measure | HTTP/2 not enabled, FTP not fully disabled, missing CMK on non-sensitive storage |
 | **Informational** | Best practice observation, no direct security impact | Naming conventions, tag policies, documentation gaps |
 
@@ -141,6 +183,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | 7 | Virtual Machines | X | Y | Z | nn% |
 | 8 | Key Vault | X | Y | Z | nn% |
 | 9 | App Service | X | Y | Z | nn% |
+| Supplemental | Container Apps and workload identity | X | Y | Z | nn% |
 
 ### Detailed Findings
 
@@ -184,6 +227,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | 7 | Virtual Machines | Azure Bastion, managed disks, disk encryption with CMK, approved extensions, endpoint protection |
 | 8 | Key Vault | Key/secret expiration, soft delete, purge protection, RBAC authorization, private endpoints |
 | 9 | App Service | Authentication, HTTPS redirect, TLS version, client certificates, Entra ID registration, HTTP/2, FTP disabled |
+| Supplemental | Container Apps and workload identity | Direct vs. Key Vault-backed secrets, managed identity, ingress exposure, federated identity credential precision |
 
 ### CIS Profile Levels
 
@@ -200,6 +244,9 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **NSG rules using service tags.** A rule with `source_address_prefix = "Internet"` is equivalent to `0.0.0.0/0`. Both must be flagged for CIS 6.1 and 6.2.
 5. **Key Vault purge protection is irreversible.** CIS 8.5 requires `purge_protection_enabled = true`. Note this cannot be disabled once enabled -- flag this for awareness during remediation.
 6. **App Service TLS version on both Linux and Windows.** Check `azurerm_linux_web_app` and `azurerm_windows_web_app` resources separately.
+7. **Container Apps secrets are not App Service settings.** Check `azurerm_container_app.secret`, ARM/Bicep `configuration.secrets`, env secret refs, volume refs, and scale-rule secret refs separately.
+8. **Key Vault reference does not prove least privilege.** Verify the runtime identity and Key Vault role/access policy scope, not just the presence of a Key Vault URI.
+9. **OIDC federation is only safe when scoped.** GitHub, GitLab, Terraform Cloud, and custom issuers need precise issuer, audience, subject, branch/environment, and Azure RBAC evidence.
 
 ---
 
@@ -225,10 +272,14 @@ Produce the final report using the structure defined in the Output Format sectio
 - Azure Storage Security: https://learn.microsoft.com/en-us/azure/storage/common/storage-security-guide
 - Azure Key Vault Best Practices: https://learn.microsoft.com/en-us/azure/key-vault/general/best-practices
 - Azure App Service Security: https://learn.microsoft.com/en-us/azure/app-service/overview-security
+- Azure Container Apps secrets: https://learn.microsoft.com/en-us/azure/container-apps/manage-secrets
+- Azure Container Apps managed identities: https://learn.microsoft.com/en-us/azure/container-apps/managed-identity
+- Microsoft Entra Workload Identity Federation: https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation
 - Terraform AzureRM Provider Documentation: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
 
 ---
 
 ## Changelog
 
+- **1.1.0** -- Added Azure Container Apps secrets, ingress, managed identity, and workload identity federation evidence gates.
 - **1.0.0** -- Initial release. Full coverage of CIS Microsoft Azure Foundations Benchmark v2.1.0 sections 1 through 9.

--- a/skills/cloud/azure-review/benchmark-checklist.md
+++ b/skills/cloud/azure-review/benchmark-checklist.md
@@ -675,6 +675,133 @@ resource "azurerm_linux_web_app" {
 
 ### CIS 9.5 -- Ensure that Register with Entra ID is enabled on App Service
 
+---
+
+## Supplemental Section -- Azure Container Apps and Workload Identity
+
+Evaluate Azure Container Apps and external workload identity federation evidence when `azurerm_container_app`, ARM/Bicep `Microsoft.App/containerApps`, managed identities, Key Vault references, or `azuread_application_federated_identity_credential` resources are present.
+
+### AZ-ACA-01 -- Avoid direct Container Apps secret values in production IaC
+
+Check Terraform:
+
+```hcl
+# Vulnerable for production
+resource "azurerm_container_app" "webhook" {
+  secret {
+    name  = "stripe-webhook-secret"
+    value = "whsec_plaintext_value"
+  }
+}
+```
+
+Prefer Key Vault-backed secret references for production:
+
+```hcl
+resource "azurerm_container_app" "api" {
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.runtime.id]
+  }
+
+  secret {
+    name                = "payment-api-key"
+    key_vault_secret_id = "${azurerm_key_vault.app.vault_uri}secrets/payment-api-key/0a1b2c3d4e5f"
+    identity            = azurerm_user_assigned_identity.runtime.id
+  }
+}
+```
+
+Also check ARM/Bicep `configuration.secrets[].value`. Mark direct values in non-production examples separately when evidence proves they are not live secrets.
+
+### AZ-ACA-02 -- Verify managed identity and Key Vault access scope
+
+For Key Vault-backed Container Apps secrets, verify:
+
+- `identity` block on the Container App.
+- Secret-level `identity` value matches the runtime identity.
+- Key Vault RBAC or access policy grants only required secret read permissions.
+- Scope is the specific vault or narrower, not subscription-wide broad access.
+- Purge protection, soft delete, and private endpoint expectations still follow Key Vault checks.
+
+**Fail signal:** Key Vault URI is present but no managed identity, no `Key Vault Secrets User`-equivalent role, or overly broad Key Vault/RBAC scope is evidenced.
+
+### AZ-ACA-03 -- Record secret reference type and version pinning
+
+Classify Container Apps secret use:
+
+| Field | Values |
+|---|---|
+| Secret source | Direct value / Key Vault reference / not evaluable |
+| Reference use | Environment variable / volume / scale rule / other |
+| Version handling | Pinned Key Vault version / latest version / direct value / not applicable |
+| Sensitivity | Production secret / non-production secret / placeholder / not evaluable |
+
+Flag missing version evidence as Medium when change control or reproducibility requires pinned secret versions. Do not fail latest-version references automatically when rotation policy intentionally uses latest.
+
+### AZ-ACA-04 -- Review Container Apps ingress exposure
+
+Check Terraform:
+
+```hcl
+resource "azurerm_container_app" "admin_api" {
+  ingress {
+    external_enabled           = true
+    target_port                = 8080
+    allow_insecure_connections = true
+  }
+}
+```
+
+Record:
+
+- `external_enabled`.
+- `allow_insecure_connections`.
+- Internal Container Apps environment or private endpoint evidence.
+- Client certificate mode where applicable.
+- Application-layer authentication and authorization evidence.
+- Traffic restrictions, allowed origins, upstream gateway, or WAF evidence where relevant.
+
+**Fail signal:** public or admin-oriented ingress is externally enabled without HTTPS-only behavior, auth evidence, private endpoint/internal environment, or compensating upstream controls.
+
+### AZ-WIF-01 -- Review federated identity credential precision
+
+Check Terraform:
+
+```hcl
+resource "azuread_application_federated_identity_credential" "github" {
+  application_id = azuread_application.deploy.id
+  issuer         = "https://token.actions.githubusercontent.com"
+  audiences      = ["api://AzureADTokenExchange"]
+  subject        = "repo:example-org/example-repo:*"
+}
+```
+
+Validate:
+
+- Issuer is expected for the CI/CD platform.
+- Audience is restricted to the intended token exchange.
+- Subject is constrained to repository plus branch, tag, pull request, or environment as appropriate.
+- Wildcards are justified and risk accepted.
+- The federated application or service principal Azure RBAC assignments are scoped to the deployment need.
+
+**Fail signal:** wildcard subject such as `repo:org/repo:*` or broad issuer/audience trust combines with subscription/resource-group Contributor, Owner, or broad Key Vault access.
+
+### AZ-WIF-02 -- Prefer scoped federation over long-lived deployment secrets
+
+Where workload identity federation is available and expected, record whether long-lived client secrets remain for the same deployment path.
+
+**Fail signal:** CI/CD retains a long-lived Entra application secret with broad Azure RBAC while OIDC federation is configured only partially or not at all.
+
+### Not Evaluable Guidance
+
+Mark Container Apps or workload identity checks `Not Evaluable` when:
+
+- Container Apps definitions are present but secret source, identity, or ingress settings are not exported.
+- Key Vault reference exists but role assignment/access policy evidence is missing.
+- External ingress is present but no auth, private endpoint, or upstream authorization evidence is available.
+- Federated identity credential exists but issuer, audience, subject, or Azure RBAC assignment evidence is missing.
+
 Check for identity configuration:
 
 ```hcl


### PR DESCRIPTION
Implements #966.

Bounty requested: improver moderate/substantial if accepted. Payment details can be provided privately after maintainer acceptance.

Summary:
- Adds an Azure Container Apps and workload identity evidence gate to azure-review.
- Covers direct vs Key Vault-backed Container Apps secrets, managed identity access to Key Vault, secret version evidence, public/insecure ingress, and external OIDC federation precision.
- Adds output fields, severity calibration, common pitfalls, references, and supplemental benchmark checklist items for AZ-ACA and AZ-WIF controls.

Validation:
- git diff --check
- azure-review SKILL.md frontmatter parses as YAML
- content checks for AZ-ACA, AZ-WIF, Container Apps, workload identity, Key Vault secret references, external ingress, and insecure connection evidence
- markdown code-fence balance check for SKILL.md and benchmark-checklist.md