### PR TITLE
Add effective EC2 metadata option evidence to aws review

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-AWS-v3.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -198,7 +198,7 @@ Produce the final report using the structure defined in the Output Format sectio
 2. **Missing account-level vs. bucket-level S3 public access blocks.** CIS 2.1.4 requires both. An account-level block can override permissive bucket settings, but the bucket-level block should also be set.
 3. **Confusing CloudTrail multi-region with organization trail.** CIS 3.1 requires multi-region, not necessarily an organization trail. Both are valid, but the control checks `is_multi_region_trail`.
 4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
-5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
+5. **Overlooking effective EC2 metadata options.** CIS 5.6 applies across direct instances, launch templates, launch configurations, Auto Scaling metadata options, account-level defaults, AMI defaults, and running-instance evidence. Checking only direct `aws_instance` definitions misses inherited settings, auto-scaled instances, disabled metadata endpoints, IPv6 metadata endpoints, and hop-limit exceptions for container workloads.
 6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
 
 ---
@@ -232,3 +232,4 @@ Produce the final report using the structure defined in the Output Format sectio
 ## Changelog
 
 - **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 (62 recommendations).
+

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -488,3 +488,24 @@ resource "aws_launch_template" {
   }
 }
 ```
+
+Also record the effective source and all metadata sub-options:
+
+| Evidence Source | What to Verify | Pass / False-Positive Guard |
+|---|---|---|
+| `aws_instance.metadata_options` | `http_tokens`, `http_endpoint`, `http_put_response_hop_limit`, `http_protocol_ipv6`, `instance_metadata_tags` | `http_tokens = "required"` or `http_endpoint = "disabled"` |
+| `aws_launch_template.metadata_options` | Same metadata options and launch template version used by Auto Scaling | Active launch template version enforces IMDSv2 or disables IMDS |
+| Auto Scaling metadata options | Launch configuration/template or API `InstanceMetadataOptions` | Auto-scaled instances inherit IMDSv2-required or endpoint-disabled settings |
+| Account-level defaults | `get-instance-metadata-defaults` / IaC equivalent per region | Account default enforces `HttpTokens=required`; note if enforcement blocks noncompliant launches |
+| AMI defaults | AMI `ImdsSupport` / launch documentation | AMI default is `v2.0`, but record when launch parameters override it |
+| Running-instance evidence | `describe-instances` `MetadataOptions` | Effective instances show `HttpTokens=required` or `HttpEndpoint=disabled` |
+
+Flag these conditions:
+
+- `http_tokens = "optional"` with `http_endpoint = "enabled"`.
+- Metadata options omitted and no account-level, AMI, launch-template, or running-instance evidence proves IMDSv2.
+- `http_put_response_hop_limit > 1` without documented container or proxy need.
+- `http_protocol_ipv6 = "enabled"` without an IPv6 metadata access rationale and network controls.
+- `instance_metadata_tags = "enabled"` without approval for exposing instance tags through metadata.
+
+Do not fail an instance solely because `http_tokens` is omitted when `http_endpoint = "disabled"` or when authoritative inherited evidence proves `HttpTokens=required`.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `aws-review`
**Skill path:** `skills/cloud/aws-review/`

### What Was Wrong
The CIS 5.6 checklist only looked for `http_tokens = "required"` on `aws_instance` and `aws_launch_template`. That misses effective EC2 metadata posture from disabled metadata endpoints, account-level defaults, AMI defaults, Auto Scaling metadata options, running-instance evidence, IPv6 metadata endpoints, instance metadata tags, and hop-limit exceptions.

Fixes #991.

### What This PR Fixes
- Expands CIS 5.6 evidence for `HttpEndpoint`, `HttpTokens`, `HttpPutResponseHopLimit`, `HttpProtocolIpv6`, and `InstanceMetadataTags`.
- Adds evidence sources for direct instances, launch templates, Auto Scaling metadata options, account-level defaults, AMI defaults, and running-instance state.
- Adds false-positive guard for `http_endpoint = "disabled"` and inherited `HttpTokens=required` evidence.
- Adds flags for undocumented hop limits above 1, IPv6 metadata endpoint enablement, and metadata tags exposure.
- Updates the common pitfall to focus on effective EC2 metadata options across launch paths.
- Bumps `aws-review` to v1.0.1.

### Validation
- Checked markdown fence balance for both edited files.
- Checked edited files remain ASCII-only.
- Checked IMDS markers for hop limit and disabled endpoint are present.
- Cross-checked AWS EC2 metadata option docs, Auto Scaling metadata options, AWS CLI examples, and Terraform metadata options.

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Payment details can be provided privately after maintainer acceptance.