### PR TITLE
Add container service mesh mTLS evidence gates

### DIFF
--- a/skills/cloud/container-security/SKILL.md
+++ b/skills/cloud/container-security/SKILL.md
@@ -60,6 +60,7 @@ NIST SP 800-190 identifies five risk categories: image risks, registry risks, or
 - Kubernetes manifests (YAML), Helm charts, or Kustomize overlays
 - RBAC configuration files (Roles, ClusterRoles, RoleBindings)
 - NetworkPolicy definitions
+- Service mesh security policies, if present (Istio `PeerAuthentication` / `AuthorizationPolicy`, Linkerd policy resources, SPIFFE/SPIRE registration entries)
 - Pod Security Standard configurations or OPA/Gatekeeper policies
 - Container registry configurations (if available)
 
@@ -160,6 +161,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | Pod Security | CIS K8s 5.2.x | X | X | X | X | X |
 | RBAC | CIS K8s 5.1.x | X | X | X | X | X |
 | Network Policies | CIS K8s 5.3.x | X | X | X | X | X |
+| Service Mesh / Workload Identity | NIST 800-190 CM-8 | X | X | X | X | X |
 | Secrets Management | CIS K8s 5.4.x | X | X | X | X | X |
 | Runtime Hardening | NIST 800-190 | X | X | X | X | X |
 | Control Plane | CIS K8s 1.x-4.x | X | X | X | X | X |
@@ -184,6 +186,12 @@ Produce the final report using the structure defined in the Output Format sectio
 |----------|-----------|-----------|------------|
 | deploy/app | production | Baseline (not Restricted) | runAsRoot, no seccomp |
 | deploy/worker | production | Privileged | privileged: true |
+
+### Service Mesh / Workload Identity Matrix
+
+| Workload | Namespace | Service Account | Mesh Participation | mTLS Mode | Authorization Policy | Evidence Status |
+|----------|-----------|-----------------|--------------------|-----------|----------------------|-----------------|
+| deploy/payments-api | payments | payments-api | sidecar/ambient enabled | STRICT | principals scoped to caller SAs | Pass |
 
 ### Prioritized Remediation Plan
 
@@ -256,7 +264,8 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Base64 encoding is not encryption.** Kubernetes Secrets store data as base64, which is trivially decodable. Secrets committed to version control in manifests are effectively plaintext.
 5. **`readOnlyRootFilesystem` breaks many applications.** When recommending this control, also recommend adding writable `emptyDir` volume mounts for directories the application needs to write to (e.g., `/tmp`, `/var/cache`).
 6. **Network policies are additive, not subtractive.** A default-deny policy must be explicitly created. Without it, all pod-to-pod traffic is allowed regardless of other NetworkPolicy resources.
-7. **Distroless images have no shell.** While this is excellent for security, note that debugging requires ephemeral containers (`kubectl debug`). Flag this as a consideration, not a problem.
+7. **Service mesh installed does not mean service mesh enforced.** Verify mesh enrollment for each workload, STRICT mTLS or equivalent, selector-to-workload matches, principal-specific authorization, and negative tests for plaintext or wrong-principal traffic. NetworkPolicy and mesh policy are complementary controls, not substitutes for one another.
+8. **Distroless images have no shell.** While this is excellent for security, note that debugging requires ephemeral containers (`kubectl debug`). Flag this as a consideration, not a problem.
 
 ---
 
@@ -285,6 +294,9 @@ Produce the final report using the structure defined in the Output Format sectio
 - Kubernetes Pod Security Admission: https://kubernetes.io/docs/concepts/security/pod-security-admission/
 - Kubernetes Network Policies: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 - Kubernetes RBAC: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Istio PeerAuthentication: https://istio.io/latest/docs/reference/config/security/peer_authentication/
+- Istio Authorization Policy: https://istio.io/latest/docs/reference/config/security/authorization-policy/
+- SPIFFE/SPIRE Concepts: https://spiffe.io/docs/latest/spire-about/spire-concepts/
 - Docker Security Best Practices: https://docs.docker.com/develop/security-best-practices/
 - Dockerfile Best Practices: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
 - NSA/CISA Kubernetes Hardening Guide: https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF

--- a/skills/cloud/container-security/cis-benchmarks.md
+++ b/skills/cloud/container-security/cis-benchmarks.md
@@ -431,6 +431,127 @@ spec:
 
 **Critical check:** A default-deny NetworkPolicy should exist in every namespace.
 
+### Service Mesh mTLS and Workload Identity Evidence (NIST 800-190 CM-8)
+
+Service mesh controls can complement NetworkPolicy by enforcing workload identity, mTLS, and application-layer authorization. Do not treat a mesh installation as evidence by itself. Verify effective policy coverage for each sensitive namespace and workload.
+
+#### Mesh Participation
+
+Check that workloads expected to be protected by the mesh are actually enrolled:
+
+```yaml
+# GOOD: namespace-level sidecar injection enabled
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: payments
+  labels:
+    istio-injection: enabled
+```
+
+```yaml
+# RISK: workload disables mesh participation
+metadata:
+  labels:
+    sidecar.istio.io/inject: "false"
+```
+
+Evidence to collect:
+
+- Namespace and workload mesh enrollment labels or ambient enrollment labels.
+- Sidecar or mesh dataplane presence for Deployments, StatefulSets, DaemonSets, Jobs, and CronJobs.
+- Exceptions for jobs, init containers, hostNetwork pods, or workloads that intentionally bypass mesh traffic.
+
+#### mTLS Mode
+
+```yaml
+# RISK: allows plaintext fallback during migration
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: production
+spec:
+  mtls:
+    mode: PERMISSIVE
+```
+
+```yaml
+# GOOD: denies non-mTLS traffic for the namespace
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: production
+spec:
+  mtls:
+    mode: STRICT
+```
+
+Flag PERMISSIVE or DISABLE modes on sensitive workloads unless there is a time-bound migration exception, owner, deadline, and telemetry showing remaining plaintext sources.
+
+#### Authorization Policy Selector Coverage
+
+```yaml
+# RISK: selector does not match the workload labels
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-web
+spec:
+  selector:
+    matchLabels:
+      app: web
+```
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: web
+```
+
+Verify that every AuthorizationPolicy selector matches the intended pod template labels. If a policy has no selector, confirm whether namespace-wide behavior is intended and does not over-allow unrelated workloads.
+
+#### Workload Principal Specificity
+
+```yaml
+# RISK: high-risk service uses a shared/default identity
+spec:
+  serviceAccountName: default
+```
+
+```yaml
+# GOOD: authorization scoped to a specific caller principal
+rules:
+  - from:
+      - source:
+          principals:
+            - cluster.local/ns/orders/sa/orders-api
+```
+
+Reviewers should confirm:
+
+- Sensitive workloads use dedicated service accounts, not `default`.
+- Allowed principals are specific namespaces/service accounts or SPIFFE IDs, not broad namespace or wildcard identities.
+- Shared service accounts are justified and mapped to all workloads using them.
+- Wrong-principal and plaintext-client negative tests fail closed.
+
+#### Review Checklist
+
+- [ ] Every sensitive workload has documented mesh participation or a documented non-mesh compensating control.
+- [ ] mTLS is STRICT or equivalent for sensitive east-west traffic; PERMISSIVE/DISABLE modes have time-bound exceptions.
+- [ ] AuthorizationPolicy selectors match actual workload labels and are evaluated in the correct namespace.
+- [ ] Allowed principals are workload-specific and backed by dedicated service accounts or SPIFFE identities.
+- [ ] Default service accounts are not used for high-risk mesh-authorized workloads.
+- [ ] Negative tests cover plaintext clients, wrong namespace/service account principals, missing sidecar/ambient enrollment, and unmatched selectors.
+- [ ] Mark as Not Evaluable when mesh configs are referenced but effective enrollment, policy selection, or traffic test evidence is missing.
+
 ### CIS 5.4 -- Secrets Management
 
 #### CIS 5.4.1 -- Prefer using Secrets as files over Secrets as environment variables


### PR DESCRIPTION
Implements #993.

## Summary

- Adds service mesh security policies to the `container-security` discovery scope.
- Adds a Service Mesh / Workload Identity report matrix for workload, service account, mesh participation, mTLS mode, authorization policy, and evidence status.
- Adds a detailed service-mesh evidence gate to `cis-benchmarks.md` covering mesh enrollment, STRICT mTLS, AuthorizationPolicy selector coverage, workload principal specificity, default service-account risk, and negative tests.
- Adds references for Istio PeerAuthentication, Istio AuthorizationPolicy, and SPIFFE/SPIRE concepts.

## Bounty

Claiming Improver / Moderate ($100) if accepted. This is a focused methodology improvement for Kubernetes east-west traffic and workload identity validation.

Preferred payment method: PayPal details can be provided privately after maintainer acceptance.

## Validation

- `git diff --check -- skills/cloud/container-security/SKILL.md skills/cloud/container-security/cis-benchmarks.md`
- Markdown fence-balance check for both edited files
- ASCII check for both edited files
- Content assertions for `PeerAuthentication`, `AuthorizationPolicy`, `STRICT`, `PERMISSIVE`, `SPIFFE`, plaintext/wrong-principal negative tests, and service mesh report output
