### PR TITLE
Add S3 Object Ownership evidence to aws review

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-AWS-v3.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -195,7 +195,7 @@ Produce the final report using the structure defined in the Output Format sectio
 ## Common Pitfalls
 
 1. **Checking only Terraform state, not all resource definitions.** Security groups and IAM policies may be defined across dozens of files. Always use Glob to find all `.tf` files before evaluating.
-2. **Missing account-level vs. bucket-level S3 public access blocks.** CIS 2.1.4 requires both. An account-level block can override permissive bucket settings, but the bucket-level block should also be set.
+2. **Confusing S3 Block Public Access with Object Ownership.** CIS 2.1.4 requires account-level and bucket-level public access blocks, but those settings do not prove ACLs are disabled or that the bucket owner controls every object. Record S3 Object Ownership separately: `BucketOwnerEnforced` disables ACLs, while `BucketOwnerPreferred` and `ObjectWriter` require additional ACL and upload-policy evidence.
 3. **Confusing CloudTrail multi-region with organization trail.** CIS 3.1 requires multi-region, not necessarily an organization trail. Both are valid, but the control checks `is_multi_region_trail`.
 4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
 5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
@@ -232,3 +232,4 @@ Produce the final report using the structure defined in the Output Format sectio
 ## Changelog
 
 - **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 (62 recommendations).
+

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -215,6 +215,26 @@ Also verify account-level public access block:
 aws_s3_account_public_access_block
 ```
 
+#### S3 Object Ownership and ACL-Disabled Evidence
+
+Block Public Access reduces public ACL and policy exposure, but it does not prove that ACLs are disabled or that the bucket owner owns every object. For each bucket, also record S3 Object Ownership evidence.
+
+| Evidence Source | What to Verify | Pass / Follow-Up |
+|---|---|---|
+| Terraform `aws_s3_bucket_ownership_controls` | `rule.object_ownership` | `BucketOwnerEnforced` passes ACL-disabled evidence |
+| CloudFormation `OwnershipControls` | `ObjectOwnership` rule | `BucketOwnerEnforced` passes ACL-disabled evidence |
+| AWS CLI / inventory | `get-bucket-ownership-controls` result | Existing/imported buckets have verified ownership mode |
+| Guardrail policy | IAM/SCP condition on `s3:x-amz-object-ownership` | New buckets are required to use `BucketOwnerEnforced` |
+
+Flag these conditions:
+
+- `ObjectWriter` without a documented legacy exception and ACL review.
+- `BucketOwnerPreferred` without bucket policy or client evidence requiring `bucket-owner-full-control` on cross-account `PutObject` requests.
+- Missing ownership-controls evidence for existing or imported buckets where new-bucket defaults cannot be assumed.
+- ACL-dependent clients with no migration plan before moving to `BucketOwnerEnforced`.
+
+Do not treat `BucketOwnerEnforced` buckets as ACL-exposed solely because historical ACL resources are present. With ACLs disabled, access is controlled by policies rather than bucket/object ACL grants.
+
 ### CIS 2.2.1 -- Ensure EBS Volume Encryption is Enabled in all Regions
 
 Check for default EBS encryption:
@@ -488,3 +508,4 @@ resource "aws_launch_template" {
   }
 }
 ```
+


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `aws-review`
**Skill path:** `skills/cloud/aws-review/`

### What Was Wrong
The S3 storage checks covered Block Public Access, but did not require S3 Object Ownership evidence. Block Public Access is important, but it does not prove ACLs are disabled or that the bucket owner owns every object.

Fixes #995.

### What This PR Fixes
- Adds S3 Object Ownership and ACL-disabled evidence under CIS 2.1.4.
- Requires evidence for Terraform `aws_s3_bucket_ownership_controls`, CloudFormation `OwnershipControls`, AWS CLI/inventory evidence, or guardrail policy.
- Treats `BucketOwnerEnforced` as ACL-disabled evidence.
- Flags `ObjectWriter`, incomplete `BucketOwnerPreferred` evidence, missing controls for existing/imported buckets, and ACL-dependent clients without migration plans.
- Updates the S3 common pitfall to distinguish Block Public Access from Object Ownership.
- Bumps `aws-review` to v1.0.1.

### Validation
- Checked markdown fence balance for both edited files.
- Checked edited files remain ASCII-only.
- Checked `BucketOwnerEnforced` evidence markers are present.
- Cross-checked AWS S3 Object Ownership and Terraform ownership controls documentation.

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Payment details can be provided privately after maintainer acceptance.