### PR TITLE
Add Key Vault recovery and private access evidence to azure review

### DIFF
--- a/skills/cloud/azure-review/SKILL.md
+++ b/skills/cloud/azure-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-Azure-v2.1.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -198,7 +198,7 @@ Produce the final report using the structure defined in the Output Format sectio
 2. **Missing Defender for Cloud plan coverage.** Each resource type (Servers, SQL, Storage, etc.) requires its own Defender plan enablement. A single `azurerm_security_center_subscription_pricing` resource only covers one type.
 3. **Overlooking `allow_nested_items_to_be_public` on storage accounts.** CIS 3.7 checks the account-level setting, not individual container access levels. The account setting must be `false` to prevent any container from being public.
 4. **NSG rules using service tags.** A rule with `source_address_prefix = "Internet"` is equivalent to `0.0.0.0/0`. Both must be flagged for CIS 6.1 and 6.2.
-5. **Key Vault purge protection is irreversible.** CIS 8.5 requires `purge_protection_enabled = true`. Note this cannot be disabled once enabled -- flag this for awareness during remediation.
+5. **Key Vault private endpoint is not private-only access by itself.** CIS 8.5 and 8.7 require recoverability and private access evidence, but a private endpoint does not prove public network access is disabled, firewall exceptions are scoped, or private DNS is linked. Record soft-delete retention, purge protection, public network access, trusted-service exceptions, private endpoint approval, and `privatelink.vaultcore.azure.net` DNS linkage.
 6. **App Service TLS version on both Linux and Windows.** Check `azurerm_linux_web_app` and `azurerm_windows_web_app` resources separately.
 
 ---
@@ -232,3 +232,4 @@ Produce the final report using the structure defined in the Output Format sectio
 ## Changelog
 
 - **1.0.0** -- Initial release. Full coverage of CIS Microsoft Azure Foundations Benchmark v2.1.0 sections 1 through 9.
+

--- a/skills/cloud/azure-review/benchmark-checklist.md
+++ b/skills/cloud/azure-review/benchmark-checklist.md
@@ -609,6 +609,17 @@ resource "azurerm_key_vault" {
 }
 ```
 
+Also record the recovery evidence source and operational impact:
+
+| Evidence | What to Verify | Pass / Follow-Up |
+|---|---|---|
+| Terraform `azurerm_key_vault` | `soft_delete_retention_days`, `purge_protection_enabled` | Retention is documented and purge protection is enabled for production/high-value vaults |
+| Bicep/ARM `Microsoft.KeyVault/vaults` | `enableSoftDelete`, `enablePurgeProtection`, retention settings | Effective template enforces recoverability |
+| Azure CLI / inventory | `az keyvault show` recovery and purge properties | Existing/imported vault settings match policy |
+| Exception record | Reason, environment, owner, expiry | Non-production or migration exceptions are time-bound |
+
+Flag `purge_protection_enabled = false` for production, customer-managed-key, or regulated vaults. If retention is less than the standard policy window, record the owner and justification. Note that purge protection cannot be disabled after it is enabled.
+
 ### CIS 8.6 -- Enable Role Based Access Control for Azure Key Vault
 
 ```hcl
@@ -629,6 +640,22 @@ resource "azurerm_private_endpoint" {
   }
 }
 ```
+
+Private endpoint presence is not enough. Record effective private-access evidence:
+
+| Evidence | What to Verify | Risk if Missing |
+|---|---|---|
+| Key Vault network ACLs | `publicNetworkAccess` / `public_network_access_enabled`, bypass/trusted-services setting, default action, IP/VNet rules | Vault may remain reachable through public endpoint |
+| Private endpoint connection | Approved state, target vault resource ID, `subresource_names = ["vault"]` | Endpoint exists but is not connected to the intended vault |
+| Private DNS | `privatelink.vaultcore.azure.net` zone and VNet link, or equivalent enterprise DNS forwarding | Clients may resolve the public vault endpoint |
+| Client path evidence | Workload subnet/VNet, peering, DNS resolver, and service-specific access path | Application may still require public access exceptions |
+
+Flag these conditions:
+
+- Private endpoint exists while public network access remains enabled with broad firewall rules.
+- Missing private DNS zone link or resolver evidence for workloads expected to use the private endpoint.
+- Trusted-services bypass is enabled without documenting which Azure services need it.
+- Public network access is required for a managed service, but there is no scoped exception, owner, or compensating control.
 
 ---
 
@@ -704,3 +731,4 @@ resource "azurerm_linux_web_app" {
   }
 }
 ```
+


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `azure-review`
**Skill path:** `skills/cloud/azure-review/`

### What Was Wrong
The Key Vault checks covered recoverability, RBAC, and private endpoint presence, but did not require effective evidence for retention, purge protection exceptions, public network access, trusted-service bypass, private endpoint approval, or private DNS linkage.

Fixes #999.

### What This PR Fixes
- Adds Key Vault recovery evidence for Terraform, Bicep/ARM, Azure CLI/inventory, and exception records.
- Requires soft-delete retention and purge-protection evidence with production/high-value vault expectations.
- Adds private-access evidence for public network access, firewall/trusted-service exceptions, private endpoint approval, private DNS, and client path.
- Flags private endpoints that coexist with broad public access, missing DNS linkage, undocumented trusted-service bypass, and unscoped public exceptions.
- Updates the common pitfall to avoid treating private endpoint presence as private-only access.
- Bumps `azure-review` to v1.0.1.

### Validation
- Checked markdown fence balance for both edited files.
- Checked edited files remain ASCII-only.
- Checked Key Vault recovery/private-access markers are present.
- Cross-checked Microsoft Key Vault soft-delete, recovery, network security, and Private Link documentation.

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Payment details can be provided privately after maintainer acceptance.