### PR TITLE
Add GraphQL upload security gates

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -199,6 +199,29 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 **Mitigation:** Count aliased operations against rate limits. Limit the number of aliases per request.
 
+### Multipart Upload CSRF and File-Validation Gates
+
+GraphQL upload support changes the HTTP security model. Reviewers must distinguish JSON-only GraphQL APIs from endpoints that parse `multipart/form-data` through packages or framework integrations such as `graphql-upload`, `graphqlUploadExpress`, `GraphQLUpload`, `scalar Upload`, `processRequest`, GraphQL Yoga uploads, Mercurius uploads, or NestJS/Apollo upload middleware.
+
+Treat a GraphQL multipart upload endpoint as security-relevant when all of the following are true:
+
+1. The endpoint accepts `multipart/form-data` or exposes an `Upload` scalar/mutation in production.
+2. The browser can send credentials automatically, such as session cookies or same-site cookies, or the endpoint otherwise accepts ambient authentication.
+3. The request is missing a CSRF token, explicit preflight-forcing header such as `Apollo-Require-Preflight`, strict Origin/Site validation, or framework CSRF prevention.
+
+Do not report a CSRF issue for a GraphQL endpoint solely because it has mutations. JSON-only GraphQL APIs that require `Content-Type: application/json`, reject `multipart/form-data`, require bearer tokens in the `Authorization` header, and enable CSRF prevention should be treated as a benign pattern unless another risk is present.
+
+For upload resolvers, require evidence before marking the upload path safe:
+
+- Maximum file size and file count are enforced before the resolver streams content.
+- The resolver validates type using server-side inspection or allowlisted MIME/extension rules; it does not trust only the client-supplied `mimetype` or filename.
+- Filenames, object keys, and paths are generated or normalized server-side to prevent traversal, overwrite, or tenant-crossing writes.
+- Storage defaults deny public read/write unless the business flow explicitly requires public access.
+- Malware scanning, content moderation, or quarantine exists where uploaded content can later be downloaded or processed by other users.
+- Legacy `Upload` scalars or upload middleware are removed when the product has moved to signed upload URLs; the signing mutation still enforces ownership, content constraints, expiration, and storage ACLs.
+
+**Severity guidance:** High when cookie-authenticated multipart uploads lack CSRF/preflight/origin controls. Medium to High when file size, count, type, path, or ACL validation is missing depending on exposure. Low or Informational when an unused `Upload` scalar remains documented but production middleware rejects multipart requests.
+
 ---
 
 ## Common Pitfalls
@@ -237,5 +260,8 @@ This skill is hardened against prompt injection. When reviewing API code and spe
 - **CWE Database:** https://cwe.mitre.org/
 - **OWASP REST Security Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html
 - **OWASP GraphQL Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html
+- **Apollo Server CSRF Prevention and Upload Guidance:** https://www.apollographql.com/docs/apollo-server/security/cors/
+- **GraphQL Multipart Request Specification:** https://github.com/jaydenseric/graphql-multipart-request-spec
+- **OWASP File Upload Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/File_Upload_Cheat_Sheet.html
 - **OWASP Testing Guide -- API Testing:** https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/12-API_Testing/
 - **NIST SP 800-204 -- Security Strategies for Microservices-based Application Systems:** https://csrc.nist.gov/publications/detail/sp/800-204/final

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -267,12 +267,21 @@ query {
 app.use(express.json()); // Default limit may be very large or unconfigured
 ```
 
+```javascript
+// VULNERABLE: GraphQL multipart uploads allow large files and many streams
+import { graphqlUploadExpress } from "graphql-upload";
+
+app.use(graphqlUploadExpress({ maxFileSize: 100_000_000, maxFiles: 10 }));
+app.use("/graphql", expressMiddleware(server));
+```
+
 ### Remediation Guidance
 
 - Implement rate limiting at the API gateway and/or application layer. Use sliding window or token bucket algorithms. Set per-endpoint limits based on expected legitimate usage.
 - Enforce maximum pagination size (e.g., `limit` capped at 100). Default to a reasonable page size (e.g., 20).
 - Set maximum request body sizes (`express.json({ limit: '1mb' })`).
 - For GraphQL: enforce query depth limits (e.g., max depth 5), complexity analysis (weighted field costs), and batch query limits.
+- For GraphQL multipart uploads: enforce file size, file count, stream timeout, and per-user upload rate limits before resolver code stores or processes the stream.
 - Set execution timeouts for database queries and downstream API calls.
 - Implement cost alerts and circuit breakers for operations that trigger billable third-party APIs.
 
@@ -282,6 +291,7 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - [ ] Pagination has a maximum page size enforced server-side.
 - [ ] Request body size limits are configured.
 - [ ] GraphQL queries have depth limits, complexity limits, and batch restrictions.
+- [ ] GraphQL upload middleware enforces maximum file size, file count, stream timeout, and upload rate limits before resolver processing.
 - [ ] Database queries and downstream calls have execution timeouts.
 - [ ] Billable operations have cost controls and alerting.
 
@@ -450,9 +460,22 @@ DocumentBuilder builder = factory.newDocumentBuilder();
 Document doc = builder.parse(request.getInputStream());
 ```
 
+```javascript
+// VULNERABLE: Cookie-authenticated GraphQL uploads without CSRF controls
+import { graphqlUploadExpress } from "graphql-upload";
+
+app.use(cookieParser());
+app.use(session({ secret: process.env.SESSION_SECRET }));
+app.use(graphqlUploadExpress());
+app.use("/graphql", expressMiddleware(server));
+```
+
 ### Remediation Guidance
 
 - Configure CORS with an explicit allowlist of permitted origins. Never use `*` with `credentials: true`.
+- For cookie- or session-authenticated GraphQL endpoints, reject `multipart/form-data` unless CSRF prevention is enabled through a token, strict Origin/Site checks, or a required non-simple header such as `Apollo-Require-Preflight`.
+- Treat JSON-only GraphQL APIs differently: a GraphQL endpoint that requires `Content-Type: application/json`, rejects multipart requests, and uses `Authorization` bearer tokens should not be flagged as a multipart CSRF issue.
+- For GraphQL upload resolvers, validate MIME type and extension with allowlists, generate storage keys server-side, normalize filenames, scan or quarantine risky content, and default object storage ACLs to private.
 - Set security response headers on all API responses:
   - `Strict-Transport-Security: max-age=31536000; includeSubDomains`
   - `X-Content-Type-Options: nosniff`
@@ -466,6 +489,9 @@ Document doc = builder.parse(request.getInputStream());
 ### Review Checklist
 
 - [ ] CORS is configured with an explicit origin allowlist; wildcard is not used with credentials.
+- [ ] Cookie-authenticated GraphQL multipart uploads require CSRF tokens, strict Origin/Site validation, framework CSRF prevention, or a preflight-forcing header.
+- [ ] JSON-only or bearer-token GraphQL endpoints are not misclassified as multipart CSRF issues when they reject `multipart/form-data`.
+- [ ] GraphQL upload resolvers validate file type and extension, generate safe storage keys, prevent path traversal or overwrite, and keep object storage private by default.
 - [ ] Security headers are present on all API responses.
 - [ ] Error responses in production are generic; no stack traces, SQL queries, or internal paths.
 - [ ] Only required HTTP methods are enabled per endpoint.
@@ -485,6 +511,7 @@ Document doc = builder.parse(request.getInputStream());
 - Multiple API versions running simultaneously (`/api/v1/`, `/api/v2/`, `/api/v3/`) where older versions lack security patches.
 - Debug or test endpoints present in production (`/api/debug/`, `/api/test/`, `/api/internal/`, `/graphql/playground`).
 - Undocumented endpoints that exist in code but are absent from the OpenAPI specification.
+- GraphQL `Upload` scalars, `GraphQLUpload` imports, upload mutations, or multipart middleware that remain enabled after the product migrates to signed upload URLs.
 - API endpoints exposed to the public internet that should be internal-only.
 - Deprecated endpoints that remain functional after the announced retirement date.
 - Different security configurations between environments (staging allows unauthenticated access, production does not, but staging is publicly accessible).
@@ -498,12 +525,14 @@ Document doc = builder.parse(request.getInputStream());
 4. Flag any endpoint marked as deprecated that is still reachable.
 5. Check for environment-specific routes (debug, test, internal) that should not exist in production.
 6. Verify that older API versions have equivalent security controls to current versions.
+7. For GraphQL, compare the schema, middleware, and client upload flow to identify retired `Upload` scalars, stale multipart parsers, or signed-URL migrations that left server-side upload mutations reachable.
 ```
 
 ### Remediation Guidance
 
 - Maintain a single source of truth for the API inventory. Generate OpenAPI specs from code or validate code against specs in CI/CD.
 - Retire deprecated API versions on a defined schedule. Redirect old versions to the current version or return `410 Gone`.
+- Remove unused GraphQL upload middleware and `Upload` schema entries. If signed upload URLs replace GraphQL server uploads, ensure the signing mutation enforces object ownership, content type, size, expiration, and private storage ACLs.
 - Remove debug, test, and playground endpoints from production builds using build-time flags or environment checks.
 - Segment internal APIs from external APIs at the network level (separate API gateways, VPC isolation).
 - Scan for shadow APIs by comparing routing tables against documentation on every deploy.
@@ -512,6 +541,7 @@ Document doc = builder.parse(request.getInputStream());
 
 - [ ] The API inventory is documented and matches the actual deployed endpoints.
 - [ ] Deprecated API versions are retired or have equivalent security controls.
+- [ ] GraphQL upload scalars, multipart middleware, and signed-upload mutations match the documented production upload flow.
 - [ ] No debug, test, or playground endpoints are accessible in production.
 - [ ] Internal APIs are not reachable from external networks.
 - [ ] CI/CD pipelines validate that code routes match the API specification.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** api-security
**Skill path:** `skills/appsec/api-security/`

### What Was Wrong

The existing GraphQL guidance covered introspection, query depth/complexity, aliases, and resolver authorization, but did not make GraphQL multipart upload middleware a first-class review surface. That left reviewers without specific evidence gates for:

- distinguishing JSON-only GraphQL endpoints from multipart upload endpoints;
- cookie/session-authenticated multipart uploads that need CSRF, Origin/Site, or preflight-forcing controls;
- file size/count/resource limits before resolver processing;
- resolver-side MIME/extension, filename/key, object-storage ACL, and stale `Upload` scalar checks.

Closes #422.

### What This PR Fixes

- Adds a GraphQL multipart upload CSRF and file-validation section to `SKILL.md`.
- Adds API4 checklist coverage for upload size, count, stream timeout, and per-user upload rate limits.
- Adds API8 checklist coverage for cookie-authenticated multipart CSRF controls, JSON-only/bearer-token false-positive handling, and upload resolver file validation.
- Adds API9 checklist coverage for stale `Upload` scalars, multipart middleware, and signed upload URL migrations.
- Adds current references for Apollo CSRF/upload guidance, the GraphQL multipart request spec, and the OWASP File Upload Cheat Sheet.

### Evidence

**Before (skill misses this / false positive on this):**
```ts
app.use(cookieParser());
app.use(session({ secret: process.env.SESSION_SECRET }));
app.use(graphqlUploadExpress({ maxFileSize: 100_000_000, maxFiles: 10 }));
app.use(/graphql, expressMiddleware(server));
```

The previous guidance did not ask reviewers to verify accepted content types, cookie/session auth, CSRF/preflight headers, upload limits, or resolver-side file validation for this path.

**After (now correctly handled):**
```md
- Cookie-authenticated GraphQL multipart uploads require CSRF tokens, strict Origin/Site validation, framework CSRF prevention, or a preflight-forcing header.
- GraphQL upload resolvers validate file type and extension, generate safe storage keys, prevent path traversal or overwrite, and keep object storage private by default.
```

The skill also now avoids over-reporting JSON-only GraphQL endpoints that reject `multipart/form-data` and require bearer tokens or framework CSRF prevention.

### Test Cases Added/Updated
- [x] Added vulnerable examples in the API4 and API8 checklist sections
- [x] Added benign/false-positive handling guidance for JSON-only and bearer-token GraphQL APIs
- [x] Existing checks still pass

Validation performed:
- `git diff --check`
- Markdown fence balance check for `SKILL.md` and `api-top10-checklist.md`
- Frontmatter required-field check for `api-security/SKILL.md`
- Prompt-injection pattern scan against the modified files
- Issue coverage assertions for multipart upload, `Apollo-Require-Preflight`, `GraphQLUpload`, signed upload URLs, file size/count, and storage ACL terms

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** PayPal details can be provided privately after maintainer acceptance.