### PR TITLE
Improve Azure Key Vault recovery and private access evidence

### DIFF
--- a/skills/cloud/azure-review/SKILL.md
+++ b/skills/cloud/azure-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-Azure-v2.1.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -182,7 +182,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | 5 | Logging and Monitoring | Diagnostic settings, activity log alerts (policy, NSG, SQL firewall, public IP), Key Vault logging, Network Watcher |
 | 6 | Networking | NSG rules (RDP, SSH, UDP, HTTP), flow log retention, traffic analytics |
 | 7 | Virtual Machines | Azure Bastion, managed disks, disk encryption with CMK, approved extensions, endpoint protection |
-| 8 | Key Vault | Key/secret expiration, soft delete, purge protection, RBAC authorization, private endpoints |
+| 8 | Key Vault | Key/secret expiration, soft delete retention, purge protection, RBAC authorization, public network access, firewall exceptions, private endpoints, private DNS linkage |
 | 9 | App Service | Authentication, HTTPS redirect, TLS version, client certificates, Entra ID registration, HTTP/2, FTP disabled |
 
 ### CIS Profile Levels
@@ -199,7 +199,8 @@ Produce the final report using the structure defined in the Output Format sectio
 3. **Overlooking `allow_nested_items_to_be_public` on storage accounts.** CIS 3.7 checks the account-level setting, not individual container access levels. The account setting must be `false` to prevent any container from being public.
 4. **NSG rules using service tags.** A rule with `source_address_prefix = "Internet"` is equivalent to `0.0.0.0/0`. Both must be flagged for CIS 6.1 and 6.2.
 5. **Key Vault purge protection is irreversible.** CIS 8.5 requires `purge_protection_enabled = true`. Note this cannot be disabled once enabled -- flag this for awareness during remediation.
-6. **App Service TLS version on both Linux and Windows.** Check `azurerm_linux_web_app` and `azurerm_windows_web_app` resources separately.
+6. **Key Vault private endpoints without effective private-only access.** Do not treat a private endpoint resource as sufficient by itself. Also verify public network access state, firewall or trusted-service exceptions, approved private endpoint connection status, private DNS zone linkage for `privatelink.vaultcore.azure.net`, and client network path evidence. If those artifacts are missing, mark the Key Vault network finding **Not Evaluable** instead of passing it.
+7. **App Service TLS version on both Linux and Windows.** Check `azurerm_linux_web_app` and `azurerm_windows_web_app` resources separately.
 
 ---
 
@@ -224,6 +225,10 @@ Produce the final report using the structure defined in the Output Format sectio
 - Microsoft Entra ID Security: https://learn.microsoft.com/en-us/entra/identity/
 - Azure Storage Security: https://learn.microsoft.com/en-us/azure/storage/common/storage-security-guide
 - Azure Key Vault Best Practices: https://learn.microsoft.com/en-us/azure/key-vault/general/best-practices
+- Azure Key Vault Soft Delete Overview: https://learn.microsoft.com/en-us/azure/key-vault/general/soft-delete-change
+- Azure Key Vault Recovery Management: https://learn.microsoft.com/en-us/azure/key-vault/general/key-vault-recovery
+- Azure Key Vault Network Security: https://learn.microsoft.com/en-us/azure/key-vault/general/how-to-azure-key-vault-network-security
+- Azure Key Vault Private Link: https://learn.microsoft.com/en-us/azure/key-vault/general/private-link-service
 - Azure App Service Security: https://learn.microsoft.com/en-us/azure/app-service/overview-security
 - Terraform AzureRM Provider Documentation: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
 
@@ -231,4 +236,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Added Key Vault effective recovery and private-access evidence gates covering soft-delete retention, purge protection, public network access, firewall exceptions, private endpoint approval, private DNS linkage, and CLI or inventory evidence.
 - **1.0.0** -- Initial release. Full coverage of CIS Microsoft Azure Foundations Benchmark v2.1.0 sections 1 through 9.

--- a/skills/cloud/azure-review/benchmark-checklist.md
+++ b/skills/cloud/azure-review/benchmark-checklist.md
@@ -600,14 +600,31 @@ Same check for classic access policy-based Key Vaults.
 
 ### CIS 8.5 -- Ensure that the Key Vault is Recoverable
 
-**Critical check -- enable soft delete and purge protection:**
+**Critical check -- verify effective recovery controls, not just resource presence:**
 
 ```hcl
 resource "azurerm_key_vault" {
-  soft_delete_retention_days = 90
+  soft_delete_retention_days = 90    # Prefer 90 days for production/high-value vaults
   purge_protection_enabled   = true  # Must be true
 }
 ```
+
+Required evidence:
+
+- `soft_delete_retention_days` is set and appropriate for the vault's business criticality. Treat missing retention evidence from imported or existing vaults as **Not Evaluable** until Azure CLI, ARM export, or inventory evidence confirms the effective value.
+- `purge_protection_enabled = true` for production, customer-managed-key, and high-value vaults. If purge protection is disabled, classify as **High** unless the vault is demonstrably non-production with documented compensating controls and accepted recovery risk.
+- Rollout impact is documented because purge protection is irreversible after enablement.
+- Existing/imported vaults are checked with runtime evidence such as `az keyvault show --query "{softDeleteRetentionInDays:properties.softDeleteRetentionInDays, enablePurgeProtection:properties.enablePurgeProtection}"` or equivalent inventory export. Do not rely only on new IaC defaults.
+
+Flag as **Fail** when:
+
+- Purge protection is disabled or absent for a production/high-value vault.
+- Retention is minimal, for example 7 days, without environment classification and risk acceptance.
+- Review evidence only shows soft delete, but does not confirm purge protection.
+
+Treat as **Not Evaluable** when:
+
+- The vault exists outside the submitted IaC and no CLI, ARM, Bicep, Terraform import, or inventory output confirms the effective retention and purge-protection state.
 
 ### CIS 8.6 -- Enable Role Based Access Control for Azure Key Vault
 
@@ -619,7 +636,7 @@ resource "azurerm_key_vault" {
 
 ### CIS 8.7 -- Ensure that Private Endpoints are used for Azure Key Vault
 
-Check for private endpoint connections to Key Vault:
+Check for private endpoint connections to Key Vault, and verify they create effective private-only access:
 
 ```hcl
 resource "azurerm_private_endpoint" {
@@ -629,6 +646,50 @@ resource "azurerm_private_endpoint" {
   }
 }
 ```
+
+Do not pass this control from private endpoint creation alone. Require evidence for the full access path:
+
+```hcl
+resource "azurerm_key_vault" "prod" {
+  public_network_access_enabled = false
+  network_acls {
+    default_action = "Deny"
+    bypass         = "AzureServices" # Only when scoped and justified
+  }
+}
+
+resource "azurerm_private_dns_zone" "kv" {
+  name = "privatelink.vaultcore.azure.net"
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "kv" {
+  private_dns_zone_name = azurerm_private_dns_zone.kv.name
+  virtual_network_id    = azurerm_virtual_network.prod.id
+}
+```
+
+Required evidence:
+
+- `public_network_access_enabled = false`, or firewall/network ACL evidence showing `default_action = "Deny"` with only documented service-scope exceptions.
+- Trusted-service or public-network exceptions include the exact service scope, business reason, owner, expiry or review cadence, and compensating controls. A broad exception without this context is a finding.
+- The private endpoint targets the same vault under review, uses `subresource_names = ["vault"]`, and is approved, not pending, rejected, or disconnected. For live reviews, confirm with `az network private-endpoint-connection list` or resource inventory evidence.
+- Private DNS for `privatelink.vaultcore.azure.net` exists and is linked to every client VNet that should resolve the vault privately. For custom DNS, require resolver or conditional-forwarder evidence proving private resolution.
+- Client path evidence shows workloads reach the vault through the private endpoint path, for example VNet/subnet membership, hub-spoke routing, private resolver configuration, or test output resolving to the private endpoint IP.
+- Terraform, Bicep, ARM, Azure CLI, and inventory evidence are all acceptable, but the finding must state which evidence source was reviewed.
+
+Flag as **Fail** when:
+
+- A private endpoint exists but `public_network_access_enabled = true` and no restrictive firewall rules or documented exception scope are present.
+- Private DNS zone linkage is absent for client VNets, making public endpoint resolution likely.
+- Private endpoint connection status is not approved.
+- The private endpoint exists for another vault, another subresource, or an unrelated subscription/resource group.
+
+Treat as **Not Evaluable** when:
+
+- IaC shows a private endpoint but omits public network access state, firewall rules, private DNS linkage, or endpoint approval status.
+- Managed services require public or trusted-service access and the review cannot determine the actual service exception scope.
+
+Report output must include these Key Vault fields when applicable: `soft_delete_retention_days`, `purge_protection_enabled`, `public_network_access_enabled`, firewall default action, trusted-service exceptions, private endpoint connection state, private DNS zone/link evidence, client network path evidence, and evidence source.
 
 ---
 


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

/claim #999

### Skill Modified
**Skill name:** `azure-review`
**Skill path:** `skills/cloud/azure-review/`

### What Was Wrong
The Key Vault checks covered basic recoverability and private endpoint presence, but they did not require reviewers to prove effective recovery and private-only access. That leaves false positives where a vault has a private endpoint but still allows public access, lacks private DNS linkage, has pending endpoint approval, or has purge protection disabled on a production/high-value vault.

Fixes #999.

### What This PR Fixes
- Requires effective recovery evidence for `soft_delete_retention_days`, purge protection, imported/existing vault inventory, and rollout impact.
- Adds fail and Not Evaluable handling for missing retention, disabled purge protection, and IaC that omits live recovery state.
- Expands private-access evidence beyond endpoint creation to public network access, firewall default action, trusted-service exceptions, endpoint approval, private DNS zone/VNet linkage, and client path evidence.
- Adds explicit output fields so reports capture recovery, network, DNS, endpoint state, and evidence source.
- Updates the main skill version, Section 8 scope, common pitfalls, Microsoft Key Vault references, and changelog.

### Validation
- `git diff --check`
- Markdown fence balance check for both edited files
- ASCII-only scan for both edited files
- Required marker checks for `public_network_access_enabled`, `privatelink.vaultcore.azure.net`, `private endpoint connection state`, `Not Evaluable`, and `Azure Key Vault Private Link`
- Live Microsoft reference checks returned HTTP 200 for Key Vault soft-delete, recovery management, network security, and Private Link documentation

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Payment details can be provided privately after maintainer acceptance.