### PR TITLE
Improve AI data privacy vector deletion gates

### DIFF
--- a/skills/ai-security/ai-data-privacy/SKILL.md
+++ b/skills/ai-security/ai-data-privacy/SKILL.md
@@ -13,7 +13,7 @@ phase: [design, build, review, operate]
 frameworks: [NIST-AI-RMF-1.0, OWASP-LLM02-2025]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -76,6 +76,9 @@ Before beginning the assessment, gather the following. If any item is unavailabl
 | Data processing agreements (DPAs) | Legal/compliance documentation | Establishes legal basis for data processing |
 | Privacy policy | Public-facing policy documents | Defines commitments to users about data handling |
 | Data retention policies | Internal governance docs, code configs | Determines how long AI-processed data persists |
+| Derived AI data inventory | Vector database schema, chunk manifests, embedding pipelines, cache configuration | Shows where source personal data may persist after AI ingestion |
+| Retrieval authorization model | RAG service code, middleware, ACL service, tenant filters | Proves whether current access checks protect retrieved content |
+| Deletion job and audit evidence | Erasure workers, tombstone tables, queue logs, reindex jobs | Confirms deletion propagates to embeddings, caches, replicas, and audit records |
 | Logging configuration | Application code, infrastructure configs | Reveals what prompt/completion data is captured |
 | Training/fine-tuning data documentation | Data pipeline docs, dataset cards | Identifies personal data in training corpus |
 | Consent management implementation | Frontend code, API code, database schemas | Shows how user consent is captured and enforced |
@@ -248,7 +251,9 @@ For each source document or data subject deletion path, require evidence that de
 | Retrieval metadata and ACL index | Current entitlement, group, tenant, and document ACL state is refreshed or invalidated | Retrieval uses stale ingest-time ACL metadata |
 | Prompt/reranker caches | Cached contexts and reranker results are invalidated for deleted sources | Deleted source text can still appear from cache |
 | Analytics/evaluation copies | Derived datasets have retention limits and deletion handling | Evaluation copies retain personal data indefinitely |
-| Backups/replicas | Restore window and replica propagation are documented | Replicas remain active retrieval surfaces after deletion |
+| Backups and snapshots | Restore window, access restrictions, purge deadline, and re-delete-on-restore behavior are documented | Restored data can return to active retrieval after deletion |
+| Regional replicas | Region list, propagation state, lag SLA, and failed-region escalation path are documented | A replica remains an active retrieval surface after deletion |
+| Not Evaluable reason | Missing vector schema, opaque managed vector service, unavailable queue logs, or missing backup policy is recorded | Reviewer silently treats missing evidence as passing |
 
 **Retrieval Authorization Evidence:**
 
@@ -261,6 +266,7 @@ Required evidence:
 - Group, role, and entitlement changes invalidate or refresh vector metadata before old documents can be retrieved.
 - Multi-tenant stores use namespace or partition controls plus explicit authorization filters; do not rely on namespace alone.
 - The report records `Not Evaluable` when the reviewer cannot trace the source document ID to chunk IDs and vector IDs.
+- Negative tests prove cross-tenant, revoked-user, and deleted-document retrieval fails closed instead of returning unfiltered matches.
 
 **What constitutes a finding:**
 
@@ -457,9 +463,25 @@ user input -> prompt assembly -> LLM API -> completion -> output -> logging/stor
 - **Location:** [file path, configuration, or architectural component]
 - **Description:** [What the privacy risk is and why it matters]
 - **Evidence:** [Code pattern, configuration, or architectural observation]
+- **Derived AI data affected:** [source document, chunks, embeddings, caches, backups, replicas, analytics]
+- **Deletion propagation status:** [complete / partial / missing / Not Evaluable, with tombstone, queue job, or audit evidence]
+- **Retrieval authorization evidence:** [tenant filter, user/document ACL, source-of-truth check, fail-closed behavior, negative test]
+- **Stale exposure window:** [maximum time deleted or unauthorized data remains actively retrievable]
 - **Impact:** [What personal data is at risk and for how many data subjects]
 - **Recommendation:** [Specific remediation with regulatory alignment]
 - **Priority:** [P0 / P1 / P2 / P3]
+
+## Vector Deletion Propagation Matrix
+
+| Source ID | Tenant | Chunks | Embeddings | Caches | Backups | Replicas | Tombstone/Job | Result |
+|---|---|---|---|---|---|---|---|---|
+| [doc-123] | [tenant-a] | [deleted/tombstoned] | [delete count or filter] | [invalidated] | [restore window] | [region status] | [job-id] | [Pass/Fail/Not Evaluable] |
+
+## Retrieval Authorization Evidence
+
+| Query Path | Tenant Filter | User/Document ACL | Source-of-Truth Check | Fail Closed | Negative Test |
+|---|---|---|---|---|---|
+| [rag/search endpoint] | [field/namespace] | [policy/service] | [yes/no] | [yes/no] | [pass/fail/Not Evaluable] |
 
 ## Privacy Control Summary
 
@@ -511,6 +533,10 @@ user input -> prompt assembly -> LLM API -> completion -> output -> logging/stor
 4. **Conflating data minimization with data deletion.** Data minimization (collecting only what is necessary) is a design-time principle. Data deletion (removing data when it is no longer needed or when a subject requests erasure) is an operational requirement. Both are needed. Many teams implement minimization at the application layer but fail to propagate deletion to downstream AI data stores (vector databases, training dataset snapshots, model checkpoints, conversation logs, analytics pipelines).
 
 5. **Ignoring model memorization as a privacy risk.** Organizations that use pre-trained or fine-tuned models often do not test for memorization of personal data. A model that has memorized PII from its training corpus is effectively a data store containing personal data -- it can reproduce that data on specific prompts. This has regulatory implications: if the model contains memorized PII of EU residents, GDPR obligations apply to the model weights themselves, not just the training dataset.
+
+6. **Trusting ingest-time retrieval metadata after access changes.** RAG systems often stamp tenant or ACL metadata at ingestion and later assume it is still correct. Query-time retrieval must check the current source of truth because group membership, subscriptions, document entitlements, consent, and deletion state can change after embeddings are created.
+
+7. **Deleting the source row while leaving active derived stores.** Source deletion is incomplete if chunks, embeddings, reranker caches, prompt caches, analytics copies, backups, or regional replicas can still return or reconstruct personal data. Require propagation evidence, tombstone or job IDs, and stale-retrieval tests.
 
 ---
 

--- a/skills/ai-security/ai-data-privacy/SKILL.md
+++ b/skills/ai-security/ai-data-privacy/SKILL.md
@@ -145,6 +145,7 @@ Assess whether personal data is exposed, leaked, or inadequately protected in th
 - System prompts that contain PII (customer names, account numbers, internal user data hardcoded for testing or personalization).
 - Model completions returned to users without PII scanning -- the model may reproduce PII from its context or generate plausible PII from memorized training data.
 - PII transmitted to third-party LLM APIs where the provider's data handling terms are unclear or insufficient.
+- RAG vector retrieval that relies only on ingest-time metadata rather than rechecking the current user's tenant, document ACL, consent state, and source-system authorization at query time.
 
 **Detection methods using allowed tools:**
 
@@ -162,6 +163,8 @@ Grep: "openai|anthropic|api.key|azure.openai|bedrock|vertex.ai|cohere|mistral" i
 
 # Check for access control in RAG retrieval
 Grep: "metadata_filter|access_control|permission|authorization|tenant" in **/*.{py,ts,js}
+Grep: "vector.search|similarity_search|query_vector|topK|namespace|where|filter" in **/*.{py,ts,js}
+Grep: "document_acl|source_document|entitlement|group_membership|tenant_id" in **/*.{py,ts,js,yaml,yml,json}
 ```
 
 **Model memorization risk:** LLMs can memorize and reproduce training data, including PII. Research by Carlini et al. (2021, 2023) demonstrated that GPT-2 and GPT-3 could be prompted to emit memorized training data including names, phone numbers, email addresses, and physical addresses. The risk is proportional to data frequency in training (repeated PII is more likely to be memorized) and inversely proportional to model size diversity (smaller fine-tuned models on narrow datasets memorize more). For fine-tuned models, this risk is especially acute -- the fine-tuning data is typically smaller and more repetitive than pre-training data, increasing memorization likelihood.
@@ -193,6 +196,8 @@ Assess whether AI-specific data stores have appropriate retention policies, dele
 - User session data (conversation history, context) persisted beyond the session without user consent or retention policy.
 - Backup systems that retain AI data beyond the primary store's retention period, undermining deletion compliance.
 - Audit logs containing full prompt/completion text retained longer than necessary.
+- Source document deletion handlers that do not also delete or tombstone derived chunks, embeddings, vector-store rows, retrieval metadata, prompt caches, reranker caches, analytics copies, and regional replicas.
+- Vector-store delete calls that are not scoped by source document ID, tenant ID, and current authorization state.
 
 **Detection methods using allowed tools:**
 
@@ -213,6 +218,11 @@ Grep: "log_prompt|log_completion|log_conversation|log_message|prompt_log|chat_lo
 # Check backup configurations
 Glob: **/backup*.{py,sh,yaml,yml}
 Grep: "backup|snapshot|archive" in **/*.{yaml,yml,json,toml}
+
+# Check deletion propagation to derived AI stores
+Grep: "delete|deleteMany|remove|purge|tombstone|reindex|invalidate" in **/*.{py,ts,js}
+Grep: "chunk_id|chunk_ids|vector_id|vector_ids|embedding_id|source_document_id|document_id" in **/*.{py,ts,js,yaml,yml,json}
+Grep: "vector_store|vectordb|embedding|rerank|prompt_cache|retrieval_cache" in **/*.{py,ts,js,yaml,yml,json}
 ```
 
 **AI-specific retention considerations:**
@@ -226,6 +236,32 @@ Grep: "backup|snapshot|archive" in **/*.{yaml,yml,json,toml}
 | RAG source documents | Original documents with full content including PII | Align retention with document source system; propagate deletions to vector store |
 | Evaluation/test datasets | May contain real user data used for testing | Anonymize or use synthetic data; apply same retention as production data |
 
+**Vector Store Deletion Propagation Evidence:**
+
+For each source document or data subject deletion path, require evidence that deletion propagates through all derived AI retrieval stores. Do not treat source-row deletion as sufficient by itself.
+
+| Derived Store | Evidence Required | Finding Trigger |
+|---|---|---|
+| Source document row | Source delete or tombstone event includes tenant and document identity | Delete path lacks tenant or document scope |
+| Chunk manifest | Chunk IDs linked to the source document are deleted, tombstoned, or excluded from retrieval | Chunks persist after source deletion |
+| Embedding/vector rows | Vector IDs are deleted or filtered by source document and tenant | Embeddings persist and remain queryable |
+| Retrieval metadata and ACL index | Current entitlement, group, tenant, and document ACL state is refreshed or invalidated | Retrieval uses stale ingest-time ACL metadata |
+| Prompt/reranker caches | Cached contexts and reranker results are invalidated for deleted sources | Deleted source text can still appear from cache |
+| Analytics/evaluation copies | Derived datasets have retention limits and deletion handling | Evaluation copies retain personal data indefinitely |
+| Backups/replicas | Restore window and replica propagation are documented | Replicas remain active retrieval surfaces after deletion |
+
+**Retrieval Authorization Evidence:**
+
+For every RAG retrieval path, verify that vector queries enforce source-of-truth authorization at query time. A static tenant namespace is not enough when document entitlements, group memberships, consent, subscriptions, or deletion state can change after ingestion.
+
+Required evidence:
+
+- Query filters include tenant, user or service identity, source document ID or ACL handle, and deletion/tombstone state.
+- Retrieval joins or checks the current authorization source before returning source text or chunks to the prompt.
+- Group, role, and entitlement changes invalidate or refresh vector metadata before old documents can be retrieved.
+- Multi-tenant stores use namespace or partition controls plus explicit authorization filters; do not rely on namespace alone.
+- The report records `Not Evaluable` when the reviewer cannot trace the source document ID to chunk IDs and vector IDs.
+
 **What constitutes a finding:**
 
 | Condition | Severity |
@@ -233,6 +269,8 @@ Grep: "backup|snapshot|archive" in **/*.{yaml,yml,json,toml}
 | No retention policy defined for conversation logs containing PII | High |
 | Vector store accumulates data indefinitely with no lifecycle management | High |
 | Deletion requests cannot be propagated to vector stores (embeddings persist after source deletion) | High |
+| RAG retrieval returns chunks without query-time tenant, document ACL, and deletion-state enforcement | High |
+| Source deletion removes the document but leaves chunks, embeddings, caches, or retrieval metadata queryable | High |
 | Fine-tuning datasets with PII retained without justification or retention period | Medium |
 | Backup systems retain AI data beyond primary retention period | Medium |
 | No automated purge mechanism for expired AI data | Medium |
@@ -430,6 +468,8 @@ user input -> prompt assembly -> LLM API -> completion -> output -> logging/stor
 | Training data privacy | [Yes/Partial/No] | [description] | [severity] |
 | PII in prompts/completions | [Yes/Partial/No] | [description] | [severity] |
 | Data retention | [Yes/Partial/No] | [description] | [severity] |
+| Vector deletion propagation | [Yes/Partial/No/Not Evaluable] | [description] | [severity] |
+| RAG retrieval authorization | [Yes/Partial/No/Not Evaluable] | [description] | [severity] |
 | Memorization risk | [Yes/Partial/No] | [description] | [severity] |
 | EU AI Act compliance | [Yes/Partial/No/N/A] | [description] | [severity] |
 | Consent management | [Yes/Partial/No] | [description] | [severity] |

--- a/skills/ai-security/ai-data-privacy/tests/benign/rag-vector-delete-propagated.ts
+++ b/skills/ai-security/ai-data-privacy/tests/benign/rag-vector-delete-propagated.ts
@@ -1,0 +1,20 @@
+async function deleteDocument(documentId: string, tenantId: string) {
+  await sourceDocuments.delete({ where: { id: documentId, tenantId } });
+  await chunkManifest.deleteMany({ where: { sourceDocumentId: documentId, tenantId } });
+  await vectorStore.delete({ filter: { source_document_id: documentId, tenant_id: tenantId } });
+  await promptCache.invalidate({ sourceDocumentId: documentId, tenantId });
+}
+
+async function retrieveContext(queryEmbedding: number[], userId: string, tenantId: string) {
+  const allowedDocumentIds = await authorizationService.allowedDocumentIds(userId, tenantId);
+
+  return vectorStore.query({
+    vector: queryEmbedding,
+    topK: 8,
+    filter: {
+      tenant_id: tenantId,
+      source_document_id: { $in: allowedDocumentIds },
+      deleted_at: null,
+    },
+  });
+}

--- a/skills/ai-security/ai-data-privacy/tests/vulnerable/rag-vector-delete-missing.ts
+++ b/skills/ai-security/ai-data-privacy/tests/vulnerable/rag-vector-delete-missing.ts
@@ -1,0 +1,10 @@
+async function deleteDocument(documentId: string, tenantId: string) {
+  await sourceDocuments.delete({ where: { id: documentId, tenantId } });
+  // Missing: chunk manifest, vector rows, prompt cache, and retrieval metadata
+  // remain queryable for this source document.
+}
+
+async function retrieveContext(queryEmbedding: number[]) {
+  const matches = await vectorStore.query({ vector: queryEmbedding, topK: 8 });
+  return matches.map((match) => match.metadata.text);
+}


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** ai-data-privacy
**Skill path:** `skills/ai-security/ai-data-privacy/`

### What Was Wrong

The skill already recognized that vector stores and embeddings are privacy-relevant, but it did not force reviewers to prove that source document deletion propagates through derived AI retrieval stores, or that RAG retrieval rechecks current authorization at query time.

That can miss two common privacy failures:

- Source document deletion removes the primary row while chunks, embeddings, prompt caches, or retrieval metadata remain queryable.
- Vector retrieval trusts ingest-time tenant metadata instead of checking current tenant, document ACL, entitlement, and deletion state before returning source text.

### What This PR Fixes

- Adds explicit vector-store deletion propagation evidence requirements.
- Adds query-time RAG retrieval authorization evidence requirements.
- Adds derived-AI-data inventory context requirements for vector schemas, chunk manifests, embedding pipelines, caches, deletion jobs, and retrieval authorization models.
- Adds a vector deletion propagation matrix and retrieval authorization evidence table to the report output.
- Adds finding triggers for stale embeddings, caches, chunks, retrieval metadata, and missing tenant/document ACL/deletion-state enforcement.
- Adds output fields for affected derived AI data, deletion propagation status, retrieval authorization evidence, and stale exposure window.
- Adds one vulnerable and one benign TypeScript fixture showing the missed case and the expected safe pattern.

Addresses #1004.

### Evidence

**Before (skill misses this / false positive on this):**
```ts
async function deleteDocument(documentId: string, tenantId: string) {
  await sourceDocuments.delete({ where: { id: documentId, tenantId } });
  // Chunks, embeddings, prompt cache, and retrieval metadata remain queryable.
}

async function retrieveContext(queryEmbedding: number[]) {
  const matches = await vectorStore.query({ vector: queryEmbedding, topK: 8 });
  return matches.map((match) => match.metadata.text);
}
```

**After (now correctly handled):**
```ts
await vectorStore.delete({
  filter: { source_document_id: documentId, tenant_id: tenantId }
});

const allowedDocumentIds = await authorizationService.allowedDocumentIds(userId, tenantId);
await vectorStore.query({
  vector: queryEmbedding,
  topK: 8,
  filter: {
    tenant_id: tenantId,
    source_document_id: { $in: allowedDocumentIds },
    deleted_at: null,
  },
});
```

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Added report matrix/output-field coverage for deletion propagation and retrieval authorization evidence
- [x] Existing tests still pass

### Bounty Tier
- [ ] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** GitHub Sponsors

## Pull Request Checklist

- [x] Skill follows the format specification in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] At least one real framework is cited with correct control IDs
- [x] All framework references verified against primary sources
- [x] Prompt Injection Safety Notice section included
- [x] `injection-hardened: true` set in frontmatter
- [x] `allowed-tools` scoped to minimum necessary permissions
- [x] Tested with at least one AI coding agent: Codex
- [x] No prohibited patterns per [SECURITY.md](../SECURITY.md)
- [x] `index.yaml` updated with new skill entry (not applicable; existing skill only)

## What This PR Does

Improves `ai-data-privacy` so reviewers assess derived vector stores and RAG retrieval authorization as first-class privacy controls, not just generic retention keywords.

Follow-up hardening added on the same branch: version `1.1.0`, derived AI data inventory context, backup/replica/Not Evaluable propagation evidence, negative-test evidence, and report tables for the propagation matrix and retrieval authorization.

## Framework References

- NIST AI RMF 1.0 MAP 5.1 and MEASURE 2.9
- OWASP LLM02:2025 Sensitive Information Disclosure
- GDPR Article 17 right to erasure

## Testing

- `rg -n "Vector Store Deletion Propagation|Retrieval Authorization Evidence|source-of-truth authorization|vector_ids|chunk_ids|tombstone|reindex job" skills/ai-security/ai-data-privacy/SKILL.md`
- `rg -n "Vector Deletion Propagation Matrix|Stale exposure window|Negative Test|Derived AI data affected" skills/ai-security/ai-data-privacy/SKILL.md`
- `rg -n "version: \"1\\.1\\.0\"|Derived AI data inventory|Regional replicas|Not Evaluable reason|stale-retrieval tests" skills/ai-security/ai-data-privacy/SKILL.md`
- `rg -n "vectorStore\\.delete|allowedDocumentIds|source_document_id|deleted_at" skills/ai-security/ai-data-privacy/tests`
- Local equivalent of `.github/workflows/lint-skills.yml` frontmatter check
- `git diff --check`
