### PR TITLE
Improve API GraphQL batching and JWT confusion gates

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -11,7 +11,7 @@ phase: [design, build, review]
 frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -92,7 +92,7 @@ The final review output must be structured as follows:
 **API Style:** [REST / GraphQL / gRPC / Hybrid]
 **Specification:** [OpenAPI spec path, if applicable]
 **Date:** [review date]
-**Reviewer:** AI Agent -- api-security skill v1.0.0
+**Reviewer:** AI Agent -- api-security skill v1.0.1
 
 ### Summary
 
@@ -181,6 +181,42 @@ Deeply nested or highly complex queries can exhaust server resources (API4:2023)
 - **Query complexity scoring** -- assign cost weights to fields and reject queries exceeding a threshold.
 - **Batch query limits** -- restrict the number of queries in a single request (query batching/aliasing).
 
+### GraphQL Batch Execution and Alias Abuse
+
+GraphQL batching can turn one HTTP request into many resolver executions. Reviewers must prove that the server counts every operation, alias, and mutation attempt against abuse controls instead of applying limits only once per HTTP request.
+
+**Evidence required:**
+- Maximum operations per request, including array-style batching and multipart GraphQL uploads.
+- Alias count limits for sensitive fields such as `login`, password reset, invitation, checkout, search, and export operations.
+- Per-operation rate-limit accounting that records the caller, operation name, field name, and resolver cost.
+- Mutation batching policy: either disabled for sensitive mutations or capped with transaction/rollback behavior documented.
+- Error handling that fails closed when the query parser, cost analyzer, or rate-limit backend is unavailable.
+
+**Finding trigger:** report API4/API6 when a single GraphQL request can submit many credential attempts, expensive searches, exports, or state-changing mutations while consuming only one gateway request quota.
+
+#### GraphQL Batch Execution Abuse Matrix
+
+| Control | Required Evidence | Finding When Missing |
+|---|---|---|
+| Batch array cap | Maximum number of operations accepted in a JSON array request | Unbounded batched operations per request |
+| Alias cap | Parser or validation rule limiting aliases per operation | Alias-based brute force or business-flow abuse |
+| Resolver cost accounting | Per-field or per-operation cost charged to caller quota | Expensive resolvers bypass HTTP-level rate limits |
+| Sensitive mutation policy | Sensitive mutations cannot be batched or are transactionally capped | Bulk account/payment/state changes in one request |
+| Failure mode | Parser/cost/rate-limit failures reject or degrade safely | Limits silently disabled during analyzer errors |
+
+### JWT Algorithm Confusion Evidence
+
+JWT checks must reject algorithm confusion instead of trusting `alg` from the token header. This is especially important for APIs that accept both first-party and third-party identity providers, or both symmetric and asymmetric algorithms.
+
+**Evidence required:**
+- Algorithm allowlist evidence for each token issuer and audience.
+- Key-type binding evidence: RSA/ECDSA public keys are never reused as HMAC secrets.
+- Explicit rejection of `none`, unexpected `HS*`/`RS*` swaps, `jku`/`x5u` untrusted key URLs, and unknown `kid` values.
+- Issuer, audience, expiration, not-before, and clock-skew checks.
+- Negative-test evidence for `alg:none`, HS256-with-public-key, mismatched issuer/audience, expired tokens, and unknown key IDs.
+
+**Finding trigger:** report API2 when JWT validation accepts the token's requested algorithm dynamically, permits multiple algorithm families for one issuer without key binding, disables signature checks, or fetches verification keys from attacker-controlled header URLs.
+
 ### Field-Level Authorization
 
 Unlike REST, where authorization can be enforced per endpoint, GraphQL requires authorization at the resolver level. Every resolver that returns sensitive data or performs a privileged mutation must independently verify permissions.
@@ -209,11 +245,15 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 3. **Treating GraphQL as inherently different from REST for security.** GraphQL shares all the same authorization, authentication, and injection risks as REST. The query language adds additional concerns (depth attacks, introspection, alias abuse) but does not eliminate any REST security requirements.
 
-4. **Testing only documented endpoints.** Shadow APIs -- endpoints that exist in code but are absent from documentation -- are among the most common sources of vulnerabilities. Always compare the routing table in code against the published API specification.
+4. **Counting only HTTP requests for GraphQL abuse.** A single GraphQL request can contain multiple operations or many aliases. Review the resolver execution count and field-level cost, not just gateway request totals.
 
-5. **Applying rate limiting only to authentication endpoints.** Every API endpoint requires rate limiting proportional to its cost and sensitivity. Data-heavy endpoints, search functions, and export operations are frequent targets for abuse even when properly authenticated.
+5. **Testing only documented endpoints.** Shadow APIs -- endpoints that exist in code but are absent from documentation -- are among the most common sources of vulnerabilities. Always compare the routing table in code against the published API specification.
 
-6. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
+6. **Applying rate limiting only to authentication endpoints.** Every API endpoint requires rate limiting proportional to its cost and sensitivity. Data-heavy endpoints, search functions, and export operations are frequent targets for abuse even when properly authenticated.
+
+7. **Letting JWT headers choose verification policy.** Treat token headers as untrusted input. The issuer configuration must choose the allowed algorithm and key material before verification.
+
+8. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
 
 ---
 

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -115,6 +115,8 @@ APIs are particularly susceptible to authentication flaws because they expose ma
 
 - Authentication endpoints without brute-force protection (rate limiting, account lockout, CAPTCHA).
 - JWT validation that is missing or incomplete -- no signature verification, no expiration check, acceptance of the `none` algorithm.
+- JWT algorithm confusion -- validation that trusts the token header's `alg`, allows both symmetric and asymmetric algorithms for one issuer, or reuses an RSA/ECDSA public key as an HMAC secret.
+- Untrusted JWT key discovery -- accepting `jku`, `x5u`, or arbitrary JWKS URLs from token headers instead of a configured issuer key set.
 - API keys transmitted in URL query strings (logged in server access logs, browser history, proxies).
 - Missing or weak token rotation -- refresh tokens that never expire or are not rotated on use.
 - Password reset or account recovery flows that leak tokens or allow enumeration.
@@ -126,6 +128,15 @@ APIs are particularly susceptible to authentication flaws because they expose ma
 # VULNERABLE: JWT signature not verified
 import jwt
 token_data = jwt.decode(token, options={"verify_signature": False})
+```
+
+```javascript
+// VULNERABLE: Algorithm confusion. The token header chooses verification mode.
+const header = jwt.decode(token, { complete: true }).header;
+const key = header.alg.startsWith("HS") ? PUBLIC_RSA_KEY : jwks.get(header.kid);
+const claims = jwt.verify(token, key, {
+  algorithms: ["HS256", "RS256"], // One issuer should not accept both families
+});
 ```
 
 ```javascript
@@ -153,6 +164,8 @@ paths:
 
 - Enforce rate limiting on all authentication endpoints (e.g., 5 attempts per minute per IP/account).
 - Validate JWT signatures using a strong algorithm (RS256, ES256). Reject `none` and `HS256` if RSA is expected (algorithm confusion attack).
+- Bind each issuer and audience to one explicit algorithm family and key source. Never select HMAC vs RSA/ECDSA verification based on the untrusted token header.
+- Reject untrusted `jku`/`x5u` header URLs, unknown `kid` values, `alg:none`, expired tokens, and issuer/audience mismatches.
 - Transmit API keys and tokens in HTTP headers (`Authorization` header), never in URL query strings.
 - Implement token expiration: access tokens (5-15 minutes), refresh tokens (hours to days with rotation).
 - Use `bcrypt`, `scrypt`, or `Argon2id` for password storage.
@@ -163,6 +176,8 @@ paths:
 - [ ] All authentication endpoints have brute-force protections (rate limiting, lockout).
 - [ ] JWTs are validated for signature, expiration (`exp`), issuer (`iss`), and audience (`aud`).
 - [ ] The `none` algorithm and algorithm confusion attacks are prevented by explicit algorithm allowlisting.
+- [ ] Each issuer has key-type binding evidence proving RSA/ECDSA public keys cannot be reused as HMAC secrets.
+- [ ] Negative tests cover `alg:none`, HS256-with-public-key, unexpected algorithm family, unknown `kid`, expired token, and wrong issuer/audience.
 - [ ] API keys and tokens are transmitted in headers, not query strings.
 - [ ] Refresh tokens are rotated on each use and revocable.
 - [ ] Service-to-service communication is explicitly authenticated.
@@ -263,6 +278,27 @@ query {
 ```
 
 ```javascript
+// VULNERABLE: Gateway counts one HTTP request while GraphQL executes every item.
+app.post("/graphql", rateLimit({ max: 10 }), async (req, res) => {
+  const operations = Array.isArray(req.body) ? req.body : [req.body];
+  const results = [];
+  for (const operation of operations) {
+    results.push(await graphql({ schema, source: operation.query, contextValue: req.user }));
+  }
+  res.json(results);
+});
+```
+
+```graphql
+# VULNERABLE: Alias batching turns one request into many credential attempts.
+mutation {
+  a1: login(email: "user@example.com", password: "guess1") { token }
+  a2: login(email: "user@example.com", password: "guess2") { token }
+  a3: login(email: "user@example.com", password: "guess3") { token }
+}
+```
+
+```javascript
 // VULNERABLE: No request body size limit
 app.use(express.json()); // Default limit may be very large or unconfigured
 ```
@@ -273,6 +309,8 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - Enforce maximum pagination size (e.g., `limit` capped at 100). Default to a reasonable page size (e.g., 20).
 - Set maximum request body sizes (`express.json({ limit: '1mb' })`).
 - For GraphQL: enforce query depth limits (e.g., max depth 5), complexity analysis (weighted field costs), and batch query limits.
+- Count GraphQL operations, aliases, and resolver cost against caller quotas. Do not rely on HTTP request count alone.
+- Disable batching for sensitive mutations such as login, password reset, invitation, checkout, transfer, export, or bulk update, or cap those mutations separately with transaction-safe failure behavior.
 - Set execution timeouts for database queries and downstream API calls.
 - Implement cost alerts and circuit breakers for operations that trigger billable third-party APIs.
 
@@ -282,6 +320,10 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - [ ] Pagination has a maximum page size enforced server-side.
 - [ ] Request body size limits are configured.
 - [ ] GraphQL queries have depth limits, complexity limits, and batch restrictions.
+- [ ] GraphQL batch arrays have a documented maximum operation count.
+- [ ] Alias counts are capped for sensitive fields and mutations.
+- [ ] Resolver-level cost is charged to the caller quota, not just the HTTP request.
+- [ ] Analyzer/rate-limit failures reject the request or degrade safely instead of executing without limits.
 - [ ] Database queries and downstream calls have execution timeouts.
 - [ ] Billable operations have cost controls and alerting.
 

--- a/skills/appsec/api-security/tests/benign/graphql-batch-jwt-guarded.ts
+++ b/skills/appsec/api-security/tests/benign/graphql-batch-jwt-guarded.ts
@@ -1,0 +1,52 @@
+import express from "express";
+import jwt from "jsonwebtoken";
+import { parse, visit, graphql } from "graphql";
+import { schema } from "./schema";
+import { jwksForIssuer, chargeResolverQuota } from "./security-controls";
+
+const app = express();
+const MAX_OPERATIONS_PER_REQUEST = 3;
+const MAX_ALIASES_PER_OPERATION = 5;
+
+function countAliases(query: string): number {
+  let aliases = 0;
+  visit(parse(query), {
+    Field(node) {
+      if (node.alias) aliases += 1;
+    },
+  });
+  return aliases;
+}
+
+app.post("/graphql", async (req, res) => {
+  const operations = Array.isArray(req.body) ? req.body : [req.body];
+  if (operations.length > MAX_OPERATIONS_PER_REQUEST) {
+    return res.status(429).json({ error: "too many GraphQL operations" });
+  }
+
+  const issuer = "https://issuer.example.com/";
+  const key = await jwksForIssuer(issuer).getKey("current");
+  const claims = jwt.verify(req.token, key.publicKey, {
+    algorithms: ["RS256"],
+    issuer,
+    audience: "api",
+    clockTolerance: 30,
+  });
+
+  const results = [];
+  for (const operation of operations) {
+    if (countAliases(operation.query) > MAX_ALIASES_PER_OPERATION) {
+      return res.status(429).json({ error: "too many GraphQL aliases" });
+    }
+    await chargeResolverQuota(claims.sub, operation.operationName, operation.query);
+    results.push(
+      await graphql({
+        schema,
+        source: operation.query,
+        contextValue: { claims },
+      }),
+    );
+  }
+
+  res.json(results);
+});

--- a/skills/appsec/api-security/tests/vulnerable/graphql-batch-jwt-confusion.ts
+++ b/skills/appsec/api-security/tests/vulnerable/graphql-batch-jwt-confusion.ts
@@ -1,0 +1,31 @@
+import express from "express";
+import jwt from "jsonwebtoken";
+import { graphql } from "graphql";
+import { schema } from "./schema";
+
+const app = express();
+const PUBLIC_RSA_KEY = process.env.PUBLIC_RSA_KEY || "-----BEGIN PUBLIC KEY-----...";
+
+app.post("/graphql", async (req, res) => {
+  const token = String(req.headers.authorization || "").replace(/^Bearer\s+/i, "");
+  const header = jwt.decode(token, { complete: true })?.header;
+
+  const claims = jwt.verify(token, PUBLIC_RSA_KEY, {
+    algorithms: header?.alg ? [header.alg as jwt.Algorithm] : ["HS256", "RS256"],
+  });
+
+  const operations = Array.isArray(req.body) ? req.body : [req.body];
+  const results = [];
+
+  for (const operation of operations) {
+    results.push(
+      await graphql({
+        schema,
+        source: operation.query,
+        contextValue: { claims },
+      }),
+    );
+  }
+
+  res.json(results);
+});


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** api-security
**Skill path:** `skills/appsec/api-security/`

### What Was Wrong

The skill mentioned GraphQL batch limits and JWT algorithm confusion, but it did not require reviewers to gather concrete evidence for two common API failure modes:

- GraphQL servers that count one HTTP request while executing many batched operations or aliased resolver calls.
- JWT validators that let the untrusted token header choose the accepted algorithm family or key source.

That can miss single-request credential stuffing, bulk mutation abuse, expensive resolver DoS, and HS/RS algorithm confusion paths.

### What This PR Fixes

- Adds a GraphQL batch execution and alias abuse evidence gate.
- Adds a GraphQL Batch Execution Abuse Matrix for batch array caps, alias caps, resolver-cost accounting, sensitive mutation batching, and failure modes.
- Adds a JWT Algorithm Confusion Evidence gate covering issuer/audience algorithm allowlists, key-type binding, `none`, HS/RS swaps, untrusted `jku`/`x5u`, and unknown `kid` values.
- Expands the detailed API2/API4 checklist with vulnerable examples, remediation guidance, and negative-test requirements.
- Adds one vulnerable and one benign TypeScript fixture showing the missed GraphQL batching and JWT confusion pattern.

Addresses #1026.

### Evidence

**Before (skill misses this):**
```ts
const header = jwt.decode(token, { complete: true })?.header;
const claims = jwt.verify(token, PUBLIC_RSA_KEY, {
  algorithms: header?.alg ? [header.alg] : ["HS256", "RS256"],
});

const operations = Array.isArray(req.body) ? req.body : [req.body];
for (const operation of operations) {
  await graphql({ schema, source: operation.query, contextValue: { claims } });
}
```

**After (now required as safe evidence):**
```ts
if (operations.length > MAX_OPERATIONS_PER_REQUEST) {
  return res.status(429).json({ error: "too many GraphQL operations" });
}

const claims = jwt.verify(req.token, key.publicKey, {
  algorithms: ["RS256"],
  issuer,
  audience: "api",
});

await chargeResolverQuota(claims.sub, operation.operationName, operation.query);
```

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Added report matrix/checklist coverage for GraphQL batching and JWT algorithm confusion evidence
- [x] Existing checks still pass

### Bounty Tier
- [ ] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** GitHub Sponsors

## Pull Request Checklist

- [x] Skill follows the format specification in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] At least one real framework is cited with correct control IDs
- [x] All framework references verified against primary sources
- [x] Prompt Injection Safety Notice section included
- [x] `injection-hardened: true` set in frontmatter
- [x] `allowed-tools` scoped to minimum necessary permissions
- [x] Tested with at least one AI coding agent: Codex
- [x] No prohibited patterns per [SECURITY.md](../SECURITY.md)
- [x] `index.yaml` updated with new skill entry (not applicable; existing skill only)

## What This PR Does

Improves `api-security` so reviewers assess GraphQL batching and JWT algorithm/key confusion as first-class API review evidence, not just generic rate-limit or token-validation keywords.

## Framework References

- OWASP API Security Top 10:2023 API2, API4, and API6
- OWASP GraphQL Cheat Sheet
- OWASP JWT Cheat Sheet

## Testing

- `rg -n "GraphQL Batch Execution Abuse Matrix|JWT Algorithm Confusion Evidence|batched operations per request|algorithm allowlist evidence" skills/appsec/api-security/SKILL.md skills/appsec/api-security/api-top10-checklist.md`
- `rg -n "jwt\\.verify|header\\.alg|Array\\.isArray\\(req\\.body\\)|MAX_OPERATIONS_PER_REQUEST|MAX_ALIASES_PER_OPERATION|chargeResolverQuota" skills/appsec/api-security/tests`
- Exact local equivalent of `.github/workflows/lint-skills.yml` frontmatter check
- `rg -n "PRIVATE|SECRET|PASSWORD|BEGIN PRIVATE|ghp_|gho_|sk-|xox|AKIA" skills/appsec/api-security`
- `git diff --check`
