### PR TITLE
Improve gcp-review service account impersonation graph

### DIFF
--- a/skills/cloud/gcp-review/SKILL.md
+++ b/skills/cloud/gcp-review/SKILL.md
@@ -14,7 +14,7 @@ phase: [assess, operate]
 frameworks: [CIS-GCP-v2.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.1.0"
+version: "1.1.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -77,6 +77,8 @@ Use Glob to locate all GCP-related infrastructure definitions.
 **/org-policies/**/*.json
 **/org-policies/**/*.yaml
 **/iam/**/*.json
+**/artifact-registry/**/*.tf
+**/compute/**/*.tf
 ```
 
 Record all discovered files. If no GCP configurations are found, report that finding and halt.
@@ -113,7 +115,43 @@ For each target service account, produce an effective impersonation graph:
 
 Classify broad or inherited `Token Creator`, `Service Account User`, `Workload Identity User`, `SignBlob`, or `SignJwt` grants as high risk when they can reach privileged service accounts without narrow conditions. Do not over-report tightly conditioned workload identity federation where the evidence binds issuer, subject, repository, branch/tag or environment, audience, and target service account, and where the service account's downstream permissions are appropriate for that workload.
 
+Do not automatically classify every user-managed service-account key as Critical when a validated hybrid-cloud exception exists. An exception must include all of the following evidence: Workload Identity Federation or service account impersonation is not supported for the legacy external workload, the key is scoped away from project-level Owner/Editor/Admin roles, the key has a rotation period of 90 days or less, the key is stored in an approved secret manager, Cloud Audit Logs are reviewed for key use, and there is a decommission plan. Without that evidence, keep the CIS 1.4/1.7 finding.
+
 If group membership, parent-resource IAM, deny policies, or principal access boundary evidence is unavailable, mark the impersonation path as `Not Evaluable` instead of assuming it is safe.
+
+---
+
+### Step 2B: Check Organization Policy Inheritance Drift
+
+Org-policy presence is not enough. Verify whether project or folder policies weaken an organization-level constraint, especially when the root policy is not enforced strongly enough to prevent override.
+
+Collect:
+
+| Constraint | Org Policy | Folder Policy | Project Policy | Override Direction | Status |
+|---|---|---|---|---|---|
+| `constraints/iam.disableServiceAccountKeyCreation` | enforced/not enforced | inherited/overridden | inherited/overridden | stricter/weaker | Pass/Fail/Not Evaluable |
+
+Flag project-level `google_project_organization_policy` or folder-level policies that contradict stricter organization-level settings, including service-account key creation, public access prevention, default network creation, serial-port access, public IP controls, and allowed image or repository policies.
+
+---
+
+### Step 2C: Check Artifact Registry Supply-Chain Controls
+
+Artifact Registry is the successor to Container Registry and should be reviewed alongside Storage controls. Verify:
+
+- Artifact Registry API is enabled only where needed.
+- Container vulnerability scanning / Artifact Analysis is enabled for image repositories.
+- Remote repositories restrict upstreams to trusted domains and approved package ecosystems.
+- IAM on repositories avoids broad writers, public readers, and inherited deploy privileges.
+- Build/deploy pipelines fail or require approval for critical vulnerabilities where policy requires it.
+
+---
+
+### Step 2D: Check Confidential VM Evidence for Sensitive Workloads
+
+For Level 2 or high-sensitivity workloads that process secrets, regulated data, signing material, or confidential customer data in memory, verify Confidential VM or an explicit risk-accepted exception.
+
+Evidence should include VM machine family compatibility, `enable_confidential_compute = true`, Shielded VM settings, CMEK disk encryption, workload data classification, and exception approval for workloads that cannot use AMD SEV or Intel TDX.
 
 ---
 
@@ -184,7 +222,8 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Description:** <what was found>
 - **Evidence:** <specific configuration or code snippet>
 - **Effective Access Evidence:** <impersonation path, inherited scope, condition, group membership, downstream service account privileges>
-- **Remediation:** <specific fix with code example>
+- **Terraform Remediation:** <specific IaC fix with code example>
+- **Emergency gcloud Remediation:** <one-liner for immediate containment where safe>
 
 ### Prioritized Remediation Plan
 
@@ -211,7 +250,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | 2 | Logging and Monitoring | Cloud Audit Logs (admin/data read/write), log sinks, bucket lock retention, metric filters and alerts (8 categories), DNS logging, Cloud Asset Inventory |
 | 3 | Networking | Default network removal, legacy networks, DNSSEC, firewall rules (SSH/RDP from internet), VPC flow logs, SSL policies, IAP-only access |
 | 4 | Virtual Machines | Default service accounts, access scopes, project SSH key blocking, OS Login, serial port, IP forwarding, CMEK disks, Shielded VM, public IPs, Confidential Computing |
-| 5 | Storage | Public bucket access, uniform bucket-level access |
+| 5 | Storage | Public bucket access, uniform bucket-level access, Artifact Registry scanning and remote repository trust |
 | 6 | Cloud SQL | MySQL/PostgreSQL/SQL Server database flags, SSL enforcement, authorized networks, public IP, automated backups |
 | 7 | BigQuery | Public dataset access, CMEK encryption for tables and datasets |
 
@@ -231,6 +270,10 @@ Produce the final report using the structure defined in the Output Format sectio
 5. **BigQuery dataset-level vs. table-level CMEK.** CIS 7.2 checks table-level encryption, while CIS 7.3 checks the dataset default. Both should be evaluated independently.
 6. **Default compute service account identification.** The default SA follows the pattern `PROJECT_NUMBER-compute@developer.gserviceaccount.com`. Grep for this pattern, not just the string "default."
 7. **Flat IAM reviews miss impersonation chains.** A project-level `Token Creator` or `Service Account User` grant can be more dangerous than a direct role assignment because it lets the principal inherit a privileged service account's permissions. Resolve inherited bindings, Google Group membership, workload identity attributes, IAM Conditions, deny policies, and the target service account's own roles before classifying the path.
+8. **Treating hybrid service-account keys as always identical.** User-managed keys are high risk by default, but a short-lived, tightly scoped, audited key for a legacy on-prem workload is different from an unrotated project-admin key. Require documented exception evidence before downgrading.
+9. **Checking org policies only at the project.** A project policy can weaken an inherited organization or folder control. Compare org, folder, and project policy values and classify weaker overrides as drift.
+10. **Skipping Artifact Registry because Storage was reviewed.** Image repositories, remote upstreams, and vulnerability scanning are separate supply-chain controls from GCS buckets.
+11. **Treating Confidential VM as optional for every workload.** For Level 2 or sensitive in-memory processing, require Confidential VM evidence or a documented incompatibility and risk acceptance.
 
 ---
 
@@ -258,6 +301,9 @@ Produce the final report using the structure defined in the Output Format sectio
 - Google Cloud IAM Conditions: https://cloud.google.com/iam/docs/conditions-overview
 - Google Cloud Policy Analyzer: https://cloud.google.com/policy-intelligence/docs/analyze-iam-policies
 - Google Cloud Audit Logs: https://cloud.google.com/logging/docs/audit
+- Google Cloud Organization Policy Service: https://cloud.google.com/resource-manager/docs/organization-policy/overview
+- Google Cloud Artifact Registry vulnerability scanning: https://cloud.google.com/artifact-analysis/docs/scan-os-automatically
+- Google Cloud Confidential VM: https://cloud.google.com/confidential-computing/confidential-vm/docs
 - Google Cloud VPC Documentation: https://cloud.google.com/vpc/docs
 - Google Cloud SQL Security: https://cloud.google.com/sql/docs/mysql/configure-ssl-instance
 - Terraform Google Provider Documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs
@@ -266,5 +312,6 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.1.1** -- Added validated hybrid service-account key exceptions, organization-policy drift checks, Artifact Registry scanning and remote repository gates, Confidential VM evidence, and emergency gcloud remediation fields.
 - **1.1.0** -- Added effective service account impersonation graph evidence, workload identity federation false-positive handling, inherited IAM scope review, and impersonation fixtures.
 - **1.0.0** -- Initial release. Full coverage of CIS Google Cloud Platform Foundation Benchmark v2.0.0 sections 1 through 7.

--- a/skills/cloud/gcp-review/SKILL.md
+++ b/skills/cloud/gcp-review/SKILL.md
@@ -5,15 +5,16 @@ description: >
   Foundation Benchmark v2.0.0. Auto-invoked when reviewing GCP infrastructure,
   IAM bindings, VPC firewall rules, Cloud Audit Logs, or GCS bucket security.
   Walks through all seven benchmark sections, evaluates each recommendation,
-  and produces a prioritized findings report with remediation guidance mapped
-  to specific CIS control IDs.
-tags: [cloud, gcp, cis-benchmark]
+  builds an effective service-account impersonation graph, and produces a
+  prioritized findings report with remediation guidance mapped to specific CIS
+  control IDs.
+tags: [cloud, gcp, cis-benchmark, iam]
 role: [cloud-security-engineer, security-engineer]
 phase: [assess, operate]
 frameworks: [CIS-GCP-v2.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -52,6 +53,8 @@ The CIS Google Cloud Platform Foundation Benchmark v2.0.0 is a consensus-driven 
 - Access to GCP infrastructure-as-code files (Terraform `.tf`, Deployment Manager `.yaml`/`.jinja`)
 - gcloud CLI output or configuration exports (if reviewing a live environment)
 - IAM policy bindings and org policy definitions
+- Service account IAM policies, workload identity federation provider settings,
+  group membership evidence, and inherited project/folder/org IAM bindings
 - VPC and firewall rule definitions
 - Cloud Audit Logs configuration
 
@@ -88,6 +91,32 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
+### Step 2A: Build Effective Service Account Impersonation Graph
+
+Before classifying service-account findings, map every principal that can mint, sign, attach, or indirectly use a service account credential. A flat IAM role list is not enough because impersonation can be inherited from project, folder, or organization bindings, delegated through groups, or constrained by IAM Conditions and workload identity federation attributes.
+
+Collect evidence for these grant types:
+
+| Grant Type | Roles / Permissions | Evidence to Collect | Review Question |
+|---|---|---|---|
+| Token minting | `roles/iam.serviceAccountTokenCreator`, `iam.serviceAccounts.getAccessToken`, `iam.serviceAccounts.getOpenIdToken` | Binding resource scope, member, condition, inherited parent, target service account, service account roles | Can the principal mint credentials for a higher-privilege service account? |
+| Service account attachment | `roles/iam.serviceAccountUser`, `iam.serviceAccounts.actAs` | Compute, Cloud Run, GKE, Dataflow, Cloud Build, or deployment resources that can attach the service account | Can the principal run workloads as the service account? |
+| Workload identity federation | `roles/iam.workloadIdentityUser`, pool/provider attribute mapping, principalSet selectors, IAM Conditions | Repository, branch/tag, environment, subject, audience, issuer, and expiry constraints | Is impersonation constrained to the intended workload identity? |
+| Signing and delegation | `iam.serviceAccounts.signBlob`, `iam.serviceAccounts.signJwt`, `roles/iam.serviceAccountKeyAdmin` | Principal, target service account, key/signing use, audit log evidence | Can the principal create signed assertions or durable credentials? |
+| Inherited or external membership | Project/folder/org IAM, Google Groups, external IdP groups | Parent resource, group owner, membership source, last verified timestamp | Does effective access differ from the local Terraform file? |
+
+For each target service account, produce an effective impersonation graph:
+
+| Principal | Principal Source | Grant Scope | Grant Type | Condition / Attribute Constraints | Target Service Account | Target SA Privileges | Compensating Controls | Classification |
+|---|---|---|---|---|---|---|---|---|
+| [user/group/workload/serviceAccount] | [direct/group/WIF/inherited] | [SA/project/folder/org] | [TokenCreator/SAUser/WIF/signing] | [repo/branch/audience/time/none] | [service account] | [key roles/resources] | [deny policy/PAB/audit/approval] | [Pass/Fail/Not Evaluable] |
+
+Classify broad or inherited `Token Creator`, `Service Account User`, `Workload Identity User`, `SignBlob`, or `SignJwt` grants as high risk when they can reach privileged service accounts without narrow conditions. Do not over-report tightly conditioned workload identity federation where the evidence binds issuer, subject, repository, branch/tag or environment, audience, and target service account, and where the service account's downstream permissions are appropriate for that workload.
+
+If group membership, parent-resource IAM, deny policies, or principal access boundary evidence is unavailable, mark the impersonation path as `Not Evaluable` instead of assuming it is safe.
+
+---
+
 ### Step 9: Compile Assessment Report
 
 
@@ -100,7 +129,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | Severity | Definition | Examples |
 |----------|-----------|----------|
 | **Critical** | Immediate risk of data breach or unauthorized access | Public GCS buckets, firewall rules allowing 0.0.0.0/0 on SSH/RDP, Cloud SQL with public IP and no SSL, user-managed SA keys with admin roles |
-| **High** | Significant security gap that materially weakens posture | Default service accounts with broad scopes, missing Cloud Audit Logs, no VPC flow logs, instances with public IPs |
+| **High** | Significant security gap that materially weakens posture | Default service accounts with broad scopes, inherited Token Creator on privileged service accounts, missing Cloud Audit Logs, no VPC flow logs, instances with public IPs |
 | **Medium** | Control gap that should be addressed in normal cycle | Missing log metric filters, DNSSEC not enabled, Shielded VM not enabled, uniform bucket access not set |
 | **Low** | Hardening recommendation or defense-in-depth measure | OS Login not enabled, serial port access not explicitly disabled, BigQuery tables without CMEK |
 | **Informational** | Best practice observation, no direct security impact | Default network still exists (non-production), naming conventions, documentation gaps |
@@ -138,6 +167,12 @@ Produce the final report using the structure defined in the Output Format sectio
 | 6 | Cloud SQL | X | Y | Z | nn% |
 | 7 | BigQuery | X | Y | Z | nn% |
 
+### Effective Service Account Impersonation Graph
+
+| Principal | Principal Source | Grant Scope | Grant Type | Condition / Attribute Constraints | Target Service Account | Target SA Privileges | Compensating Controls | Status |
+|---|---|---|---|---|---|---|---|---|
+| <principal> | <direct/group/WIF/inherited> | <service-account/project/folder/org> | <TokenCreator/SAUser/WIF/signing> | <repo/branch/audience/time/none> | <service account> | <roles/resources> | <deny policy/PAB/audit/approval> | <Pass/Fail/Not Evaluable> |
+
 ### Detailed Findings
 
 #### [CIS X.Y] <Recommendation Title>
@@ -148,6 +183,7 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration or code snippet>
+- **Effective Access Evidence:** <impersonation path, inherited scope, condition, group membership, downstream service account privileges>
 - **Remediation:** <specific fix with code example>
 
 ### Prioritized Remediation Plan
@@ -194,6 +230,7 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Cloud SQL authorized_networks vs. private IP.** CIS 6.5 flags `0.0.0.0/0` in authorized networks, but CIS 6.6 goes further and recommends disabling public IP entirely in favor of private networking.
 5. **BigQuery dataset-level vs. table-level CMEK.** CIS 7.2 checks table-level encryption, while CIS 7.3 checks the dataset default. Both should be evaluated independently.
 6. **Default compute service account identification.** The default SA follows the pattern `PROJECT_NUMBER-compute@developer.gserviceaccount.com`. Grep for this pattern, not just the string "default."
+7. **Flat IAM reviews miss impersonation chains.** A project-level `Token Creator` or `Service Account User` grant can be more dangerous than a direct role assignment because it lets the principal inherit a privileged service account's permissions. Resolve inherited bindings, Google Group membership, workload identity attributes, IAM Conditions, deny policies, and the target service account's own roles before classifying the path.
 
 ---
 
@@ -216,6 +253,10 @@ Produce the final report using the structure defined in the Output Format sectio
 - CIS Google Cloud Platform Foundation Benchmark v2.0.0: https://www.cisecurity.org/benchmark/google_cloud_computing_platform
 - Google Cloud Security Best Practices: https://cloud.google.com/security/best-practices
 - Google Cloud IAM Documentation: https://cloud.google.com/iam/docs
+- Google Cloud service account impersonation: https://cloud.google.com/iam/docs/service-account-impersonation
+- Google Cloud Workload Identity Federation with deployment pipelines: https://cloud.google.com/iam/docs/workload-identity-federation-with-deployment-pipelines
+- Google Cloud IAM Conditions: https://cloud.google.com/iam/docs/conditions-overview
+- Google Cloud Policy Analyzer: https://cloud.google.com/policy-intelligence/docs/analyze-iam-policies
 - Google Cloud Audit Logs: https://cloud.google.com/logging/docs/audit
 - Google Cloud VPC Documentation: https://cloud.google.com/vpc/docs
 - Google Cloud SQL Security: https://cloud.google.com/sql/docs/mysql/configure-ssl-instance
@@ -225,4 +266,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.1.0** -- Added effective service account impersonation graph evidence, workload identity federation false-positive handling, inherited IAM scope review, and impersonation fixtures.
 - **1.0.0** -- Initial release. Full coverage of CIS Google Cloud Platform Foundation Benchmark v2.0.0 sections 1 through 7.

--- a/skills/cloud/gcp-review/benchmark-checklist.md
+++ b/skills/cloud/gcp-review/benchmark-checklist.md
@@ -72,6 +72,59 @@ resource "google_project_iam_member" {
 
 These roles should be granted at the service account level, not project level.
 
+**Effective impersonation graph check:**
+
+Do not stop at direct project-level user bindings. Build a graph of principals that can mint, attach, sign as, or otherwise use service accounts.
+
+Include:
+
+- `roles/iam.serviceAccountTokenCreator`
+- `roles/iam.serviceAccountUser`
+- `roles/iam.workloadIdentityUser`
+- `iam.serviceAccounts.signBlob`
+- `iam.serviceAccounts.signJwt`
+- project, folder, and organization inherited IAM
+- Google Group or external IdP group membership
+- workload identity federation pool/provider attribute mappings
+- IAM Conditions, deny policies, and principal access boundary evidence
+
+**Bad: inherited broad Token Creator path**
+
+```hcl
+resource "google_project_iam_member" "contractor_token_creator" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = "group:contractors@example.com"
+}
+
+resource "google_project_iam_member" "deploy_sa_editor" {
+  project = var.project_id
+  role    = "roles/editor"
+  member  = "serviceAccount:deploy-prod@${var.project_id}.iam.gserviceaccount.com"
+}
+```
+
+Report this as high risk if the group can mint tokens for the privileged service account and no narrow condition, deny policy, approval gate, or verified membership boundary limits the path.
+
+**Benign when evidence is complete: conditioned workload identity federation**
+
+```hcl
+resource "google_service_account_iam_binding" "ci_token_creator" {
+  service_account_id = google_service_account.deploy.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  members = [
+    "principalSet://iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/ci/attribute.repository/my-org/prod-deploy"
+  ]
+
+  condition {
+    title      = "prod-deploy-main-only"
+    expression = "assertion.repository == 'my-org/prod-deploy' && assertion.ref == 'refs/heads/main' && assertion.aud == 'deploy-prod'"
+  }
+}
+```
+
+Do not report this as broad impersonation when repository, branch/tag or environment, subject/audience, issuer, target service account, and downstream service-account privileges are all evidenced and appropriate for the deployment workflow.
+
 ### CIS 1.7 -- Ensure User-Managed/External Keys for Service Accounts Are Rotated Every 90 Days or Fewer
 
 Check for key rotation mechanisms or expiration policies on service account keys.

--- a/skills/cloud/gcp-review/benchmark-checklist.md
+++ b/skills/cloud/gcp-review/benchmark-checklist.md
@@ -41,6 +41,19 @@ resource "google_service_account_key" {
 
 Look for any `google_service_account_key` resources. GCP-managed keys (used automatically by Compute Engine, GKE, etc.) do not require explicit creation.
 
+**Validated hybrid-cloud exception:**
+
+Do not downgrade a user-managed service-account key unless all of this evidence exists:
+
+- The workload is external or legacy on-premises and cannot use Workload Identity Federation, service-account impersonation, or a supported short-lived credential path.
+- The service account does not have project-level Owner, Editor, IAM Admin, Service Account Admin, or broad data-admin roles.
+- Rotation is 90 days or less and enforced by inventory, automation, or an approved ticketed process.
+- The private key is stored in an approved secret manager, not in source, CI variables without masking, or local files.
+- Cloud Audit Logs or equivalent SIEM detections monitor service-account key use.
+- There is a migration or decommission plan for the key.
+
+If any evidence is missing, keep CIS 1.4/1.7 as Fail or Not Evaluable instead of treating the key as benign.
+
 ### CIS 1.5 -- Ensure that Service Account Has No Admin Privileges
 
 **Grep patterns:**
@@ -128,6 +141,15 @@ Do not report this as broad impersonation when repository, branch/tag or environ
 ### CIS 1.7 -- Ensure User-Managed/External Keys for Service Accounts Are Rotated Every 90 Days or Fewer
 
 Check for key rotation mechanisms or expiration policies on service account keys.
+
+**Emergency gcloud containment:**
+
+```bash
+gcloud iam service-accounts keys list --iam-account SERVICE_ACCOUNT_EMAIL
+gcloud iam service-accounts keys delete KEY_ID --iam-account SERVICE_ACCOUNT_EMAIL
+```
+
+Use deletion only after confirming dependent workloads can switch to a replacement key or short-lived credential path.
 
 ### CIS 1.8 -- Ensure that Separation of Duties is Enforced While Assigning Service Account Related Roles to Users
 
@@ -585,11 +607,29 @@ resource "google_compute_instance" {
 }
 ```
 
+For Level 2 or high-sensitivity workloads, also verify workload data classification and exception evidence. VMs that process signing keys, regulated customer data, medical identifiers, or production secrets in memory should either enable Confidential VM or document hardware-family incompatibility and risk acceptance.
+
+**Grep patterns:**
+
+```
+confidential_instance_config
+enable_confidential_compute
+n2d-
+c2d-
+c3-
+```
+
+**Emergency gcloud verification:**
+
+```bash
+gcloud compute instances describe INSTANCE --zone ZONE --format='value(confidentialInstanceConfig.enableConfidentialCompute)'
+```
+
 ---
 
 ## Section 5 -- Storage
 
-Evaluate Cloud Storage configurations against CIS GCP v2.0.0 Section 5 recommendations.
+Evaluate Cloud Storage and Artifact Registry configurations against CIS GCP v2.0.0 Section 5 recommendations and current GCP supply-chain expectations.
 
 ### CIS 5.1 -- Ensure that Cloud Storage Bucket Is Not Anonymously or Publicly Accessible
 
@@ -623,6 +663,105 @@ resource "google_organization_policy" {
 resource "google_storage_bucket" {
   uniform_bucket_level_access = true  # Must be true
 }
+```
+
+### CIS 5.x -- Ensure Artifact Registry Repositories Have Vulnerability Scanning and Trusted Upstreams
+
+Artifact Registry is the successor to Container Registry and should be reviewed for image/package supply-chain controls.
+
+**Checks:**
+
+- Artifact Analysis / container scanning is enabled where image repositories are used.
+- Remote repositories restrict upstreams to trusted domains and approved ecosystems.
+- Repository IAM avoids `allUsers`, broad writers, and inherited deploy privileges.
+- Critical vulnerability findings block deployment or require documented approval.
+
+**Terraform patterns:**
+
+```hcl
+resource "google_project_service" "artifact_analysis" {
+  service = "containeranalysis.googleapis.com"
+}
+
+resource "google_artifact_registry_repository" "remote" {
+  mode = "REMOTE_REPOSITORY"
+  remote_repository_config {
+    docker_repository {
+      public_repository = "DOCKER_HUB"
+    }
+  }
+}
+
+# BAD: public or overly broad repository access
+resource "google_artifact_registry_repository_iam_member" "public_reader" {
+  role   = "roles/artifactregistry.reader"
+  member = "allUsers"
+}
+```
+
+**Grep patterns:**
+
+```
+google_artifact_registry_repository
+REMOTE_REPOSITORY
+remote_repository_config
+containeranalysis.googleapis.com
+artifactregistry.reader
+artifactregistry.writer
+allUsers
+allAuthenticatedUsers
+```
+
+**Emergency gcloud verification:**
+
+```bash
+gcloud services list --enabled --filter='containeranalysis.googleapis.com'
+gcloud artifacts repositories describe REPOSITORY --location LOCATION
+gcloud artifacts repositories get-iam-policy REPOSITORY --location LOCATION
+```
+
+---
+
+## Cross-Cutting -- Organization Policy Inheritance Drift
+
+For controls enforced through Organization Policy, compare organization, folder, and project policy state. A project-level override that weakens a stricter parent policy should be treated as drift.
+
+**Terraform patterns:**
+
+```hcl
+resource "google_organization_policy" "disable_sa_keys" {
+  constraint = "iam.disableServiceAccountKeyCreation"
+  boolean_policy {
+    enforced = true
+  }
+}
+
+# BAD: weaker project-level override against parent intent
+resource "google_project_organization_policy" "allow_sa_keys" {
+  constraint = "iam.disableServiceAccountKeyCreation"
+  boolean_policy {
+    enforced = false
+  }
+}
+```
+
+**Constraints to compare:**
+
+```
+iam.disableServiceAccountKeyCreation
+storage.publicAccessPrevention
+compute.skipDefaultNetworkCreation
+compute.disableSerialPortAccess
+compute.vmExternalIpAccess
+constraints/gcp.resourceLocations
+```
+
+**Emergency gcloud verification:**
+
+```bash
+gcloud org-policies describe CONSTRAINT --organization ORG_ID
+gcloud org-policies describe CONSTRAINT --folder FOLDER_ID
+gcloud org-policies describe CONSTRAINT --project PROJECT_ID
 ```
 
 ---

--- a/skills/cloud/gcp-review/tests/benign/conditioned-wif-deploy-impersonation.tf
+++ b/skills/cloud/gcp-review/tests/benign/conditioned-wif-deploy-impersonation.tf
@@ -1,0 +1,29 @@
+variable "project_id" {
+  type = string
+}
+
+resource "google_service_account" "deploy" {
+  account_id   = "deploy-prod"
+  display_name = "Production deployment service account"
+}
+
+resource "google_service_account_iam_binding" "ci_token_creator" {
+  service_account_id = google_service_account.deploy.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+
+  members = [
+    "principalSet://iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/ci/attribute.repository/my-org/prod-deploy"
+  ]
+
+  condition {
+    title       = "prod-deploy-main-only"
+    description = "Only the production deployment workflow on the main branch can mint deploy credentials."
+    expression  = "assertion.repository == 'my-org/prod-deploy' && assertion.ref == 'refs/heads/main' && assertion.aud == 'deploy-prod'"
+  }
+}
+
+resource "google_project_iam_member" "deploy_limited_role" {
+  project = var.project_id
+  role    = "roles/run.developer"
+  member  = "serviceAccount:${google_service_account.deploy.email}"
+}

--- a/skills/cloud/gcp-review/tests/vulnerable/project-level-token-creator-chain.tf
+++ b/skills/cloud/gcp-review/tests/vulnerable/project-level-token-creator-chain.tf
@@ -1,0 +1,26 @@
+variable "project_id" {
+  type = string
+}
+
+resource "google_service_account" "deploy_prod" {
+  account_id   = "deploy-prod"
+  display_name = "Production deployment service account"
+}
+
+resource "google_project_iam_member" "deploy_sa_editor" {
+  project = var.project_id
+  role    = "roles/editor"
+  member  = "serviceAccount:${google_service_account.deploy_prod.email}"
+}
+
+resource "google_project_iam_member" "contractor_token_creator" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = "group:contractors@example.com"
+}
+
+resource "google_project_iam_member" "contractor_service_account_user" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountUser"
+  member  = "group:contractors@example.com"
+}


### PR DESCRIPTION
/claim #1057
/claim #1111

## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `gcp-review`
**Skill path:** `skills/cloud/gcp-review/`

Addresses #1057 and #1111.

### What Was Wrong

The GCP review skill needed stronger evidence for effective service-account impersonation paths and newer GCP posture gaps that are easy to miss when only direct Terraform bindings are reviewed.

Two practical gaps were addressed:

- Service-account risk can be misclassified if inherited IAM, group membership, Workload Identity Federation, Token Creator, Service Account User, SignBlob, SignJwt, and target-service-account privileges are not resolved together.
- GCP posture review can miss Artifact Registry scanning/remote-repository trust, organization-policy inheritance drift, Confidential VM requirements for sensitive workloads, and justified hybrid-cloud exceptions for user-managed service-account keys.

### What This PR Fixes

- Bumps `gcp-review` to `1.1.1`.
- Adds an effective service-account impersonation graph and output table.
- Adds evidence requirements for inherited project/folder/org IAM, Google Groups, WIF attributes, IAM Conditions, deny policies, principal access boundaries, and target service-account privileges.
- Adds validated hybrid-cloud exception criteria for user-managed service-account keys, without downgrading keys lacking rotation, scope, storage, audit, and decommission evidence.
- Adds organization-policy inheritance drift checks across org, folder, and project scopes.
- Adds Artifact Registry supply-chain gates for vulnerability scanning, trusted remote repositories, IAM, and deployment policy response.
- Adds Confidential VM evidence for Level 2 or sensitive in-memory workloads.
- Adds emergency `gcloud` remediation/verification fields and checklist commands for analyst response.
- Adds vulnerable and benign Terraform fixtures for the impersonation graph lane.

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing checks still pass

### Validation

- `git diff --check`
- Markdown fence-balance check for `SKILL.md` and `benchmark-checklist.md`
- Targeted content assertions for hybrid SA-key exceptions, org-policy drift, Artifact Registry, Confidential VM, and emergency `gcloud` remediation fields
- Targeted scan for public payment/payout strings in the changed skill files
- Live HTTP 200 checks for official Google Cloud Organization Policy, Artifact Analysis scanning, and Confidential VM references

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New evidence gates and false-positive handling
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Payment details can be provided privately after maintainer acceptance.