### PR TITLE
Add GCP impersonation graph evidence

### DIFF
--- a/skills/cloud/gcp-review/SKILL.md
+++ b/skills/cloud/gcp-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-GCP-v2.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -52,6 +52,7 @@ The CIS Google Cloud Platform Foundation Benchmark v2.0.0 is a consensus-driven 
 - Access to GCP infrastructure-as-code files (Terraform `.tf`, Deployment Manager `.yaml`/`.jinja`)
 - gcloud CLI output or configuration exports (if reviewing a live environment)
 - IAM policy bindings and org policy definitions
+- Effective IAM policy exports for project, folder, organization, and service-account resources when service-account impersonation is in scope
 - VPC and firewall rule definitions
 - Cloud Audit Logs configuration
 
@@ -88,7 +89,41 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
-### Step 9: Compile Assessment Report
+### Step 9: Build Service Account Impersonation Graph
+
+For IAM findings that involve service accounts, build an effective impersonation graph before assigning final risk. Static role presence is not enough: the review must identify who can mint tokens, attach service accounts to workloads, sign blobs/JWTs, or federate into deployment identities.
+
+Collect the following grant types from service-account, project, folder, and organization IAM policies:
+
+- `roles/iam.serviceAccountTokenCreator`
+- `roles/iam.serviceAccountUser`
+- `roles/iam.workloadIdentityUser`
+- custom roles that include `iam.serviceAccounts.getAccessToken`, `iam.serviceAccounts.signBlob`, or `iam.serviceAccounts.signJwt`
+
+For each path, record:
+
+| Field | Evidence Required |
+|---|---|
+| Principal | User, group, service account, workload identity principal, or principal set |
+| Grant source | Service-account, project, folder, or organization IAM binding and file/resource path |
+| Target service account | Email/name and project |
+| Target privileges | Roles held by the target service account, especially admin, deploy, KMS, storage, BigQuery, owner/editor, or CI/CD release roles |
+| Condition | IAM Condition expression, title, and whether it constrains repository, branch/tag, audience, environment, time, or request attributes |
+| Inheritance | Whether the binding is inherited from project/folder/org scope or direct on the service account |
+| Effective risk | Critical, High, Medium, Low, Pass, or Not Evaluable |
+
+Risk decision rules:
+
+- Mark broad human, group, domain, or all-authenticated Token Creator paths to privileged service accounts as **High** or **Critical** unless strong conditions and group membership evidence prove a narrow path.
+- Treat service-account-to-service-account impersonation as a chain. Follow the target account's roles and any next-hop impersonation grants before scoring.
+- Treat workload identity federation as lower risk only when repository/project, branch/tag or environment, subject, and audience constraints are present and bound to the expected CI/CD identity.
+- Treat time-only conditions or descriptions without technical predicates as insufficient constraints.
+- Mark inherited project/folder/org Token Creator or Service Account User grants as higher risk than direct service-account grants because the blast radius can include future service accounts.
+- If deny policies, principal access boundary policies, or org policies reduce effective access, record the policy evidence and residual scope instead of flagging the raw grant alone.
+
+---
+
+### Step 10: Compile Assessment Report
 
 
 Produce the final report using the structure defined in the Output Format section.
@@ -150,6 +185,12 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Evidence:** <specific configuration or code snippet>
 - **Remediation:** <specific fix with code example>
 
+### Service Account Impersonation Graph
+
+| Principal | Grant Source | Target Service Account | Target Roles | Condition Summary | Inherited? | Effective Risk | Required Action |
+|-----------|--------------|------------------------|--------------|-------------------|------------|----------------|-----------------|
+| <member> | <resource/file/line> | <service-account> | <roles> | <repo/ref/audience/time/none> | Yes/No | Critical/High/Medium/Low/Pass/Not Evaluable | <remove, constrain, verify group, add deny/PAB, or document evidence> |
+
 ### Prioritized Remediation Plan
 
 1. **[Critical]** CIS X.Y -- <action item>
@@ -194,6 +235,8 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Cloud SQL authorized_networks vs. private IP.** CIS 6.5 flags `0.0.0.0/0` in authorized networks, but CIS 6.6 goes further and recommends disabling public IP entirely in favor of private networking.
 5. **BigQuery dataset-level vs. table-level CMEK.** CIS 7.2 checks table-level encryption, while CIS 7.3 checks the dataset default. Both should be evaluated independently.
 6. **Default compute service account identification.** The default SA follows the pattern `PROJECT_NUMBER-compute@developer.gserviceaccount.com`. Grep for this pattern, not just the string "default."
+7. **Confusing all Token Creator grants with equal risk.** A tightly conditioned workload identity federation binding can be acceptable, while a project-level user or group Token Creator grant can be a privilege-escalation path. Record the condition and target service-account privileges before scoring.
+8. **Missing inherited impersonation paths.** Folder or organization bindings can grant access into a project even when the reviewed Terraform module only shows safe service-account-level bindings.
 
 ---
 
@@ -216,6 +259,9 @@ Produce the final report using the structure defined in the Output Format sectio
 - CIS Google Cloud Platform Foundation Benchmark v2.0.0: https://www.cisecurity.org/benchmark/google_cloud_computing_platform
 - Google Cloud Security Best Practices: https://cloud.google.com/security/best-practices
 - Google Cloud IAM Documentation: https://cloud.google.com/iam/docs
+- Google Cloud Service Account Impersonation: https://cloud.google.com/iam/docs/service-account-impersonation
+- Google Cloud Workload Identity Federation: https://cloud.google.com/iam/docs/workload-identity-federation
+- Google Cloud Policy Analyzer: https://cloud.google.com/policy-intelligence/docs/analyze-iam-policies
 - Google Cloud Audit Logs: https://cloud.google.com/logging/docs/audit
 - Google Cloud VPC Documentation: https://cloud.google.com/vpc/docs
 - Google Cloud SQL Security: https://cloud.google.com/sql/docs/mysql/configure-ssl-instance
@@ -226,3 +272,4 @@ Produce the final report using the structure defined in the Output Format sectio
 ## Changelog
 
 - **1.0.0** -- Initial release. Full coverage of CIS Google Cloud Platform Foundation Benchmark v2.0.0 sections 1 through 7.
+- **1.1.0** -- Adds effective service-account impersonation graph evidence, inherited binding review, and workload identity federation constraint handling.

--- a/skills/cloud/gcp-review/benchmark-checklist.md
+++ b/skills/cloud/gcp-review/benchmark-checklist.md
@@ -72,6 +72,68 @@ resource "google_project_iam_member" {
 
 These roles should be granted at the service account level, not project level.
 
+#### Effective Service Account Impersonation Graph Evidence
+
+CIS 1.6 is not only a flat project-level role check. Resolve effective service-account impersonation paths before assigning risk.
+
+**Grant types to collect:**
+
+| Grant / Permission | Why It Matters |
+|---|---|
+| `roles/iam.serviceAccountTokenCreator` | Can mint access tokens and sign blobs/JWTs for the target service account. |
+| `roles/iam.serviceAccountUser` | Can attach or run workloads as the target service account. |
+| `roles/iam.workloadIdentityUser` | Allows external or Kubernetes identities to act as the service account. |
+| Custom roles with `iam.serviceAccounts.getAccessToken` | Can mint access tokens even when the predefined role name is absent. |
+| Custom roles with `iam.serviceAccounts.signBlob` or `iam.serviceAccounts.signJwt` | Can sign artifacts or JWTs as the service account. |
+
+**Terraform and policy patterns:**
+
+```
+google_service_account_iam_member
+google_service_account_iam_binding
+google_project_iam_member
+google_project_iam_binding
+google_folder_iam_member
+google_folder_iam_binding
+google_organization_iam_member
+google_organization_iam_binding
+roles/iam.serviceAccountTokenCreator
+roles/iam.serviceAccountUser
+roles/iam.workloadIdentityUser
+iam.serviceAccounts.getAccessToken
+iam.serviceAccounts.signBlob
+iam.serviceAccounts.signJwt
+principalSet://iam.googleapis.com
+google_iam_workload_identity_pool_provider
+```
+
+**Impersonation graph table:**
+
+| Principal | Grant Source | Resource Level | Target Service Account | Target SA Roles | Condition | Risk |
+|---|---|---|---|---|---|---|
+| user/group/serviceAccount/principalSet | file/resource/line | service-account/project/folder/org | service account email | owner/editor/deploy/KMS/etc. | repository/ref/audience/time/none | Critical/High/Medium/Low/Pass/Not Evaluable |
+
+**Risk rules:**
+
+- **High/Critical:** `group:*`, `user:*`, broad `principalSet:*`, or service account chains can impersonate privileged service accounts without repository, branch/tag, audience, environment, or group-membership evidence.
+- **High:** Project, folder, or organization `roles/iam.serviceAccountTokenCreator` or `roles/iam.serviceAccountUser` is granted to a human/group principal. Inherited grants can affect future service accounts, not just those visible in the module.
+- **High:** A service account can impersonate another service account with broader project, deployment, KMS, storage, BigQuery, owner/editor, or IAM roles.
+- **Medium/Not Evaluable:** IAM Conditions exist but are time-only, description-only, or depend on external group membership that is not available for review.
+- **Pass/Low:** Workload identity federation is constrained by subject/repository, branch or tag, expected audience, and a narrow service-account target; the target service account has least-privilege deployment roles.
+- **Pass/Low:** Deny policies or principal access boundary policies are present and demonstrably block the risky impersonation path; record the policy evidence.
+
+**Workload identity federation evidence:**
+
+For CI/CD or external identity providers, record the provider attribute mappings and service-account IAM Condition. Require predicates such as:
+
+```
+assertion.repository == "my-org/prod-deploy"
+assertion.ref == "refs/heads/main"
+assertion.aud == "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/ci/providers/github"
+```
+
+Do not treat workload identity federation as safe when the binding only checks time, issuer, or a broad principal set without repository and ref constraints.
+
 ### CIS 1.7 -- Ensure User-Managed/External Keys for Service Accounts Are Rotated Every 90 Days or Fewer
 
 Check for key rotation mechanisms or expiration policies on service account keys.

--- a/skills/cloud/gcp-review/tests/benign/constrained-workload-identity.tf
+++ b/skills/cloud/gcp-review/tests/benign/constrained-workload-identity.tf
@@ -1,0 +1,17 @@
+resource "google_service_account" "deploy" {
+  account_id = "prod-deploy"
+}
+
+resource "google_service_account_iam_binding" "github_deploy" {
+  service_account_id = google_service_account.deploy.name
+  role               = "roles/iam.workloadIdentityUser"
+  members = [
+    "principalSet://iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/ci/attribute.repository/my-org/prod-deploy"
+  ]
+
+  condition {
+    title       = "prod-main-only"
+    description = "Only the production deploy workflow on main can impersonate this account."
+    expression  = "assertion.repository == 'my-org/prod-deploy' && assertion.ref == 'refs/heads/main' && assertion.aud == '//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/ci/providers/github'"
+  }
+}

--- a/skills/cloud/gcp-review/tests/benign/impersonation-graph-evidence.md
+++ b/skills/cloud/gcp-review/tests/benign/impersonation-graph-evidence.md
@@ -1,0 +1,12 @@
+# Impersonation Graph Evidence Fixture
+
+This fixture represents acceptable evidence for a constrained workload identity
+federation path.
+
+| Principal | Grant Source | Resource Level | Target Service Account | Target SA Roles | Condition | Risk |
+|---|---|---|---|---|---|---|
+| `principalSet://.../attribute.repository/my-org/prod-deploy` | `google_service_account_iam_binding.github_deploy` | service-account | `prod-deploy@project.iam.gserviceaccount.com` | narrow deploy role | repository, ref, and audience constrained | Pass |
+
+Decision: no broad human/group Token Creator path is present, the federated
+principal is repository-scoped, and the IAM Condition binds repository, branch,
+and audience.

--- a/skills/cloud/gcp-review/tests/vulnerable/broad-token-creator.tf
+++ b/skills/cloud/gcp-review/tests/vulnerable/broad-token-creator.tf
@@ -1,0 +1,16 @@
+resource "google_service_account" "deploy" {
+  account_id   = "prod-deploy"
+  display_name = "Production deploy account"
+}
+
+resource "google_project_iam_member" "deploy_owner" {
+  project = var.project_id
+  role    = "roles/owner"
+  member  = "serviceAccount:${google_service_account.deploy.email}"
+}
+
+resource "google_project_iam_member" "contractor_token_creator" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = "group:contractors@example.com"
+}

--- a/skills/cloud/gcp-review/tests/vulnerable/unconstrained-workload-identity.tf
+++ b/skills/cloud/gcp-review/tests/vulnerable/unconstrained-workload-identity.tf
@@ -1,0 +1,24 @@
+resource "google_service_account" "deploy" {
+  account_id = "release-deploy"
+}
+
+resource "google_iam_workload_identity_pool_provider" "github" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.ci.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github"
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+
+  attribute_mapping = {
+    "google.subject" = "assertion.sub"
+  }
+}
+
+resource "google_service_account_iam_binding" "github_deploy" {
+  service_account_id = google_service_account.deploy.name
+  role               = "roles/iam.workloadIdentityUser"
+  members = [
+    "principalSet://iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/ci/*"
+  ]
+}


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** gcp-review
**Skill path:** `skills/cloud/gcp-review/`

### What Was Wrong
The GCP review covered CIS IAM checks, but service-account impersonation risk needs an effective graph rather than a flat role list. A project/folder/org-level `roles/iam.serviceAccountTokenCreator` grant, a custom role with `iam.serviceAccounts.signBlob` / `signJwt`, or an unconstrained workload identity binding can let a principal inherit a privileged service account's access.

The previous guidance could also over-report safe workload identity federation when the binding is tightly constrained to a repository, branch/tag, audience, and narrow target service account.

### What This PR Fixes
This PR adds effective service-account impersonation graph evidence to `gcp-review`:

- collects `roles/iam.serviceAccountTokenCreator`, `roles/iam.serviceAccountUser`, `roles/iam.workloadIdentityUser`, and custom roles with token/signing permissions
- resolves direct and inherited service-account, project, folder, and organization grants
- records principal, grant source, resource level, target service account, target SA roles, condition, inheritance, and effective risk
- follows service-account-to-service-account impersonation chains before scoring
- distinguishes constrained workload identity federation from broad human/group impersonation
- adds output format for the service account impersonation graph
- adds detailed checklist rules for repository/ref/audience constraints, deny/PAB evidence, and group membership uncertainty

### Evidence
**Before (skill misses this):**
```hcl
resource "google_project_iam_member" "contractor_token_creator" {
  project = var.project_id
  role    = "roles/iam.serviceAccountTokenCreator"
  member  = "group:contractors@example.com"
}
```

The principal can mint tokens for service accounts in the project, including privileged deployment accounts, but a flat IAM role check does not show the full path.

**Before (false positive risk):**
```hcl
resource "google_service_account_iam_binding" "github_deploy" {
  role = "roles/iam.workloadIdentityUser"
  members = [
    "principalSet://iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/ci/attribute.repository/my-org/prod-deploy"
  ]
  condition {
    expression = "assertion.repository == 'my-org/prod-deploy' && assertion.ref == 'refs/heads/main' && assertion.aud == '//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/ci/providers/github'"
  }
}
```

The updated guidance records the constraint evidence and does not treat all workload identity paths as equally risky.

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing checks still pass

Added fixtures:

- `tests/vulnerable/broad-token-creator.tf`
- `tests/vulnerable/unconstrained-workload-identity.tf`
- `tests/benign/constrained-workload-identity.tf`
- `tests/benign/impersonation-graph-evidence.md`

Validation performed:

- `git diff --check`
- `git diff --cached --check`
- workflow-equivalent frontmatter required-field check
- workflow-equivalent prompt-injection pattern scan
- marker checks for impersonation graph, workload identity, custom signing permissions, principal sets, and repository/audience constraints
- added-line ASCII check
- source URL checks for Google service-account impersonation, Workload Identity Federation, and Policy Analyzer docs

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Crypto or PayPal; payment details can be provided privately after maintainer acceptance.
