### PR TITLE
Improve threat modeling object authorization evidence

### DIFF
--- a/skills/appsec/threat-modeling/SKILL.md
+++ b/skills/appsec/threat-modeling/SKILL.md
@@ -13,7 +13,7 @@ phase: [design, review]
 frameworks: [STRIDE, PASTA, MITRE-ATT&CK]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -47,6 +47,7 @@ Before beginning the threat model, gather the following. Mark each item as obtai
 - [ ] **Data flow descriptions** — How data moves between components, including protocols (HTTPS, gRPC, AMQP), serialization formats (JSON, Protobuf), and transport security (TLS version, mTLS).
 - [ ] **Trust boundaries** — Where authentication and authorization are enforced; boundaries between internal networks, DMZs, public internet, third-party services, and user devices.
 - [ ] **Authentication and authorization mechanisms** — OAuth 2.0 flows, API keys, JWTs, SAML, RBAC/ABAC policies, service-to-service identity (SPIFFE/mTLS).
+- [ ] **Sensitive object inventory and scope source** -- Tenant-scoped, user-owned, shared, delegated, transferred, or admin-managed object classes, plus whether object scope comes from request parameters, signed session claims, server-side joins, policy engines, or background job context.
 - [ ] **Data classification** — What data is stored or processed (PII, PHI, financial data, credentials, secrets) and its sensitivity level.
 - [ ] **Threat actor profiles** — External attackers, malicious insiders, compromised supply chain, nation-state actors, automated bots.
 - [ ] **Compliance and regulatory requirements** — Applicable standards (SOC 2, PCI DSS, HIPAA, GDPR, FedRAMP).
@@ -258,6 +259,42 @@ Threat: An attacker gains access to resources or actions beyond their authorized
 | Can an attacker exploit deserialization or injection for code execution? | Remote code execution via insecure deserialization |
 | Are default credentials and unnecessary services removed? | Default admin/admin on management interfaces |
 
+### Step 4.5: Object Authorization Abuse-Case Evidence Gate
+
+Before finalizing Elevation of Privilege or Information Disclosure threats for APIs, data stores, GraphQL resolvers, search indexes, background processors, or webhook handlers, build an actor/object/action matrix. This prevents two common threat-modeling mistakes: over-reporting BOLA/IDOR when object scope is derived and enforced server-side, and missing object authorization bypasses in bulk, async, webhook, cache, and read-model paths.
+
+#### Actor/Object/Action Matrix
+
+For every sensitive object class, record the authorization evidence below:
+
+| Evidence Field | What to Capture | Why It Matters |
+|----------------|-----------------|----------------|
+| Actor and role | Customer user, customer admin, support agent, system job, webhook sender, service account, impersonated admin | Authorization behavior depends on the actor and delegated authority. |
+| Object class | Invoice, ticket, organization, file, report, payment method, audit event, search document | Each object class can have different ownership and sharing rules. |
+| Action | Read, list, export, create, update, delete, approve, transfer, impersonate, webhook mutate | Single-object CRUD coverage does not prove bulk or async paths are safe. |
+| Object-scope source | Signed session claim, server-side tenant join, request path ID, request body ID list, queue payload, webhook payload, cache key, search index document | Request-controlled IDs require stronger negative testing than server-derived scope. |
+| Enforcement point | API gateway, controller, service method, policy engine, ORM global scope, database RLS, queue consumer, webhook validator, search filter | The threat model must identify where authorization is actually enforced. |
+| Negative evidence | Cross-tenant test, cross-owner test, bulk mixed-ID test, async replay test, webhook mismatch test, search/index isolation test | Designs should provide proof that unauthorized object attempts fail. |
+| Exception path | Admin impersonation, support tooling, break-glass, delegated access, shared ownership, transfer workflow | Legitimate cross-boundary access needs approval, audit, and scope limits. |
+| Residual risk | Cache staleness, membership removal delay, eventual consistency, stale search index, queued job replay, missing tenant fixture | Object authorization can fail outside the request-time happy path. |
+
+#### Abuse-Case Prompts
+
+- Can a caller mix authorized and unauthorized IDs in a bulk export, batch update, report download, GraphQL list, or search request?
+- Does every background job, scheduled task, queue consumer, and webhook handler reload the target object under the expected tenant/user scope instead of trusting payload IDs?
+- Do nested GraphQL resolvers, joins, and read models reapply object scope after the root resolver is authorized?
+- Are cached authorization decisions invalidated when membership, ownership, delegation, or tenant assignments change?
+- Can support/admin impersonation intentionally cross object boundaries, and if so, is it approved, scoped, time-bounded, and audited?
+- Are shared, delegated, transferred, or group-owned objects handled by policy rules rather than simple `owner_id == user_id` checks?
+
+#### Evaluation Guidance
+
+- Mark a route as **Not Evaluable** when the design shows request-controlled object IDs but provides no enforcement point or negative authorization evidence.
+- Mark bulk, export, search, reporting, webhook, or async paths as **High** when they can process mixed-tenant or cross-owner object IDs without per-object scope checks.
+- Treat server-derived tenant scope as lower risk only when the evidence identifies the signed claim/session source, the server-side join or policy, and a negative test or design proof.
+- Treat admin/support impersonation as acceptable only when approval, audit event, actor identity, target scope, and expiry are documented.
+- Record stale cache, stale search index, queued event replay, and membership-removal delay as residual risks when they can preserve access after authorization changes.
+
 ### Step 5: Build Component-Threat Matrix
 
 Synthesize the STRIDE-per-element analysis into a heatmap-style matrix. For each component, rate the threat level (H=High, M=Medium, L=Low, N=None) per STRIDE category based on Step 4 findings, then derive an overall risk.
@@ -400,6 +437,14 @@ Produce the threat register as a structured table. Each row represents one ident
 | TM-005 | Denial of Service | Unbounded file upload allows resource exhaustion via large payload submission | File Upload `/api/v1/upload` | T1499.003 — Application Exhaustion Flood | High | Medium | High | Enforce max file size (10MB), implement request timeout, add rate limiting per user | Storage Team | Open |
 | TM-006 | Elevation of Privilege | IDOR vulnerability allows regular users to access other users' records by modifying resource ID | User Profile `/api/v1/users/{id}` | T1068 — Exploitation for Privilege Escalation | High | High | Critical | Implement object-level authorization checks, validate resource ownership at service layer | Backend Team | Open |
 
+### Object Authorization Abuse-Case Matrix
+
+Include this matrix when the system exposes tenant-scoped, user-owned, shared, delegated, or admin-managed objects.
+
+| Object Class | Actor/Role | Action/Path | Object-Scope Source | Enforcement Point | Negative Evidence | Exception Path | Residual Risk | Verdict |
+|--------------|------------|-------------|---------------------|-------------------|-------------------|----------------|---------------|---------|
+| Invoice | customer_admin | `POST /api/invoices/export` | request body `invoice_ids[]` | service policy per invoice | mixed-tenant export rejected | none | none | Pass/Fail/Not Evaluable |
+
 ## 6. Framework Reference
 
 ### STRIDE (Microsoft, 2003)
@@ -467,6 +512,10 @@ Threat models become stale as architectures evolve. New services, changed data f
 
 A threat register full of identified threats but no prioritized, assignable mitigations provides no security value. Every identified threat must have a corresponding mitigation with a clear owner, a severity-based SLA, and a tracking mechanism (e.g., linked Jira ticket or GitHub issue). If a threat is accepted rather than mitigated, document the risk acceptance with an approving authority and review date.
 
+### Pitfall 6: Modeling Authorization Only at Single-Object CRUD Paths
+
+Threat models often identify IDOR on `/objects/{id}` but miss bulk exports, search indexes, GraphQL nested resolvers, background jobs, webhooks, reporting endpoints, and cache-backed read models. Object authorization evidence must cover every path that reads, lists, mutates, exports, transfers, or replays sensitive object identifiers.
+
 ## 8. Prompt Injection Safety Notice
 
 This skill processes user-supplied content that may include system descriptions, architecture diagrams, configuration files, and design documents. The agent must adhere to the following safety constraints:
@@ -489,3 +538,10 @@ This skill processes user-supplied content that may include system descriptions,
 8. **NIST SP 800-154** — Guide to Data-Centric System Threat Modeling — https://csrc.nist.gov/publications/detail/sp/800-154/draft
 9. **STRIDE Original Paper** — Kohnfelder, L. & Garg, P. (1999). "The Threats to Our Products." Microsoft Internal Document.
 10. **OWASP Risk Rating Methodology** — https://owasp.org/www-community/OWASP_Risk_Rating_Methodology
+11. **OWASP API Security Top 10 2023 API1: Broken Object Level Authorization** -- https://owasp.org/API-Security/editions/2023/en/0xa1-broken-object-level-authorization/
+12. **OWASP ASVS Authorization Verification Requirements** -- https://owasp.org/www-project-application-security-verification-standard/
+
+## 10. Changelog
+
+- **1.0.1** -- Added object authorization abuse-case evidence gates for actor/object/action matrices, scope-source proof, enforcement points, and negative evidence across single-resource, bulk, async, webhook, cache, and search/read-model paths.
+- **1.0.0** -- Initial release. Structured STRIDE threat modeling with actor profiles, data-flow and trust-boundary analysis, ATT&CK mapping, risk rating, and threat register output.

--- a/skills/appsec/threat-modeling/tests/benign/object-authorization-server-scoped-negative-tests.yaml
+++ b/skills/appsec/threat-modeling/tests/benign/object-authorization-server-scoped-negative-tests.yaml
@@ -1,0 +1,42 @@
+system: billing-platform
+object_classes:
+  - name: invoice
+    sensitivity: financial
+    ownership: tenant_scoped
+paths:
+  - name: invoice_list
+    route: GET /api/invoices
+    actor: customer_admin
+    object_scope_source: signed_session_tenant_claim
+    enforcement_point: orm_global_tenant_scope
+    negative_evidence:
+      cross_tenant_id_rejected: true
+      search_index_isolation_test: true
+  - name: bulk_invoice_export
+    route: POST /api/invoices/export
+    actor: customer_admin
+    object_scope_source: request_body_invoice_ids
+    enforcement_point: service_policy_per_invoice
+    negative_evidence:
+      mixed_tenant_ids_rejected: true
+      unauthorized_ids_omitted_with_audit_event: true
+  - name: webhook_invoice_finalized
+    route: POST /webhooks/invoice-finalized
+    actor: payment_provider
+    object_scope_source: webhook_payload_invoice_id
+    enforcement_point: signed_webhook_then_server_side_invoice_reload_by_tenant
+    negative_evidence:
+      tenant_invoice_mismatch_rejected: true
+  - name: support_impersonation
+    route: POST /admin/impersonations
+    actor: support_admin
+    object_scope_source: approved_case_scope
+    enforcement_point: policy_engine_with_expiring_approval
+    exception_path:
+      approval_required: true
+      audit_event_required: true
+      expires_minutes: 30
+expected_threat_model_outcome:
+  - server-derived tenant scope is supported by a named enforcement point
+  - bulk and webhook object paths include negative authorization evidence
+  - support impersonation is treated as an exception path with approval, expiry, and audit evidence

--- a/skills/appsec/threat-modeling/tests/vulnerable/object-authorization-bulk-async-bypass.yaml
+++ b/skills/appsec/threat-modeling/tests/vulnerable/object-authorization-bulk-async-bypass.yaml
@@ -1,0 +1,37 @@
+system: billing-platform
+object_classes:
+  - name: invoice
+    sensitivity: financial
+    ownership: tenant_scoped
+paths:
+  - name: bulk_invoice_export
+    route: POST /api/invoices/export
+    actor: customer_admin
+    object_scope_source: request_body_invoice_ids
+    enforcement_point: route_tenant_check_only
+    negative_evidence:
+      mixed_tenant_ids_rejected: false
+    sample_request:
+      actor_tenant: tenant_a
+      invoice_ids:
+        - inv_tenant_a_001
+        - inv_tenant_b_009
+  - name: webhook_invoice_finalized
+    route: POST /webhooks/invoice-finalized
+    actor: payment_provider
+    object_scope_source: webhook_payload_tenant_id_and_invoice_id
+    enforcement_point: signature_only_no_object_reload
+    negative_evidence:
+      tenant_invoice_mismatch_rejected: false
+  - name: search_invoice_read_model
+    route: GET /api/search?q=invoice
+    actor: customer_user
+    object_scope_source: search_index_document_tenant
+    enforcement_point: root_query_filter_only
+    residual_risk:
+      stale_index_after_membership_removal: true
+expected_threat_model_findings:
+  - bulk export can process mixed-tenant object IDs without per-object authorization
+  - webhook handler trusts payload object scope instead of reloading under tenant context
+  - search read model can preserve stale cross-tenant access after membership changes
+  - object authorization paths should be marked high or not evaluable until negative evidence exists


### PR DESCRIPTION
## Pull Request Checklist

Please confirm the following before submitting:

- [x] Skill follows the format specification in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] At least one real framework is cited with correct control IDs
- [x] All framework references verified against primary sources (not blogs or AI output)
- [x] Prompt Injection Safety Notice section included
- [x] `injection-hardened: true` set in frontmatter
- [x] `allowed-tools` scoped to minimum necessary permissions
- [x] Tested with at least one AI coding agent (which one: Codex)
- [x] No prohibited patterns per [SECURITY.md](../SECURITY.md)
- [x] `index.yaml` updated with new skill entry (if adding a skill; N/A, this improves an existing skill)

## What This PR Does

Closes #1058

/claim #1058

Bounty target: Improver Moderate ($100) if accepted. Payment details can be provided privately after maintainer acceptance.

This improves `skills/appsec/threat-modeling/SKILL.md` by adding an object authorization abuse-case evidence gate. The new section requires an actor/object/action matrix, object-scope source, enforcement point, negative authorization evidence, exception paths, and residual risk tracking before finalizing BOLA/IDOR-related findings.

The change also expands coverage for paths that are often missed by single-resource CRUD review:

- bulk export and batch mutation requests with mixed authorized/unauthorized IDs
- background jobs, scheduled tasks, queue consumers, and webhook handlers that trust payload IDs
- GraphQL nested resolvers, joins, search indexes, reports, and cache-backed read models
- admin/support impersonation, delegated access, shared ownership, and object transfer workflows
- stale cache/search index and membership-removal residual risks

Added fixtures:

- vulnerable: `object-authorization-bulk-async-bypass.yaml`
- benign: `object-authorization-server-scoped-negative-tests.yaml`

## Framework References

- OWASP API Security Top 10 2023 API1: Broken Object Level Authorization
- OWASP ASVS Authorization Verification Requirements
- STRIDE Elevation of Privilege and Information Disclosure analysis, with existing MITRE ATT&CK references such as T1068 and T1499.003 retained in the skill examples

Primary references verified:

- https://owasp.org/API-Security/editions/2023/en/0xa1-broken-object-level-authorization/
- https://owasp.org/www-project-application-security-verification-standard/

## Testing

Tested with Codex against the review scenario in #1058.

Local validation completed:

- `git diff --check`
- YAML parse check for both new fixture files
- Markdown fence balance check for `skills/appsec/threat-modeling/SKILL.md`
- object authorization marker coverage check
- CI-equivalent frontmatter required-field check
- CI-equivalent prompt injection pattern scan from `.github/workflows/injection-scan.yml`
- CI-equivalent index file existence check using `yq v4.44.1`
- OWASP reference link HTTP checks returned 200
