### PR TITLE
Add GraphQL batching and JWT confusion gates

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -11,7 +11,7 @@ phase: [design, build, review]
 frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -33,7 +33,7 @@ Before analyzing any endpoint, establish a complete inventory of the API surface
 
 1. **Identify the API style** -- REST (OpenAPI/Swagger), GraphQL, gRPC, or hybrid. Each style has distinct attack patterns.
 2. **Catalog all endpoints and operations** -- For REST, list every path and HTTP method. For GraphQL, list all queries, mutations, and subscriptions.
-3. **Map authentication mechanisms** -- OAuth 2.0 flows, API keys, JWTs, session cookies, mTLS, or custom tokens. Note which endpoints require authentication and which are public.
+3. **Map authentication mechanisms** -- OAuth 2.0 flows, API keys, JWTs, session cookies, mTLS, or custom tokens. Note which endpoints require authentication and which are public. For JWTs, record issuer, audience, accepted algorithms, key source, key type, `kid` lookup behavior, and required claims.
 4. **Identify authorization models** -- RBAC, ABAC, ownership-based, or no authorization. Document how object-level and function-level access control decisions are made.
 5. **Catalog data objects** -- List the resources/entities exposed by the API and their sensitivity classification (PII, financial, internal, public).
 6. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, or cost-control mechanisms at the gateway or application layer.
@@ -154,6 +154,23 @@ The final review output must be structured as follows:
 
 GraphQL APIs share all ten OWASP API risks with REST but introduce additional attack surface due to their query language flexibility.
 
+### GraphQL Operation Batching and Alias Accounting
+
+GraphQL protections must be evaluated per operation, per alias, and per resolved field, not only per HTTP request. A single POST to `/graphql` can contain many operations or many aliases of the same expensive resolver.
+
+When reviewing GraphQL resource controls, record:
+
+| Evidence Item | What To Verify |
+|---|---|
+| Batch transport | Whether the server accepts a JSON array of GraphQL operations in one request |
+| Operation count | Maximum operations per HTTP request and per authenticated principal |
+| Alias count | Maximum aliases per operation, especially for login, search, export, checkout, or expensive resolver fields |
+| Resolver cost | Weighted cost per field, list multiplier, nested fan-out, and downstream API/database calls |
+| Rate-limit accounting | Whether aliased and batched operations count individually against rate limits, auth attempt limits, and business-flow quotas |
+| Persisted operation policy | Whether production allows only approved operation names or persisted query hashes for sensitive flows |
+
+Mark the control as insufficient if rate limiting, lockout, or quota logic only counts the outer HTTP request while aliased or batched operations execute independently.
+
 ### Introspection Exposure
 
 ```graphql
@@ -180,6 +197,8 @@ Deeply nested or highly complex queries can exhaust server resources (API4:2023)
 - **Maximum query depth** (e.g., 5-10 levels depending on schema complexity).
 - **Query complexity scoring** -- assign cost weights to fields and reject queries exceeding a threshold.
 - **Batch query limits** -- restrict the number of queries in a single request (query batching/aliasing).
+- **Alias and operation accounting** -- count each aliased resolver and each batched operation against rate limits, auth attempt counters, and cost budgets.
+- **Persisted operation allowlists** -- require operation names or persisted query hashes for sensitive production GraphQL flows when practical.
 
 ### Field-Level Authorization
 
@@ -199,6 +218,22 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 **Mitigation:** Count aliased operations against rate limits. Limit the number of aliases per request.
 
+### JWT Algorithm and Key-Confusion Evidence
+
+JWT authentication reviews must prove that the verifier does not trust attacker-controlled header metadata. Record the accepted algorithms, key source, key type, issuer/audience binding, and `kid` lookup behavior.
+
+High-risk findings include:
+
+- accepting `alg: none`
+- allowing both symmetric (`HS*`) and asymmetric (`RS*`, `ES*`) algorithms for the same issuer without key-type separation
+- verifying an RSA public key as an HMAC secret in HS/RS confusion cases
+- fetching `jku`, `x5u`, or embedded `jwk` values from token headers without an issuer-pinned allowlist
+- using `kid` to select local files, URLs, SQL rows, or cache entries without strict allowlisting and issuer binding
+- skipping `exp`, `nbf`, `iat`, `iss`, or `aud` validation
+- falling back to a default secret or accepting tokens when JWKS retrieval fails
+
+Require negative tests or configuration evidence showing rejected `none`, HS/RS confusion, unknown `kid`, wrong issuer, wrong audience, expired token, and not-yet-valid token cases.
+
 ---
 
 ## Common Pitfalls
@@ -214,6 +249,10 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 5. **Applying rate limiting only to authentication endpoints.** Every API endpoint requires rate limiting proportional to its cost and sensitivity. Data-heavy endpoints, search functions, and export operations are frequent targets for abuse even when properly authenticated.
 
 6. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
+
+7. **Counting only the outer GraphQL HTTP request.** A single GraphQL request can contain dozens of operations or aliases. Rate limits, auth attempt counters, and cost budgets must count the work actually executed.
+
+8. **Trusting JWT headers to choose verification behavior.** Token headers are attacker-controlled metadata. Algorithm allowlists, key type, `kid`, `jku`, `x5u`, and issuer/audience binding must be enforced by server-side configuration.
 
 ---
 

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -149,10 +149,50 @@ paths:
           in: query  # Should be in header
 ```
 
+```javascript
+// VULNERABLE: algorithm/key confusion and attacker-controlled kid handling
+const header = JSON.parse(Buffer.from(token.split('.')[0], 'base64url').toString());
+const key = await lookupKey(header.kid);
+const claims = jwt.verify(token, key); // No explicit algorithm allowlist or issuer/audience binding
+```
+
+```python
+# VULNERABLE: mixes symmetric and asymmetric algorithms for one issuer
+claims = jwt.decode(
+    token,
+    verification_key,
+    algorithms=["HS256", "RS256"],
+    options={"verify_aud": False},
+)
+```
+
+### JWT Algorithm and Key-Confusion Review
+
+Token headers are attacker-controlled metadata. Do not let `alg`, `kid`, `jku`, `x5u`, or embedded `jwk` values decide verification behavior without server-side policy.
+
+| Evidence Item | Required Review |
+|---|---|
+| Algorithm allowlist | Accepted algorithms are fixed per issuer/client and do not include `none` or unexpected symmetric/asymmetric mixes. |
+| Key type binding | HS* uses symmetric secrets; RS*/ES* uses public keys. The same key material is not accepted across both families. |
+| `kid` lookup | `kid` is matched against an issuer-scoped allowlist or trusted JWKS cache, not a file path, URL, SQL fragment, or unbounded cache key. |
+| Remote key headers | `jku`, `x5u`, and embedded `jwk` are ignored or restricted to issuer-pinned trusted origins. |
+| Required claims | `exp`, `nbf`, `iat`, `iss`, `aud`, and subject/client claims are validated for every protected API. |
+| Failure mode | Unknown `kid`, JWKS fetch failure, wrong issuer/audience, expired token, and unsupported algorithm fail closed. |
+
+**Negative cases to require in tests or configuration evidence:**
+
+- `alg: none` token is rejected.
+- HS256 token signed with an RSA public key as HMAC secret is rejected when RS256 is expected.
+- RS256 token is rejected for an issuer configured for HS256 only.
+- Unknown or path-like `kid` is rejected.
+- Token with attacker-controlled `jku`/`x5u` is rejected unless the origin is explicitly pinned.
+- Wrong `iss`, wrong `aud`, expired `exp`, and future `nbf` are rejected.
+
 ### Remediation Guidance
 
 - Enforce rate limiting on all authentication endpoints (e.g., 5 attempts per minute per IP/account).
-- Validate JWT signatures using a strong algorithm (RS256, ES256). Reject `none` and `HS256` if RSA is expected (algorithm confusion attack).
+- Validate JWT signatures using an explicit server-side algorithm allowlist (for example RS256 or ES256 for an issuer). Reject `none` and reject `HS256` when an asymmetric algorithm is expected.
+- Bind JWT key lookup to issuer and key type. Do not fetch arbitrary `jku`/`x5u` URLs or use untrusted `kid` values as paths, URLs, or query fragments.
 - Transmit API keys and tokens in HTTP headers (`Authorization` header), never in URL query strings.
 - Implement token expiration: access tokens (5-15 minutes), refresh tokens (hours to days with rotation).
 - Use `bcrypt`, `scrypt`, or `Argon2id` for password storage.
@@ -163,6 +203,8 @@ paths:
 - [ ] All authentication endpoints have brute-force protections (rate limiting, lockout).
 - [ ] JWTs are validated for signature, expiration (`exp`), issuer (`iss`), and audience (`aud`).
 - [ ] The `none` algorithm and algorithm confusion attacks are prevented by explicit algorithm allowlisting.
+- [ ] JWT key lookup is issuer-scoped; `kid`, `jku`, `x5u`, and embedded `jwk` cannot select attacker-controlled verification keys.
+- [ ] Negative tests or equivalent evidence cover `none`, HS/RS confusion, unknown `kid`, wrong issuer/audience, expired token, and not-yet-valid token cases.
 - [ ] API keys and tokens are transmitted in headers, not query strings.
 - [ ] Refresh tokens are rotated on each use and revocable.
 - [ ] Service-to-service communication is explicitly authenticated.
@@ -262,17 +304,55 @@ query {
 }
 ```
 
+```graphql
+# VULNERABLE: alias-based batching bypasses per-request login throttles
+mutation {
+  a1: login(email: "victim@example.com", password: "guess1") { token }
+  a2: login(email: "victim@example.com", password: "guess2") { token }
+  a3: login(email: "victim@example.com", password: "guess3") { token }
+}
+```
+
+```json
+[
+  { "query": "query Export($ids:[ID!]!){ invoices(ids:$ids){ id total pdfUrl } }", "variables": { "ids": ["1","2"] } },
+  { "query": "query Export($ids:[ID!]!){ invoices(ids:$ids){ id total pdfUrl } }", "variables": { "ids": ["3","4"] } }
+]
+```
+
 ```javascript
 // VULNERABLE: No request body size limit
 app.use(express.json()); // Default limit may be very large or unconfigured
 ```
+
+### GraphQL Batch and Alias Abuse Review
+
+GraphQL rate limits must count operations and resolver work, not just HTTP requests to `/graphql`.
+
+| Evidence Item | Required Review |
+|---|---|
+| Batched request support | Determine whether the server accepts an array of GraphQL operations in one HTTP request. |
+| Operation limit | Enforce a maximum operation count per request and per principal. |
+| Alias limit | Enforce a maximum alias count, especially on auth, search, export, checkout, and mutation fields. |
+| Cost model | Weight fields by resolver cost, list size, nesting, and downstream calls. Include variables that multiply work. |
+| Auth attempt accounting | Count each aliased or batched login/password-reset/MFA operation against lockout and velocity limits. |
+| Business-flow quotas | Count each aliased or batched checkout, reservation, invite, coupon, export, or report action against per-user quotas. |
+| Persisted operations | For production-sensitive flows, require operation-name allowlists or persisted query hashes where practical. |
+
+**High-risk finding examples:**
+
+- A single request with 100 aliases can execute 100 login attempts while rate limiting sees one HTTP request.
+- A batched request can run multiple expensive exports/searches while gateway quotas see one `/graphql` call.
+- Complexity scoring ignores aliases, list arguments, or nested resolver fan-out.
+- Production accepts arbitrary anonymous GraphQL operations for sensitive business flows instead of persisted operations or allowlisted operation names.
 
 ### Remediation Guidance
 
 - Implement rate limiting at the API gateway and/or application layer. Use sliding window or token bucket algorithms. Set per-endpoint limits based on expected legitimate usage.
 - Enforce maximum pagination size (e.g., `limit` capped at 100). Default to a reasonable page size (e.g., 20).
 - Set maximum request body sizes (`express.json({ limit: '1mb' })`).
-- For GraphQL: enforce query depth limits (e.g., max depth 5), complexity analysis (weighted field costs), and batch query limits.
+- For GraphQL: enforce query depth limits (e.g., max depth 5), complexity analysis (weighted field costs), alias limits, operation-count limits, and batch query limits.
+- Count each batched operation and aliased resolver against rate limits, auth attempt counters, and business-flow quotas.
 - Set execution timeouts for database queries and downstream API calls.
 - Implement cost alerts and circuit breakers for operations that trigger billable third-party APIs.
 
@@ -281,7 +361,9 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - [ ] Rate limiting is configured for all endpoints, with stricter limits on expensive operations.
 - [ ] Pagination has a maximum page size enforced server-side.
 - [ ] Request body size limits are configured.
-- [ ] GraphQL queries have depth limits, complexity limits, and batch restrictions.
+- [ ] GraphQL queries have depth limits, complexity limits, alias limits, operation-count limits, and batch restrictions.
+- [ ] GraphQL auth and business-flow rate limits count each alias and each batched operation, not only the outer HTTP request.
+- [ ] Sensitive production GraphQL flows use persisted query hashes or operation-name allowlists where practical.
 - [ ] Database queries and downstream calls have execution timeouts.
 - [ ] Billable operations have cost controls and alerting.
 

--- a/skills/appsec/api-security/tests/benign/graphql-cost-accounting.js
+++ b/skills/appsec/api-security/tests/benign/graphql-cost-accounting.js
@@ -1,0 +1,19 @@
+const MAX_OPERATIONS = 3;
+const MAX_ALIASES = 5;
+const MAX_COST = 100;
+
+function enforceGraphqlBudget(request, principal) {
+  const operations = Array.isArray(request.body) ? request.body : [request.body];
+  if (operations.length > MAX_OPERATIONS) throw new Error("too many operations");
+
+  let totalCost = 0;
+  for (const operation of operations) {
+    const aliasCount = countAliases(operation.query);
+    if (aliasCount > MAX_ALIASES) throw new Error("too many aliases");
+
+    totalCost += estimateComplexity(operation.query, operation.variables);
+  }
+
+  if (totalCost > MAX_COST) throw new Error("query too expensive");
+  rateLimiter.consume(principal.id, operations.length + totalCost);
+}

--- a/skills/appsec/api-security/tests/benign/jwt-strict-allowlist.js
+++ b/skills/appsec/api-security/tests/benign/jwt-strict-allowlist.js
@@ -1,0 +1,20 @@
+const jwt = require("jsonwebtoken");
+
+const ISSUER = "https://issuer.example.com/";
+const AUDIENCE = "api://orders";
+const ALGORITHMS = ["RS256"];
+const TRUSTED_KIDS = new Set(["orders-2026-01"]);
+
+function authenticate(token) {
+  const header = JSON.parse(Buffer.from(token.split(".")[0], "base64url").toString("utf8"));
+  if (!TRUSTED_KIDS.has(header.kid)) throw new Error("unknown kid");
+  if (header.jku || header.x5u || header.jwk) throw new Error("untrusted remote key header");
+
+  const publicKey = jwksCache.get(ISSUER, header.kid);
+  return jwt.verify(token, publicKey, {
+    algorithms: ALGORITHMS,
+    issuer: ISSUER,
+    audience: AUDIENCE,
+    clockTolerance: 30,
+  });
+}

--- a/skills/appsec/api-security/tests/vulnerable/graphql-batched-login.graphql
+++ b/skills/appsec/api-security/tests/vulnerable/graphql-batched-login.graphql
@@ -1,0 +1,6 @@
+mutation BatchedLoginBypass {
+  a1: login(email: "victim@example.com", password: "guess1") { token }
+  a2: login(email: "victim@example.com", password: "guess2") { token }
+  a3: login(email: "victim@example.com", password: "guess3") { token }
+  a4: login(email: "victim@example.com", password: "guess4") { token }
+}

--- a/skills/appsec/api-security/tests/vulnerable/jwt-algorithm-confusion.js
+++ b/skills/appsec/api-security/tests/vulnerable/jwt-algorithm-confusion.js
@@ -1,0 +1,13 @@
+const jwt = require("jsonwebtoken");
+
+async function authenticate(token) {
+  const header = JSON.parse(Buffer.from(token.split(".")[0], "base64url").toString("utf8"));
+  const key = await lookupKey(header.kid);
+
+  // Vulnerable: algorithm and issuer/audience are not fixed by server-side policy.
+  return jwt.verify(token, key);
+}
+
+async function lookupKey(kid) {
+  return keyStore.get(kid);
+}


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** api-security
**Skill path:** `skills/appsec/api-security/`

### What Was Wrong
The API security skill mentioned GraphQL depth/complexity and basic JWT validation, but it did not require enough evidence for two common bypass classes:

- GraphQL batching and alias abuse, where one HTTP request can execute many operations or repeated expensive/auth-sensitive resolvers while rate limits count only the outer request.
- JWT algorithm/key confusion, where attacker-controlled token headers such as `alg`, `kid`, `jku`, `x5u`, or embedded `jwk` influence verification behavior.

### What This PR Fixes
This PR adds explicit review gates for both areas:

- GraphQL operation batching and alias accounting in the main skill
- batch transport, operation-count, alias-count, resolver cost, auth-attempt, business-flow quota, and persisted-operation evidence
- API4 checklist guidance for batched GraphQL requests and alias-based login/search/export abuse
- JWT authentication evidence for accepted algorithms, key source, key type, issuer/audience binding, `kid` lookup, remote key headers, and fail-closed behavior
- API2 checklist negative cases for `alg: none`, HS/RS confusion, unknown `kid`, attacker-controlled `jku`/`x5u`, wrong issuer/audience, expired tokens, and future `nbf`

### Evidence
**Before (GraphQL batching miss):**
```graphql
mutation {
  a1: login(email: "victim@example.com", password: "guess1") { token }
  a2: login(email: "victim@example.com", password: "guess2") { token }
  a3: login(email: "victim@example.com", password: "guess3") { token }
}
```

If the rate limiter counts only one POST to `/graphql`, the auth attempt counter is bypassed.

**Before (JWT confusion miss):**
```javascript
const header = JSON.parse(Buffer.from(token.split(".")[0], "base64url").toString());
const key = await lookupKey(header.kid);
const claims = jwt.verify(token, key);
```

The verifier does not pin algorithms, issuer, audience, key type, or `kid` source.

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing checks still pass

Added fixtures:

- `tests/vulnerable/graphql-batched-login.graphql`
- `tests/vulnerable/jwt-algorithm-confusion.js`
- `tests/benign/graphql-cost-accounting.js`
- `tests/benign/jwt-strict-allowlist.js`

Validation performed:

- `git diff --check`
- `git diff --cached --check`
- workflow-equivalent frontmatter required-field check
- workflow-equivalent prompt-injection pattern scan
- marker checks for JWT confusion, `jku`/`x5u`, `kid`, GraphQL batch/alias evidence, operation-count limits, and fixtures
- added-line ASCII check

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Crypto or PayPal; payment details can be provided privately after maintainer acceptance.
