### PR TITLE
Improve SAST dataflow and false-positive evidence gates

### DIFF
--- a/skills/devsecops/sast-config/SKILL.md
+++ b/skills/devsecops/sast-config/SKILL.md
@@ -12,7 +12,7 @@ phase: [build]
 frameworks: [OWASP-ASVS-4.0.3, CWE-Top-25]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -58,8 +58,11 @@ Use Glob and Grep to locate SAST tool configurations, custom rules, and CI integ
 **/.semgrep.yml
 **/.semgrep.yaml
 **/.semgrep/
+**/.semgrep/**/*.yml
+**/.semgrep/**/*.yaml
 **/semgrep*
 **/.semgrepignore
+**/semgrep-rules/**
 
 # CodeQL
 **/.github/codeql/
@@ -67,6 +70,7 @@ Use Glob and Grep to locate SAST tool configurations, custom rules, and CI integ
 **/*.ql
 **/*.qll
 **/qlpack.yml
+**/codeql-queries/**
 **/.github/workflows/*codeql*
 
 # General SAST
@@ -90,6 +94,8 @@ Categorize by:
 - **Tool:** Semgrep, CodeQL, SonarQube, Bandit, ESLint-security, etc.
 - **Rule source:** Default/managed rules, community rules, custom org rules.
 - **Integration point:** Pre-commit, PR check, scheduled scan, IDE plugin.
+- **Scope boundary:** whole repository, changed files only, package/workspace subset, generated code excluded.
+- **Dataflow depth:** syntax-only matching, Semgrep taint mode, CodeQL path queries, or tool-specific interprocedural analysis.
 
 ---
 
@@ -223,12 +229,58 @@ rules:
 
 - [ ] `id` follows a namespace convention (e.g., `custom.category.name`).
 - [ ] `pattern` uses metavariables (`$VAR`) correctly for taint tracking.
+- [ ] Taint rules use `mode: taint` when source-to-sink flow matters; syntax-only rules are not accepted as coverage for injection, SSRF, path traversal, or deserialization flows.
+- [ ] `pattern-sources`, `pattern-sinks`, `pattern-sanitizers`, and `pattern-propagators` are present when the vulnerability depends on dataflow.
 - [ ] `message` explains the vulnerability AND references the fix.
 - [ ] `severity` is `ERROR` (blocks CI), `WARNING` (reported), or `INFO` (informational).
 - [ ] `metadata` includes `cwe`, `owasp`, and/or `asvs` references.
 - [ ] `confidence` is documented (HIGH, MEDIUM, LOW).
 - [ ] `languages` is explicitly specified.
 - [ ] `pattern-not` or `pattern-not-inside` handles known safe patterns to reduce false positives.
+- [ ] Safe wrappers and validators are modeled as sanitizers, not suppressed wholesale.
+- [ ] Rule tests include at least one vulnerable flow and one benign flow for every sanitizer or wrapper exception.
+
+#### 3.3 Semgrep Taint Mode and Safe-Wrapper Review
+
+For custom Semgrep rules that claim injection, SSRF, file path, template, deserialization, or authorization dataflow coverage, verify the rule is a taint rule rather than a single syntactic pattern.
+
+**Vulnerable fixture that should be caught:**
+
+```python
+from flask import request
+import subprocess
+
+def export_report():
+    report_id = request.args["id"]
+    subprocess.run(f"report-cli --id {report_id}", shell=True)
+```
+
+**Benign fixture that should not be caught:**
+
+```python
+from flask import request
+import subprocess
+
+def validate_report_id(value: str) -> str:
+    if not value.isdecimal():
+        raise ValueError("invalid report id")
+    return value
+
+def export_report():
+    report_id = validate_report_id(request.args["id"])
+    subprocess.run(["report-cli", "--id", report_id], check=True)
+```
+
+**What to verify:**
+
+- Sources include framework inputs, message queues, CLI arguments, environment variables, and deserialized request bodies.
+- Sinks match the actual dangerous APIs, not only helper names (`subprocess`, raw SQL execution, filesystem reads, HTTP clients, template rendering, dynamic imports).
+- Sanitizers model specific validators, encoders, parameterized query builders, allowlists, or typed parsers.
+- Safe wrappers are accepted only when their implementation is in scope and covered by a benign fixture.
+- `pattern-not` exceptions do not remove the entire sink family or all calls inside a broad directory.
+- For monorepos, taint rules are tested in at least one package boundary where shared helpers and app code live in different workspaces.
+
+**Finding classification:** A dataflow vulnerability class represented by syntax-only rules is **High** for CWE Top 10 injection classes and **Medium** for other dataflow classes. A sanitizer that is not backed by code evidence or a benign fixture is **Medium**. A broad `pattern-not` that masks a sink family is **High**.
 
 ---
 
@@ -260,6 +312,8 @@ query-filters:
 - Custom query directory exists for org-specific patterns.
 - `paths-ignore` does not exclude production source code.
 - `query-filters` exclusions have documented justification.
+- Custom query packs are included in the workflow/config actually used by CI.
+- Path queries use source, sink, sanitizer, and additional taint steps that match the framework and shared helper patterns in the repository.
 
 #### 4.2 CodeQL Custom Query Structure
 
@@ -306,6 +360,43 @@ select sink.getNode(), source, sink, "SQL injection from $@.", source.getNode(),
 - [ ] `@tags` include CWE and OWASP references.
 - [ ] Taint tracking uses appropriate source and sink definitions.
 - [ ] Query is tested against known-vulnerable and known-safe code samples.
+- [ ] Sanitizers, validators, encoders, and safe wrapper APIs are explicitly modeled.
+- [ ] Additional taint steps cover framework-specific wrappers, DTO mappers, ORM builders, and shared utility functions when those appear in the codebase.
+- [ ] Query pack tests include generated-code and test-fixture exclusions so production coverage is not confused with fixture coverage.
+
+#### 4.3 CodeQL Dataflow Customization Review
+
+Default CodeQL packs often miss organization-specific wrapper APIs. When reviewing custom CodeQL coverage, require evidence that dataflow configuration matches the application architecture.
+
+**Vulnerable fixture that should be caught:**
+
+```javascript
+app.get("/search", async (req, res) => {
+  const where = buildWhereClause(req.query.q)
+  const rows = await db.raw(`select * from tickets where ${where}`)
+  res.json(rows)
+})
+```
+
+**Benign fixture that should not be caught:**
+
+```javascript
+app.get("/search", async (req, res) => {
+  const q = parseSearchTerm(req.query.q)
+  const rows = await db("tickets").where("title", "like", `%${q}%`)
+  res.json(rows)
+})
+```
+
+**What to verify:**
+
+- Query configs include the correct framework source libraries, such as Express, Next.js route handlers, Django views, Rails controllers, Spring MVC, or serverless event handlers.
+- Query packs model internal helper APIs that wrap sinks (`db.raw`, HTTP clients, template renderers, filesystem clients, shell runners).
+- Sanitizer predicates distinguish validation, encoding, allowlisting, and parameterization instead of treating all helper calls as safe.
+- `@precision` matches the rule evidence; low-precision queries should not block CI without manual triage.
+- Query tests show one vulnerable path and one benign safe-wrapper path for each custom source/sink/sanitizer family.
+
+**Finding classification:** Custom CodeQL path queries without sanitizer or wrapper modeling are **Medium**. Missing source/sink coverage for a production framework is **High** for injection and SSRF classes. Query filters that exclude production paths without justification are **High**.
 
 ---
 
@@ -363,14 +454,51 @@ value = request.args.get("id")  # nosemgrep: python.django.security.injection.sq
 - Suppressions are reviewed periodically (quarterly).
 - False positive rate is tracked as a metric (target: < 20% FP rate).
 - True positive findings have a defined SLA (Critical: 7 days, High: 30 days, Medium: 90 days).
+- Suppressions for wrapper APIs include a link to the wrapper implementation and a safe-fixture test.
+- Generated-code suppressions identify the generator, generation command, and the checked-in/generated boundary.
+- Duplicate findings from monorepo packages are grouped without hiding unique sinks in separate deployable services.
 
 **Finding classification:** No false positive management process is **Medium**. Suppressions without justification is **High**. No SLA for true positive remediation is **Medium**.
 
 ---
 
-### Step 6: CI Integration Review
+### Step 6: Generated Code, Monorepo, and Incremental Scan Boundaries
 
-#### 6.1 CI Pipeline Integration Patterns
+SAST configuration must preserve production coverage while keeping generated and third-party noise manageable.
+
+**What to verify:**
+
+- Generated paths are excluded only when the generator is documented and source templates remain scanned.
+- Vendored, third-party, fixture, and migration paths are separated from first-party runtime code.
+- Monorepo configs enumerate all deployable packages/services and do not scan only the first workspace discovered.
+- Incremental PR scans are paired with scheduled full-repository scans so cross-file dataflow and stale suppressions are still evaluated.
+- CodeQL databases are built for every language/package actually deployed, not only the root package.
+- Semgrep `--include` and `--exclude` settings are reviewed against the repository tree and current package list.
+
+**Benign exclusion example:**
+
+```yaml
+# .semgrepignore
+generated/openapi/**  # generated by scripts/generate-openapi.sh; templates are scanned under api/spec/
+vendor/**
+node_modules/**
+```
+
+**Risky exclusion example:**
+
+```yaml
+# .semgrepignore
+services/**
+packages/**
+```
+
+**Finding classification:** Excluding generated code with documented scanned sources is **Low**. Excluding broad production service/package trees is **High**. PR-only incremental scanning without a scheduled full scan is **Medium**.
+
+---
+
+### Step 7: CI Integration Review
+
+#### 7.1 CI Pipeline Integration Patterns
 
 **GitHub Actions -- Semgrep:**
 
@@ -441,7 +569,7 @@ jobs:
 |----------|-----------|
 | **Critical** | No SAST tooling deployed; CWE Top 5 weaknesses with zero rule coverage for languages in active use. |
 | **High** | SAST not a required CI check; CWE Top 10 coverage gap; suppressions without justification; no triage workflow; custom rules with incorrect severity mapping. |
-| **Medium** | CWE 11-25 coverage gap; no false positive management process; no scheduled full-repo scan; no remediation SLA; excessive path exclusions; FP rate > 30%. |
+| **Medium** | CWE 11-25 coverage gap; no false positive management process; no scheduled full-repo scan; no remediation SLA; excessive path exclusions; FP rate > 30%; custom dataflow query lacks sanitizer modeling. |
 | **Low** | Rule naming convention inconsistencies; missing metadata on custom rules; suboptimal scan performance; cosmetic configuration issues. |
 
 ---
@@ -474,6 +602,20 @@ jobs:
 | Required status check | Yes/No | <branch protection config> |
 | Scheduled full scan | Yes/No | <cron schedule> |
 | Results dashboard | Yes/No | <dashboard URL or tool> |
+
+### Dataflow and False-Positive Evidence
+
+| Tool | Flow Class | Source/Sink Evidence | Sanitizer/Wrapper Evidence | Vulnerable Fixture | Benign Fixture | Gap |
+|------|------------|----------------------|-----------------------------|--------------------|----------------|-----|
+| Semgrep | Command injection | `request.args` -> `subprocess.run(shell=True)` | `validate_report_id()` + arg-array execution | `tests/sast/command-injection-vuln.py` | `tests/sast/command-injection-safe.py` | None |
+| CodeQL | SQL injection | Express query -> `db.raw()` | `parseSearchTerm()` + query builder | `qltest/sql-vuln.js` | `qltest/sql-safe.js` | Missing custom helper model |
+
+### Scope Boundary Evidence
+
+- Generated code policy: <generator, source template path, excluded generated path>
+- Monorepo packages scanned: <package/service list>
+- Incremental scan scope: <PR scan behavior>
+- Scheduled full scan: <workflow and schedule>
 
 ### Findings
 
@@ -536,6 +678,12 @@ jobs:
 
 5. **Ignoring SAST scan performance.** If SAST takes 30 minutes on a PR check, developers will find ways to bypass it. Target under 10 minutes for PR scans. Use diff-aware scanning for PRs and reserve full analysis for scheduled scans.
 
+6. **Claiming dataflow coverage with syntax-only rules.** A rule that matches `db.raw(...)` does not prove SQL injection coverage unless it tracks untrusted data into that sink and models parameterization or validation as safe.
+
+7. **Treating every wrapper as a sanitizer.** Helper functions such as `clean()`, `normalize()`, or `buildWhereClause()` are not safe by name. Review their implementation and require benign fixtures before marking them as sanitizers.
+
+8. **Letting generated-code exclusions hide production logic.** Generated clients can be excluded when templates/specs are scanned, but broad `services/**` or `packages/**` exclusions create blind spots in monorepos.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -555,8 +703,10 @@ This skill processes SAST configuration files, custom rules, and code patterns t
 - CWE Top 25 (2024): https://cwe.mitre.org/top25/archive/2024/2024_cwe_top25.html
 - Semgrep Documentation: https://semgrep.dev/docs/
 - Semgrep Rule Syntax: https://semgrep.dev/docs/writing-rules/rule-syntax/
+- Semgrep Taint Mode: https://semgrep.dev/docs/writing-rules/data-flow/taint-mode/
 - Semgrep Registry: https://semgrep.dev/r
 - CodeQL Documentation: https://codeql.github.com/docs/
+- CodeQL Data Flow Analysis: https://codeql.github.com/docs/writing-codeql-queries/about-data-flow-analysis/
 - CodeQL for GitHub: https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql
 - SonarQube Documentation: https://docs.sonarsource.com/sonarqube/
 
@@ -564,4 +714,5 @@ This skill processes SAST configuration files, custom rules, and code patterns t
 
 ## Changelog
 
+- **1.1.0** -- Added Semgrep taint-mode and CodeQL custom dataflow review gates, safe-wrapper false-positive evidence, generated-code and monorepo scan-boundary checks, and report fields for vulnerable/benign fixture evidence.
 - **1.0.0** -- Initial release. Full coverage of SAST configuration review against OWASP ASVS 4.0.3 and CWE Top 25, with Semgrep and CodeQL patterns.

--- a/skills/devsecops/sast-config/SKILL.md
+++ b/skills/devsecops/sast-config/SKILL.md
@@ -12,7 +12,7 @@ phase: [build]
 frameworks: [OWASP-ASVS-4.0.3, CWE-Top-25]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.1.0"
+version: "1.1.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -239,6 +239,7 @@ rules:
 - [ ] `pattern-not` or `pattern-not-inside` handles known safe patterns to reduce false positives.
 - [ ] Safe wrappers and validators are modeled as sanitizers, not suppressed wholesale.
 - [ ] Rule tests include at least one vulnerable flow and one benign flow for every sanitizer or wrapper exception.
+- [ ] Fixture evidence records the expected result, rule or query family, and scan output for each true-positive and true-negative sample.
 
 #### 3.3 Semgrep Taint Mode and Safe-Wrapper Review
 
@@ -605,10 +606,10 @@ jobs:
 
 ### Dataflow and False-Positive Evidence
 
-| Tool | Flow Class | Source/Sink Evidence | Sanitizer/Wrapper Evidence | Vulnerable Fixture | Benign Fixture | Gap |
-|------|------------|----------------------|-----------------------------|--------------------|----------------|-----|
-| Semgrep | Command injection | `request.args` -> `subprocess.run(shell=True)` | `validate_report_id()` + arg-array execution | `tests/sast/command-injection-vuln.py` | `tests/sast/command-injection-safe.py` | None |
-| CodeQL | SQL injection | Express query -> `db.raw()` | `parseSearchTerm()` + query builder | `qltest/sql-vuln.js` | `qltest/sql-safe.js` | Missing custom helper model |
+| Tool | Flow Class | Source/Sink Evidence | Sanitizer/Wrapper Evidence | Vulnerable Fixture | Benign Fixture | Scan Evidence | Gap |
+|------|------------|----------------------|-----------------------------|--------------------|----------------|---------------|-----|
+| Semgrep | Command injection | `request.args` -> `subprocess.run(shell=True)` | `validate_report_id()` + arg-array execution | `tests/sast/command-injection-vuln.py` | `tests/sast/command-injection-safe.py` | <rule id, command, true-positive/true-negative output> | None |
+| CodeQL | SQL injection | Express query -> `db.raw()` | `parseSearchTerm()` + query builder | `qltest/sql-vuln.js` | `qltest/sql-safe.js` | <query id, database/query command, result path> | Missing custom helper model |
 
 ### Scope Boundary Evidence
 
@@ -714,5 +715,7 @@ This skill processes SAST configuration files, custom rules, and code patterns t
 
 ## Changelog
 
+- **1.1.1** -- Added explicit fixture evidence expectations for true-positive
+  and true-negative SAST samples.
 - **1.1.0** -- Added Semgrep taint-mode and CodeQL custom dataflow review gates, safe-wrapper false-positive evidence, generated-code and monorepo scan-boundary checks, and report fields for vulnerable/benign fixture evidence.
 - **1.0.0** -- Initial release. Full coverage of SAST configuration review against OWASP ASVS 4.0.3 and CWE Top 25, with Semgrep and CodeQL patterns.

--- a/skills/devsecops/sast-config/SKILL.md
+++ b/skills/devsecops/sast-config/SKILL.md
@@ -240,6 +240,7 @@ rules:
 - [ ] Safe wrappers and validators are modeled as sanitizers, not suppressed wholesale.
 - [ ] Rule tests include at least one vulnerable flow and one benign flow for every sanitizer or wrapper exception.
 - [ ] Fixture evidence records the expected result, rule or query family, and scan output for each true-positive and true-negative sample.
+- [ ] Evidence fixtures are paired with a runnable rule/query snippet or command so reviewers can reproduce the expected true-positive and true-negative behavior.
 
 #### 3.3 Semgrep Taint Mode and Safe-Wrapper Review
 
@@ -280,6 +281,7 @@ def export_report():
 - Safe wrappers are accepted only when their implementation is in scope and covered by a benign fixture.
 - `pattern-not` exceptions do not remove the entire sink family or all calls inside a broad directory.
 - For monorepos, taint rules are tested in at least one package boundary where shared helpers and app code live in different workspaces.
+- Evidence packs include the rule id, scan command, vulnerable fixture path, benign fixture path, and observed finding counts.
 
 **Finding classification:** A dataflow vulnerability class represented by syntax-only rules is **High** for CWE Top 10 injection classes and **Medium** for other dataflow classes. A sanitizer that is not backed by code evidence or a benign fixture is **Medium**. A broad `pattern-not` that masks a sink family is **High**.
 

--- a/skills/devsecops/sast-config/tests/README.md
+++ b/skills/devsecops/sast-config/tests/README.md
@@ -1,0 +1,18 @@
+# SAST Fixture Evidence
+
+These fixtures give reviewers compact true-positive and true-negative samples
+for the dataflow checks described by `sast-config`. Use them to verify that a
+custom Semgrep rule or CodeQL query detects vulnerable flows without flagging
+validated wrappers or parameterized query builders.
+
+| Fixture | Expected Result | Flow Class | Evidence to Record |
+|---------|-----------------|------------|--------------------|
+| `vulnerable/command-injection-taint.py` | True positive | Flask request argument reaches `subprocess.run(..., shell=True)` | Rule/query id and finding output |
+| `benign/validated-command-wrapper.py` | True negative | Flask request argument is decimal-validated and passed as an argument array | Rule/query id and no-finding output |
+| `vulnerable/express-raw-sql-flow.js` | True positive | Express query parameter reaches raw SQL construction | Rule/query id and finding output |
+| `benign/express-query-builder.js` | True negative | Express query parameter flows through parser plus query builder API | Rule/query id and no-finding output |
+
+When a review accepts a sanitizer or wrapper as safe, cite the matching benign
+fixture path and the scan output that stayed quiet. When a rule claims
+source-to-sink coverage, cite the matching vulnerable fixture path and the
+finding output that proves the flow is detected.

--- a/skills/devsecops/sast-config/tests/README.md
+++ b/skills/devsecops/sast-config/tests/README.md
@@ -12,6 +12,24 @@ validated wrappers or parameterized query builders.
 | `vulnerable/express-raw-sql-flow.js` | True positive | Express query parameter reaches raw SQL construction | Rule/query id and finding output |
 | `benign/express-query-builder.js` | True negative | Express query parameter flows through parser plus query builder API | Rule/query id and no-finding output |
 
+## Reproducible Semgrep Evidence
+
+The sample rules in `semgrep-rules/dataflow-evidence.yml` are intentionally
+small. They give reviewers a concrete way to prove that a SAST configuration
+tracks source-to-sink flow without flagging the paired benign wrapper.
+
+Expected checks:
+
+```bash
+semgrep --config tests/semgrep-rules/dataflow-evidence.yml tests/vulnerable
+semgrep --config tests/semgrep-rules/dataflow-evidence.yml tests/benign
+```
+
+Record the rule id, command, and finding count for each run. The vulnerable
+directory should produce findings for the matching rule family; the benign
+directory should stay quiet unless the reviewed sanitizer model is too broad or
+too weak.
+
 When a review accepts a sanitizer or wrapper as safe, cite the matching benign
 fixture path and the scan output that stayed quiet. When a rule claims
 source-to-sink coverage, cite the matching vulnerable fixture path and the

--- a/skills/devsecops/sast-config/tests/benign/express-query-builder.js
+++ b/skills/devsecops/sast-config/tests/benign/express-query-builder.js
@@ -1,0 +1,5 @@
+app.get("/search", async (req, res) => {
+  const q = parseSearchTerm(req.query.q);
+  const rows = await db("tickets").where("title", "like", `%${q}%`);
+  res.json(rows);
+});

--- a/skills/devsecops/sast-config/tests/benign/validated-command-wrapper.py
+++ b/skills/devsecops/sast-config/tests/benign/validated-command-wrapper.py
@@ -1,0 +1,13 @@
+from flask import request
+import subprocess
+
+
+def validate_report_id(value: str) -> str:
+    if not value.isdecimal():
+        raise ValueError("invalid report id")
+    return value
+
+
+def export_report():
+    report_id = validate_report_id(request.args["id"])
+    subprocess.run(["report-cli", "--id", report_id], check=True)

--- a/skills/devsecops/sast-config/tests/semgrep-rules/dataflow-evidence.yml
+++ b/skills/devsecops/sast-config/tests/semgrep-rules/dataflow-evidence.yml
@@ -1,0 +1,40 @@
+rules:
+  - id: evidence.python.command-injection-taint
+    mode: taint
+    languages: [python]
+    severity: ERROR
+    message: User-controlled request data reaches shell execution.
+    pattern-sources:
+      - pattern: request.args[$KEY]
+    pattern-sanitizers:
+      - pattern: validate_report_id(...)
+    pattern-sinks:
+      - pattern: subprocess.run($CMD, shell=True, ...)
+    metadata:
+      cwe:
+        - "CWE-78: OS Command Injection"
+      evidence-fixtures:
+        true-positive: tests/vulnerable/command-injection-taint.py
+        true-negative: tests/benign/validated-command-wrapper.py
+
+  - id: evidence.javascript.raw-sql-dataflow
+    mode: taint
+    languages: [javascript]
+    severity: ERROR
+    message: User-controlled request data reaches raw SQL construction.
+    pattern-sources:
+      - pattern: req.query.$FIELD
+    pattern-propagators:
+      - pattern: $OUT = buildWhereClause($IN)
+        from: $IN
+        to: $OUT
+    pattern-sanitizers:
+      - pattern: parseSearchTerm(...)
+    pattern-sinks:
+      - pattern: db.raw(...)
+    metadata:
+      cwe:
+        - "CWE-89: SQL Injection"
+      evidence-fixtures:
+        true-positive: tests/vulnerable/express-raw-sql-flow.js
+        true-negative: tests/benign/express-query-builder.js

--- a/skills/devsecops/sast-config/tests/vulnerable/command-injection-taint.py
+++ b/skills/devsecops/sast-config/tests/vulnerable/command-injection-taint.py
@@ -1,0 +1,7 @@
+from flask import request
+import subprocess
+
+
+def export_report():
+    report_id = request.args["id"]
+    subprocess.run(f"report-cli --id {report_id}", shell=True, check=True)

--- a/skills/devsecops/sast-config/tests/vulnerable/express-raw-sql-flow.js
+++ b/skills/devsecops/sast-config/tests/vulnerable/express-raw-sql-flow.js
@@ -1,0 +1,5 @@
+app.get("/search", async (req, res) => {
+  const where = buildWhereClause(req.query.q);
+  const rows = await db.raw(`select * from tickets where ${where}`);
+  res.json(rows);
+});


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** sast-config
**Skill path:** `skills/devsecops/sast-config/`

### What Was Wrong
The skill covered general Semgrep and CodeQL configuration quality, but it did not require dataflow-specific evidence for Semgrep taint mode or custom CodeQL path queries. That left a review gap where syntax-only matching could be counted as coverage for injection, SSRF, path traversal, or deserialization flows, and where safe wrappers could be treated as sanitizers without fixture-backed proof.

### What This PR Fixes
- Adds Semgrep taint-mode review gates for `pattern-sources`, `pattern-sinks`, `pattern-sanitizers`, and `pattern-propagators`.
- Adds safe-wrapper false-positive checks requiring implementation evidence plus benign fixtures.
- Adds CodeQL custom dataflow review guidance for source/sink/sanitizer modeling and additional taint steps.
- Adds generated-code, monorepo, and incremental-scan boundary checks so broad exclusions do not hide production coverage gaps.
- Adds output report fields for vulnerable/benign fixture evidence and scan-scope boundary evidence.
- Adds a runnable Semgrep evidence pack that pairs rule snippets with vulnerable and benign fixtures.
- Updates the skill version/changelog to `1.1.1`.

### Evidence
**Before (skill misses this / false positive on this):**
```python
from flask import request
import subprocess

def export_report():
    report_id = request.args["id"]
    subprocess.run(f"report-cli --id {report_id}", shell=True)
```

**After (now correctly handled):**
```python
from flask import request
import subprocess

def validate_report_id(value: str) -> str:
    if not value.isdecimal():
        raise ValueError("invalid report id")
    return value

def export_report():
    report_id = validate_report_id(request.args["id"])
    subprocess.run(["report-cli", "--id", report_id], check=True)
```

The updated skill now requires SAST reviews to distinguish the vulnerable source-to-shell sink flow from the benign validated/argument-array flow, instead of accepting a syntax-only `subprocess` match or a broad suppression.

### Test Cases Added/Updated
- [x] Added vulnerable evidence examples in the skill body
- [x] Added benign evidence examples in the skill body
- [x] Added a runnable Semgrep evidence pack for true-positive/true-negative checks
- [x] Existing repository validation checks still pass

Validation run locally:
```text
frontmatter ok
injection scan ok
markdown fences ok: 32
git diff --check
```

### Bounty Tier
- [ ] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the CONTRIBUTING.md bounty terms
- **Preferred payment method:** Can provide privately after maintainer acceptance.

/claim #1028
