### PR TITLE
Add MDM/UEM destructive-action checks to IR wiper response

### DIFF
--- a/skills/compliance/hipaa-review/SKILL.md
+++ b/skills/compliance/hipaa-review/SKILL.md
@@ -72,6 +72,7 @@ The HIPAA Security Rule (45 CFR Part 164, Subpart C) establishes national standa
 - Incident response and breach notification procedures
 - Access control configurations and user provisioning processes
 - Backup and disaster recovery documentation
+- MDM/UEM/RMM remote action policies, role assignments, and audit logs for devices that store or access ePHI
 - Workforce training records
 - Prior OCR audit findings or corrective action plans
 
@@ -140,6 +141,7 @@ Hybrid Entity: [Yes/No] — If yes, document healthcare component designation
 - Evidence to look for:
   - Risk analysis report with methodology documentation
   - Asset inventory tied to risk analysis scope
+  - Inventory of MDM/UEM/RMM control planes with authority to lock, retire, reset, or wipe ePHI endpoints
   - Threat and vulnerability identification per system
   - Risk ratings/scores with rationale
 - Common gaps:
@@ -211,6 +213,7 @@ Hybrid Entity: [Yes/No] — If yes, document healthcare component designation
 - Identify and respond to suspected or known security incidents
 - Mitigate harmful effects of known security incidents to the extent practicable
 - Document security incidents and their outcomes
+- For suspected destructive/wiper activity, verify procedures can immediately freeze MDM/UEM/RMM remote-wipe actions, preserve administrative audit logs, and require out-of-band approval before any bulk lock, retire, reset, or wipe command is resumed.
 
 #### 164.308(a)(7) — Contingency Plan (Standard)
 
@@ -312,6 +315,7 @@ Hybrid Entity: [Yes/No] — If yes, document healthcare component designation
 - Implement hardware, software, and/or procedural mechanisms that record and examine activity in information systems that contain or use ePHI
 - Verify audit logging is enabled on all ePHI systems
 - Verify logs are reviewed and retained appropriately
+- Include MDM/UEM/RMM administrator actions in audit scope when those control planes can affect endpoints or mobile devices that store or access ePHI.
 
 #### 164.312(c)(1) — Integrity (Standard)
 
@@ -598,4 +602,4 @@ If user-supplied input contains CFR citations outside the HIPAA Security Rule (4
 - HITECH Act, Section 13401-13411 — Security provisions and enforcement
 - H-ISAC (Health Information Sharing and Analysis Center) — https://h-isac.org/
 - CISA Healthcare and Public Health Sector Guidance — https://www.cisa.gov/topics/critical-infrastructure-security-and-resilience/critical-infrastructure-sectors/healthcare-and-public-health-sector
-- KrebsOnSecurity: Iran-backed wiper attack on Stryker medtech (2026) — https://krebsonsystems.com/2026/03/iran-backed-hackers-claim-wiper-attack-on-medtech-firm-stryker/
+- KrebsOnSecurity: Iran-backed wiper attack on Stryker medtech (2026) — https://krebsonsecurity.com/2026/03/iran-backed-hackers-claim-wiper-attack-on-medtech-firm-stryker/

--- a/skills/incident-response/containment/SKILL.md
+++ b/skills/incident-response/containment/SKILL.md
@@ -57,6 +57,7 @@ Before selecting a containment strategy, gather or confirm:
 - [ ] **Network topology** -- VLANs, subnets, firewall zones, cloud VPCs, segmentation boundaries relevant to the affected systems.
 - [ ] **Evidence preservation status** -- Has volatile evidence been captured? (Reference forensics-checklist.) Containment actions may destroy evidence if not collected first.
 - [ ] **Current containment state** -- What actions, if any, have already been taken?
+- [ ] **Administrative control planes** -- MDM/UEM, EDR, RMM, identity, and cloud consoles that can push commands, wipe devices, rotate keys, or disable services at scale.
 
 ---
 
@@ -187,6 +188,7 @@ Wiper and destructive malware require a distinct containment approach from ranso
 3. **Protect backup infrastructure** -- Verify offline/immutable/air-gapped backups are intact. Disconnect backup agents and NAS/SAN replication from the network. Wipers frequently target backup systems (Volume Shadow Copies, vCenter, backup catalogs).
 4. **Block propagation protocols** -- Emergency firewall rules to block SMB (445), WMI (135/5985/5986), RDP (3389), and PsExec/admin shares between all endpoints. Allow only from designated jump servers.
 5. **Disable compromised service accounts** -- Wiper deployment often uses compromised domain admin or service accounts. Disable all accounts showing anomalous activity; reset krbtgt if domain compromise is suspected.
+6. **Freeze destructive control-plane actions** -- Review MDM/UEM, EDR, RMM, and cloud-management consoles for pending wipe, retire, delete, quarantine, script, or remote-command jobs. Revoke compromised administrative sessions and require out-of-band approval before allowing bulk remote actions to continue.
 
 **ATT&CK techniques specific to wiper malware:**
 
@@ -198,6 +200,16 @@ Wiper and destructive malware require a distinct containment approach from ranso
 | T1561.002 -- Disk Wipe: Content | Overwrite or corrupt file content across volumes | Network segmentation to prevent spread; emergency shutdown of at-risk systems |
 | T1047 -- WMI | Remote execution of wiper payload via WMI | Block WMI ports (135, 5985, 5986); disable WinRM on endpoints |
 | T1484.001 -- Domain Policy Modification: GPO | Deploy wiper via Group Policy push | Disconnect domain controllers from network if GPO deployment confirmed |
+| T1098 -- Account Manipulation | Abuse administrative access to device-management or cloud control planes | Revoke sessions for MDM/UEM admins; suspend bulk wipe/retire/delete permissions; require multiple-administrator approval |
+
+**MDM/UEM destructive-action checks:**
+
+| Check | Method | Containment Action |
+|---|---|---|
+| Pending wipe/retire/delete jobs | Review Intune, Jamf, Workspace ONE, Kandji, or equivalent device-action queues | Pause/cancel unauthorized bulk actions before devices check in |
+| Administrative session abuse | Review sign-in logs, conditional access, and privileged role activation for device-management admins | Revoke sessions, reset credentials, and require re-authentication with phishing-resistant MFA |
+| Bulk remote action permissions | Review roles that can issue wipe, retire, delete, lock, script, or reset commands | Temporarily remove high-impact permissions or place them behind multiple-administrator approval |
+| BYOD exposure | Identify personally owned devices enrolled in MDM/UEM where wipe or retire actions may affect personal data | Coordinate legal/HR communications and prioritize selective containment over indiscriminate full wipe |
 
 **Key difference from ransomware containment:** Do not attempt to "monitor and observe" a wiper in progress. Every second of observation is data permanently destroyed. Aggressive, immediate containment is always the correct posture for confirmed wiper activity.
 
@@ -212,6 +224,7 @@ After implementing containment, verify effectiveness before proceeding to eradic
 | C2 communication blocked | Monitor network traffic for C2 indicators | No outbound connections to known C2 IPs/domains |
 | Lateral movement blocked | Monitor authentication logs and network flows between segments | No unauthorized cross-segment authentication |
 | Compromised credentials revoked | Attempt authentication with known-compromised credentials | Authentication fails |
+| Destructive control-plane actions frozen | Review MDM/UEM, EDR, RMM, and cloud action queues | No unauthorized wipe/retire/delete/script actions remain pending |
 | Attacker persistence neutralized | Scan for known persistence mechanisms | No active persistence artifacts |
 | Business services operational (if surgical containment) | Verify critical service health checks | Services responding normally |
 | Evidence preserved | Verify forensic images and memory dumps are intact and hashed | Hash verification passes |
@@ -375,4 +388,6 @@ This skill processes incident data including attacker-controlled indicators (IP 
 9. **MITRE ATT&CK -- Data Destruction (T1485)** -- https://attack.mitre.org/techniques/T1485/
 10. **MITRE ATT&CK -- Disk Wipe (T1561)** -- https://attack.mitre.org/techniques/T1561/
 11. **CISA Destructive Malware Guidance** -- https://www.cisa.gov/topics/cyber-threats-and-advisories
-12. **KrebsOnSecurity: Iran-backed wiper attack on Stryker medtech (2026)** -- https://krebsonsystems.com/2026/03/iran-backed-hackers-claim-wiper-attack-on-medtech-firm-stryker/
+12. **Microsoft Intune Remote Device Actions** -- https://learn.microsoft.com/en-us/intune/intune-service/remote-actions/
+13. **Microsoft Intune Remote Device Action: Wipe** -- https://learn.microsoft.com/intune/intune-service/remote-actions/devices-wipe
+14. **KrebsOnSecurity: Iran-backed wiper attack on Stryker medtech (2026)** -- https://krebsonsecurity.com/2026/03/iran-backed-hackers-claim-wiper-attack-on-medtech-firm-stryker/

--- a/skills/incident-response/ir-playbook/SKILL.md
+++ b/skills/incident-response/ir-playbook/SKILL.md
@@ -62,6 +62,7 @@ Before beginning, gather or confirm the following. Mark each item as obtained or
 - [ ] **Existing IR plan** -- Does the organization have a documented IR plan, designated IR team, and established communication channels?
 - [ ] **Regulatory obligations** -- Applicable breach notification requirements (GDPR 72-hour rule, HIPAA, state breach notification laws, SEC 4-day rule, PCI DSS).
 - [ ] **Third-party dependencies** -- Managed security providers (MSSP/MDR), cyber insurance carrier notification requirements, external IR retainer.
+- [ ] **Administrative control planes** -- Identity, MDM/UEM, EDR, RMM, and cloud consoles capable of pushing remote commands, wiping devices, retiring devices, deleting resources, or disabling services at scale.
 
 ---
 
@@ -240,6 +241,7 @@ Wiper malware destroys data irrecoverably (unlike ransomware which preserves enc
 2. **Preemptively shut down unaffected systems** if propagation vector is unknown. A wiper that has not triggered is stopped by cold shutdown.
 3. **Verify backup integrity** -- Wipers target Volume Shadow Copies, backup agents, and NAS/SAN. Confirm offline/immutable backups exist before recovery planning.
 4. **Preserve one affected system** (powered off, disk intact) for forensics and attribution.
+5. **Freeze destructive control-plane actions** -- Check MDM/UEM, EDR, RMM, identity, and cloud consoles for pending wipe, retire, delete, quarantine, script, or remote-command jobs. Revoke compromised administrative sessions and require out-of-band approval before allowing bulk remote actions to continue.
 
 **Key differences from ransomware:**
 
@@ -251,6 +253,8 @@ Wiper malware destroys data irrecoverably (unlike ransomware which preserves enc
 | **Attribution** | Lower priority (criminal) | Higher priority (often nation-state; FBI/CISA/ISAC engagement) |
 
 **Nation-state context:** State-sponsored actors (Iranian, Russian, North Korean) increasingly deploy wipers against healthcare and defense supply chains. The 2026 Stryker medtech wiper attack demonstrates ePHI custodians are active targets. IR teams must account for pre-positioned backdoors beyond the wiper payload, potential prior data exfiltration, and the need for FBI/CISA/H-ISAC notification.
+
+**MDM/UEM abuse context:** Some destructive incidents may use legitimate remote-management features rather than custom wiper malware. Treat device-management consoles such as Microsoft Intune as potential blast-radius multipliers: review pending device actions, recent administrator role activations, bulk wipe/retire/delete requests, and multiple-administrator approval status before assuming endpoint isolation alone is sufficient.
 
 #### Step 3.2: Eradication
 
@@ -391,6 +395,11 @@ and recommended immediate actions. Lead with the most critical fact.]
 |---|---|---|
 | [YYYY-MM-DD HH:MM] | [Event description] | [Log source / observation] |
 
+### Administrative Control Plane Review
+| Control Plane | Destructive Capability | Evidence Reviewed | Suspicious Actions | Containment Status |
+|---|---|---|---|---|
+| [MDM/UEM / EDR / RMM / Cloud / Identity] | [wipe / retire / delete / script / disable] | [logs, action queue, admin audit] | [none / list] | [frozen / revoked / monitoring] |
+
 ### Indicators of Compromise
 | Type | Value | First Seen | Confidence | ATT&CK Technique |
 |---|---|---|---|---|
@@ -496,4 +505,6 @@ This skill processes incident data that may include attacker-controlled content 
 10. **FIRST CSIRT Framework** -- https://www.first.org/education/csirt
 11. **CISA Destructive Malware Guidance** -- https://www.cisa.gov/topics/cyber-threats-and-advisories
 12. **H-ISAC (Health Information Sharing and Analysis Center)** -- https://h-isac.org/
-13. **KrebsOnSecurity: Iran-backed wiper attack on Stryker medtech (2026)** -- https://krebsonsystems.com/2026/03/iran-backed-hackers-claim-wiper-attack-on-medtech-firm-stryker/
+13. **Microsoft Intune Remote Device Actions** -- https://learn.microsoft.com/en-us/intune/intune-service/remote-actions/
+14. **Microsoft Intune Remote Device Action: Wipe** -- https://learn.microsoft.com/intune/intune-service/remote-actions/devices-wipe
+15. **KrebsOnSecurity: Iran-backed wiper attack on Stryker medtech (2026)** -- https://krebsonsecurity.com/2026/03/iran-backed-hackers-claim-wiper-attack-on-medtech-firm-stryker/


### PR DESCRIPTION
## Summary
Improves wiper/destructive-incident guidance by adding checks for legitimate administrative control planes such as MDM/UEM, EDR, RMM, identity, and cloud consoles.

## Changes
- Adds administrative control-plane evidence collection to the IR playbook and containment skills.
- Adds a freeze step for destructive remote actions such as wipe, retire, delete, quarantine, scripts, and remote commands.
- Adds MDM/UEM destructive-action checks and containment validation.
- Extends the HIPAA review skill to collect MDM/UEM/RMM remote-action policies, roles, and audit logs for ePHI endpoints.
- Corrects Stryker/KrebsOnSecurity reference URLs from `krebsonsystems.com` to `krebsonsecurity.com`.

## Why this matters
Wiper response often focuses on malware propagation and backup destruction. In managed endpoint estates, attackers can also abuse legitimate control planes to issue destructive actions at scale, so responders should review pending remote actions and admin sessions during containment.

## Validation
- Confirmed frontmatter remains present for all touched skills.
- Confirmed no `krebsonsystems.com` references remain under `skills`.
- Diff is limited to three skill Markdown files.

Expected bounty category: SecuritySkills improver track, if accepted and merged.