### PR TITLE
fix(skill): add SIEM trust-context gates

### DIFF
--- a/skills/secops/siem-rules/SKILL.md
+++ b/skills/secops/siem-rules/SKILL.md
@@ -12,7 +12,7 @@ phase: [operate]
 frameworks: [MITRE-ATT&CK-v16]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -603,6 +603,8 @@ Produce SIEM rule deliverables in this structure:
 
 ### Known False Positives
 - [List specific FP sources]
+- Corporate VPN, SASE, proxy, and identity-provider egress nodes can create impossible-travel geography artifacts. Suppress or lower severity only when trusted egress evidence is current and tied to the observed source IP.
+- Service accounts, service principals, and managed identities often run outside business hours by design. Split identity types before treating off-hours activity as human privileged-account behavior.
 
 ### Tuning Guidance
 - [Specific tuning recommendations]

--- a/skills/secops/siem-rules/SKILL.md
+++ b/skills/secops/siem-rules/SKILL.md
@@ -99,6 +99,44 @@ Select the appropriate detection logic pattern based on the threat being detecte
 
 ---
 
+#### Pre-Alert Enrichment Gates
+
+Before treating identity detections as alertable, document the trust context that separates adversary behavior from normal enterprise routing and automation. Apply these gates when generating or reviewing impossible-travel, password-spray, off-hours privileged-use, and similar identity rules.
+
+| Gate | Purpose | Example Evidence |
+|------|---------|------------------|
+| Trusted egress ranges | Suppress geography artifacts from corporate VPN, SASE, proxy, and IdP egress nodes | Sentinel named locations, Splunk CIDR lookup, proxy egress inventory |
+| ASN / provider continuity | Distinguish unmanaged source changes from movement between known corporate or carrier networks | ASN lookup, ISP/provider field, cloud egress owner |
+| Device and session continuity | Avoid alerting when the same managed device/session explains rapid location changes | DeviceId, SessionId, MDE device state, compliance state |
+| Identity type | Split human users, break-glass accounts, service accounts, service principals, and managed identities | IdP account type, app/service principal flag, workload identity inventory |
+| GeoIP confidence | Avoid severity decisions based on low-confidence or headquarters-based GeoIP results | GeoIP source, precision/confidence field, enrichment timestamp |
+
+If a gate cannot be populated, keep the condition visible in the rule output as an evidence gap rather than silently replacing it with a broad exclusion. Unknown ASN changes, unmanaged devices, risky sign-in state, or unfamiliar sessions should remain alertable.
+
+**KQL trusted egress pattern:**
+
+```kql
+let TrustedEgress = datatable(IPAddress:string, Provider:string, Asn:int)
+[
+    "198.51.100.10", "Corporate SASE", 64512,
+    "203.0.113.20", "Corporate SASE", 64512
+];
+SigninLogs
+| where TimeGenerated > ago(24h)
+| lookup kind=leftouter TrustedEgress on IPAddress
+| extend IsTrustedEgress = isnotempty(Provider)
+```
+
+**SPL identity-type pattern:**
+
+```spl
+index=o365 Operation=UserLoggedIn
+| lookup identity_inventory user as UserId output identity_type, privileged, managed_device
+| where identity_type!="service_account" AND identity_type!="managed_identity"
+```
+
+---
+
 #### Detection: Brute Force -- Password Spray (KQL)
 
 **ATT&CK:** T1110.003 -- Brute Force: Password Spraying
@@ -160,10 +198,17 @@ SigninLogs
 let travel_speed_kmh = 900;  // Maximum plausible travel speed (commercial flight)
 let min_distance_km = 500;   // Minimum distance to flag (avoids VPN/proxy noise)
 let time_window = 24h;
+let TrustedEgress = datatable(IPAddress:string, Provider:string)
+[
+    "198.51.100.10", "Corporate VPN",
+    "203.0.113.20", "Corporate SASE"
+];
 SigninLogs
 | where TimeGenerated > ago(time_window)
 | where ResultType == 0  // Successful logins only
 | where isnotempty(LocationDetails.geoCoordinates.latitude)
+| lookup kind=leftouter TrustedEgress on IPAddress
+| where isempty(Provider)  // Remove trusted VPN/SASE/proxy geography artifacts
 | extend
     Latitude = todouble(LocationDetails.geoCoordinates.latitude),
     Longitude = todouble(LocationDetails.geoCoordinates.longitude),
@@ -214,10 +259,13 @@ SigninLogs
 let business_start = 7;   // 7 AM
 let business_end = 19;    // 7 PM
 let weekend_days = dynamic(["Saturday", "Sunday"]);
-let privileged_patterns = dynamic(["admin", "svc-", "sa-", "break-glass", "emergency"]);
+let privileged_patterns = dynamic(["admin", "break-glass", "emergency"]);
+let service_identity_patterns = dynamic(["svc-", "sa-"]);
 SigninLogs
 | where TimeGenerated > ago(24h)
 | where ResultType == 0
+| extend IsServiceIdentity = UserPrincipalName has_any (service_identity_patterns)
+| where IsServiceIdentity == false
 | extend
     HourOfDay = hourofday(TimeGenerated),
     DayOfWeek = dayofweek(TimeGenerated),
@@ -335,7 +383,9 @@ index=o365 sourcetype="o365:management:activity" Operation=UserLoggedIn
 `comment("Privileged Account Off-Hours Logon -- ATT&CK T1078.002")`
 `comment("Detects privileged account logins outside business hours")`
 index=wineventlog sourcetype="WinEventLog:Security" EventCode=4624
-    (TargetUserName="admin*" OR TargetUserName="svc-*" OR TargetUserName="sa-*")
+    (TargetUserName="admin*" OR TargetUserName="break-glass*" OR TargetUserName="emergency*")
+| lookup identity_inventory user as TargetUserName output identity_type, privileged
+| where identity_type!="service_account" AND identity_type!="managed_identity"
 | eval hour = strftime(_time, "%H")
 | eval day_of_week = strftime(_time, "%A")
 | where (hour < 7 OR hour >= 19)
@@ -540,6 +590,16 @@ Produce SIEM rule deliverables in this structure:
 | Account | [UserPrincipalName / TargetUserName] |
 | IP | [IPAddress / IpAddress] |
 | Host | [Computer / ComputerName] |
+| Device / Session | [DeviceId / SessionId / WorkstationName] |
+| Identity Type | [identity_type / service principal flag / managed identity flag] |
+
+### Enrichment and Trust Context
+| Context | Lookup / Source | Key Field | Freshness | Alert Behavior |
+|---------|-----------------|-----------|-----------|----------------|
+| Trusted egress | [Named location / CIDR lookup] | [IPAddress] | [Updated date] | [Suppress / lower severity / retain as evidence gap] |
+| ASN / provider | [GeoIP or ASN lookup] | [IPAddress] | [Updated date] | [Alert on unmanaged provider change] |
+| Identity inventory | [IdP / CMDB / Splunk identity lookup] | [UserPrincipalName] | [Updated date] | [Separate human, service, break-glass, managed identity] |
+| Device/session | [MDE / EDR / IdP session fields] | [DeviceId / SessionId] | [Updated date] | [Require unmanaged or unfamiliar context for high severity] |
 
 ### Known False Positives
 - [List specific FP sources]

--- a/skills/secops/siem-rules/tests/benign/service-identity-off-hours-suppressed.spl
+++ b/skills/secops/siem-rules/tests/benign/service-identity-off-hours-suppressed.spl
@@ -1,0 +1,7 @@
+`comment("Benign: service identity runs outside business hours by design")`
+index=wineventlog sourcetype="WinEventLog:Security" EventCode=4624
+| eval TargetUserName="svc-backup"
+| eval hour="02"
+| lookup identity_inventory user as TargetUserName output identity_type, privileged
+| eval identity_type=coalesce(identity_type, "service_account")
+| where identity_type!="service_account" AND identity_type!="managed_identity"

--- a/skills/secops/siem-rules/tests/benign/trusted-sase-impossible-travel-suppressed.kql
+++ b/skills/secops/siem-rules/tests/benign/trusted-sase-impossible-travel-suppressed.kql
@@ -1,0 +1,18 @@
+// Benign: same user appears in two distant locations because both IPs are
+// corporate SASE egress nodes. A production rule should suppress or lower
+// severity only when the trusted-egress lookup is current.
+let TrustedEgress = datatable(IPAddress:string, Provider:string, Asn:int)
+[
+    "198.51.100.10", "Corporate SASE", 64512,
+    "203.0.113.20", "Corporate SASE", 64512
+];
+let SigninLogs = datatable(TimeGenerated:datetime, UserPrincipalName:string, IPAddress:string, ResultType:int)
+[
+    datetime(2026-06-05T13:00:00Z), "analyst@example.com", "198.51.100.10", 0,
+    datetime(2026-06-05T13:08:00Z), "analyst@example.com", "203.0.113.20", 0
+];
+SigninLogs
+| lookup kind=leftouter TrustedEgress on IPAddress
+| extend IsTrustedEgress = isnotempty(Provider)
+| summarize TrustedEgressCount=countif(IsTrustedEgress) by UserPrincipalName
+| where TrustedEgressCount == 2

--- a/skills/secops/siem-rules/tests/vulnerable/impossible-travel-without-trusted-egress-gate.kql
+++ b/skills/secops/siem-rules/tests/vulnerable/impossible-travel-without-trusted-egress-gate.kql
@@ -1,0 +1,13 @@
+// Vulnerable rule shape: alerts on raw GeoIP distance without checking whether
+// both IPs are trusted VPN/SASE/proxy egress nodes or whether the same managed
+// device/session explains the movement.
+SigninLogs
+| where TimeGenerated > ago(24h)
+| where ResultType == 0
+| where isnotempty(LocationDetails.geoCoordinates.latitude)
+| sort by UserPrincipalName asc, TimeGenerated asc
+| serialize
+| extend PrevLatitude = prev(todouble(LocationDetails.geoCoordinates.latitude), 1)
+| extend PrevLongitude = prev(todouble(LocationDetails.geoCoordinates.longitude), 1)
+| where UserPrincipalName == prev(UserPrincipalName, 1)
+| project TimeGenerated, UserPrincipalName, IPAddress, PrevLatitude, PrevLongitude

--- a/skills/secops/siem-rules/tests/vulnerable/service-account-off-hours-misclassified.spl
+++ b/skills/secops/siem-rules/tests/vulnerable/service-account-off-hours-misclassified.spl
@@ -1,0 +1,6 @@
+`comment("Vulnerable rule shape: treats svc-* and sa-* as human privileged users")`
+index=wineventlog sourcetype="WinEventLog:Security" EventCode=4624
+    (TargetUserName="admin*" OR TargetUserName="svc-*" OR TargetUserName="sa-*")
+| eval hour = strftime(_time, "%H")
+| where hour < 7 OR hour >= 19
+| table _time, TargetUserName, LogonType


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `siem-rules`
**Skill path:** `skills/secops/siem-rules/`

### What Was Wrong
The existing impossible-travel and privileged off-hours examples could generate high-noise alerts because they relied on raw GeoIP distance, fixed speed thresholds, and username patterns without documenting trust context.

Specific false-positive sources:
- Corporate VPN, SASE, proxy, and IdP egress points can make a user appear to travel between countries in minutes.
- Service accounts, service principals, and managed identities often run outside business hours by design, but the previous example treated `svc-*` and `sa-*` like human privileged users.
- The output format did not require trusted-network, ASN/provider, device/session, identity-type, or GeoIP-confidence evidence.

Related review issue: #1093

/claim #1093

### What This PR Fixes
- Adds a `Pre-Alert Enrichment Gates` section for identity detections.
- Adds KQL/SPL patterns for trusted egress and identity inventory lookups.
- Updates impossible-travel KQL to suppress known trusted VPN/SASE/proxy geography artifacts.
- Updates privileged off-hours KQL/SPL examples to separate service identities from human privileged accounts.
- Expands the output schema with device/session, identity type, and an `Enrichment and Trust Context` table.

### Evidence

**Before (false positive on this):**
```kql
let privileged_patterns = dynamic(["admin", "svc-", "sa-", "break-glass", "emergency"]);
SigninLogs
| where ResultType == 0
| where UserPrincipalName has_any (privileged_patterns)
| where hourofday(TimeGenerated) < 7 or hourofday(TimeGenerated) >= 19
```

This alerts on scheduled service identities such as `svc-backup@example.com` even when the off-hours behavior is expected.

**After (now correctly handled):**
```kql
let privileged_patterns = dynamic(["admin", "break-glass", "emergency"]);
let service_identity_patterns = dynamic(["svc-", "sa-"]);
SigninLogs
| where ResultType == 0
| extend IsServiceIdentity = UserPrincipalName has_any (service_identity_patterns)
| where IsServiceIdentity == false
| where UserPrincipalName has_any (privileged_patterns)
```

Impossible-travel examples now include a trusted egress lookup before alerting on geography artifacts.

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing frontmatter lint still passes locally for `skills/secops/siem-rules/SKILL.md`

Added SIEM rule-shape fixtures for trusted SASE impossible-travel suppression, service-identity off-hours suppression, raw GeoIP impossible-travel false positives, and service-account off-hours misclassification.

### Bounty Tier
- [ ] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Crypto, preferably USDC on Base: `0x1b58008Fde85832845817F9B24E64d139E418EeF`
