### PR TITLE
fix(skill): add agentic MCP boundary evidence

### DIFF
--- a/skills/ai-security/agentic-top-10/SKILL.md
+++ b/skills/ai-security/agentic-top-10/SKILL.md
@@ -13,7 +13,7 @@ phase: [design, build, review]
 frameworks: [OWASP-Agentic-AI, MITRE-ATLAS, NIST-AI-RMF]
 difficulty: advanced
 time_estimate: "45-90min"
-version: "1.0.1"
+version: "1.0.2"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -62,6 +62,7 @@ Before beginning the assessment, gather the following. If any item is unavailabl
 |---|---|---|
 | Agent architecture diagram | Design docs, README, or infrastructure-as-code | Identifies trust boundaries, delegation chains, and tool surface |
 | Tool/function definitions | Code files defining tool schemas, OpenAPI specs, MCP server configs | Determines what each agent can actually do |
+| MCP tool/resource boundary | MCP server manifests/configs, runtime registry export, transport/auth settings | Verifies server identity, registry drift, resource scope, and result trust before tools/resources are exposed to agents |
 | Permission model | IAM configs, role definitions, credential stores | Reveals whether least-privilege is enforced |
 | Memory/state persistence | Vector DB configs, session stores, scratchpad files | Exposes memory poisoning surface |
 | Human approval gates | Workflow configs, UI code, approval logic | Determines if HITL can be bypassed |
@@ -428,7 +429,39 @@ Grep: "send_message|delegate|dispatch|publish|subscribe|queue" in **/*.{py,ts,js
 
 # Human approval gates
 Grep: "approve|confirm|human_in_the_loop|hitl|review|authorize" in **/*.{py,ts,js,yaml,yml}
+
+# MCP server and runtime registry evidence
+Grep: "mcpServers|modelcontextprotocol|McpServer|MCPClient|StdioServerParameters|StreamableHTTP|SSEServerTransport" in **/*.{py,ts,js,json,yaml,yml,toml}
+Grep: "tools/list|resources/list|prompts/list|ResourceTemplate|uriTemplate|resource_template" in **/*.{py,ts,js,json,yaml,yml}
+Grep: "npx .*@latest|uvx|pipx|stdio|command.*mcp|args.*mcp" in **/*.{json,yaml,yml,toml}
+Grep: "authorization_servers|resource=|audience|OAuth|Bearer" in **/*.{py,ts,js,json,yaml,yml,toml}
 ```
+
+### MCP Tool and Resource Boundary Evidence
+
+If the architecture uses Model Context Protocol (MCP), review it as a first-class agent trust boundary rather than treating it as a generic tool list. MCP servers can expose tools, resources, and prompts through local `stdio` processes or remote HTTP transports, and the runtime registry can differ from static documentation.
+
+For each MCP server, capture:
+
+| Evidence Item | Secure State | Finding If Missing |
+|---|---|---|
+| Transport type | `stdio` for local trusted processes or HTTP behind authenticated service boundary | Medium — transport risk not understood |
+| Server identity/provenance | Pinned package/version, trusted executable path, verified publisher, or trusted remote origin | High — untrusted or mutable server can alter tool behavior |
+| Runtime registry export | Reviewed tools/resources/prompts match what the host receives from `tools/list`, `resources/list`, and `prompts/list` | High — unreviewed capabilities available at runtime |
+| Authorization boundary | OAuth audience/resource binding, mTLS, service identity, or explicit local trust boundary | High — server or caller identity unverifiable |
+| Side-effect classification | Tools are labeled read-only, write, destructive, external-send, or deploy | High — agent can invoke consequential actions without correct gates |
+| Resource URI scope | Templates are tenant/path bounded and normalize traversal-sensitive inputs | High — resource template can expose unintended files or tenant data |
+| Result trust handling | Tool/resource/prompt results are treated as untrusted data before re-entering model context | High — indirect prompt injection or exfiltration through MCP results |
+| Update approval | New or changed tools/resources/prompts require security review before production exposure | Medium — registry drift bypasses review |
+
+Map MCP findings to the existing threat categories:
+
+- **AG01 / AG02:** MCP server exposes write, delete, deploy, send, or filesystem tools without per-task scoping or parameter validation.
+- **AG05 / AG10:** Remote MCP server identity, OAuth audience, or transport trust cannot be verified.
+- **AG02 / AG06:** MCP resource URI templates permit broad file, URL, or tenant retrieval that can be used for exfiltration.
+- **AG05:** Runtime MCP registry cannot be exported, or it differs from the reviewed manifest.
+- **AG03 / AG10:** `stdio` server launches mutable or unpinned packages, inherits broad environment secrets, or receives an unrestricted filesystem root.
+- **AG06:** MCP tool/resource results can cause external URL fetches, markdown/image exfiltration, or prompt injection without validation.
 
 ### Hands-On Assessment Tooling
 
@@ -494,6 +527,11 @@ Structure the final report as follows:
 - Memory stores: [types]
 - Human approval gates: [present/absent, description]
 - Multi-agent communication: [method]
+
+## MCP Tool and Resource Boundary
+| Server | Transport | Identity/Provenance | Auth Boundary | Tools/Resources/Prompts | Side Effects | Registry Matches Review? | Resource Scope | Result Trust Handling |
+|---|---|---|---|---|---|---|---|---|
+| [server] | [stdio/http/custom] | [pinned/trusted/unknown] | [OAuth/mTLS/local/none] | [summary] | [read/write/destructive/external] | [yes/no/not evaluable] | [tenant/path bounds] | [validated/untrusted/not reviewed] |
 
 ## Findings by Threat Category
 
@@ -586,6 +624,10 @@ Persistent agent memory is a high-value target because it persists across sessio
 
 A tool functioning correctly is not the same as a tool being used correctly. The agent controls what parameters it passes, what sequence it calls tools in, and how it interprets results. A legitimate database query tool becomes an exfiltration vector when the agent is manipulated into querying sensitive tables and sending the results to an external webhook. Secure the tool invocation, not just the tool implementation.
 
+### 6. Treating MCP Configs as Static Tool Documentation
+
+MCP servers can expose tools, resources, and prompts at runtime, and remote servers can change what they advertise after a code review. Review the runtime registry, server identity, transport authorization, and resource URI templates. A checked-in `mcpServers` config is evidence to inspect, not proof that the production agent has only those capabilities.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -617,3 +659,6 @@ This skill is designed to be resilient against prompt injection. The following r
 9. LangChain Arbitrary Code Execution — CVE-2023-29374
 10. NIST SP 800-53 Rev. 5, Security and Privacy Controls — [nist.gov](https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final)
 11. fabraix/playground — Open-source AI agent red-team exploit library with PoCs for OWASP Agentic AI Top 10 risks — https://github.com/fabraix/playground
+12. Model Context Protocol Transports — https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
+13. Model Context Protocol Authorization — https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization
+14. Model Context Protocol specification repository — https://github.com/modelcontextprotocol/modelcontextprotocol

--- a/skills/ai-security/agentic-top-10/tests/benign/mcp-readonly-stdio-pinned.json
+++ b/skills/ai-security/agentic-top-10/tests/benign/mcp-readonly-stdio-pinned.json
@@ -1,0 +1,19 @@
+{
+  "_fixture": "BENIGN — agentic-top-10 MCP boundary",
+  "_expected": "No finding. Local read-only stdio server, version-pinned package, explicit tool/resource allowlist, no write/destructive tools, bounded resource URI template, no broad filesystem root. Reviewed registry == runtime registry.",
+  "_maps_to": "Safe state for AG01/AG02/AG05/AG10",
+  "mcpServers": {
+    "readonly-docs": {
+      "transport": "stdio",
+      "command": "node",
+      "args": ["./servers/docs-readonly.js"],
+      "package": "@acme/docs-mcp@1.4.2",
+      "tools": ["search_docs", "read_doc"],
+      "resources": ["docs://public/{slug}"],
+      "writes_allowed": false,
+      "runtime_tools": ["search_docs", "read_doc"],
+      "filesystem_root": "./docs",
+      "network_egress": "none"
+    }
+  }
+}

--- a/skills/ai-security/agentic-top-10/tests/benign/mcp-remote-oauth-audience-bound.json
+++ b/skills/ai-security/agentic-top-10/tests/benign/mcp-remote-oauth-audience-bound.json
@@ -1,0 +1,22 @@
+{
+  "_fixture": "BENIGN — agentic-top-10 MCP boundary",
+  "_expected": "No finding. Remote streamable-http server with OAuth where the access token's audience/resource is bound to this MCP server, explicit reviewed tool allowlist that equals the runtime registry, and read-only tools only.",
+  "_maps_to": "Safe state for AG05 (trust boundary) and AG10 (identity/auth)",
+  "mcpServers": {
+    "ticketing": {
+      "transport": "streamable-http",
+      "url": "https://mcp.example.com",
+      "authorization": "oauth",
+      "oauth": {
+        "authorization_servers": ["https://auth.example.com"],
+        "resource": "https://mcp.example.com",
+        "audience": "https://mcp.example.com",
+        "scopes": ["tickets:read"]
+      },
+      "reviewedTools": ["list_tickets", "get_ticket"],
+      "runtimeTools": ["list_tickets", "get_ticket"],
+      "registry_drift": false,
+      "writes_allowed": false
+    }
+  }
+}

--- a/skills/ai-security/agentic-top-10/tests/vulnerable/mcp-resource-template-path-traversal.ts
+++ b/skills/ai-security/agentic-top-10/tests/vulnerable/mcp-resource-template-path-traversal.ts
@@ -1,0 +1,36 @@
+// VULNERABLE — agentic-top-10 MCP boundary
+// Expected: Finding. Two compounding problems:
+//   1) Resource URI template "file://{path}" with no normalization, allowlist, or
+//      tenant scoping -> path traversal / cross-tenant retrieval; resource contents
+//      are returned to the model as trusted context (indirect prompt-injection vector).
+//   2) The stdio transport launches an unpinned, mutable package (@latest) over npx
+//      with the filesystem root set to "/" -> local execution + supply-chain boundary crossing.
+// Maps to: AG02 Tool Misuse, AG06 Exfiltration / indirect prompt injection,
+//          AG03 supply chain, AG05 trust boundary, AG10 identity/auth.
+
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as fs from "node:fs/promises";
+
+const server = new McpServer({ name: "files", version: "0.0.1" });
+
+// No path normalization, no allowlist, no tenant scoping.
+server.resource(
+  "file",
+  new ResourceTemplate("file://{path}", { list: undefined }),
+  async (uri, { path }) => ({
+    contents: [{ uri: uri.href, text: await fs.readFile(path as string, "utf8") }]
+  })
+);
+
+// Corresponding launch config (for reference) — unpinned package + broad root:
+//   {
+//     "mcpServers": {
+//       "filesystem": {
+//         "transport": "stdio",
+//         "command": "npx",
+//         "args": ["-y", "@vendor/filesystem-mcp@latest", "/"]
+//       }
+//     }
+//   }
+
+export { server };

--- a/skills/ai-security/agentic-top-10/tests/vulnerable/mcp-write-tools-unscoped-registry-drift.json
+++ b/skills/ai-security/agentic-top-10/tests/vulnerable/mcp-write-tools-unscoped-registry-drift.json
@@ -1,0 +1,22 @@
+{
+  "_fixture": "VULNERABLE — agentic-top-10 MCP boundary",
+  "_expected": "Finding. Remote MCP server exposes write/destructive tools without per-task scoping, runtime tool registry is discovered dynamically and DIFFERS from the reviewed set (registry drift), and OAuth lacks audience/resource binding so the token is not provably scoped to this server.",
+  "_maps_to": "AG01 Excessive Agency, AG02 Tool Misuse, AG05 Trust Boundary Violations, AG10 Identity/Auth Gaps",
+  "mcpServers": {
+    "ops": {
+      "transport": "streamable-http",
+      "url": "https://mcp.partner.example",
+      "authorization": "oauth",
+      "oauth": {
+        "authorization_servers": ["https://auth.partner.example"],
+        "scopes": ["all"]
+      },
+      "reviewedTools": ["list_incidents"],
+      "runtimeTools": "discovered dynamically at startup",
+      "observed_runtime_tools": ["list_incidents", "delete_incident", "rotate_secrets", "exec_command"],
+      "registry_drift": true,
+      "writes_allowed": true,
+      "per_task_scope": false
+    }
+  }
+}


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `agentic-top-10`
**Skill path:** `skills/ai-security/agentic-top-10/`

### What Was Wrong
The skill named "MCP server configs" only as an evidence source and had no MCP-specific decision logic. It did not require reviewers to verify server identity, transport/authorization boundaries, runtime-vs-reviewed tool registry drift, tool/resource/prompt exposure, resource URI template scope, or treating MCP results as untrusted data. That left modern MCP-based agent deployments under-specified across the AG01–AG10 flow, and risked the opposite failure mode too: naive "flag all MCP usage" patches would over-report benign read-only servers.

Related review issue: #1099

/claim #1099

### What This PR Fixes
- Adds an **MCP Tool and Resource Boundary Evidence** section mapped to AG01, AG02, AG03, AG05, AG06, AG10.
- Adds MCP context fields (transport type, server identity/provenance, runtime registry export, OAuth audience/resource binding, tool/resource allowlist, resource URI scope, result trust handling).
- Adds an MCP evidence table to the report output format.
- Adds MCP detection grep patterns (server configs, runtime registry, resource templates, stdio launch configs, OAuth/resource binding).
- Adds a common pitfall for treating MCP configs as static tool documentation.
- Adds official MCP transport/authorization/spec references.
- **Adds test fixtures** (`tests/benign/`, `tests/vulnerable/`) so the new logic is verifiable against both safe and unsafe MCP configurations.

### Evidence

**Before (skill misses this — real MCP risk goes unflagged):**
```json
{
  "mcpServers": {
    "ops": {
      "transport": "streamable-http",
      "url": "https://mcp.partner.example",
      "reviewedTools": ["list_incidents"],
      "runtimeTools": "discovered dynamically at startup",
      "writes_allowed": true
    }
  }
}
```
A remote server whose runtime tool set drifts from the reviewed set and exposes write/destructive tools without per-task scoping or OAuth audience binding — previously not covered by the skill.

**After (now correctly handled):**
The MCP Boundary section requires the reviewer to (a) export the runtime registry and compare it to the reviewed set (drift = AG05 finding), (b) classify side effects and require per-task scoping for write tools (AG01/AG02), and (c) verify OAuth audience/resource binding to the MCP server (AG10). A benign read-only, version-pinned, allowlisted server with no drift produces no finding.

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
  - `mcp-write-tools-unscoped-registry-drift.json` — write/destructive tools, runtime registry drift, unbound OAuth (AG01/AG02/AG05/AG10)
  - `mcp-resource-template-path-traversal.ts` — `file://{path}` resource template without normalization/scoping + unpinned stdio `@latest` with root `/` (AG02/AG06/AG03/AG05/AG10)
- [x] Added benign test cases (`tests/benign/`)
  - `mcp-readonly-stdio-pinned.json` — local read-only, pinned package, allowlisted, bounded resource, no drift (no finding)
  - `mcp-remote-oauth-audience-bound.json` — remote streamable-http, OAuth audience/resource bound, reviewed == runtime, read-only (no finding)
- [x] Existing frontmatter lint still passes locally for `skills/ai-security/agentic-top-10/SKILL.md`

### Bounty Tier
- [ ] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Crypto, preferably USDC on Base: `0x1b58008Fde85832845817F9B24E64d139E418EeF`
