### PR TITLE
Improve API security evidence coverage

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: api-security
 description: >
-  Reviews REST and GraphQL APIs against the OWASP API Security Top 10:2023.
+  Reviews REST, GraphQL, and gRPC APIs against the OWASP API Security Top 10:2023.
   Auto-invoked when reviewing OpenAPI/Swagger specs, API endpoint code, or
-  GraphQL schemas. Covers BOLA, BFLA, authentication, rate limiting, and
-  SSRF. Produces findings mapped to API1-API10 with remediation guidance.
-tags: [appsec, api, rest, graphql]
+  GraphQL schemas, protobuf service definitions, or API gateway policy.
+  Covers BOLA, BFLA, authentication, rate limiting, webhook integrity, and
+  SSRF with explicit evidence-coverage states. Produces findings mapped to
+  API1-API10 with remediation guidance.
+tags: [appsec, api, rest, graphql, grpc]
 role: [appsec-engineer, security-engineer]
 phase: [design, build, review]
 frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
@@ -21,7 +23,7 @@ argument-hint: "[target-file-or-directory]"
 
 # API Security Review -- OWASP API Security Top 10:2023
 
-A structured, repeatable process for reviewing REST and GraphQL APIs against the OWASP API Security Top 10:2023. This skill produces findings mapped to API1 through API10 with associated CWE identifiers, severity ratings, and actionable remediation guidance. It applies to OpenAPI/Swagger specifications, API endpoint source code, GraphQL schemas, and API gateway configurations.
+A structured, repeatable process for reviewing REST, GraphQL, and gRPC APIs against the OWASP API Security Top 10:2023. This skill produces findings mapped to API1 through API10 with associated CWE identifiers, severity ratings, and actionable remediation guidance. It applies to OpenAPI/Swagger specifications, API endpoint source code, GraphQL schemas, protobuf service definitions, API gateway configurations, and webhook/API consumer code.
 
 ---
 
@@ -32,12 +34,13 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 Before analyzing any endpoint, establish a complete inventory of the API surface under review.
 
 1. **Identify the API style** -- REST (OpenAPI/Swagger), GraphQL, gRPC, or hybrid. Each style has distinct attack patterns.
-2. **Catalog all endpoints and operations** -- For REST, list every path and HTTP method. For GraphQL, list all queries, mutations, and subscriptions.
+2. **Catalog all endpoints and operations** -- For REST, list every path and HTTP method. For GraphQL, list all queries, mutations, and subscriptions. For gRPC, list every `.proto` service, method, message, and streaming mode.
 3. **Map authentication mechanisms** -- OAuth 2.0 flows, API keys, JWTs, session cookies, mTLS, or custom tokens. Note which endpoints require authentication and which are public.
 4. **Identify authorization models** -- RBAC, ABAC, ownership-based, or no authorization. Document how object-level and function-level access control decisions are made.
 5. **Catalog data objects** -- List the resources/entities exposed by the API and their sensitivity classification (PII, financial, internal, public).
-6. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, or cost-control mechanisms at the gateway or application layer.
-7. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
+6. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, or cost-control mechanisms at the gateway or application layer. If only application code is available, mark gateway or platform evidence as not provided instead of assuming it is absent.
+7. **Identify downstream dependencies** -- Third-party APIs, internal microservices, webhook receivers, webhook senders, or service-mesh routes that the API consumes or exposes.
+8. **Record evidence coverage by layer** -- Separate what was reviewed in application code, gateway/IaC, identity provider configuration, service mesh, and runtime/platform settings.
 
 > **Gate:** Do not proceed until the API style, authentication model, authorization model, and endpoint inventory are documented. Incomplete scope leads to missed findings.
 
@@ -67,7 +70,18 @@ Each finding produced by this review must include the following fields:
 | **Description** | What the vulnerability is and why it matters |
 | **Evidence** | Relevant code snippet or spec excerpt demonstrating the issue |
 | **Remediation** | Specific fix with code example where possible |
-| **Status** | Open, Mitigated, Accepted Risk, False Positive |
+| **Status** | Open, Mitigated, Accepted Risk, False Positive, Not Evaluable |
+
+### Evidence Coverage States
+
+Use explicit coverage states when a control may live outside the files under review. This prevents false positives caused by missing platform, gateway, or identity-provider context.
+
+| State | Use When |
+|---|---|
+| **Confirmed Missing** | The relevant application, gateway/IaC, IdP, or runtime evidence was reviewed and no control exists. |
+| **Present in Application** | The control is enforced in source code, resolvers, interceptors, serializers, or handlers. |
+| **Present at Gateway/Platform** | The control is enforced by API Gateway, service mesh, WAF, IdP policy, Terraform, Helm, or equivalent platform config. |
+| **Not Evaluable** | The available files do not include the layer where the control is normally configured. Do not report as a confirmed vulnerability unless exploit evidence exists. |
 
 ### Severity Definitions
 
@@ -93,6 +107,15 @@ The final review output must be structured as follows:
 **Specification:** [OpenAPI spec path, if applicable]
 **Date:** [review date]
 **Reviewer:** AI Agent -- api-security skill v1.0.0
+
+### Evidence Coverage
+
+| Layer | Evidence reviewed | Missing evidence | Impact on findings |
+|---|---|---|---|
+| Application code | [routes/controllers/resolvers/interceptors] | [none or gaps] | [confirmed / partial] |
+| API gateway / IaC | [gateway, ingress, Terraform, Helm] | [none or gaps] | [confirmed / not evaluable] |
+| Identity provider | [OAuth/JWT client config, JWKS, tenant policy] | [none or gaps] | [confirmed / not evaluable] |
+| Service mesh / runtime | [mTLS, timeouts, limits, runner/platform settings] | [none or gaps] | [confirmed / not evaluable] |
 
 ### Summary
 
@@ -171,7 +194,7 @@ GraphQL APIs share all ten OWASP API risks with REST but introduce additional at
 }
 ```
 
-**Mitigation:** Disable introspection in production. If introspection is required for internal tooling, restrict it to authenticated internal consumers.
+**Mitigation:** Treat unauthenticated public introspection as a finding. If introspection is required for internal tooling, restrict it to authenticated internal consumers, mTLS/VPN access, or persisted-query workflows with complexity limits. Authenticated internal introspection may be informational rather than a vulnerability when exposure and compensating controls are documented.
 
 ### Query Depth and Complexity Attacks
 
@@ -201,11 +224,41 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 ---
 
+## gRPC-Specific Considerations
+
+gRPC APIs share the same OWASP API risks as REST and GraphQL, but the vulnerable surface appears in protobuf schemas, generated handlers, interceptors, reflection services, and service-to-service transport.
+
+### Discovery Patterns
+
+Review these files when present:
+
+```text
+**/*.proto
+**/*grpc*.{go,java,kt,cs,py,ts,js}
+**/*Interceptor*.{go,java,kt,cs,py,ts,js}
+**/buf.yaml
+**/buf.gen.yaml
+**/prototool.yaml
+```
+
+### gRPC Review Checks
+
+- Authentication must be enforced on services and methods, not only at a gateway boundary.
+- Authorization interceptors must make per-method and per-object decisions for sensitive RPCs.
+- mTLS or signed service tokens should protect service-to-service traffic.
+- Deadlines, timeouts, and maximum receive/send message sizes must be enforced even when clients omit deadlines.
+- Server reflection should be disabled or restricted in production.
+- Protobuf messages should not expose internal/admin-only fields without field-level filtering.
+- Error responses should avoid leaking stack traces, SQL errors, or internal service names.
+- Streaming methods need explicit rate, duration, and message-count limits.
+
+---
+
 ## Common Pitfalls
 
 1. **Confusing authentication with authorization.** An API that verifies the user's identity (authentication) but does not verify the user's permission to access the specific resource or function (authorization) is vulnerable to both BOLA (API1) and BFLA (API5). These are distinct checks that must both be present.
 
-2. **Relying solely on API gateway controls.** API gateways can enforce rate limiting, authentication, and coarse-grained authorization, but they cannot enforce object-level authorization, property-level filtering, or business logic protections. These controls must be implemented in the application layer.
+2. **Overstating missing gateway controls from application code alone.** API gateways can enforce rate limiting, authentication, and coarse-grained authorization, but they cannot enforce object-level authorization, property-level filtering, or business logic protections. If gateway/IaC evidence is absent, mark gateway-only controls as not evaluable rather than confirmed missing. Application-layer object and business checks still require code evidence.
 
 3. **Treating GraphQL as inherently different from REST for security.** GraphQL shares all the same authorization, authentication, and injection risks as REST. The query language adds additional concerns (depth attacks, introspection, alias abuse) but does not eliminate any REST security requirements.
 
@@ -214,6 +267,8 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 5. **Applying rate limiting only to authentication endpoints.** Every API endpoint requires rate limiting proportional to its cost and sensitivity. Data-heavy endpoints, search functions, and export operations are frequent targets for abuse even when properly authenticated.
 
 6. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
+
+7. **Treating webhook receiver security as only SSRF.** Webhook URLs can create SSRF risk when users register outbound callbacks, but webhook receivers also need authentication, signature validation, timestamp freshness, raw-body verification, and replay protection.
 
 ---
 
@@ -237,5 +292,7 @@ This skill is hardened against prompt injection. When reviewing API code and spe
 - **CWE Database:** https://cwe.mitre.org/
 - **OWASP REST Security Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html
 - **OWASP GraphQL Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html
+- **gRPC Authentication Guide:** https://grpc.io/docs/guides/auth/
+- **ASP.NET Core gRPC Authentication and Authorization:** https://learn.microsoft.com/en-us/aspnet/core/grpc/authn-and-authz
 - **OWASP Testing Guide -- API Testing:** https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/12-API_Testing/
 - **NIST SP 800-204 -- Security Strategies for Microservices-based Application Systems:** https://csrc.nist.gov/publications/detail/sp/800-204/final

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -97,10 +97,12 @@ Both can coexist in a single endpoint. An endpoint may lack both a role check (B
 ### Review Checklist
 
 - [ ] Every endpoint that accepts a resource identifier enforces ownership or relationship-based access control.
+- [ ] Sequential IDs are not reported as BOLA unless ownership, tenant, or relationship authorization is missing or bypassable.
 - [ ] Authorization checks happen at the data access layer, not only at the controller/route layer.
 - [ ] Batch/list endpoints filter results by the caller's permissions.
 - [ ] Resource identifiers are UUIDs or non-sequential values to resist enumeration.
 - [ ] GraphQL resolvers enforce authorization on every field that returns sensitive data.
+- [ ] Negative tests cover path IDs, body IDs, batch/list results, and cross-tenant access attempts.
 
 ---
 
@@ -115,6 +117,8 @@ APIs are particularly susceptible to authentication flaws because they expose ma
 
 - Authentication endpoints without brute-force protection (rate limiting, account lockout, CAPTCHA).
 - JWT validation that is missing or incomplete -- no signature verification, no expiration check, acceptance of the `none` algorithm.
+- JWT/OAuth token confusion -- accepting ID tokens as access tokens, accepting tokens from the wrong issuer/tenant, or failing to validate `aud`, `azp`, `iss`, and environment-specific issuer values.
+- Unsafe JWKS handling -- accepting arbitrary `jku` or `x5u` headers, failing open when JWKS fetch fails, or caching keys without issuer binding.
 - API keys transmitted in URL query strings (logged in server access logs, browser history, proxies).
 - Missing or weak token rotation -- refresh tokens that never expire or are not rotated on use.
 - Password reset or account recovery flows that leak tokens or allow enumeration.
@@ -149,10 +153,20 @@ paths:
           in: query  # Should be in header
 ```
 
+```javascript
+// VULNERABLE: Validates signature but misses issuer/audience and trusts kid-only key lookup
+jwt.verify(token, getKeyFromHeaderKidOnly, {
+  algorithms: ['RS256'],
+  // missing issuer, audience, tenant, and token-use checks
+});
+```
+
 ### Remediation Guidance
 
 - Enforce rate limiting on all authentication endpoints (e.g., 5 attempts per minute per IP/account).
 - Validate JWT signatures using a strong algorithm (RS256, ES256). Reject `none` and `HS256` if RSA is expected (algorithm confusion attack).
+- Validate issuer, audience, authorized party (`azp`) where applicable, token use (`access_token` vs ID token), tenant/realm, and environment-specific issuer values.
+- Bind JWKS keys to a trusted issuer configuration. Ignore attacker-controlled `jku` and `x5u` headers unless explicitly allowlisted, and fail closed when key resolution fails.
 - Transmit API keys and tokens in HTTP headers (`Authorization` header), never in URL query strings.
 - Implement token expiration: access tokens (5-15 minutes), refresh tokens (hours to days with rotation).
 - Use `bcrypt`, `scrypt`, or `Argon2id` for password storage.
@@ -163,6 +177,9 @@ paths:
 - [ ] All authentication endpoints have brute-force protections (rate limiting, lockout).
 - [ ] JWTs are validated for signature, expiration (`exp`), issuer (`iss`), and audience (`aud`).
 - [ ] The `none` algorithm and algorithm confusion attacks are prevented by explicit algorithm allowlisting.
+- [ ] OAuth token-use checks prevent ID tokens from being accepted where access tokens are required.
+- [ ] JWKS resolution is pinned to trusted issuers and fails closed on fetch or key mismatch errors.
+- [ ] Multi-tenant APIs validate tenant/realm claims and reject staging/dev issuers in production.
 - [ ] API keys and tokens are transmitted in headers, not query strings.
 - [ ] Refresh tokens are rotated on each use and revocable.
 - [ ] Service-to-service communication is explicitly authenticated.
@@ -278,7 +295,7 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 
 ### Review Checklist
 
-- [ ] Rate limiting is configured for all endpoints, with stricter limits on expensive operations.
+- [ ] Rate limiting is configured for all endpoints, with stricter limits on expensive operations; if only application code is available and gateway/IaC policy is missing, record this as not evaluable rather than confirmed absent.
 - [ ] Pagination has a maximum page size enforced server-side.
 - [ ] Request body size limits are configured.
 - [ ] GraphQL queries have depth limits, complexity limits, and batch restrictions.
@@ -399,6 +416,14 @@ def register_webhook():
     return jsonify({"status": "registered"})
 ```
 
+```javascript
+// VULNERABLE: Webhook receiver trusts unsigned provider payloads
+app.post('/webhooks/payment', express.json(), async (req, res) => {
+  await markInvoicePaid(req.body.invoice_id);
+  res.sendStatus(204);
+});
+```
+
 ### Remediation Guidance
 
 - Validate and sanitize all user-supplied URLs. Use an allowlist of permitted schemes (`https` only), domains, or IP ranges.
@@ -407,6 +432,7 @@ def register_webhook():
 - Use a dedicated egress proxy for outbound requests that enforces domain allowlists.
 - For cloud environments, use IMDSv2 (requires token-based access to metadata) to mitigate SSRF exploitation against cloud metadata services.
 - Do not return raw responses from fetched URLs to the client; extract only the needed data.
+- For inbound webhooks, verify provider signatures against the raw request body, enforce timestamp freshness, and deduplicate provider event IDs to prevent replay.
 
 ### Review Checklist
 
@@ -415,6 +441,7 @@ def register_webhook():
 - [ ] HTTP redirects are disabled or the final destination is re-validated.
 - [ ] Cloud metadata endpoint access is restricted (IMDSv2 on AWS, equivalent on GCP/Azure).
 - [ ] Raw responses from fetched URLs are never returned directly to the client.
+- [ ] Webhook receivers validate signatures or mTLS, reject stale timestamps, and deduplicate event IDs before triggering state changes.
 
 ---
 
@@ -544,6 +571,16 @@ const data = await enrichmentData.json();
 res.send(`<div class="bio">${data.biography}</div>`);  // Stored XSS via third party
 ```
 
+```javascript
+// VULNERABLE: Provider webhook updates state without signature or replay validation
+app.post('/provider/events', express.json(), async (req, res) => {
+  if (req.body.type === 'invoice.paid') {
+    await markPaid(req.body.data.invoice_id);
+  }
+  res.sendStatus(204);
+});
+```
+
 ### Remediation Guidance
 
 - Treat all data from external and internal APIs as untrusted input. Validate and sanitize before use.
@@ -552,6 +589,7 @@ res.send(`<div class="bio">${data.biography}</div>`);  // Stored XSS via third p
 - Implement timeouts, retry limits with backoff, and circuit breakers on all outbound API calls.
 - Restrict redirects on outbound calls. If following redirects, re-validate the destination URL.
 - Use parameterized queries when inserting data from any source, including trusted internal APIs.
+- Validate inbound webhook authenticity before treating provider payloads as trusted upstream state. Preserve the raw request body for HMAC checks, enforce timestamp skew limits, deduplicate event IDs, and fail closed on malformed or unsigned events.
 
 ### Review Checklist
 
@@ -560,3 +598,27 @@ res.send(`<div class="bio">${data.biography}</div>`);  // Stored XSS via third p
 - [ ] Response schemas from third-party APIs are validated before processing.
 - [ ] Outbound calls have timeouts, retry limits, and circuit breakers.
 - [ ] Redirect following is disabled or restricted on outbound HTTP calls.
+- [ ] Inbound provider webhooks are authenticated and replay-protected before they update business state.
+
+---
+
+## Cross-Layer Evidence Model
+
+Many API controls are split across source code, gateway/IaC, identity-provider configuration, and runtime settings. Use this table before classifying findings so missing evidence does not become a false positive.
+
+| Control Area | Application Evidence | External Evidence | Reporting Rule |
+|---|---|---|---|
+| Rate limiting / quotas | Middleware, decorators, resolver guards | API Gateway, Kong, Envoy, Cloudflare, ingress, Terraform, Helm | If external evidence is unavailable, report `Not Evaluable from provided evidence` unless an exploit path is demonstrated. |
+| JWT/OAuth validation | Token verification code, auth middleware | IdP client config, JWKS issuer policy, tenant settings | Missing issuer/audience in code can be mitigated by trusted middleware; validate the active enforcement point. |
+| Object authorization | Route handlers, resolvers, data access filters | Policy engines, service authorization sidecars | Must be proven at the object/tenant relationship layer; gateway-only auth is insufficient for BOLA. |
+| GraphQL introspection | GraphQL server config | Gateway auth, persisted-query enforcement, network exposure | Public unauthenticated introspection is a finding; authenticated/internal introspection may be informational with compensating controls. |
+| gRPC method protection | Interceptors, service implementations, proto annotations | Mesh mTLS, gateway transcoding, service auth policy | Confirm both transport authentication and per-method authorization for sensitive RPCs. |
+| Webhook integrity | Raw-body signature checks, event deduplication | Provider signing docs, mTLS, gateway signature verification | Treat unsigned state-changing webhook receivers as API10/API2 findings. |
+
+### Suggested Negative Test Cases
+
+- Sequential REST IDs with a correct `user_id` or `tenant_id` filter should not be reported as BOLA; only note enumeration hardening if needed.
+- App code without local rate-limiting middleware but Terraform/Kong policy enforcing per-route quotas should be marked protected at gateway.
+- Public unauthenticated GraphQL introspection should be reported; authenticated internal introspection with persisted queries and complexity limits should not be high severity by default.
+- gRPC reflection enabled with no method-level authorization should be reported; reflection restricted to authenticated internal tooling should be informational.
+- A webhook receiver without signature verification, timestamp freshness, or event deduplication should be reported before any business-state mutation.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** api-security
**Skill path:** `skills/appsec/api-security/`

### What Was Wrong
The main API security skill mentioned gRPC in scope but did not give reviewers a gRPC discovery workflow or gRPC-specific checks. It also treated several controls as if they always live in application code, which can create false positives when rate limits, JWT validation, introspection restrictions, or service authentication are enforced by API gateway, service mesh, IdP, or IaC configuration. Webhook receiver authentication and replay protection were also under-modeled even though they are common API2/API10 boundaries.

Related review: #1115

### What This PR Fixes
- Adds an explicit evidence coverage model so reviewers can distinguish `Confirmed Missing`, `Present in Application`, `Present at Gateway/Platform`, and `Not Evaluable`.
- Adds a report-level Evidence Coverage table for application, gateway/IaC, IdP, and runtime/service-mesh layers.
- Adds gRPC discovery patterns and review checks for protobuf services, interceptors, mTLS, reflection, message limits, deadlines, and streaming methods.
- Refines GraphQL introspection guidance so public unauthenticated exposure is a finding while authenticated/internal introspection can be classified based on exposure and compensating controls.
- Expands API2 JWT/OAuth guidance for token confusion, JWKS issuer binding, `jku`/`x5u`, tenant/realm validation, and fail-closed key resolution.
- Expands API7/API10 webhook guidance for raw-body signature validation, timestamp freshness, event deduplication, and state-changing webhook receivers.
- Adds cross-layer negative test cases to reduce false positives around sequential IDs, gateway rate limits, GraphQL introspection, gRPC reflection, and webhooks.

### Evidence
**Before (skill misses this / false positive on this):**
```text
- A REST app has no local rate-limit middleware, but Kong/Terraform enforces per-route quotas. The previous checklist could push reviewers toward reporting missing rate limiting as confirmed instead of marking gateway evidence as unavailable or present.
- A gRPC API exposes `.proto` services with method handlers and interceptors. The top-level skill said gRPC was in scope but did not tell reviewers what files to inspect or which gRPC-specific controls to verify.
- A payment webhook receiver updates invoice state from provider JSON with no signature, timestamp, or event-id replay checks. The checklist covered outbound URL/webhook SSRF, but not inbound provider webhook integrity.
```

**After (now correctly handled):**
```text
- Reviewers must record which layer was inspected and use explicit evidence states before classifying a missing control.
- gRPC reviewers get discovery patterns for `.proto`, grpc/interceptor files, Buf config, and concrete checks for authn/authz, reflection, mTLS, deadlines, message size, errors, and streams.
- API2/API10 checklists now include token confusion/JWKS handling and inbound webhook signature/replay validation before business state changes.
```

### Test Cases Added/Updated
- [ ] Added vulnerable test cases (`tests/vulnerable/`)
- [ ] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass / repository checks simulated locally for changed Markdown files

### Local Validation
- `git diff --check`
- Required frontmatter fields check for `skills/appsec/api-security/SKILL.md`
- Changed-file scan for repository prompt-injection blocklist patterns

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** PayPal; payout details can be provided privately after acceptance.