### PR TITLE
Add Pulumi and Bicep IaC evidence gates

### DIFF
--- a/skills/cloud/iac-security/SKILL.md
+++ b/skills/cloud/iac-security/SKILL.md
@@ -3,11 +3,12 @@ name: iac-security
 description: >
   Performs a security review of Infrastructure as Code templates against the OWASP
   IaC Security Cheat Sheet, SLSA v1.0, and CIS Benchmarks. Auto-invoked when
-  reviewing Terraform, CloudFormation, or Pulumi configurations. Detects hardcoded
-  secrets, public exposure patterns, encryption gaps, overly permissive IAM, and
-  misconfigurations equivalent to Checkov, tfsec, and KICS rules. Produces a
-  structured findings report with remediation guidance.
-tags: [cloud, iac, terraform, cloudformation]
+  reviewing Terraform, CloudFormation, Pulumi, or Bicep configurations. Detects
+  hardcoded secrets, insecure secret flow, public exposure patterns, encryption
+  gaps, overly permissive IAM, and misconfigurations equivalent to Checkov,
+  tfsec, KICS, Pulumi, and Bicep linter rules. Produces a structured findings
+  report with remediation guidance.
+tags: [cloud, iac, terraform, cloudformation, pulumi, bicep]
 role: [cloud-security-engineer, security-engineer, devsecops]
 phase: [build, review]
 frameworks: [OWASP-IaC-Security, SLSA-v1.0, CIS-Benchmarks]
@@ -84,9 +85,15 @@ Use Glob to locate all IaC configuration files.
 **/Pulumi.*.yaml
 **/__main__.py       # Pulumi Python
 **/index.ts          # Pulumi TypeScript
+**/index.js          # Pulumi JavaScript
+**/main.go           # Pulumi Go
+**/Program.cs        # Pulumi .NET
+**/*.bicepparam
 ```
 
 Classify the IaC stack(s) in use. Record the total file count and frameworks detected.
+
+For Pulumi, also record the programming language, stack config files, and configured secrets provider when visible. For Bicep, record parameter files, modules, deployment scripts, and whether secure parameters or secure outputs are used.
 
 ---
 
@@ -157,6 +164,8 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Status:** Fail
 - **Severity:** Critical / High / Medium / Low
 - **Equivalent Rule:** Checkov CKV_XXX_NN / tfsec xxx-xxx / KICS xxxxxxxx
+- **IaC Framework:** Terraform / CloudFormation / Pulumi / Bicep
+- **Evidence Origin:** source / plan / stack config / state / linter / not evaluable
 - **File:** <path>
 - **Line(s):** <line numbers>
 - **Description:** <what was found>
@@ -230,6 +239,8 @@ This skill applies checks equivalent to the following high-impact rules:
 5. **Confusing `aws_s3_bucket_acl` with `aws_s3_bucket_public_access_block`.** The public access block overrides ACLs. Check both, but the access block is the stronger control.
 6. **Terraform state file secrets.** Even when variables are marked `sensitive`, they may appear in plaintext in the state file. Verify state encryption and access controls.
 7. **Provider-specific encryption defaults.** Some providers encrypt by default (e.g., AWS S3 since January 2023). Know the defaults before flagging missing explicit encryption configuration.
+8. **Pulumi secret names are not always plaintext secrets.** A property named `password` is safe when it is fed by `requireSecret()`, `getSecret()`, `pulumi.secret()`, or `additionalSecretOutputs`; it is risky when it comes from plain config or is exposed inside `apply()` callbacks, logs, files, or stack outputs.
+9. **Bicep secure properties need parameter/output evidence.** `adminPassword` and similar properties are expected in Azure templates. Classify them by whether the value comes from `@secure()` parameters/outputs or from plain parameters, literals, `list*` calls, deployment-script output, or module output leakage.
 
 ---
 
@@ -260,9 +271,15 @@ This skill applies checks equivalent to the following high-impact rules:
 - cfn-nag Rules: https://github.com/stelligent/cfn_nag
 - Terraform Security Best Practices: https://developer.hashicorp.com/terraform/cloud-docs/recommended-practices
 - AWS Security Best Practices in IAM: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
+- Pulumi Secrets: https://www.pulumi.com/docs/iac/concepts/secrets/
+- Pulumi Configuration: https://www.pulumi.com/docs/iac/concepts/config/
+- Azure Bicep Secure Parameters: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/parameters
+- Bicep secure input linter rule: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/linter-rule-use-secure-value-for-secure-inputs
+- Bicep outputs should not contain secrets: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/linter-rule-outputs-should-not-contain-secrets
 
 ---
 
 ## Changelog
 
+- **1.0.1** -- Added Pulumi and Bicep evidence gates for secret-taint flow, stack config, secure parameters, and output leakage.
 - **1.0.0** -- Initial release. Coverage of eight security domains across Terraform, CloudFormation, Pulumi, and Bicep with Checkov/tfsec/KICS rule equivalents.

--- a/skills/cloud/iac-security/tests/benign/bicep-secure-parameter.bicep
+++ b/skills/cloud/iac-security/tests/benign/bicep-secure-parameter.bicep
@@ -1,0 +1,14 @@
+@secure()
+param adminPassword string
+
+resource vm 'Microsoft.Compute/virtualMachines@2025-04-01' = {
+  name: 'safe-vm'
+  location: resourceGroup().location
+  properties: {
+    osProfile: {
+      computerName: 'safe-vm'
+      adminUsername: 'azureuser'
+      adminPassword: adminPassword
+    }
+  }
+}

--- a/skills/cloud/iac-security/tests/benign/pulumi-secret-config.ts
+++ b/skills/cloud/iac-security/tests/benign/pulumi-secret-config.ts
@@ -1,0 +1,13 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const cfg = new pulumi.Config();
+const dbPassword = cfg.requireSecret("dbPassword");
+
+new aws.rds.Instance("db", {
+  allocatedStorage: 20,
+  engine: "postgres",
+  instanceClass: "db.t4g.micro",
+  username: "app",
+  password: dbPassword,
+});

--- a/skills/cloud/iac-security/tests/vulnerable/bicep-plain-secret-output.bicep
+++ b/skills/cloud/iac-security/tests/vulnerable/bicep-plain-secret-output.bicep
@@ -1,0 +1,19 @@
+param adminPassword string
+
+resource vm 'Microsoft.Compute/virtualMachines@2025-04-01' = {
+  name: 'unsafe-vm'
+  location: resourceGroup().location
+  properties: {
+    osProfile: {
+      computerName: 'unsafe-vm'
+      adminUsername: 'azureuser'
+      adminPassword: adminPassword
+    }
+  }
+}
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: 'prodsa'
+}
+
+output primaryKey string = storage.listKeys().keys[0].value

--- a/skills/cloud/iac-security/tests/vulnerable/pulumi-plain-config-secret.ts
+++ b/skills/cloud/iac-security/tests/vulnerable/pulumi-plain-config-secret.ts
@@ -1,0 +1,16 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const cfg = new pulumi.Config();
+const dbPassword = cfg.require("dbPassword");
+const apiToken = cfg.requireSecret("apiToken");
+
+new aws.ssm.Parameter("db-password", {
+  type: "SecureString",
+  value: dbPassword,
+});
+
+apiToken.apply((token) => {
+  console.log(`deploy token: ${token}`);
+  return token;
+});

--- a/skills/cloud/iac-security/tool-rules.md
+++ b/skills/cloud/iac-security/tool-rules.md
@@ -79,6 +79,102 @@ variable "db_password" {
 }
 ```
 
+### Pulumi Secret-Flow Evidence Gates
+
+Pulumi programs are real code, so sensitive resource arguments may come from SDK calls instead of literal strings. Do not flag a property name such as `password` by itself; trace whether the value is plain config, a Pulumi secret, or exposed after unwrapping.
+
+**Safe patterns:**
+
+```typescript
+const cfg = new pulumi.Config();
+const dbPassword = cfg.requireSecret("dbPassword");
+
+new aws.rds.Instance("db", {
+  username: "app",
+  password: dbPassword,
+});
+```
+
+```python
+cfg = pulumi.Config()
+api_token = cfg.require_secret("apiToken")
+```
+
+**Risky patterns:**
+
+```typescript
+const cfg = new pulumi.Config();
+const dbPassword = cfg.require("dbPassword"); // plain config value
+
+new aws.ssm.Parameter("db-password", {
+  type: "SecureString",
+  value: dbPassword,
+});
+```
+
+```typescript
+const apiToken = cfg.requireSecret("apiToken");
+
+apiToken.apply((token) => {
+  console.log(`deploy token: ${token}`); // plaintext leaves secret wrapper
+  return token;
+});
+```
+
+**Pulumi review checklist:**
+
+- [ ] Stack config files (`Pulumi.<stack>.yaml`) mark sensitive config with `secure:` / secret metadata where applicable.
+- [ ] SDK reads use `requireSecret`, `getSecret`, `pulumi.secret`, or language-equivalent APIs for secret-bearing values.
+- [ ] Plain `require` / `get` values are not passed into password, token, key, connection-string, or credential fields.
+- [ ] `apply()` callbacks do not log, write, return as non-secret, or export plaintext secret values.
+- [ ] `additionalSecretOutputs` is used for provider-computed secret outputs when the provider cannot infer secrecy.
+- [ ] The secrets provider/back end is documented or marked `not evaluable` if state encryption cannot be verified.
+
+### Bicep Secure Parameter and Output Gates
+
+Bicep often contains sensitive-looking property names because Azure resource schemas require them. Classify findings by value origin, not by property name alone.
+
+**Safe pattern:**
+
+```bicep
+@secure()
+param adminPassword string
+
+resource vm 'Microsoft.Compute/virtualMachines@2025-04-01' = {
+  name: 'safe-vm'
+  location: resourceGroup().location
+  properties: {
+    osProfile: {
+      computerName: 'safe-vm'
+      adminUsername: 'azureuser'
+      adminPassword: adminPassword
+    }
+  }
+}
+```
+
+**Risky patterns:**
+
+```bicep
+param adminPassword string
+```
+
+```bicep
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: 'prodsa'
+}
+
+output primaryKey string = storage.listKeys().keys[0].value
+```
+
+**Bicep review checklist:**
+
+- [ ] Sensitive parameters use `@secure()` when passed to password, secret, key, token, certificate, or connection-string fields.
+- [ ] Outputs do not expose secure parameters, `list*()` values, connection strings, storage keys, or deployment-script secret output.
+- [ ] Module outputs are checked for secret propagation before top-level outputs expose them.
+- [ ] `.bicepparam` files do not contain plaintext production credentials.
+- [ ] Findings reference Bicep linter-equivalent rules such as secure input and secret output checks when applicable.
+
 ---
 
 ## Public Exposure Analysis


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** iac-security
**Skill path:** `skills/cloud/iac-security/`

### What Was Wrong
The skill claims Pulumi and Bicep coverage, but the detailed rules were mostly Terraform/CloudFormation-shaped. That can create both false positives and missed findings:

- Pulumi `password`/`token` fields can be safe when fed by `requireSecret()`, `getSecret()`, `pulumi.secret()`, or secret-tainted outputs, but risky when fed by plain config or exposed inside `apply()` callbacks.
- Bicep `adminPassword` and similar schema properties are expected in Azure templates; the important evidence is whether the value comes from `@secure()` parameters/outputs or from plain parameters, literals, `list*()` calls, module outputs, or deployment-script output.
- The report format did not capture evidence origin by IaC framework, making Pulumi stack config, state, Bicep linter evidence, and not-evaluable cases harder to express.

Related review: #1116

### What This PR Fixes
- Expands `iac-security` metadata and discovery patterns for Pulumi JS/Go/.NET and Bicep parameter files.
- Adds Pulumi-specific secret-flow gates covering stack config, secret APIs, plain config reads, `apply()` leakage, `additionalSecretOutputs`, and secrets provider evidence.
- Adds Bicep secure parameter/output gates covering `@secure()`, `list*()` output leakage, module outputs, `.bicepparam`, and linter-equivalent evidence.
- Adds `IaC Framework` and `Evidence Origin` fields to detailed findings.
- Adds common pitfalls and references for Pulumi secrets/config and Bicep secure input/output rules.
- Adds vulnerable and benign fixtures for Pulumi and Bicep.

### Evidence
**Before (skill misses this / false positive on this):**
```typescript
const cfg = new pulumi.Config();
const dbPassword = cfg.require(dbPassword);

new aws.ssm.Parameter(db-password, {
  type: SecureString,
  value: dbPassword,
});
```

```bicep
param adminPassword string
output primaryKey string = storage.listKeys().keys[0].value
```

**After (now correctly handled):**
```typescript
const cfg = new pulumi.Config();
const dbPassword = cfg.requireSecret(dbPassword);
```

```bicep
@secure()
param adminPassword string
```

The updated guidance now asks reviewers to classify value origin and evidence layer before reporting a finding.

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass / repository checks simulated locally

Added:
- `skills/cloud/iac-security/tests/vulnerable/pulumi-plain-config-secret.ts`
- `skills/cloud/iac-security/tests/benign/pulumi-secret-config.ts`
- `skills/cloud/iac-security/tests/vulnerable/bicep-plain-secret-output.bicep`
- `skills/cloud/iac-security/tests/benign/bicep-secure-parameter.bicep`

### Local Validation
- `git diff --cached --check`
- Required frontmatter fields check for `skills/cloud/iac-security/SKILL.md`
- Markdown fence balance check for staged Markdown files
- Changed-file scan for repository prompt-injection blocklist patterns
- Fixture content assertions for Pulumi vulnerable/benign and Bicep vulnerable/benign examples

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** PayPal; payout details can be provided privately after acceptance.