### PR TITLE
Add secure code review endpoint classification gates

### DIFF
--- a/skills/appsec/secure-code-review/SKILL.md
+++ b/skills/appsec/secure-code-review/SKILL.md
@@ -214,11 +214,95 @@ http.HandleFunc("/transfer", func(w http.ResponseWriter, r *http.Request) {
 ```
 Remediation: Require POST with a validated CSRF token. Use a CSRF middleware library (e.g., `gorilla/csrf`).
 
-### 4.3 Review Checklist
+### 4.3 Endpoint Classification Gate
 
-- [ ] Every API endpoint and data-access path enforces authorization server-side.
+Before flagging missing authorization, classify each route or resolver by the security control it is supposed to use. Not every endpoint should require an end-user session, but every endpoint should have an explicit reason for its exposure.
+
+| Endpoint type | Examples | Required evidence |
+|---|---|---|
+| Public non-sensitive endpoint | `/.well-known/jwks.json`, health checks, robots/sitemap | Contains no private data, has safe cache behavior, and cannot trigger state changes |
+| Signed machine callback | Payment webhooks, CI callbacks, provider notifications | Verifies the provider signature over the raw payload, validates timestamp/replay windows, and is idempotent |
+| Authenticated user endpoint | Profile, invoice, order, project APIs | Requires authentication and enforces object ownership or tenant scoping |
+| Privileged/admin endpoint | User deletion, billing admin, feature flags | Requires authentication, role/permission checks, and auditable authorization decisions |
+| Internal-only endpoint | Metrics, debug, admin health | Bound to a private network, protected by service identity, or explicitly disabled in production |
+
+**TypeScript -- Signed Webhook Without Raw-Body Verification**
+```typescript
+// VULNERABLE: JSON parsing changes the payload before signature verification
+app.post('/webhooks/payments', express.json(), (req, res) => {
+  verifyProviderSignature(JSON.stringify(req.body), req.header('x-signature'));
+  processPaymentEvent(req.body);
+  res.sendStatus(204);
+});
+```
+Remediation: Verify the provider signature against the exact raw request body before parsing or processing. Enforce timestamp tolerance, reject replayed event IDs, and make processing idempotent.
+
+**TypeScript -- Public Discovery Endpoint That Should Not Be Flagged**
+```typescript
+// BENIGN: public keys are intentionally public and do not perform state changes
+app.get('/.well-known/jwks.json', (_req, res) => {
+  res.set('Cache-Control', 'public, max-age=300');
+  res.json({ keys: publicJwks });
+});
+```
+Review guidance: do not recommend adding user authentication to discovery endpoints solely because they are public. Instead, verify the endpoint is read-only, contains only public material, has safe cache headers, and cannot be confused with a privileged key-management API.
+
+### 4.4 GraphQL Resolver and Query Abuse Review
+
+When a GraphQL endpoint is in scope, do not treat authentication on the single `/graphql` route as sufficient authorization. Review each resolver and data loader that returns sensitive objects.
+
+**TypeScript -- Resolver-Level IDOR (CWE-862)**
+```typescript
+const resolvers = {
+  Query: {
+    invoice: async (_parent, args, ctx) => {
+      requireUser(ctx);
+      // VULNERABLE: no tenant or owner check on args.id
+      return db.invoice.findUnique({ where: { id: args.id } });
+    },
+  },
+};
+```
+Remediation: scope lookups to the caller's tenant or owner context, for example `where: { id: args.id, tenantId: ctx.user.tenantId }`, and apply the same checks to nested resolvers and data loaders.
+
+**GraphQL -- Query Cost and Nested Exposure**
+```graphql
+query {
+  organization(id: "org_1") {
+    projects {
+      issues {
+        comments {
+          author {
+            teams {
+              members { email }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+Review guidance: verify depth limits, complexity/cost limits, pagination caps, batching limits, resolver timeouts, introspection policy, and error redaction. A depth limit alone is not enough when broad list fields can multiply expensive nested work.
+
+**GraphQL -- Batched Authentication Attempts**
+```graphql
+mutation {
+  a1: login(email: "victim@example.com", password: "guess1") { token }
+  a2: login(email: "victim@example.com", password: "guess2") { token }
+  a3: login(email: "victim@example.com", password: "guess3") { token }
+}
+```
+Review guidance: verify that rate limits, authentication attempt counters, audit logs, and abuse detection count each operation or alias, not only the outer HTTP request.
+
+### 4.5 Review Checklist
+
+- [ ] Every API endpoint, GraphQL resolver, and data-access path has an explicit endpoint classification and matching security control.
 - [ ] Object references (IDs) cannot be tampered with to access other users' data.
 - [ ] State-changing operations use anti-CSRF tokens or SameSite cookies.
+- [ ] Signed machine callbacks verify raw-body signatures, timestamp/replay windows, provider identity, and idempotency before processing.
+- [ ] GraphQL resolvers enforce ownership/tenant checks on top-level and nested fields.
+- [ ] GraphQL endpoints enforce depth, complexity, batching, pagination, timeout, and introspection controls appropriate for the deployment.
 - [ ] Role/permission checks are centralized, not scattered across handlers.
 - [ ] Deny-by-default: all routes are denied unless explicitly permitted.
 


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** secure-code-review
**Skill path:** `skills/appsec/secure-code-review/`

Fixes #1119.

### What Was Wrong

The authorization step said every API endpoint and data-access path should enforce server-side authorization. That is right for user and admin routes, but it can create false positives when a route is intentionally public or authenticated through message integrity rather than an end-user session.

The skill also did not give GraphQL-specific checks. A review could pass because `/graphql` has authentication middleware while individual resolvers still miss ownership checks, nested field controls, query cost limits, batching controls, or alias-aware abuse accounting.

### What This PR Fixes

This PR adds focused review gates to `secure-code-review`:

- endpoint classification before flagging missing authorization;
- required evidence for public non-sensitive endpoints, signed machine callbacks, authenticated user endpoints, privileged endpoints, and internal-only endpoints;
- raw-body signature, replay-window, provider-identity, and idempotency checks for signed callbacks;
- resolver-level ownership and tenant checks for GraphQL APIs;
- GraphQL depth, complexity, batching, pagination, timeout, introspection, and error-redaction checks;
- alias-aware rate-limit and audit checks for batched GraphQL authentication attempts.

### Evidence

**Before (false positive risk):**
```ts
app.get('/.well-known/jwks.json', (_req, res) => {
  res.json({ keys: publicJwks });
});
```

The prior checklist could push reviewers to recommend user authentication for an intentionally public discovery endpoint.

**After (now correctly handled):**
```md
Public non-sensitive endpoint | `/.well-known/jwks.json`, health checks, robots/sitemap | Contains no private data, has safe cache behavior, and cannot trigger state changes
```

**Before (skill misses this):**
```ts
const resolvers = {
  Query: {
    invoice: async (_parent, args, ctx) => {
      requireUser(ctx);
      return db.invoice.findUnique({ where: { id: args.id } });
    },
  },
};
```

**After (now correctly handled):**
```md
GraphQL resolvers enforce ownership/tenant checks on top-level and nested fields.
```

### Test Cases Added/Updated
- [ ] Added vulnerable test cases (`tests/vulnerable/`)
- [ ] Added benign test cases (`tests/benign/`)
- [x] Existing checks still pass

Validation performed:

- `git diff --check`
- frontmatter required-field check matching `.github/workflows/lint-skills.yml`
- prompt-injection pattern scan matching `.github/workflows/injection-scan.yml`
- marker checks for endpoint classification, signed callbacks, raw-body signatures, GraphQL resolver ownership, complexity, and batching coverage

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Crypto; payment details can be provided privately after maintainer acceptance.
