### PR TITLE
Add AWS CIS benchmark version mapping

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -2,18 +2,19 @@
 name: aws-review
 description: >
   Performs an AWS security posture review against the CIS Amazon Web Services
-  Foundations Benchmark v3.0.0. Auto-invoked when reviewing AWS infrastructure,
+  Foundations Benchmark with version-aware handling for current Security Hub
+  CSPM standards and legacy benchmark baselines. Auto-invoked when reviewing AWS infrastructure,
   IAM policies, S3 configurations, CloudTrail settings, VPC security groups, or
-  RDS encryption. Walks through all five benchmark sections, evaluates each
-  recommendation, and produces a prioritized findings report with remediation
-  guidance mapped to specific CIS control IDs.
+  RDS encryption. Walks through the selected benchmark version, evaluates each
+  supported recommendation, and produces a prioritized findings report with
+  remediation guidance mapped to specific CIS and Security Hub control IDs.
 tags: [cloud, aws, cis-benchmark]
 role: [cloud-security-engineer, security-engineer]
 phase: [assess, operate]
-frameworks: [CIS-AWS-v3.0.0]
+frameworks: [CIS-AWS-v5.0.0, CIS-AWS-v3.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -25,9 +26,9 @@ argument-hint: "[target-file-or-directory]"
 
 ## Overview
 
-This skill performs a structured security assessment of AWS environments against the **CIS Amazon Web Services Foundations Benchmark v3.0.0**. The benchmark is organized into five sections covering identity management, storage, logging, monitoring, and networking. Each recommendation is evaluated by inspecting infrastructure-as-code definitions (Terraform, CloudFormation, CDK), AWS CLI output, or configuration files available in the repository.
+This skill performs a structured security assessment of AWS environments against the selected **CIS Amazon Web Services Foundations Benchmark** version. Current posture reviews should be version-aware instead of assuming the historical v3.0.0 baseline. AWS Security Hub CSPM supports multiple CIS AWS Foundations Benchmark versions, including v5.0.0 and v3.0.0, and AWS recommends using v5.0.0 to stay current with security best practices.
 
-The CIS AWS Foundations Benchmark v3.0.0 contains 62 recommendations across five domains. This skill evaluates each applicable control against the codebase and produces a findings report with CIS recommendation IDs, severity ratings, and actionable remediation steps.
+Each recommendation is evaluated by inspecting infrastructure-as-code definitions (Terraform, CloudFormation, CDK), AWS CLI or Security Hub CSPM exports, and configuration files available in the repository. The assessment must derive the control denominator and section mapping from the selected benchmark version instead of hard-coding the v3.0.0 count.
 
 ---
 
@@ -39,13 +40,16 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 - Assessing an existing AWS environment's security posture against CIS benchmarks
 - Preparing for a CIS benchmark audit or compliance assessment
 - Evaluating IAM policies, S3 bucket configurations, CloudTrail settings, VPC security groups, or RDS encryption configurations
+- Reviewing Security Hub CSPM findings for CIS AWS Foundations Benchmark v5.0.0 or legacy versions
 - Onboarding a new AWS account into a security program
 
 ---
 
 ## Context
 
-The CIS Amazon Web Services Foundations Benchmark v3.0.0 is a consensus-driven security configuration guide developed by the Center for Internet Security. It provides prescriptive guidance for configuring AWS accounts to a hardened baseline. Organizations use it as the foundation for AWS security assessments, compliance programs (PCI DSS, HIPAA, SOC 2), and continuous monitoring.
+The CIS Amazon Web Services Foundations Benchmark is a consensus-driven security configuration guide developed by the Center for Internet Security. It provides prescriptive guidance for configuring AWS accounts to a hardened baseline. Organizations use it as the foundation for AWS security assessments, compliance programs (PCI DSS, HIPAA, SOC 2), and continuous monitoring.
+
+Security Hub CSPM can run more than one CIS benchmark version at the same time. Treat v3.0.0 as a legacy baseline unless the requester explicitly selected it. When the evidence comes from Security Hub CSPM, record the exact standards subscription ARN or version, because a finding from `cis-aws-foundations-benchmark/v/3.0.0` is not interchangeable with a v5.0.0 result.
 
 ### Prerequisites
 
@@ -55,6 +59,8 @@ The CIS Amazon Web Services Foundations Benchmark v3.0.0 is a consensus-driven s
 - S3 bucket policies and ACL configurations
 - VPC, security group, and NACL definitions
 - CloudTrail and CloudWatch configuration files
+- Security Hub CSPM standards subscriptions or findings exports when available
+- Service-specific IaC for newer benchmark coverage, such as Lambda, ECS, EKS, API Gateway, SQS, SNS, Step Functions, and EventBridge
 
 ---
 
@@ -91,15 +97,42 @@ Record all discovered files. If no AWS configurations are found, report that fin
 
 ---
 
-### Step 2 through Step 6: CIS Benchmark Evaluation (Sections 1-5)
+### Step 2: Benchmark Version and Mapping Preflight
 
-Evaluate all AWS configurations against CIS AWS v3.0.0 Sections 1 through 5, covering Identity and Access Management, Storage, Logging, Monitoring, and Networking.
+Before scoring controls, identify the benchmark version and evidence source:
 
-For detailed CIS benchmark checklist items with specific Terraform patterns, grep patterns, and configuration examples for all five sections, see [benchmark-checklist.md](benchmark-checklist.md) in this skill directory.
+| Field | Required Evidence |
+|-------|-------------------|
+| `benchmark_version` | `v5.0.0`, `v3.0.0`, `v1.4.0`, `v1.2.0`, or explicitly unknown |
+| `benchmark_source_date` | Date of the CIS/AWS mapping source used for the review |
+| `security_hub_standard_arn_or_version` | Security Hub CSPM standard ARN/version when findings come from Security Hub |
+| `legacy_baseline` | `true` when the requester intentionally selected v3.0.0 or older |
+| `control_mapping_source` | AWS Security Hub CSPM version comparison, CIS benchmark PDF, internal GRC mapping, or custom/manual mapping |
+
+If no version is specified, default the report target to current v5.0.0-aware handling, but mark every control that cannot be mapped from available evidence as `Not Evaluable`. Do not convert old v3.0.0 control IDs to v5.0.0 IDs by guesswork.
+
+Use these support-status values in the mapping table:
+
+| Support Status | Meaning |
+|----------------|---------|
+| `current` | Control is supported by the selected benchmark version and evidence source. |
+| `legacy` | Control belongs to an older enabled benchmark and should not be counted as current v5.0.0 coverage. |
+| `removed` | Requirement was removed by CIS for the selected version. Do not report it as a current failure. |
+| `unsupported` | Security Hub CSPM or the supplied evidence source does not support this requirement. |
+| `manual` | The control requires manual or external evidence outside repository/IaC inspection. |
+| `not_evaluable_from_supplied_evidence` | The control may apply, but the supplied files cannot prove pass/fail. |
 
 ---
 
-### Step 7: Compile Assessment Report
+### Step 3 through Step 7: CIS Benchmark Evaluation
+
+Evaluate all AWS configurations against the selected CIS AWS benchmark version. Legacy v3.0.0 reviews cover Identity and Access Management, Storage, Logging, Monitoring, and Networking. Current v5.0.0-aware reviews must also check whether the selected mapping introduces, removes, or remaps controls for newer AWS services and Security Hub CSPM control IDs.
+
+For detailed benchmark checklist items with specific Terraform patterns, grep patterns, and configuration examples, see [benchmark-checklist.md](benchmark-checklist.md) in this skill directory. Treat that file as a version-aware review aid, not as permission to invent unverified CIS IDs.
+
+---
+
+### Step 8: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
 
@@ -125,26 +158,33 @@ Produce the final report using the structure defined in the Output Format sectio
 ### Environment
 - Account/Repository: <identifier>
 - Date: <assessment date>
-- Framework: CIS Amazon Web Services Foundations Benchmark v3.0.0
+- Framework: CIS Amazon Web Services Foundations Benchmark
+- Benchmark version: <v5.0.0 / v3.0.0 / v1.4.0 / v1.2.0 / unknown>
+- Security Hub standard ARN/version: <arn or version, if available>
+- Benchmark source date: <date or unknown>
+- Legacy baseline intentionally selected: <Yes/No>
 - Files reviewed: <list of IaC files>
 
 ### Executive Summary
-- Total CIS recommendations evaluated: <N>/62
+- Total CIS recommendations evaluated: <N>/<selected benchmark denominator>
 - Passed: <N>
 - Failed: <N>
 - Not Applicable: <N>
 - Not Evaluable (insufficient data): <N>
+- Legacy/Removed/Unsupported controls excluded from current score: <N>
 - Overall compliance: <percentage>
+
+### Benchmark Mapping
+
+| Control ID | Security Hub Control ID | Selected Version Requirement | Support Status | Evidence Source | Assessment Status |
+|------------|-------------------------|------------------------------|----------------|-----------------|-------------------|
+| CIS X.Y | <SecurityHub.Control> | <requirement title> | current/legacy/removed/unsupported/manual/not_evaluable_from_supplied_evidence | Security Hub/IaC/manual | Pass/Fail/N/A/Not Evaluable |
 
 ### Section Scores
 
 | Section | Description | Passed | Failed | N/A | Compliance |
 |---------|-------------|--------|--------|-----|------------|
-| 1 | Identity and Access Management | X/22 | Y | Z | nn% |
-| 2 | Storage | X/10 | Y | Z | nn% |
-| 3 | Logging | X/11 | Y | Z | nn% |
-| 4 | Monitoring | X/16 | Y | Z | nn% |
-| 5 | Networking | X/6 | Y | Z | nn% |
+| <selected benchmark section> | <domain> | X/<version-derived count> | Y | Z | nn% |
 
 ### Detailed Findings
 
@@ -152,6 +192,9 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Status:** Pass / Fail / Not Evaluable
 - **Severity:** Critical / High / Medium / Low
 - **CIS Profile:** Level 1 / Level 2
+- **Benchmark Version:** <version used for this control>
+- **Support Status:** current / legacy / removed / unsupported / manual / not_evaluable_from_supplied_evidence
+- **Security Hub Control ID:** <if available>
 - **File:** <path to relevant config>
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
@@ -175,15 +218,23 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Framework Reference
 
-### CIS AWS Foundations Benchmark v3.0.0 -- Section Map
+### CIS AWS Foundations Benchmark -- Version-Aware Handling
 
-| Section | Domain | Recommendation Count | Key Focus Areas |
-|---------|--------|---------------------|-----------------|
-| 1 | Identity and Access Management | 22 | Root account security, MFA, password policy, access keys, IAM policies, Access Analyzer, identity federation |
-| 2 | Storage | 10 | S3 bucket security (public access, encryption, TLS), EBS encryption, RDS encryption and access, EFS encryption |
-| 3 | Logging | 11 | CloudTrail (multi-region, validation, encryption), AWS Config, S3 access logging, VPC flow logs, object-level logging |
-| 4 | Monitoring | 16 | CloudWatch metric filters and alarms for 15 critical event types, Security Hub enablement |
-| 5 | Networking | 6 | NACL restrictions, security group hardening, default SG lockdown, VPC peering routes, IMDSv2 enforcement |
+| Version | How to Use |
+|---------|------------|
+| v5.0.0 | Preferred current target when no legacy baseline is requested. Use AWS Security Hub CSPM version comparison or official CIS material to derive control mapping and denominator. |
+| v3.0.0 | Legacy baseline. Use only when the requester explicitly asks for v3.0.0 or the environment still runs that standard. Do not present v3.0.0 counts as current v5.0.0 coverage. |
+| v1.4.0 / v1.2.0 | Older legacy baselines. Preserve findings for migration context, but exclude removed/unsupported controls from the current score. |
+
+### Mapping Evidence Requirements
+
+Every scored control must include:
+
+- selected benchmark version;
+- source of the mapping;
+- evidence source used for the assessment;
+- support status;
+- whether the control is current, legacy, removed, unsupported, manual, or not evaluable from supplied evidence.
 
 ### CIS Profile Levels
 
@@ -200,6 +251,9 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
 5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
 6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
+7. **Mixing benchmark versions in one denominator.** A v3.0.0 pass count and a v5.0.0 supported-control count are different baselines. Keep legacy findings visible, but exclude them from the current score unless they map cleanly to the selected version.
+8. **Reporting removed or unsupported controls as current failures.** If AWS Security Hub CSPM marks a requirement as removed by CIS or unsupported for a version, report the mapping status instead of treating it as a live fail.
+9. **Assuming Security Hub evidence proves every IaC-only question.** Some controls require manual evidence, account-level settings, or runtime service findings that cannot be proven from repository files alone.
 
 ---
 
@@ -219,7 +273,8 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## References
 
-- CIS Amazon Web Services Foundations Benchmark v3.0.0: https://www.cisecurity.org/benchmark/amazon_web_services
+- CIS Amazon Web Services Foundations Benchmark: https://www.cisecurity.org/benchmark/amazon_web_services
+- AWS Security Hub CSPM CIS AWS Foundations Benchmark: https://docs.aws.amazon.com/securityhub/latest/userguide/cis-aws-foundations-benchmark.html
 - AWS Security Best Practices: https://docs.aws.amazon.com/security/
 - AWS IAM Best Practices: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 - AWS CloudTrail Documentation: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/
@@ -231,4 +286,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.1.0** -- Added benchmark-version preflight, Security Hub CSPM standard evidence, version-derived denominators, and current/legacy/removed/unsupported mapping statuses for CIS AWS v5.0.0-aware reviews.
 - **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 (62 recommendations).

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -1,12 +1,52 @@
-# CIS AWS Foundations Benchmark v3.0.0 -- Detailed Checklist
+# CIS AWS Foundations Benchmark -- Version-Aware Detailed Checklist
 
-This file contains the detailed CIS benchmark checklist items for the AWS Security Posture Review skill. See [SKILL.md](SKILL.md) for the main skill definition, process overview, and output format.
+This file contains detailed CIS benchmark checklist items for the AWS Security Posture Review skill. See [SKILL.md](SKILL.md) for the main skill definition, process overview, benchmark-version preflight, and output format.
+
+The original checklist was written for CIS AWS Foundations Benchmark v3.0.0. Current reviews must first identify the selected benchmark version and mapping source. Use this file as evidence guidance and as a legacy v3.0.0 control map; do not treat the fixed v3.0.0 section counts as the denominator for a v5.0.0 Security Hub CSPM assessment.
+
+---
+
+## Benchmark Version Preflight
+
+Before applying any checklist item, capture the benchmark context:
+
+| Field | How to Capture |
+|-------|----------------|
+| `benchmark_version` | From the user request, Security Hub standards subscription, GRC export, or report header. |
+| `security_hub_standard_arn_or_version` | Look for `cis-aws-foundations-benchmark/v/<version>` in Security Hub subscriptions or exported findings. |
+| `control_mapping_source` | AWS Security Hub CSPM version comparison, official CIS material, or an approved internal control crosswalk. |
+| `benchmark_source_date` | Date of the AWS/CIS mapping source or internal GRC mapping. |
+| `legacy_baseline` | Set to true only when v3.0.0 or older was intentionally selected. |
+
+Use this support status vocabulary for each row in the final mapping table:
+
+| Status | Checklist Behavior |
+|--------|--------------------|
+| `current` | Score normally for the selected benchmark version. |
+| `legacy` | Preserve for migration context, but do not count as current v5.0.0 coverage. |
+| `removed` | Do not report as a current failure. Explain that the requirement was removed for the selected version. |
+| `unsupported` | Do not score from Security Hub CSPM alone. Request manual evidence if the risk still matters. |
+| `manual` | Requires evidence outside repository/IaC inspection. |
+| `not_evaluable_from_supplied_evidence` | Applies in principle, but available files cannot prove pass/fail. |
+
+Security Hub CSPM evidence to search for:
+
+```
+cis-aws-foundations-benchmark/v/5.0.0
+cis-aws-foundations-benchmark/v/3.0.0
+aws_securityhub_standards_subscription
+standards_subscription_arn
+StandardsArn
+GeneratorId
+Compliance.SecurityControlId
+Compliance.AssociatedStandards
+```
 
 ---
 
 ## Section 1 -- Identity and Access Management
 
-Evaluate IAM configurations against CIS AWS v3.0.0 Section 1 recommendations.
+Evaluate IAM configurations against the selected CIS AWS benchmark version. The legacy items below map to the v3.0.0 checklist and should be cross-checked against the selected version before scoring.
 
 ### CIS 1.1 -- Maintain current contact details
 
@@ -164,7 +204,7 @@ Look for policies restricting CloudShell access.
 
 ## Section 2 -- Storage
 
-Evaluate S3 and EBS storage configurations against Section 2 recommendations.
+Evaluate storage configurations against the selected benchmark version. The legacy v3.0.0 checklist focuses on S3, EBS, RDS, and EFS. For v5.0.0-aware reviews, first confirm whether the selected mapping adds, removes, or remaps controls for additional storage and messaging services before scoring.
 
 ### CIS 2.1.1 -- Ensure S3 Bucket Policy is set to deny HTTP requests
 
@@ -264,7 +304,7 @@ encrypted = true
 
 ## Section 3 -- Logging
 
-Evaluate logging configurations against Section 3 recommendations.
+Evaluate logging configurations against the selected benchmark version. For v5.0.0-aware reviews, verify whether the selected mapping introduces service-specific logging controls beyond the legacy CloudTrail, AWS Config, VPC Flow Logs, and S3 object-level logging items.
 
 ### CIS 3.1 -- Ensure CloudTrail is enabled in all regions
 
@@ -356,7 +396,7 @@ Same as 3.10 -- verify both read and write events are captured.
 
 ## Section 4 -- Monitoring
 
-Evaluate monitoring and alerting configurations against Section 4 recommendations.
+Evaluate monitoring and alerting configurations against the selected benchmark version. Keep CloudWatch metric-filter checks version-scoped; do not assume the legacy v3.0.0 monitoring IDs are unchanged in newer mappings.
 
 ### CIS 4.1 -- Ensure a log metric filter and alarm exist for unauthorized API calls
 
@@ -409,7 +449,7 @@ aws_securityhub_standards_subscription
 
 ## Section 5 -- Networking
 
-Evaluate network configurations against Section 5 recommendations.
+Evaluate network configurations against the selected benchmark version. The legacy items below cover NACLs, security groups, default security groups, peering route scope, and IMDSv2. For newer mappings, also check whether the selected version adds VPC endpoint, PrivateLink, Network Firewall, EKS, or ECS network controls.
 
 ### CIS 5.1 -- Ensure no Network ACLs allow ingress from 0.0.0.0/0 to remote server administration ports
 
@@ -488,3 +528,43 @@ resource "aws_launch_template" {
   }
 }
 ```
+
+---
+
+## Current-Version Expansion Gates
+
+When the selected mapping is v5.0.0 or another current Security Hub CSPM standard, add the following gates before final scoring. These gates are deliberately mapping-aware: use official AWS/CIS mapping evidence for exact control IDs instead of inventing IDs from service names.
+
+### Compute and Runtime Services
+
+| Area | Evidence to Search | Scoring Guidance |
+|------|--------------------|------------------|
+| EC2 runtime metadata | `metadata_options`, `http_tokens`, launch templates, Auto Scaling launch configurations | Score only against the selected mapping. If the environment uses launch templates but only instances were checked, mark incomplete evidence. |
+| Lambda | `aws_lambda_function`, `aws_lambda_permission`, `aws_lambda_function_url`, runtime versions, environment encryption, VPC config, logging config | Require mapping evidence before assigning a CIS ID. Missing runtime/logging/VPC evidence is `not_evaluable_from_supplied_evidence` when only partial IaC is supplied. |
+| ECS | `aws_ecs_task_definition`, task execution roles, log configuration, network mode, secrets injection, service discovery | Distinguish task execution role evidence from application task role evidence. |
+| EKS | `aws_eks_cluster`, control plane logging, public endpoint access, node security groups, IAM roles for service accounts | Do not treat generic Kubernetes YAML as proof of AWS managed-control compliance without EKS cluster evidence. |
+
+### Application and Event Services
+
+| Area | Evidence to Search | Scoring Guidance |
+|------|--------------------|------------------|
+| API Gateway / AppSync | `aws_api_gateway_*`, `aws_apigatewayv2_*`, `aws_appsync_graphql_api`, access logging, auth type, WAF association | Record whether the evidence comes from IaC, Security Hub, or manual screenshots/export. |
+| SQS / SNS | `aws_sqs_queue`, `aws_sns_topic`, encryption, queue/topic policy, dead-letter queue evidence | Separate encryption posture from cross-account policy exposure. |
+| Step Functions | `aws_sfn_state_machine`, logging configuration, tracing, encryption, execution history retention | Some controls may be manual or unsupported in Security Hub; mark status explicitly. |
+| EventBridge | `aws_cloudwatch_event_bus`, `aws_cloudwatch_event_rule`, event bus policy, archive/replay settings | Watch for cross-account event bus policies and missing owner context. |
+
+### Version-Mapping Crosswalk
+
+For every control that appears in the final report, add a row like:
+
+```
+control_id: CIS <selected-version-id>
+legacy_ids: [CIS v3.0.0 <old-id>, ...]
+security_hub_control_id: <Security Hub control, if available>
+support_status: current | legacy | removed | unsupported | manual | not_evaluable_from_supplied_evidence
+mapping_source: <AWS Security Hub CSPM version comparison / CIS material / internal crosswalk>
+evidence_source: <file, Security Hub finding, or manual artifact>
+assessment_status: Pass | Fail | Not Applicable | Not Evaluable
+```
+
+Do not include removed, unsupported, or legacy-only controls in the current benchmark denominator. Keep them in a migration appendix when they are useful for explaining why a historical report differs from the current Security Hub score.


### PR DESCRIPTION
## Summary
- add a benchmark-version preflight for AWS CIS reviews so current posture reports do not assume the legacy v3.0.0 baseline
- add Security Hub CSPM standard/version evidence fields, version-derived denominators, and mapping statuses for current, legacy, removed, unsupported, manual, and not-evaluable controls
- extend the checklist with v5.0.0-aware expansion gates for compute, runtime, application, and event services without inventing unverified CIS IDs

## Why
AWS Security Hub CSPM supports CIS AWS Foundations Benchmark v5.0.0 alongside older versions and recommends v5.0.0 for current coverage. The previous skill hard-coded v3.0.0 and `<N>/62`, which can make legacy coverage look like current posture.

## Validation
- `git diff --check`
- markdown fence balance check
- required frontmatter field check
- changed-file prompt-safety keyword scan
- rechecked open PRs for direct #213/version-mapping overlap before submission

## References
- https://docs.aws.amazon.com/securityhub/latest/userguide/cis-aws-foundations-benchmark.html
- https://aws.amazon.com/about-aws/whats-new/2025/10/aws-security-hub-cspm-cis-foundations-benchmark-v5/

## Bounty
Addresses #213. Skill Improvement / Improver candidate. Payment details can be provided privately after maintainer acceptance.