### PR TITLE
fix(skill): secrets-management FP reduction + encoded/modern-key coverage

### DIFF
--- a/skills/devsecops/secrets-management/SKILL.md
+++ b/skills/devsecops/secrets-management/SKILL.md
@@ -13,7 +13,7 @@ phase: [build, operate]
 frameworks: [OWASP-Secrets-Management, NIST-SP-800-57-Part1-Rev5]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.1"
+version: "1.0.2"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -136,6 +136,31 @@ xox[bpors]-[0-9]{10,13}-[A-Za-z0-9-]{20,}
 (?i)(?:api[_-]?key|apikey)\s*[=:]\s*['"][A-Za-z0-9]{20,}['"]
 ```
 
+**Modern provider key formats (high-incident, keep current):**
+
+```regex
+# OpenAI project/user keys
+sk-(?:proj|svcacct|admin)-[A-Za-z0-9_-]{20,}
+
+# Google API key
+AIza[0-9A-Za-z\-_]{35}
+
+# Stripe restricted key (secret-class; pk_ is publishable, see 2.2)
+rk_(?:live|test)_[A-Za-z0-9]{24,}
+
+# Slack app-level token
+xapp-[0-9]-[A-Za-z0-9-]+
+
+# npm / Hugging Face / SendGrid / Twilio
+npm_[A-Za-z0-9]{36}
+hf_[A-Za-z0-9]{34,}
+SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}
+SK[0-9a-fA-F]{32}
+
+# GCP service-account JSON (the sensitive field)
+"private_key"\s*:\s*"-----BEGIN (?:RSA )?PRIVATE KEY-----
+```
+
 **Private Keys:**
 
 ```regex
@@ -145,6 +170,8 @@ xox[bpors]-[0-9]{10,13}-[A-Za-z0-9-]{20,}
 # PGP Private Key
 -----BEGIN\sPGP\sPRIVATE\sKEY\sBLOCK-----
 ```
+
+> **Encoded-secret pass (do not skip).** The patterns above match **plaintext only**. Kubernetes `Secret` objects store every value under `data:` as base64, and credentials are frequently committed base64-encoded (`*.b64`, encoded service-account JSON, `kubeseal` inputs). For any Kubernetes `kind: Secret` `data:` value, any `stringData` rendered output, or any base64 blob ≥ 40 chars, **base64-decode it in memory and re-run the patterns above against the decoded bytes** (never print the decoded value). Without this decode-and-rescan step, the densest source of committed credentials in modern repos is invisible to detection.
 
 **Connection Strings and Passwords:**
 
@@ -164,14 +191,20 @@ eyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*
 Before flagging a detected string as a hardcoded secret, apply these verification checks:
 
 1. **Verify the value is a real secret, not a placeholder or example.** Strings like `your-api-key-here`, `CHANGEME`, `TODO`, `xxx`, `example`, `test`, `dummy`, `fake`, `<INSERT_KEY>`, or `replace-me` are placeholder values, not leaked secrets. Do NOT flag these.
-2. **Check entropy.** Real secrets (API keys, tokens, passwords) have high entropy — they appear random. Low-entropy strings like `password`, `admin`, `root`, `mysecret`, or dictionary words in config comments are not actual secrets. Only flag password assignments where the value appears to be a real credential (high-entropy, non-dictionary string of 8+ characters).
-3. **Recognize known secret prefixes.** When a string matches a known secret format (e.g., `AKIA*` for AWS, `sk-*` for Stripe/OpenAI, `ghp_*`/`gho_*`/`ghu_*` for GitHub, `xox[bpors]-*` for Slack, `glpat-*` for GitLab, `eyJ*` for JWTs), it is likely a real secret and should be flagged.
-4. **Distinguish secrets findings from architectural observations.** This skill should focus on **finding actual secrets in code and configuration**. The following are NOT secrets findings and should be excluded from the findings count:
+2. **Check entropy, but anchor it with a non-secret shape filter.** Real secrets have high entropy, but so do many benign strings. Before flagging on entropy alone, exclude values whose *shape* identifies them as non-secrets: Subresource Integrity hashes (`sha256-…`/`sha384-…`/`sha512-…`), bare hex digests of length 32/40/64 (MD5/SHA-1/SHA-256 content or commit hashes), RFC-4122 UUIDs, and lockfile integrity digests. Low-entropy strings like `password`, `admin`, `root`, or dictionary words are also not secrets. Only flag password assignments where the value is a high-entropy, non-dictionary, non-hash/non-UUID string of 8+ characters.
+3. **Exclude public-by-design keys (high-value false-positive class).** Some high-entropy keys are *meant* to ship in client code; their security comes from referer/domain/scope restrictions, not secrecy. Report these as **informational at most — never as a leaked-credential finding**:
+   - Stripe **publishable** keys: `pk_live_*` / `pk_test_*` (the secret is `sk_live_*`/`rk_live_*`)
+   - Firebase Web config `apiKey` (`AIza…` inside a `firebaseConfig`/web client object)
+   - Sentry **public** DSN (`https://<publicKey>@<org>.ingest.sentry.io/<id>`)
+   - Algolia **search-only** API key, Google Maps **browser** key, `rzp_test_*`
+   Do not flag `pk_*` as if it were `sk_*`.
+4. **Recognize known secret prefixes.** When a string matches a known secret format (e.g., `AKIA*` for AWS, `sk-*`/`sk-proj-*` for OpenAI, `sk_live_*`/`rk_live_*` for Stripe, `ghp_*`/`gho_*`/`ghu_*` for GitHub, `xox[bpors]-*`/`xapp-*` for Slack, `glpat-*` for GitLab, `AIza*` (outside a public web config) for Google, `npm_*`, `hf_*`, `SG.*` for SendGrid, `eyJ*` for JWTs), it is likely a real secret and should be flagged.
+5. **Distinguish secrets findings from architectural observations.** This skill should focus on **finding actual secrets in code and configuration**. The following are NOT secrets findings and should be excluded from the findings count:
    - Absence of secret detection tooling (note in the Detection Tooling Status table, not as a finding)
    - Absence of a centralized secrets manager (note in recommendations, not as a finding)
    - Missing rotation automation (note in recommendations, not as a finding)
    - Infrastructure misconfigurations unrelated to secrets (e.g., public S3 buckets, debug mode, public database endpoints) — these belong to other skills
-5. **Scope to the skill's domain.** Only report findings where a secret (credential, key, token, certificate) is actually present in the file. General security misconfigurations, missing best practices, and architectural gaps should be noted in the Prioritized Remediation Plan section, not as numbered findings.
+6. **Scope to the skill's domain.** Only report findings where a secret (credential, key, token, certificate) is actually present in the file. General security misconfigurations, missing best practices, and architectural gaps should be noted in the Prioritized Remediation Plan section, not as numbered findings.
 
 #### 2.3 Detection Tool Configuration Review
 
@@ -188,7 +221,7 @@ Verify that at least one secret detection tool is configured and integrated:
 
 - Tool is configured in CI pipeline (runs on every PR/push).
 - Tool is configured as a pre-commit hook (prevents secrets from entering history).
-- Baseline file is maintained (for detect-secrets).
+- Baseline file is maintained **and audited** (for detect-secrets). A `.secrets.baseline` is not a positive signal by mere presence: run `detect-secrets audit` so every entry is human-labeled, and confirm the baseline is regenerated against current `HEAD`. An entry marked `"is_secret": false` on a genuinely live secret silently suppresses it forever, and a stale baseline analyzes the wrong tree.
 - Custom rules cover organization-specific secret formats.
 - Allowlist entries are documented with justification (false positive suppression must not create blind spots).
 
@@ -471,5 +504,6 @@ This skill processes configuration files and code that may contain secret values
 
 ## Changelog
 
+- **1.0.2** -- Reduce false positives and close detection gaps: add a public-by-design key class (Stripe `pk_*`, Firebase web `apiKey`, Sentry DSN, Algolia search key) so shippable client keys are not flagged as leaks; anchor the entropy check with a non-secret shape filter (SRI/hex-digest/UUID); add a base64 decode-and-rescan pass for Kubernetes `kind: Secret` `data:` and encoded blobs; expand the prefix catalog with current high-incident formats (`sk-proj-`, `AIza`, `rk_live_`, `xapp-`, `npm_`, `hf_`, `SG.`, Twilio `SK`, GCP SA-JSON `private_key`); require `detect-secrets audit` of the baseline rather than crediting its mere presence.
 - **1.0.1** -- Add false positive filtering guidance: distinguish real secrets from placeholders/examples, verify entropy, scope findings to actual secrets (not architectural gaps).
 - **1.0.0** -- Initial release. Full coverage of OWASP Secrets Management Cheat Sheet and NIST SP 800-57 Part 1 Rev 5 for secrets management review.

--- a/skills/devsecops/secrets-management/tests/benign/public-by-design-keys.js
+++ b/skills/devsecops/secrets-management/tests/benign/public-by-design-keys.js
@@ -1,0 +1,24 @@
+// BENIGN — secrets-management
+// Expected: NO leaked-credential finding. These keys are public by design;
+// their security comes from domain/referer/scope restrictions, not secrecy.
+// At most they are informational. Flagging any of them as a leaked secret is a
+// false positive (see SKILL.md 2.2 item 3: public-by-design keys).
+
+const firebaseConfig = {
+  apiKey: "AIzaSyD-1a2B3c4D5e6F7g8H9i0J1k2L3m4N5o6P7", // Firebase Web apiKey (public)
+  authDomain: "demo-app.firebaseapp.com",
+  projectId: "demo-app",
+};
+
+const stripe = Stripe("pk_live_51HscJpKx9aQwErTyUiOpAsDfGhJkLzXcVbNm0011"); // publishable
+
+Sentry.init({ dsn: "https://abcdef0123456789@o123456.ingest.sentry.io/123" }); // public DSN
+
+const algolia = algoliasearch("APPID123", "9f8e7d6c5b4a39281706f5e4d3c2b1a0"); // search-only key
+
+// Non-secret high-entropy shapes that the entropy heuristic must NOT flag:
+const sri = "sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC";
+const commit = "9f1c2e4b7a8d3f6019e2c5b4a7d80f3c1e6b9a24"; // 40-hex git SHA
+const uuid = "550e8400-e29b-41d4-a716-446655440000";       // RFC-4122 UUID
+
+module.exports = { firebaseConfig, sri, commit, uuid };

--- a/skills/devsecops/secrets-management/tests/vulnerable/k8s-secret-base64-credentials.yaml
+++ b/skills/devsecops/secrets-management/tests/vulnerable/k8s-secret-base64-credentials.yaml
@@ -1,0 +1,16 @@
+# VULNERABLE — secrets-management
+# Expected: Finding(s). Every value under `data:` is base64 of a REAL credential.
+# Plaintext regexes never match base64, so detection REQUIRES the decode-and-rescan
+# pass (SKILL.md 2.1 "Encoded-secret pass"). After base64-decode:
+#   DATABASE_URL  -> postgres://app:Sup3rSecretP@ss@db.prod:5432/app  (connection string w/ password)
+#   gcp-sa.json   -> service-account JSON containing "private_key": "-----BEGIN PRIVATE KEY-----"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-creds
+  namespace: prod
+type: Opaque
+data:
+  DATABASE_URL: cG9zdGdyZXM6Ly9hcHA6U3VwM3JTZWNyZXRQQHNzQGRiLnByb2Q6NTQzMi9hcHA=
+  GITHUB_TOKEN: Z2hwX0FCQ0RFRjAxMjM0NTY3ODlBQkNERUYwMTIzNDU2Nzg5MDEyMzQ1
+  gcp-sa.json: ewogICJ0eXBlIjogInNlcnZpY2VfYWNjb3VudCIsCiAgInByaXZhdGVfa2V5IjogIi0tLS0tQkVHSU4gUFJJVkFURSBLRVktLS0tLVxuTUlJ..."

--- a/skills/devsecops/secrets-management/tests/vulnerable/modern-provider-keys.env
+++ b/skills/devsecops/secrets-management/tests/vulnerable/modern-provider-keys.env
@@ -1,0 +1,15 @@
+# VULNERABLE — secrets-management
+# Expected: Finding(s). Current high-incident key formats that the pre-1.0.2
+# catalog omitted (SKILL.md 2.1 "Modern provider key formats"). Bodies are
+# SHORTENED/synthetic so this fixture is committable under push protection;
+# detection here keys on the PREFIX, which is the teaching signal. (Values are
+# deliberately not full-length and are not placeholder words, so they must be
+# treated as real-credential shapes, not as 2.2-item-1 placeholders.)
+OPENAI_API_KEY=sk-proj-Zk9Qmd2Lr7Xt4Vn1Bp6Hs3Wc8Yf0Ja5Kd
+GOOGLE_API_KEY=AIzaZk9Qmd2Lr7Xt4Vn1Bp6Hs3Wc8Yf0Ja5
+STRIPE_RESTRICTED=rk_live_Zk9Qmd2Lr7Xt4Vn1Bp6
+SLACK_APP_TOKEN=xapp-1-A0ZK9QMD-7700-zk9qmd2lr7xt4vn1bp6hs3
+NPM_TOKEN=npm_Zk9Qmd2Lr7Xt4Vn1Bp6Hs3Wc8Yf0Ja5Kd
+HF_TOKEN=hf_Zk9Qmd2Lr7Xt4Vn1Bp6Hs3Wc8Yf0Ja5Kd
+SENDGRID_API_KEY=SG.Zk9Qmd2Lr7Xt4.Vn1Bp6Hs3Wc8Yf0Ja5Kd9Lp2Rt
+TWILIO_API_KEY=SKzk9qxmd2lrtxtgvnobphs3wcyyfojark


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `secrets-management`
**Skill path:** `skills/devsecops/secrets-management/`

### What Was Wrong
The 1.0.1 false-positive guidance was one-directional and left gaps in both directions (identified in review #1105):
- No "public-by-design" key class, so shippable client keys (Stripe `pk_*`, Firebase web `apiKey`, Sentry DSN, Algolia search key) were flagged as leaked secrets.
- The entropy check had no shape anchor, so SRI hashes, hex digests, and UUIDs trip it.
- Plaintext-only regexes never matched **base64-encoded** credentials — the densest real source (Kubernetes `kind: Secret` `data:`, encoded service-account JSON).
- The prefix catalog was dated (missing `sk-proj-`, `AIza`, `rk_live_`, `xapp-`, `npm_`, `hf_`, `SG.`, Twilio `SK`, GCP SA-JSON `private_key`).
- A `.secrets.baseline` was credited by mere presence, ignoring poisoned/stale baselines.

Related review issue: #1105

/claim #1105

### What This PR Fixes
- **2.2 item 3 (new):** public-by-design key class — report informational, never as a leak; explicitly distinguishes `pk_*` from `sk_*`.
- **2.2 item 2:** entropy check now anchored with a non-secret shape filter (SRI `sha*-`, 32/40/64-hex digests, RFC-4122 UUIDs).
- **2.1 (new):** "Modern provider key formats" block + an **encoded-secret decode-and-rescan pass** for Kubernetes `kind: Secret` `data:` and base64 blobs (decode in memory, never print).
- **2.3:** require `detect-secrets audit` of the baseline and HEAD-freshness, instead of crediting its presence.
- Version bump to `1.0.2` + changelog.

### Evidence

**Before (false positive — shippable client key flagged as a leak):**
```js
const stripe = Stripe("pk_live_51HscJpKx9aQwErTyUiOpAsDfGhJkLzXcVbNm0011"); // publishable, NOT a secret
```
**After (now classified public-by-design, not a leaked-credential finding).**

**Before (false negative — real creds invisible because base64):**
```yaml
kind: Secret
data:
  DATABASE_URL: cG9zdGdyZXM6Ly9hcHA6U3VwM3JTZWNyZXRQQHNzQGRiLnByb2Q6NTQzMi9hcHA=
```
**After (decode-and-rescan pass decodes `data:` values and re-runs the connection-string/private-key/prefix patterns).**

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
  - `k8s-secret-base64-credentials.yaml` — base64 DB URL / GitHub token / GCP SA-JSON requiring decode-and-rescan
  - `modern-provider-keys.env` — current high-incident prefixes (bodies shortened/synthetic so the fixture is committable under push protection; detection keys on the prefix)
- [x] Added benign test cases (`tests/benign/`)
  - `public-by-design-keys.js` — Stripe `pk_live_`, Firebase `apiKey`, Sentry DSN, Algolia search key, plus SRI/commit-hash/UUID shapes (must NOT be flagged)
- [x] Existing content preserved; markdown fences balanced; frontmatter intact.

### Bounty Tier
- [ ] **Minor** ($50)
- [x] **Moderate** ($100) — FP reduction with evidence + new coverage
- [ ] **Substantial** ($150)

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Crypto, preferably USDC on Base: `0x1b58008Fde85832845817F9B24E64d139E418EeF`
