### PR TITLE
fix(skill): dependency-scanning license FP reduction + reachability & coverage

### DIFF
--- a/skills/appsec/dependency-scanning/SKILL.md
+++ b/skills/appsec/dependency-scanning/SKILL.md
@@ -12,7 +12,7 @@ phase: [build, deploy]
 frameworks: [SLSA-v1.0, CycloneDX, SPDX, CISA-KEV]
 difficulty: intermediate
 time_estimate: "15-30min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -32,9 +32,11 @@ Identify known vulnerabilities, license compliance violations, and supply chain 
 
 This skill activates when any of the following are present:
 
-- A package manifest is shared or referenced: `package.json`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `requirements.txt`, `Pipfile.lock`, `poetry.lock`, `go.mod`, `go.sum`, `pom.xml`, `build.gradle`, `Cargo.toml`, `Cargo.lock`, `Gemfile.lock`, `composer.lock`.
+- A package manifest is shared or referenced: `package.json`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `requirements.txt`, `pyproject.toml`, `Pipfile.lock`, `poetry.lock`, `uv.lock`, `go.mod`, `go.sum`, `pom.xml`, `build.gradle`, `Cargo.toml`, `Cargo.lock`, `Gemfile`, `Gemfile.lock`, `composer.json`, `composer.lock`, `*.csproj`, `packages.config`, `packages.lock.json`, `paket.lock` (.NET/NuGet), `pubspec.lock` (Dart), `mix.lock` (Elixir).
 - The user asks about dependency security, vulnerability scanning, SBOM generation, or supply chain risk.
 - A CI/CD pipeline configuration references dependency audit steps.
+
+> **Do not stop at the listed names.** A Glob keyed only on a fixed manifest list silently skips whole ecosystems (e.g., `pyproject.toml` is now the primary Python source via PEP 621/PEP 508; NuGet and Dart/Elixir have their own files). If a project shows language sources but no recognized manifest, search for the ecosystem's native dependency file before reporting "no manifests found."
 
 ## SBOM Generation Guidance
 
@@ -100,8 +102,8 @@ Not all CVEs carry equal operational risk. Use a three-signal triage model to pr
 | Signal | Source | What It Measures | Action Threshold |
 |---|---|---|---|
 | **CVSS** | NVD / vendor advisory | Technical severity of the flaw | Critical (9.0-10.0) and High (7.0-8.9) warrant immediate review |
-| **EPSS** | [FIRST EPSS](https://www.first.org/epss/) | Probability of exploitation in the next 30 days | Score > 0.1 (10%) indicates elevated real-world risk |
-| **CISA KEV** | [CISA Known Exploited Vulnerabilities Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) | Confirmed active exploitation in the wild | Any match requires remediation within the CISA-mandated timeline |
+| **EPSS** | [FIRST EPSS](https://www.first.org/epss/) | Probability of exploitation in the next 30 days | Use **both** the probability and the **percentile**: prob > 0.1 (10%) OR percentile >= 0.95 indicates elevated real-world risk. EPSS is recalibrated daily and is right-skewed, so a single fixed cutoff misbins; a 0.08 prob at the 97th percentile is materially riskier than 0.08 at the 40th. |
+| **CISA KEV** | [CISA Known Exploited Vulnerabilities Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) | Confirmed active exploitation in the wild | Any match requires remediation within the CISA-mandated timeline. **Absence from KEV is not evidence of safety** — KEV is US-government-scoped and lags; n-day CVEs are often exploited before listing. Do not downgrade solely because KEV = No. |
 
 ### Triage Decision Matrix
 
@@ -113,6 +115,8 @@ Not all CVEs carry equal operational risk. Use a three-signal triage model to pr
 | Medium | > 0.1 | Yes | P1 - Urgent | Patch within current sprint |
 | Medium | <= 0.1 | No | P3 - Backlog | Track and remediate opportunistically |
 | Low | Any | No | P4 - Monitor | Document and revisit quarterly |
+
+> **Reachability gates the matrix.** CVSS measures the flaw's severity, not whether your code reaches it. Before assigning P0/P1 to a Critical/High CVE, establish reachability: is the vulnerable symbol on a reachable call path, and is the package shipped (not dev/test/build-only)? Use a reachability-aware scanner (`govulncheck`, Snyk reachable vulns) or a **CycloneDX VEX** statement to record `not_affected` / `affected`. A Critical CVE in an unreachable function or a dev-only dependency is routinely **non-exploitable** and should be downgraded with a documented VEX justification rather than paged.
 
 ### Enrichment Process
 
@@ -133,6 +137,10 @@ Not all CVEs carry equal operational risk. Use a three-signal triage model to pr
 | **Low - Permissive** | MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC | Minimal restrictions. Typically require attribution only. Apache-2.0 includes an explicit patent grant. |
 | **Unknown / No License** | NOASSERTION, unlicensed | No license means default copyright applies -- legally, the code cannot be used. Treat as high risk. |
 
+> **Parse SPDX expressions before assigning risk — do not substring-match.** A declared license may be an SPDX **expression** (`MPL-2.0 OR Apache-2.0` gives you a permissive choice) or carry an **exception** (`GPL-2.0-only WITH Classpath-exception-2.0` removes the linking/copyleft obligation; the OpenJDK pattern). Matching the substring `GPL` flags both as High copyleft — a false positive that blocks builds on safe licenses. Evaluate `OR`/`AND`/`WITH` operators and choose the least-restrictive satisfiable term.
+>
+> **Scope license risk to distributed components.** Copyleft/AGPL obligations attach to what you **ship or expose over a network**. A GPL/AGPL package confined to `devDependencies`, test, or build tooling that is never distributed generally does not trigger disclosure. Separate "distributed" from "dev/build-only" before rating, instead of applying copyleft uniformly to "any dependency."
+
 ### Compliance Checks
 
 1. **AGPL-3.0 in server-side code**: If any dependency (direct or transitive) uses AGPL-3.0 and the application is network-accessible, the entire application source may need to be disclosed. Flag immediately.
@@ -144,7 +152,7 @@ Not all CVEs carry equal operational risk. Use a three-signal triage model to pr
 ### Tooling
 
 - `licensed` (GitHub): Caches and verifies dependency licenses in CI.
-- `license-checker` (npm): `npx license-checker --production --failOn 'GPL-2.0;GPL-3.0;AGPL-3.0'`
+- `license-checker` (npm): `npx license-checker --production --failOn 'GPL-2.0;GPL-3.0;AGPL-3.0'` — note this is a substring gate; prefer a tool that understands SPDX expressions/exceptions (e.g., `license-checker-rseidelsohn`, FOSSA, ScanCode) to avoid the `OR`/`WITH` false positives above.
 - `pip-licenses`: `pip-licenses --with-system --format=json`
 - `go-licenses` (Google): `go-licenses check ./...`
 - `cargo-license`: `cargo license --json`
@@ -160,7 +168,7 @@ Typosquatting (also called dependency confusion or combosquatting) is a supply c
 | Pattern | Legitimate | Typosquat Example |
 |---|---|---|
 | Character swap | `requests` | `reqeusts`, `requets` |
-| Hyphen/underscore confusion | `python-dateutil` | `python_dateutil` (may or may not be malicious; verify publisher) |
+| Separator variants (NOT a squat on PyPI) | `python-dateutil` | `python_dateutil` resolves to the **same** package — PEP 503 normalizes `-`, `_`, and `.` as equivalent. Do not flag as typosquat; this is registry normalization. (Separator confusion *can* matter on registries without normalization — verify per ecosystem.) |
 | Scope/namespace omission | `@angular/core` | `angular-core` (unscoped) |
 | Prefix/suffix addition | `lodash` | `lodash-utils`, `lodash-js` |
 | Combosquatting | `colors` | `colors2`, `node-colors` |
@@ -223,11 +231,14 @@ When performing a dependency scan, produce findings in the following structure:
 1. **Identify manifests**: Use Glob to locate all package manifest and lockfiles in the project.
 2. **Inventory dependencies**: Read manifest files to enumerate direct dependencies and their declared version ranges.
 3. **Analyze lockfiles**: Read lockfiles to map the full transitive dependency tree with pinned versions.
-4. **Vulnerability scan**: Cross-reference packages and versions against known CVE databases. Apply the EPSS+CVSS+KEV triage model.
-5. **License audit**: Extract license declarations from lockfiles or registry metadata. Flag copyleft and unlicensed packages.
-6. **Typosquatting check**: Review dependency names for patterns described in the detection section.
-7. **Supply chain assessment**: Evaluate SLSA posture -- lockfile presence, pinned versions, provenance availability.
-8. **Report**: Produce the assessment using the output template above, with prioritized remediation recommendations.
+4. **Check manifest⇄lockfile sync**: Confirm the lockfile is in sync with the manifest (e.g., `npm ci --dry-run`, `poetry check`, `cargo verify-project`, `go mod verify`). A stale lockfile means the analyzed tree is **not** what `install` will resolve, so all downstream findings are computed against the wrong graph.
+5. **Resolve non-registry dependencies**: Flag dependencies pinned to a **git ref, tarball, or URL** (`git+https`, `github:org/repo#sha`, `file:`, `link:`, `http(s)://…​.tgz`) and **workspace/monorepo** protocols. These have no registry version, so CVE/version matching silently does not apply — they are high supply-chain risk (mutable refs, attacker-controlled hosts) and must be called out explicitly.
+6. **Vulnerability scan**: Cross-reference packages and versions against known CVE databases. Apply the EPSS+CVSS+KEV triage model **gated by reachability/VEX**.
+7. **Install-script & behavior check**: Extract `preinstall`/`install`/`postinstall` (npm), `build.rs` (Cargo), and `setup.py`/PEP 517 build hooks from the **resolved transitive tree**, not just direct deps. Install hooks are a primary malware delivery vector; surface them in the SBOM/output.
+8. **License audit**: Extract license declarations from lockfiles or registry metadata. Parse SPDX expressions/exceptions and scope to distributed components. Flag copyleft and unlicensed packages.
+9. **Typosquatting check**: Review dependency names for patterns described in the detection section (accounting for registry name normalization).
+10. **Supply chain assessment**: Evaluate SLSA posture -- lockfile presence, pinned versions, provenance availability.
+11. **Report**: Produce the assessment using the output template above, with prioritized remediation recommendations.
 
 ## Prompt Injection Safety Notice
 
@@ -251,3 +262,10 @@ This skill processes user-supplied content including package manifests, lockfile
 - [NIST NVD](https://nvd.nist.gov/)
 - [OpenSSF Scorecard](https://securityscorecards.dev/)
 - [Executive Order 14028 - Improving the Nation's Cybersecurity](https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/)
+
+---
+
+## Changelog
+
+- **1.0.1** -- Reduce false positives and close coverage gaps: parse SPDX license expressions/exceptions and scope copyleft risk to distributed components (not dev/build-only); pair EPSS probability with percentile and stop treating KEV-absence as a downgrade; gate the CVE triage matrix on reachability/VEX; add manifest⇄lockfile drift, non-registry (git/URL/tarball/workspace) dependency resolution, and transitive install-script extraction to the procedure; expand trigger manifests (`pyproject.toml`, NuGet, `composer.json`, `Gemfile`, `pubspec.lock`, `mix.lock`, `uv.lock`); correct the `python-dateutil`/`python_dateutil` example (PEP 503 normalization, not a typosquat).
+- **1.0.0** -- Initial release. SBOM generation, transitive risk, EPSS+CVSS+KEV triage, license compliance, and typosquatting detection aligned with SLSA v1.0, CycloneDX, SPDX, and CISA KEV.

--- a/skills/appsec/dependency-scanning/tests/benign/pyproject-manifest.toml
+++ b/skills/appsec/dependency-scanning/tests/benign/pyproject-manifest.toml
@@ -1,0 +1,15 @@
+# BENIGN fixture (coverage, not a vuln) — dependency-scanning manifest discovery
+# Expected: this file MUST be discovered as a Python manifest. Pre-1.0.1 the
+# trigger list omitted pyproject.toml (PEP 621), so a Glob keyed on the old list
+# would report "no manifests found" on a modern Python project. No license/CVE
+# finding is implied here; the point is that the scanner enumerates these deps.
+[project]
+name = "demo"
+version = "0.1.0"
+dependencies = [
+    "requests>=2.31",
+    "urllib3<2",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8"]

--- a/skills/appsec/dependency-scanning/tests/benign/spdx-expression-and-dev-only.json
+++ b/skills/appsec/dependency-scanning/tests/benign/spdx-expression-and-dev-only.json
@@ -1,0 +1,19 @@
+{
+  "_fixture": "BENIGN — dependency-scanning license logic",
+  "_expected": "No High copyleft finding. (1) SPDX expressions/exceptions resolve to a permissive or linking-safe option; (2) the GPL tool is dev-only and never distributed. Substring-matching 'GPL'/'AGPL' here is a false positive.",
+  "name": "demo-app",
+  "license": "MPL-2.0 OR Apache-2.0",
+  "dependencies": {
+    "runtime-lib": {
+      "version": "1.2.3",
+      "license": "GPL-2.0-only WITH Classpath-exception-2.0"
+    }
+  },
+  "devDependencies": {
+    "some-gpl-build-tool": {
+      "version": "3.0.0",
+      "license": "GPL-3.0-only",
+      "_note": "build-time only; not shipped or network-exposed"
+    }
+  }
+}

--- a/skills/appsec/dependency-scanning/tests/vulnerable/non-registry-and-install-scripts.json
+++ b/skills/appsec/dependency-scanning/tests/vulnerable/non-registry-and-install-scripts.json
@@ -1,0 +1,13 @@
+{
+  "_fixture": "VULNERABLE — dependency-scanning coverage gaps",
+  "_expected": "Finding(s). (1) git/URL/tarball deps have no registry version -> CVE/version matching silently does not apply; must be flagged as supply-chain risk. (2) A postinstall hook in the resolved tree is a malware-delivery vector and must be surfaced.",
+  "dependencies": {
+    "left-pad": "git+https://github.com/attacker/left-pad.git#a1b2c3d",
+    "internal-ui": "https://cdn.untrusted.example/internal-ui-1.0.0.tgz",
+    "tool": "github:org/repo#semver:^1.0.0",
+    "vendored": "file:./vendor/vendored-1.0.0"
+  },
+  "scripts": {
+    "postinstall": "node ./scripts/setup.js"
+  }
+}


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `dependency-scanning`
**Skill path:** `skills/appsec/dependency-scanning/`

### What Was Wrong
Identified in review #1143:
- License risk was substring-level: `GPL`/`AGPL` matching ignored SPDX expressions (`OR`/`WITH`) and dev-vs-distributed scope -> false copyleft findings.
- The CVE triage matrix escalated Critical/High by CVSS with no reachability dimension (over-pages on unreachable/dev-only CVEs).
- Plaintext procedure missed non-registry (git/URL/tarball/workspace) deps, transitive install scripts, and manifest<->lockfile drift.
- Trigger manifest list omitted `pyproject.toml`, NuGet, `composer.json`, `Gemfile`, `pubspec.lock`, `mix.lock` -> whole ecosystems silently skipped.
- EPSS used a fixed 0.1 cutoff; KEV-absence treated as a downgrade; `python_dateutil` listed as a typosquat (it is PEP 503 normalization).

Related review issue: #1143

/claim #1143

### What This PR Fixes
- SPDX expression/exception parsing + distributed-vs-dev scope for license risk.
- Reachability/VEX gate on the triage matrix (govulncheck / CycloneDX VEX).
- New procedure steps: manifest<->lockfile drift, non-registry dep resolution, transitive install-script extraction.
- Expanded trigger manifests (pyproject.toml, NuGet, composer.json, Gemfile, pubspec.lock, mix.lock, uv.lock).
- EPSS probability + percentile; KEV-absence no longer downgrades; corrected `python-dateutil` normalization note.
- Version bump to 1.0.1 + changelog.

### Evidence
**Before (false positive):** `"license": "MPL-2.0 OR Apache-2.0"` and a dev-only `GPL-3.0` build tool flagged as High copyleft.
**After:** SPDX expression resolves to a permissive option; dev/build-only scoped out -> no leak/copyleft finding. (`tests/benign/spdx-expression-and-dev-only.json`)

**Before (false negative):** `"left-pad": "git+https://github.com/attacker/left-pad.git#a1b2c3d"` + a `postinstall` hook — invisible to version/CVE matching.
**After:** non-registry deps and transitive install scripts are explicitly surfaced. (`tests/vulnerable/non-registry-and-install-scripts.json`)

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`) incl. `pyproject-manifest.toml` for manifest-discovery coverage
- [x] Markdown fences balanced; frontmatter intact

### Bounty Tier
- [ ] **Minor** ($50)
- [x] **Moderate** ($100) — FP reduction with evidence + new coverage
- [ ] **Substantial** ($150)

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Crypto, preferably USDC on Base: `0x1b58008Fde85832845817F9B24E64d139E418EeF`
