### PR TITLE
Add container debug evidence gates

### DIFF
--- a/skills/cloud/container-security/SKILL.md
+++ b/skills/cloud/container-security/SKILL.md
@@ -61,6 +61,9 @@ NIST SP 800-190 identifies five risk categories: image risks, registry risks, or
 - RBAC configuration files (Roles, ClusterRoles, RoleBindings)
 - NetworkPolicy definitions
 - Pod Security Standard configurations or OPA/Gatekeeper policies
+- Evidence for runtime debug-container controls when available: RBAC for
+  `pods/ephemeralcontainers`, admission policy coverage for that subresource,
+  audit events for debug-container creation, and approved debug image policy
 - Container registry configurations (if available)
 
 ---
@@ -105,11 +108,41 @@ Use Glob to locate all relevant configuration files.
 
 Classify findings by type: Dockerfiles, Kubernetes manifests, Helm charts, Kustomize overlays, and supporting configs. Record all discovered files.
 
+Also record the workload container arrays that were actually evaluated:
+
+- `spec.containers`
+- `spec.initContainers`
+- `spec.ephemeralContainers`
+
+If no `ephemeralContainers` are present in static manifests, do not assume the
+debug-container path is safe. Mark it as **Not Evaluable** unless cluster
+evidence proves that `pods/ephemeralcontainers` creation is restricted,
+admitted through the same policy controls as normal pod creation, audited, and
+limited to approved debug images.
+
 ---
 
 ### Step 2 through Step 6: CIS Benchmark and NIST SP 800-190 Evaluation
 
 Evaluate all container and Kubernetes configurations against CIS Docker Benchmark v1.6.0, CIS Kubernetes Benchmark v1.9.0, and NIST SP 800-190 countermeasures. This covers Dockerfile security, Pod Security Standards, RBAC, Network Policies, Secrets Management, Control Plane configuration, and Container Runtime Hardening.
+
+When applying Pod Security Standards, run every relevant control across regular,
+init, and ephemeral containers. A workload is not Restricted-compliant if the
+application container is hardened but a debug or ephemeral container can be
+added with `privileged: true`, UID 0, added capabilities, host namespace access,
+unconfined seccomp/AppArmor, writable root filesystem, or an unapproved mutable
+debug image.
+
+For clusters that rely on runtime `kubectl debug` workflows, require a separate
+debug-container evidence gate:
+
+| Evidence | Pass condition | Fail condition |
+|----------|----------------|----------------|
+| RBAC | Only approved break-glass groups can `create`/`update` `pods/ephemeralcontainers` | Developers or broad service accounts can add ephemeral containers in production |
+| Admission | Policy engine covers the `pods/ephemeralcontainers` subresource and all container arrays | Policies check only pod create/update and ignore the subresource |
+| Audit | Audit logs capture who added debug containers, target pod, image, and security context | No audit trail for debug-container creation |
+| Image policy | Debug images are pinned, approved, scanned, and pulled from trusted registries | Arbitrary public debug images can be used |
+| Runtime controls | Debug containers satisfy the same non-root, capabilities, seccomp, and filesystem controls as app containers | Debug containers can bypass normal Restricted controls |
 
 For detailed CIS benchmark checklist items, NIST SP 800-190 countermeasure tables, and comprehensive security context evaluation criteria, see [cis-benchmarks.md](cis-benchmarks.md) in this skill directory.
 
@@ -180,10 +213,10 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ### Pod Security Standards Compliance Matrix
 
-| Workload | Namespace | PSS Level | Violations |
-|----------|-----------|-----------|------------|
-| deploy/app | production | Baseline (not Restricted) | runAsRoot, no seccomp |
-| deploy/worker | production | Privileged | privileged: true |
+| Workload | Namespace | PSS Level | Containers Checked | Ephemeral Debug Evidence | Violations |
+|----------|-----------|-----------|--------------------|--------------------------|------------|
+| deploy/app | production | Baseline (not Restricted) | regular / init / not evaluable | Not evaluable | runAsRoot, no seccomp |
+| deploy/worker | production | Privileged | regular / init / ephemeral | Fail | privileged: true in ephemeral debug container |
 
 ### Prioritized Remediation Plan
 

--- a/skills/cloud/container-security/cis-benchmarks.md
+++ b/skills/cloud/container-security/cis-benchmarks.md
@@ -264,6 +264,21 @@ Evaluate workload configurations against Kubernetes Pod Security Standards. The 
 | **Baseline** | Minimally restrictive. Prevents known privilege escalations. | Standard workloads |
 | **Restricted** | Heavily restricted. Follows current hardening best practices. | Security-sensitive and untrusted workloads |
 
+**Container coverage requirement:** Apply every Pod Security Standard check to
+all container arrays in the pod spec:
+
+- `spec.containers`
+- `spec.initContainers`
+- `spec.ephemeralContainers`
+
+Kubernetes Pod Security Standards list ephemeral containers alongside regular
+and init containers for controls such as privileged mode, capabilities,
+AppArmor, seccomp, non-root execution, and `allowPrivilegeEscalation`. Do not
+mark a workload Restricted-compliant unless the review evidence proves that all
+present container arrays were checked. If the workload has no static
+`ephemeralContainers`, review runtime controls for the
+`pods/ephemeralcontainers` subresource before treating debug workflows as safe.
+
 #### CIS 5.2.1 -- Ensure that the cluster has at least one active policy control mechanism installed
 
 Check for Pod Security Admission labels on namespaces:
@@ -293,7 +308,36 @@ spec:
         privileged: true  # CRITICAL FAIL
 ```
 
+Also inspect `initContainers` and `ephemeralContainers`:
+
+```yaml
+# BAD: Privileged ephemeral debug container bypasses the hardened app container
+spec:
+  containers:
+    - name: app
+      securityContext:
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        seccompProfile:
+          type: RuntimeDefault
+  ephemeralContainers:
+    - name: debug
+      image: busybox:1.36
+      targetContainerName: app
+      securityContext:
+        privileged: true
+        runAsUser: 0
+        allowPrivilegeEscalation: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+```
+
 **Grep pattern:** `privileged: true`
+
+**Required result:** A privileged ephemeral debug container is a Critical
+finding even when every regular container is Restricted-compliant.
 
 #### CIS 5.2.3 -- Minimize the admission of containers wishing to share the host process ID namespace
 
@@ -605,6 +649,7 @@ Evaluate container runtime configurations against NIST SP 800-190 countermeasure
 | **CM-8:** Implement network segmentation | NetworkPolicy in every namespace |
 | **CM-9:** Use Pod Security Standards | PSA labels on namespaces or equivalent policy engine |
 | **CM-10:** Enable audit logging | Audit policy configured on API server |
+| **CM-10a:** Govern runtime debug containers | RBAC, admission, audit, and image policy cover `pods/ephemeralcontainers` |
 
 ### NIST 800-190: Container Countermeasures
 
@@ -615,6 +660,7 @@ Evaluate container runtime configurations against NIST SP 800-190 countermeasure
 | **CM-13:** Drop all capabilities | `capabilities.drop: ["ALL"]` |
 | **CM-14:** Set resource limits | CPU and memory limits set on all containers |
 | **CM-15:** Use seccomp profiles | `seccompProfile.type: RuntimeDefault` or custom |
+| **CM-16:** Apply controls to debug containers | Same non-root, read-only root filesystem, capabilities, and seccomp controls on `ephemeralContainers` |
 
 **Resource limits check:**
 
@@ -677,7 +723,44 @@ spec:
         requests:
           memory: "128Mi"
           cpu: "250m"
+  initContainers:
+    - name: migrate
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 1000
+        capabilities:
+          drop: ["ALL"]
+        seccompProfile:
+          type: RuntimeDefault
+  ephemeralContainers:
+    - name: debug
+      image: registry.example.com/debug-tools@sha256:...
+      targetContainerName: app
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 1000
+        capabilities:
+          drop: ["ALL"]
+        seccompProfile:
+          type: RuntimeDefault
 ```
+
+**Runtime debug-container evidence checklist:**
+
+| Evidence | What to verify |
+|----------|----------------|
+| RBAC | Only approved break-glass groups can `create` or `update` `pods/ephemeralcontainers` in production namespaces |
+| Admission | Kyverno/Gatekeeper/PSA policies apply to the `pods/ephemeralcontainers` subresource, not only pod create/update |
+| Audit | Audit policy records user, namespace, target pod, debug image, and requested security context for ephemeral-container changes |
+| Image policy | Debug images are pinned by digest, scanned, and pulled from trusted registries |
+| Scope | Production namespaces either disallow debug containers or require explicit incident/break-glass approval |
+
+If these runtime controls are unavailable, report the debug-container path as
+**Not Evaluable** instead of silently passing the workload.
 
 **Fields that must NOT be present for Restricted compliance:**
 


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** container-security
**Skill path:** `skills/cloud/container-security/`

Fixes #1191.

### What Was Wrong

The skill mentioned init, sidecar, and ephemeral containers as a common pitfall, but the main review flow and benchmark checklist did not force reviewers to prove which pod container arrays were checked.

That leaves a gap where a workload can look Restricted-compliant because `spec.containers` is hardened, while a runtime debug path or `spec.ephemeralContainers` entry can still introduce a privileged root debug container with added capabilities.

### What This PR Fixes

This PR adds explicit ephemeral/debug-container evidence gates:

- records whether `spec.containers`, `spec.initContainers`, and `spec.ephemeralContainers` were evaluated;
- requires Pod Security Standards checks across regular, init, and ephemeral containers;
- adds a privileged ephemeral container failure example;
- adds runtime `pods/ephemeralcontainers` evidence for RBAC, admission, audit, image policy, and runtime controls;
- updates the final PSS compliance matrix to show container coverage and ephemeral debug evidence status;
- maps the new checks into the NIST 800-190 orchestrator/container countermeasure tables.

### Evidence

**Before:**
```yaml
spec:
  containers:
    - name: app
      securityContext:
        runAsNonRoot: true
        allowPrivilegeEscalation: false
        capabilities:
          drop: ["ALL"]
        seccompProfile:
          type: RuntimeDefault
```

A reviewer could stop after the app container and miss a debug subresource path.

**After:**
```md
Also record the workload container arrays that were actually evaluated:

- `spec.containers`
- `spec.initContainers`
- `spec.ephemeralContainers`
```

and:

```md
| Evidence | Pass condition | Fail condition |
|----------|----------------|----------------|
| RBAC | Only approved break-glass groups can create/update pods/ephemeralcontainers | Developers or broad service accounts can add ephemeral containers in production |
```

### Test Cases Added/Updated
- [ ] Added vulnerable test cases (`tests/vulnerable/`)
- [ ] Added benign test cases (`tests/benign/`)
- [x] Existing checks still pass

Validation performed:

- `git diff --check`
- frontmatter required-field check matching `.github/workflows/lint-skills.yml`
- prompt-injection pattern scan with workflow-equivalent filters
- marker checks for `spec.ephemeralContainers`, `pods/ephemeralcontainers`, debug-container evidence, privileged ephemeral debug container, `CM-10a`, and `CM-16`

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Crypto; payment details can be provided privately after maintainer acceptance.
