### PR TITLE
Add AWS ECR registry evidence gates

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -38,7 +38,7 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 - Reviewing AWS infrastructure-as-code before deployment
 - Assessing an existing AWS environment's security posture against CIS benchmarks
 - Preparing for a CIS benchmark audit or compliance assessment
-- Evaluating IAM policies, S3 bucket configurations, CloudTrail settings, VPC security groups, or RDS encryption configurations
+- Evaluating IAM policies, S3 bucket configurations, CloudTrail settings, VPC security groups, RDS encryption configurations, or ECR container registry hardening
 - Onboarding a new AWS account into a security program
 
 ---
@@ -55,6 +55,7 @@ The CIS Amazon Web Services Foundations Benchmark v3.0.0 is a consensus-driven s
 - S3 bucket policies and ACL configurations
 - VPC, security group, and NACL definitions
 - CloudTrail and CloudWatch configuration files
+- ECR repository, registry scanning, lifecycle, and repository policy configurations when container images are in scope
 
 ---
 
@@ -102,6 +103,32 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 ### Step 7: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
+
+---
+
+## Supplemental AWS Service Evidence Gates
+
+The CIS AWS Foundations Benchmark is the primary scoring baseline. The supplemental gates below should be reported separately from the 62 CIS recommendations so the CIS compliance percentage is not overstated or diluted.
+
+### Amazon ECR Container Registry Hardening
+
+When Amazon ECR repositories are present, review container registry controls because mutable or unscanned images can undermine ECS, EKS, Lambda container, and deployment-pipeline assurance even when the underlying AWS account passes CIS checks.
+
+**What to look for:**
+
+- `aws_ecr_repository` resources with `image_tag_mutability` set to `IMMUTABLE`, `IMMUTABLE_WITH_EXCLUSION`, or a documented exception for mutable development tags.
+- Repository or registry scanning evidence: `image_scanning_configuration { scan_on_push = true }`, registry-level enhanced scanning, or Amazon Inspector continuous scanning filters.
+- Repository encryption configuration and KMS key ownership for sensitive images.
+- Repository policies that avoid public or broad cross-account push/pull access.
+- Lifecycle policies that expire untagged/stale images without deleting release evidence required for rollback or incident response.
+
+**Evidence template:**
+
+| Repository | Tag mutability | Scan evidence | Encryption | Repository policy exposure | Lifecycle/rollback evidence | Status |
+|------------|----------------|---------------|------------|----------------------------|-----------------------------|--------|
+| ___ | Immutable / Mutable with exception / Mutable | Scan on push / Enhanced / Manual / Missing | AES-256 / KMS CMK / Missing | Private / Scoped cross-account / Broad | Retained release tags and cleanup policy | Pass / Gap / Not Evaluable |
+
+**Finding classification:** Mutable production repositories without a documented exception are **High**. Missing scan-on-push or enhanced scanning is **Medium**. Broad cross-account or public repository access is **High**. Missing lifecycle policy is **Low** unless it prevents rollback or incident-response evidence retention.
 
 ---
 

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -488,3 +488,57 @@ resource "aws_launch_template" {
   }
 }
 ```
+
+---
+
+## Supplemental -- Amazon ECR Container Registry Hardening
+
+These checks are not CIS AWS Foundations Benchmark recommendations. Report them as supplemental AWS service findings when ECR is in scope.
+
+### ECR-REG-01 -- Ensure production ECR repositories use immutable image tags
+
+Check Terraform, CloudFormation, CDK, or CLI exports for tag mutability:
+
+```hcl
+resource "aws_ecr_repository" "app" {
+  name                 = "app"
+  image_tag_mutability = "IMMUTABLE"
+}
+```
+
+Flag production repositories with `image_tag_mutability = "MUTABLE"` or omitted mutability unless there is a documented mutable-tag exception for development workflows. If `IMMUTABLE_WITH_EXCLUSION` or mutability exclusion filters are used, verify the excluded tag patterns are limited to non-release tags such as `latest-dev` or short-lived test tags.
+
+### ECR-REG-02 -- Ensure images are scanned on push or continuously scanned
+
+Check for repository-level basic scanning or registry-level enhanced scanning evidence:
+
+```hcl
+resource "aws_ecr_repository" "app" {
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_registry_scanning_configuration" "registry" {
+  scan_type = "ENHANCED"
+}
+```
+
+If repository `scan_on_push` is absent, verify registry-level enhanced scanning or Amazon Inspector coverage before marking the control as a gap. Record scan filters and whether production repositories receive continuous scanning or scan-on-push.
+
+### ECR-REG-03 -- Review repository policy exposure and encryption
+
+Check for broad principals in `aws_ecr_repository_policy`, public ECR resources, or cross-account pull/push access that lacks organization, account, or principal constraints. Verify encryption uses AWS-managed AES-256 or a customer-managed KMS key where required by the environment.
+
+```hcl
+resource "aws_ecr_repository" "app" {
+  encryption_configuration {
+    encryption_type = "KMS"
+    kms_key         = aws_kms_key.ecr.arn
+  }
+}
+```
+
+### ECR-REG-04 -- Review lifecycle and rollback evidence
+
+Check `aws_ecr_lifecycle_policy` for cleanup of stale/untagged images and verify release tags or digests required for rollback, incident response, and provenance investigations are retained for the organization's evidence period.


### PR DESCRIPTION
Closes #1204

## Summary
- Add supplemental Amazon ECR container registry hardening gates to aws-review without counting them as CIS AWS Foundations controls.
- Cover tag immutability, scan-on-push/enhanced scanning, repository policy exposure, encryption, lifecycle cleanup, and rollback evidence.
- Add detailed ECR-REG checklist entries for Terraform/registry evidence.

## Validation
- git diff --check
- Markdown fence balance check for both edited files
- Marker checks for Amazon ECR, image_tag_mutability, scan_on_push, and aws_ecr_registry_scanning_configuration