### PR TITLE
Add Azure ACR registry evidence gates

### DIFF
--- a/skills/cloud/azure-review/SKILL.md
+++ b/skills/cloud/azure-review/SKILL.md
@@ -3,10 +3,11 @@ name: azure-review
 description: >
   Performs an Azure security posture review against the CIS Microsoft Azure
   Foundations Benchmark v2.1.0. Auto-invoked when reviewing Azure infrastructure,
-  Entra ID configurations, NSG rules, Defender for Cloud settings, or Key Vault
-  access policies. Walks through all nine benchmark sections, evaluates each
-  recommendation, and produces a prioritized findings report with remediation
-  guidance mapped to specific CIS control IDs.
+  Entra ID configurations, NSG rules, Defender for Cloud settings, Key Vault
+  access policies, or Azure Container Registry hardening. Walks through all
+  nine benchmark sections, evaluates each recommendation, and produces a
+  prioritized findings report with remediation guidance mapped to specific CIS
+  control IDs, plus supplemental evidence gates for service-specific risks.
 tags: [cloud, azure, cis-benchmark]
 role: [cloud-security-engineer, security-engineer]
 phase: [assess, operate]
@@ -25,7 +26,7 @@ argument-hint: "[target-file-or-directory]"
 
 ## Overview
 
-This skill performs a structured security assessment of Azure environments against the **CIS Microsoft Azure Foundations Benchmark v2.1.0**. The benchmark is organized into nine sections covering identity management, security center, storage, database services, logging and monitoring, networking, virtual machines, Key Vault, and App Service. Each recommendation is evaluated by inspecting infrastructure-as-code definitions (Terraform, Bicep, ARM templates), Azure CLI output, or configuration files available in the repository.
+This skill performs a structured security assessment of Azure environments against the **CIS Microsoft Azure Foundations Benchmark v2.1.0**. The benchmark is organized into nine sections covering identity management, security center, storage, database services, logging and monitoring, networking, virtual machines, Key Vault, and App Service. Each recommendation is evaluated by inspecting infrastructure-as-code definitions (Terraform, Bicep, ARM templates), Azure CLI output, or configuration files available in the repository. The skill also records supplemental Azure service evidence, such as Azure Container Registry identity, network, and image-scanning posture, without counting those observations toward the CIS section score.
 
 The CIS Azure Foundations Benchmark v2.1.0 provides prescriptive guidance across nine domains. This skill evaluates each applicable control and produces a findings report with CIS recommendation IDs, severity ratings, and actionable remediation steps.
 
@@ -39,6 +40,7 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 - Assessing an existing Azure environment's security posture against CIS benchmarks
 - Preparing for a CIS benchmark audit or compliance assessment
 - Evaluating Entra ID configurations, NSG rules, Defender for Cloud, Storage account security, or Key Vault access policies
+- Reviewing Azure Container Registry configurations for admin-account, public-network, private endpoint, RBAC, and image-scanning evidence
 - Onboarding a new Azure subscription into a security program
 
 ---
@@ -54,6 +56,7 @@ The CIS Microsoft Azure Foundations Benchmark v2.1.0 is a consensus-driven secur
 - Entra ID (Azure AD) configuration files or policy documents
 - NSG and firewall rule definitions
 - Key Vault access policies and RBAC assignments
+- Azure Container Registry definitions, private endpoint resources, repository-scoped tokens, role assignments, and Defender for Cloud plan evidence when registry workloads are in scope
 
 ---
 
@@ -91,7 +94,30 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, Bic
 
 ---
 
-### Step 11: Compile Assessment Report
+### Step 11: Supplemental Azure Service Evidence
+
+If the reviewed repository contains Azure Container Registry resources or live
+ACR exports, evaluate the supplemental gates in
+[benchmark-checklist.md](benchmark-checklist.md). These checks capture
+service-specific risks not represented directly in CIS Azure Foundations v2.1.0.
+
+Do not include supplemental ACR gates in the CIS pass/fail denominator. Report
+them in a separate "Supplemental Azure Service Findings" section and link each
+finding to the affected registry, identity, network rule, private endpoint,
+repository token, or Defender for Cloud configuration.
+
+Record at least:
+
+- Registry SKU and environment criticality
+- Admin account state and any documented exception
+- Public network access mode, firewall default action, private endpoint status, and trusted-services bypass setting
+- Registry pull/push identities, RBAC role scope, managed identity usage, service principal usage, and repository-scoped tokens
+- Defender for Containers or registry vulnerability-assessment coverage, including network-restricted registry prerequisites
+- Retention, quarantine, soft-delete, or export controls when configured
+
+---
+
+### Step 12: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
 
@@ -106,6 +132,14 @@ Produce the final report using the structure defined in the Output Format sectio
 | **Medium** | Control gap that should be addressed in normal cycle | Missing activity log alerts, soft delete not enabled, TLS below 1.2 |
 | **Low** | Hardening recommendation or defense-in-depth measure | HTTP/2 not enabled, FTP not fully disabled, missing CMK on non-sensitive storage |
 | **Informational** | Best practice observation, no direct security impact | Naming conventions, tag policies, documentation gaps |
+
+For supplemental ACR findings, public production registry access combined with
+an enabled admin account or missing pull/push identity evidence is typically
+High. A public registry with explicit firewall allowlists, disabled admin
+account, and documented business justification is usually Medium or Low
+depending on data sensitivity. Missing retention or scanning evidence is usually
+Medium unless the registry stores regulated or internet-facing production
+images.
 
 ---
 
@@ -152,6 +186,20 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration or code snippet>
+- **Remediation:** <specific fix with code example>
+
+### Supplemental Azure Service Findings
+
+#### [ACR-REG-X] <Recommendation Title>
+- **Status:** Pass / Fail / Not Evaluable
+- **Severity:** High / Medium / Low / Informational
+- **Service:** Azure Container Registry
+- **Registry:** <registry name or resource id>
+- **File:** <path to relevant config>
+- **Line(s):** <line numbers if applicable>
+- **Description:** <what was found>
+- **Evidence:** <admin account, network, private endpoint, identity, token, scanning, or retention evidence>
+- **CIS impact:** Supplemental; not included in CIS Azure v2.1.0 score
 - **Remediation:** <specific fix with code example>
 
 ### Prioritized Remediation Plan
@@ -225,10 +273,15 @@ Produce the final report using the structure defined in the Output Format sectio
 - Azure Storage Security: https://learn.microsoft.com/en-us/azure/storage/common/storage-security-guide
 - Azure Key Vault Best Practices: https://learn.microsoft.com/en-us/azure/key-vault/general/best-practices
 - Azure App Service Security: https://learn.microsoft.com/en-us/azure/app-service/overview-security
+- Azure Container Registry Authentication: https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication
+- Azure Container Registry Private Link: https://learn.microsoft.com/en-us/azure/container-registry/container-registry-private-endpoints
+- Azure Container Registry Public Network Rules: https://learn.microsoft.com/en-us/azure/container-registry/container-registry-access-selected-networks
+- Microsoft Defender image scanning for registries: https://learn.microsoft.com/en-us/azure/container-registry/scan-images-defender
 - Terraform AzureRM Provider Documentation: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
 
 ---
 
 ## Changelog
 
+- **1.1.0** -- Added supplemental Azure Container Registry evidence gates for admin-account, public-network, private endpoint, identity/RBAC, repository-token, image-scanning, and retention posture.
 - **1.0.0** -- Initial release. Full coverage of CIS Microsoft Azure Foundations Benchmark v2.1.0 sections 1 through 9.

--- a/skills/cloud/azure-review/benchmark-checklist.md
+++ b/skills/cloud/azure-review/benchmark-checklist.md
@@ -704,3 +704,209 @@ resource "azurerm_linux_web_app" {
   }
 }
 ```
+
+---
+
+## Supplemental -- Azure Container Registry Hardening
+
+These checks are not CIS Microsoft Azure Foundations Benchmark v2.1.0 controls.
+Use them when Azure Container Registry (ACR) resources are present so the review
+captures service-specific identity, network, and image assurance risks. Report
+them separately from the CIS section scores.
+
+### ACR-REG-01 -- Ensure local admin account is disabled
+
+The ACR admin account is disabled by default and has full push/pull access to
+the registry. It is mainly intended for individual testing or narrow Azure
+service integration cases. For production registries, flag an enabled admin
+account unless there is a documented exception, compensating credential
+rotation, and migration plan to Microsoft Entra identities.
+
+```hcl
+resource "azurerm_container_registry" "prod" {
+  name                = "prodacr"
+  resource_group_name = azurerm_resource_group.prod.name
+  location            = azurerm_resource_group.prod.location
+  sku                 = "Premium"
+  admin_enabled       = false
+}
+```
+
+**Fail patterns:**
+
+- `admin_enabled = true` on `azurerm_container_registry` without a scoped exception.
+- ARM/Bicep `properties.adminUserEnabled: true` for production or shared registries.
+- Scripts using `az acr credential show` or static registry username/password values as the default deployment path.
+
+**Severity guidance:**
+
+- High when a production registry has admin enabled and stores deployable application images.
+- Medium when admin is enabled only for a time-bound migration or non-production registry.
+- Informational when admin is disabled and identities are documented.
+
+### ACR-REG-02 -- Restrict public network access and verify private endpoint or firewall evidence
+
+ACR accepts public network connections by default. Production registries should
+either disable public network access and use Private Link, or restrict the public
+endpoint with explicit IP allowlists and a default deny posture. Private Link is
+available for the Premium SKU and requires matching DNS and client network
+evidence.
+
+```hcl
+resource "azurerm_container_registry" "prod" {
+  name                          = "prodacr"
+  resource_group_name           = azurerm_resource_group.prod.name
+  location                      = azurerm_resource_group.prod.location
+  sku                           = "Premium"
+  admin_enabled                 = false
+  public_network_access_enabled = false
+  network_rule_bypass_option    = "AzureServices"
+}
+
+resource "azurerm_private_endpoint" "acr" {
+  name                = "prod-acr-pe"
+  resource_group_name = azurerm_resource_group.prod.name
+  location            = azurerm_resource_group.prod.location
+  subnet_id           = azurerm_subnet.private_endpoints.id
+
+  private_service_connection {
+    name                           = "prod-acr"
+    is_manual_connection           = false
+    private_connection_resource_id = azurerm_container_registry.prod.id
+    subresource_names              = ["registry"]
+  }
+}
+```
+
+For registries that must keep a public endpoint, require the firewall default
+action and allowed ranges:
+
+```hcl
+resource "azurerm_container_registry" "partner" {
+  name                          = "partneracr"
+  resource_group_name           = azurerm_resource_group.prod.name
+  location                      = azurerm_resource_group.prod.location
+  sku                           = "Premium"
+  public_network_access_enabled = true
+
+  network_rule_set {
+    default_action = "Deny"
+
+    ip_rule {
+      action   = "Allow"
+      ip_range = "203.0.113.0/24"
+    }
+  }
+}
+```
+
+**Fail patterns:**
+
+- `public_network_access_enabled = true` with no `network_rule_set` and no business justification.
+- `network_rule_set.default_action = "Allow"` for a production registry.
+- Private endpoint exists but DNS, subnet, or client build-agent reachability is not documented.
+- Trusted-services bypass is enabled but Defender/build-service use cases are not documented.
+
+**Severity guidance:**
+
+- High when a production registry is public to all networks and hosts sensitive or deployable images.
+- Medium when public access is restricted but the allowed ranges, private endpoint DNS, or build-agent reachability evidence is incomplete.
+- Low when private endpoint or firewall posture is strong but exception documentation is missing.
+
+### ACR-REG-03 -- Review RBAC, managed identities, service principals, and repository-scoped tokens
+
+Prefer Microsoft Entra-based authentication for users, managed identities, and
+service principals. Repository-scoped tokens can be appropriate for
+non-Entra-integrated clients, but the review must verify scope maps, expiration,
+and whether tokens grant only the required repository actions.
+
+```hcl
+resource "azurerm_user_assigned_identity" "aks_pull" {
+  name                = "aks-acr-pull"
+  resource_group_name = azurerm_resource_group.prod.name
+  location            = azurerm_resource_group.prod.location
+}
+
+resource "azurerm_role_assignment" "aks_can_pull_acr" {
+  scope                = azurerm_container_registry.prod.id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_user_assigned_identity.aks_pull.principal_id
+}
+```
+
+Check for repository-scoped token resources or CLI exports:
+
+```hcl
+resource "azurerm_container_registry_scope_map" "partner_read" {
+  name                    = "partner-read"
+  container_registry_name = azurerm_container_registry.partner.name
+  resource_group_name     = azurerm_resource_group.prod.name
+  actions                 = ["repositories/partner/content/read"]
+}
+
+resource "azurerm_container_registry_token" "partner_read" {
+  name                    = "partner-read"
+  container_registry_name = azurerm_container_registry.partner.name
+  resource_group_name     = azurerm_resource_group.prod.name
+  scope_map_id            = azurerm_container_registry_scope_map.partner_read.id
+}
+```
+
+**Fail patterns:**
+
+- `AcrPush`, `Owner`, or `Contributor` assigned at subscription/resource-group scope when registry scope is sufficient.
+- CI/CD service principals reusing broad registry credentials across environments.
+- Repository-scoped tokens granting wildcard write/delete actions without expiration, owner, and rotation evidence.
+- Workloads pulling with admin credentials instead of managed identity, AKS integration, service principal, or scoped token.
+
+**Severity guidance:**
+
+- High when deploy pipelines or runtime workloads use broad admin credentials or high-privilege role assignments.
+- Medium when Entra identities are used but role scope is broader than required.
+- Low when least privilege is mostly correct but token ownership or rotation evidence is incomplete.
+
+### ACR-REG-04 -- Verify vulnerability scanning, retention, quarantine, and export controls
+
+Defender for Containers can provide registry image vulnerability assessment, but
+network-restricted registries may need trusted-services bypass or additional
+configuration for scanning to function. The review should tie scanning evidence
+to the registry and record whether untagged manifest retention, quarantine, soft
+delete, or export controls are configured for the workload's risk level.
+
+```hcl
+resource "azurerm_security_center_subscription_pricing" "containers" {
+  tier          = "Standard"
+  resource_type = "Containers"
+}
+
+resource "azurerm_container_registry" "prod" {
+  name                       = "prodacr"
+  resource_group_name        = azurerm_resource_group.prod.name
+  location                   = azurerm_resource_group.prod.location
+  sku                        = "Premium"
+  quarantine_policy_enabled  = true
+  retention_policy_in_days   = 30
+  network_rule_bypass_option = "AzureServices"
+}
+```
+
+**Evidence to collect:**
+
+- Defender for Containers pricing tier and registry image scanning coverage.
+- Scan results or policy exports that prove production images are assessed before deployment.
+- Whether network restrictions still allow required Microsoft Defender access.
+- Retention period for untagged manifests and rollback requirements.
+- Quarantine, soft-delete, or export controls where available and appropriate.
+
+**Fail patterns:**
+
+- Defender for Containers is absent or not tied to registry scanning evidence.
+- Private endpoint or public access restrictions block scanning and no exception is documented.
+- Production registries have no retention/rollback policy for untagged manifests or image promotion workflows.
+- Image export is allowed from sensitive registries without data-loss-prevention rationale.
+
+**Severity guidance:**
+
+- High when unscanned production images deploy directly to internet-facing workloads or regulated environments.
+- Medium when scanning exists but network-restricted registry prerequisites or scan-result evidence is incomplete.
+- Low when scanning and network posture are sound but retention/quarantine evidence is missing.


### PR DESCRIPTION
## Summary
- add supplemental Azure Container Registry evidence guidance to `azure-review`
- add `ACR-REG-*` checklist controls for admin account, public/private network access, RBAC/token scope, Defender scanning, and retention/quarantine posture
- keep ACR findings separate from CIS Azure v2.1.0 scoring so the benchmark denominator remains intact

## Validation
- `git diff --check`
- verified ACR markers for admin/network/private endpoint/Defender/token/retention coverage
- verified markdown code fences are balanced

Closes #1206