### PR TITLE
Add Cloud Run evidence gates to GCP review

### DIFF
--- a/skills/cloud/gcp-review/SKILL.md
+++ b/skills/cloud/gcp-review/SKILL.md
@@ -3,10 +3,11 @@ name: gcp-review
 description: >
   Performs a GCP security posture review against the CIS Google Cloud Platform
   Foundation Benchmark v2.0.0. Auto-invoked when reviewing GCP infrastructure,
-  IAM bindings, VPC firewall rules, Cloud Audit Logs, or GCS bucket security.
-  Walks through all seven benchmark sections, evaluates each recommendation,
-  and produces a prioritized findings report with remediation guidance mapped
-  to specific CIS control IDs.
+  IAM bindings, VPC firewall rules, Cloud Audit Logs, GCS bucket security, or
+  Cloud Run service posture. Walks through all seven benchmark sections,
+  evaluates each recommendation, and produces a prioritized findings report with
+  remediation guidance mapped to specific CIS control IDs, plus supplemental
+  evidence gates for service-specific risks.
 tags: [cloud, gcp, cis-benchmark]
 role: [cloud-security-engineer, security-engineer]
 phase: [assess, operate]
@@ -25,7 +26,7 @@ argument-hint: "[target-file-or-directory]"
 
 ## Overview
 
-This skill performs a structured security assessment of Google Cloud Platform environments against the **CIS Google Cloud Platform Foundation Benchmark v2.0.0**. The benchmark is organized into seven sections covering identity and access management, logging and monitoring, networking, virtual machines, storage, Cloud SQL, and BigQuery. Each recommendation is evaluated by inspecting infrastructure-as-code definitions (Terraform, Deployment Manager), gcloud CLI output, or configuration files available in the repository.
+This skill performs a structured security assessment of Google Cloud Platform environments against the **CIS Google Cloud Platform Foundation Benchmark v2.0.0**. The benchmark is organized into seven sections covering identity and access management, logging and monitoring, networking, virtual machines, storage, Cloud SQL, and BigQuery. Each recommendation is evaluated by inspecting infrastructure-as-code definitions (Terraform, Deployment Manager), gcloud CLI output, or configuration files available in the repository. The skill also records supplemental service evidence, such as Cloud Run ingress, invoker IAM, service identity, VPC egress, and Binary Authorization posture, without counting those observations toward the CIS section score.
 
 The CIS GCP Foundation Benchmark v2.0.0 provides prescriptive guidance for hardening GCP projects and organizations. This skill evaluates each applicable control and produces a findings report with CIS recommendation IDs, severity ratings, and actionable remediation steps.
 
@@ -39,6 +40,7 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 - Assessing an existing GCP environment's security posture against CIS benchmarks
 - Preparing for a CIS benchmark audit or compliance assessment
 - Evaluating IAM bindings, org policies, VPC firewall rules, Cloud Audit Logs, or GCS bucket configurations
+- Reviewing Cloud Run services for public invoker exposure, ingress restrictions, least-privilege service identity, VPC egress, and trusted image deployment controls
 - Onboarding a new GCP project or organization into a security program
 
 ---
@@ -54,6 +56,7 @@ The CIS Google Cloud Platform Foundation Benchmark v2.0.0 is a consensus-driven 
 - IAM policy bindings and org policy definitions
 - VPC and firewall rule definitions
 - Cloud Audit Logs configuration
+- Cloud Run service definitions, service/job IAM policies, service accounts, VPC connector or Direct VPC egress settings, Binary Authorization policies, and Cloud Audit Logs when serverless workloads are in scope
 
 ---
 
@@ -88,7 +91,33 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
-### Step 9: Compile Assessment Report
+### Step 9: Supplemental GCP Service Evidence
+
+If the reviewed repository contains Cloud Run services, jobs, Terraform
+`google_cloud_run_v2_service` resources, Knative service YAML, or gcloud exports,
+evaluate the supplemental Cloud Run gates in
+[benchmark-checklist.md](benchmark-checklist.md). These checks capture
+serverless-specific risks that are not represented directly in CIS GCP
+Foundation Benchmark v2.0.0.
+
+Do not include supplemental Cloud Run gates in the CIS pass/fail denominator.
+Report them in a separate "Supplemental GCP Service Findings" section and link
+each finding to the affected service, job, IAM binding, service identity, VPC
+egress setting, Binary Authorization policy, or audit log source.
+
+Record at least:
+
+- Cloud Run resource type, region, environment, and data sensitivity
+- Ingress setting, default `run.app` exposure, custom domain or load balancer path, and whether IAP or Cloud Armor is part of the public path
+- Invoker IAM bindings, including `allUsers`, `allAuthenticatedUsers`, project-level `roles/run.invoker`, and conditional bindings
+- Runtime service account, default service account use, service-account role scope, and `GOOGLE_APPLICATION_CREDENTIALS` secrets or key files
+- Direct VPC egress or Serverless VPC Access connector configuration, egress mode, Shared VPC permissions, and firewall evidence
+- Binary Authorization, image digest pinning/provenance, and breakglass evidence
+- Admin activity and data access audit logs for service changes, IAM policy changes, invocations where available, and deployment breakglass events
+
+---
+
+### Step 10: Compile Assessment Report
 
 
 Produce the final report using the structure defined in the Output Format section.
@@ -104,6 +133,13 @@ Produce the final report using the structure defined in the Output Format sectio
 | **Medium** | Control gap that should be addressed in normal cycle | Missing log metric filters, DNSSEC not enabled, Shielded VM not enabled, uniform bucket access not set |
 | **Low** | Hardening recommendation or defense-in-depth measure | OS Login not enabled, serial port access not explicitly disabled, BigQuery tables without CMEK |
 | **Informational** | Best practice observation, no direct security impact | Default network still exists (non-production), naming conventions, documentation gaps |
+
+For supplemental Cloud Run findings, public unauthenticated access combined with
+`INGRESS_TRAFFIC_ALL`, default service account usage, broad project-level roles,
+or missing deployment provenance is typically High. A public API behind an
+external Application Load Balancer with IAP or Cloud Armor, explicit `allUsers`
+justification, least-privilege service identity, and audit evidence is usually
+Medium or Low depending on data sensitivity.
 
 ---
 
@@ -148,6 +184,20 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration or code snippet>
+- **Remediation:** <specific fix with code example>
+
+### Supplemental GCP Service Findings
+
+#### [GCP-RUN-X] <Recommendation Title>
+- **Status:** Pass / Fail / Not Evaluable
+- **Severity:** Critical / High / Medium / Low / Informational
+- **Service:** Cloud Run
+- **Resource:** <service/job name, region, or resource id>
+- **File:** <path to relevant config>
+- **Line(s):** <line numbers if applicable>
+- **Description:** <what was found>
+- **Evidence:** <ingress, invoker IAM, service identity, VPC egress, Binary Authorization, image, or audit evidence>
+- **CIS impact:** Supplemental; not included in CIS GCP v2.0.0 score
 - **Remediation:** <specific fix with code example>
 
 ### Prioritized Remediation Plan
@@ -219,10 +269,16 @@ Produce the final report using the structure defined in the Output Format sectio
 - Google Cloud Audit Logs: https://cloud.google.com/logging/docs/audit
 - Google Cloud VPC Documentation: https://cloud.google.com/vpc/docs
 - Google Cloud SQL Security: https://cloud.google.com/sql/docs/mysql/configure-ssl-instance
+- Cloud Run ingress controls: https://cloud.google.com/run/docs/securing/ingress
+- Cloud Run IAM access control: https://cloud.google.com/run/docs/securing/managing-access
+- Cloud Run service identity: https://cloud.google.com/run/docs/securing/service-identity
+- Cloud Run Direct VPC egress: https://cloud.google.com/run/docs/configuring/vpc-direct-vpc
+- Cloud Run Binary Authorization: https://cloud.google.com/run/docs/securing/binary-authorization
 - Terraform Google Provider Documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs
 
 ---
 
 ## Changelog
 
+- **1.1.0** -- Added supplemental Cloud Run evidence gates for ingress, invoker IAM, service identity, VPC egress, Binary Authorization, image provenance, and audit posture.
 - **1.0.0** -- Initial release. Full coverage of CIS Google Cloud Platform Foundation Benchmark v2.0.0 sections 1 through 7.

--- a/skills/cloud/gcp-review/benchmark-checklist.md
+++ b/skills/cloud/gcp-review/benchmark-checklist.md
@@ -773,3 +773,245 @@ resource "google_bigquery_dataset" {
 ### CIS 7.3 -- Ensure that a Default Customer-Managed Encryption Key (CMEK) Is Specified for All BigQuery Datasets
 
 Verify `default_encryption_configuration` is set on all datasets.
+
+---
+
+## Supplemental -- Cloud Run Service Hardening
+
+These checks are not CIS Google Cloud Platform Foundation Benchmark v2.0.0
+controls. Use them when Cloud Run services or jobs are present so the review
+captures serverless ingress, identity, egress, image provenance, and audit risks.
+Report them separately from the CIS section scores.
+
+### GCP-RUN-01 -- Verify ingress mode and public request path
+
+Cloud Run ingress controls whether requests can reach the service from the
+internet, internal networks, or Cloud Load Balancing paths. Public APIs can be
+valid, but the review must distinguish direct public `run.app` reachability from
+traffic forced through an external Application Load Balancer with Identity-Aware
+Proxy, Cloud Armor, CDN, or other edge controls.
+
+```hcl
+resource "google_cloud_run_v2_service" "internal_api" {
+  name     = "internal-api"
+  location = "us-central1"
+  ingress  = "INGRESS_TRAFFIC_INTERNAL_ONLY"
+
+  template {
+    service_account = google_service_account.internal_api.email
+
+    containers {
+      image = "us-docker.pkg.dev/example/prod/internal-api@sha256:abc123"
+    }
+  }
+}
+```
+
+For public APIs that must use an external load balancer, require explicit
+evidence for the intended path:
+
+```hcl
+resource "google_cloud_run_v2_service" "public_api" {
+  name     = "public-api"
+  location = "us-central1"
+  ingress  = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+
+  template {
+    service_account = google_service_account.public_api.email
+
+    containers {
+      image = "us-docker.pkg.dev/example/prod/public-api@sha256:def456"
+    }
+  }
+}
+```
+
+**Fail patterns:**
+
+- `ingress = "INGRESS_TRAFFIC_ALL"` on sensitive or administrative services without a public API justification.
+- Knative YAML or annotations setting `run.googleapis.com/ingress: "all"` without edge-control evidence.
+- Public `run.app` URL enabled when the design expects all internet traffic to pass through a load balancer, IAP, API Gateway, or Cloud Armor.
+- No evidence showing whether custom domains, load balancers, or serverless NEGs are in the request path.
+
+**Severity guidance:**
+
+- High when an internal, administrative, or sensitive service allows direct internet ingress.
+- Medium when a public service has intended internet exposure but lacks documented edge controls or path evidence.
+- Low when ingress is restricted but documentation for allowed sources is incomplete.
+
+### GCP-RUN-02 -- Verify invoker IAM and public access decisions
+
+Cloud Run uses IAM to control who can invoke services and jobs. Public access is
+typically granted by assigning `roles/run.invoker` to `allUsers`. That can be
+correct for unauthenticated public APIs, but it should be explicit, justified,
+and separated from internal service-to-service invoker grants.
+
+```hcl
+resource "google_cloud_run_v2_service_iam_member" "frontend_can_call_api" {
+  project  = google_cloud_run_v2_service.internal_api.project
+  location = google_cloud_run_v2_service.internal_api.location
+  name     = google_cloud_run_v2_service.internal_api.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.frontend.email}"
+}
+```
+
+**Fail patterns:**
+
+- `member = "allUsers"` or `member = "allAuthenticatedUsers"` on non-public Cloud Run services.
+- Project-level `roles/run.invoker` grants that unintentionally allow invocation of multiple services or jobs.
+- Public invoker access combined with `INGRESS_TRAFFIC_ALL` and no authentication, authorization, or abuse-control evidence.
+- Missing conditional IAM evidence when invocation should be limited by host, path, or principal context.
+
+**Severity guidance:**
+
+- Critical when an administrative or data-modifying service is public and unauthenticated.
+- High when sensitive services grant public invoker or project-wide invoker access.
+- Medium when public access is intended but rate limiting, auth, or edge-control evidence is incomplete.
+- Informational when public access is intentional and fully documented.
+
+### GCP-RUN-03 -- Use least-privilege service identity and avoid default service account drift
+
+Cloud Run runs as a service identity. Google recommends user-managed service
+accounts with only the permissions needed by the workload. If no service account
+is specified, Cloud Run can use the Compute Engine default service account,
+which may have broad project permissions in older projects.
+
+```hcl
+resource "google_service_account" "checkout_api" {
+  account_id   = "checkout-api"
+  display_name = "Checkout API runtime"
+}
+
+resource "google_project_iam_member" "checkout_can_read_secret" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.checkout_api.email}"
+}
+
+resource "google_cloud_run_v2_service" "checkout_api" {
+  name     = "checkout-api"
+  location = "us-central1"
+
+  template {
+    service_account = google_service_account.checkout_api.email
+
+    containers {
+      image = "us-docker.pkg.dev/example/prod/checkout-api@sha256:abc123"
+    }
+  }
+}
+```
+
+**Fail patterns:**
+
+- No `service_account` configured in `template`, causing default service account use.
+- Runtime service account has `roles/editor`, `roles/owner`, broad storage/admin roles, or cross-environment access.
+- `GOOGLE_APPLICATION_CREDENTIALS` points to a key file in Cloud Run env vars, Secret Manager mounts, or container images instead of using service identity.
+- Deployers receive `iam.serviceAccountUser` or `iam.serviceAccountTokenCreator` at project scope when service-account scope is sufficient.
+
+**Severity guidance:**
+
+- High when a public or internet-facing service runs as a default or broadly privileged service account.
+- Medium when a user-managed service account exists but IAM scope is broader than the workload needs.
+- Low when least privilege is mostly correct but ownership, review cadence, or policy-simulator evidence is missing.
+
+### GCP-RUN-04 -- Review VPC egress, Shared VPC permissions, and private dependency access
+
+Cloud Run can use Direct VPC egress or Serverless VPC Access connectors to reach
+private resources. Reviewers should record whether outbound traffic is limited
+to private ranges or all traffic, whether Shared VPC permissions are in place,
+and whether firewall rules, NAT, and Private Google Access align with the data
+flow.
+
+```hcl
+resource "google_cloud_run_v2_service" "worker" {
+  name     = "worker"
+  location = "us-central1"
+
+  template {
+    service_account = google_service_account.worker.email
+
+    vpc_access {
+      network_interfaces {
+        network    = google_compute_network.app.id
+        subnetwork = google_compute_subnetwork.serverless.id
+        tags       = ["cloud-run-worker"]
+      }
+      egress = "PRIVATE_RANGES_ONLY"
+    }
+
+    containers {
+      image = "us-docker.pkg.dev/example/prod/worker@sha256:fed789"
+    }
+  }
+}
+```
+
+Connector-based configurations should include both connector and egress mode:
+
+```yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  annotations:
+    run.googleapis.com/ingress: internal
+spec:
+  template:
+    metadata:
+      annotations:
+        run.googleapis.com/vpc-access-connector: projects/example/locations/us-central1/connectors/prod
+        run.googleapis.com/vpc-access-egress: private-ranges-only
+```
+
+**Fail patterns:**
+
+- Service reaches private databases, internal APIs, or restricted Google APIs with no Direct VPC egress or connector evidence.
+- `egress = "ALL_TRAFFIC"` or `run.googleapis.com/vpc-access-egress: all-traffic` without Cloud NAT, firewall, and destination-allowlist evidence.
+- Shared VPC is configured but the Cloud Run service agent lacks subnet-level `roles/compute.networkUser` or equivalent custom permissions.
+- Firewall rules allow broad egress from connector ranges or Direct VPC subnets without workload-specific tags or destination constraints.
+
+**Severity guidance:**
+
+- High when sensitive private dependencies are reachable over public paths or broad egress permits data exfiltration.
+- Medium when VPC egress exists but route, NAT, firewall, or Shared VPC permission evidence is incomplete.
+- Low when egress is restricted and only documentation or flow-log evidence is missing.
+
+### GCP-RUN-05 -- Enforce trusted image deployment and audit breakglass
+
+Cloud Run can use Binary Authorization to require trusted container images at
+deployment time. For production services, tie image references to immutable
+digests, Artifact Registry provenance, vulnerability scanning, and documented
+breakglass approvals.
+
+```hcl
+resource "google_cloud_run_v2_service" "payments" {
+  name     = "payments"
+  location = "us-central1"
+
+  binary_authorization {
+    use_default = true
+  }
+
+  template {
+    service_account = google_service_account.payments.email
+
+    containers {
+      image = "us-docker.pkg.dev/example/prod/payments@sha256:012345"
+    }
+  }
+}
+```
+
+**Fail patterns:**
+
+- Production Cloud Run service uses mutable image tags such as `:latest` with no digest pinning or promotion evidence.
+- No Binary Authorization, Artifact Registry scanning, or provenance evidence for sensitive services.
+- Binary Authorization breakglass is used without approval, justification, expiration, and audit log evidence.
+- Deployment pipeline can change image, service account, ingress, or IAM policy without review.
+
+**Severity guidance:**
+
+- High when production services deploy mutable or untrusted images directly to internet-facing workloads.
+- Medium when image provenance exists but Binary Authorization, scanning, or breakglass evidence is incomplete.
+- Low when controls exist but release evidence is not linked to the service in the report.


### PR DESCRIPTION
## Summary
- add supplemental Cloud Run review guidance to `gcp-review`
- add `GCP-RUN-*` checklist controls for ingress, public invoker IAM, service identity, VPC egress, Binary Authorization, image provenance, and audit evidence
- keep Cloud Run findings separate from CIS GCP v2.0.0 scoring so the benchmark denominator remains intact

## Validation
- `git diff --check`
- verified Cloud Run markers for ingress, invoker IAM, service identity, VPC egress, Binary Authorization, and audit coverage
- verified markdown code fences are balanced

Closes #1208