### PR TITLE
Bound patch prioritization EPSS relative trend escalation

### DIFF
--- a/skills/vuln-management/patch-prioritization/SKILL.md
+++ b/skills/vuln-management/patch-prioritization/SKILL.md
@@ -13,7 +13,7 @@ phase: [operate]
 frameworks: [SSVC-2.1, EPSS-v3, CISA-KEV]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -51,7 +51,7 @@ Before starting, collect or confirm:
 - [ ] **Change management constraints:** Maintenance windows, freeze periods, change advisory board (CAB) schedules
 - [ ] **Compensating controls inventory:** WAF rules, network segmentation, EDR policies, disabled features currently in place
 - [ ] **Compliance mandates:** Applicable regulatory requirements (CISA BOD 22-01, PCI DSS 4.0 Requirement 6.3.3, HIPAA, FedRAMP)
-- [ ] **Historical EPSS data:** EPSS score trends over 7/30/90 days if available (API: https://api.first.org/data/v1/epss)
+- [ ] **Historical EPSS data:** EPSS score and percentile trends over 7/30/90 days, source date, and history status (complete, missing, stale, first-seen, or zero baseline) if available (API: https://api.first.org/data/v1/epss)
 
 If asset context is missing, assume internet-facing and business-critical, and flag assumptions in the output.
 
@@ -119,13 +119,23 @@ Analyze EPSS score trajectory to identify vulnerabilities with increasing exploi
 1. Retrieve current EPSS score and percentile for each CVE
 2. Compare against 7-day, 30-day, and 90-day historical scores (EPSS API: `https://api.first.org/data/v1/epss?cve=[CVE-ID]`)
 3. Calculate the trend direction and magnitude
+4. Record EPSS source date, historical data freshness, current percentile, percentile movement when available, and whether the 30-day baseline is missing, zero, stale, or newly available
+5. Apply organization-defined trend policy floors before a relative EPSS increase can change an SLA tier; relative growth from a near-zero baseline is a monitoring signal, not automatic urgency
 
 #### EPSS Trend Classification
 
+Treat the following values as default policy floors. Adjust them to the organization's vulnerability volume, exposure model, and patch capacity before using them as hard automation thresholds.
+
+- **Surging relative floor:** relative change >= 200% only counts as Surging when current EPSS is >= 0.05 and 30-day absolute delta is >= 0.02.
+- **Rising relative floor:** relative change >= 50% only counts as Rising when current EPSS is >= 0.01 and 30-day absolute delta is >= 0.005.
+- **Insufficient history:** missing, zero, stale, or first-seen historical EPSS values must not produce a relative trend label or SLA escalation from trend alone.
+
 | Trend | Definition | Action |
 |---|---|---|
-| **Surging** | EPSS increased by >= 0.2 (absolute) or >= 200% (relative) in 30 days | Escalate one SLA tier immediately; flag for out-of-cycle patching |
-| **Rising** | EPSS increased by >= 0.05 (absolute) or >= 50% (relative) in 30 days | Monitor closely; prepare patch for next available window |
+| **Surging** | EPSS increased by >= 0.2 absolute in 30 days, or relative change is >= 200% while meeting the Surging relative floor | Recommend one-tier escalation only when SSVC, exposure, exploit intelligence, KEV status, asset criticality, or local policy also supports out-of-cycle patching |
+| **Rising** | EPSS increased by >= 0.05 absolute in 30 days, or relative change is >= 50% while meeting the Rising relative floor | Monitor closely; prepare patch for next available window; do not change SLA tier on relative movement alone |
+| **Low-baseline Monitor** | Relative increase is large, but current EPSS, absolute delta, or percentile movement remains below policy floors | Keep the SSVC-driven SLA; note the relative movement and monitor for continued growth |
+| **Insufficient History** | 30-day historical EPSS is missing, zero, stale, or first-seen, making relative change undefined or misleading | Do not assign Surging/Rising from trend; rely on current EPSS, SSVC, KEV, exposure, and exploit intelligence until history is usable |
 | **Stable** | EPSS change < 0.05 in 30 days | Maintain current SLA tier |
 | **Declining** | EPSS decreased by >= 0.05 in 30 days | May support risk acceptance for Scheduled/Defer tier findings |
 
@@ -136,8 +146,13 @@ EPSS Trend Analysis:
 - 7-day prior EPSS:    [score]
 - 30-day prior EPSS:   [score]
 - 90-day prior EPSS:   [score]
-- Trend:               [Surging | Rising | Stable | Declining]
+- Absolute Delta:      [current - 30-day prior]
+- Relative Delta:      [percentage or Not Calculable]
+- Percentile Movement: [changed percentile or Not Available]
+- History Status:      [Complete | Missing | Zero Baseline | Stale | First Seen]
+- Trend:               [Surging | Rising | Low-baseline Monitor | Insufficient History | Stable | Declining]
 - Trend Impact:        [Escalate tier | Monitor | Maintain | Supports deferral]
+- Rationale:           [Why the trend did or did not meet policy floors]
 ```
 
 ### Step 4: Compensating Controls Assessment
@@ -301,11 +316,11 @@ findings requiring immediate action.]
 **Patch Posture:** [Critical Backlog | Elevated Risk | On Track | Healthy]
 
 ### EPSS Trend Alerts
-[List any CVEs with Surging or Rising EPSS trends and recommended tier adjustments]
+[List any CVEs with Surging, Rising, Low-baseline Monitor, or Insufficient History trend outcomes and the evidence behind any recommended tier adjustment]
 
-| CVE ID | Current EPSS | 30-day Prior | Trend | Recommended Action |
-|---|---|---|---|---|
-| [CVE-ID] | [score] | [score] | [Surging/Rising] | [Action] |
+| CVE ID | Current EPSS | 30-day Prior | Absolute Delta | Relative Delta | History Status | Trend | Recommended Action |
+|---|---|---|---|---|---|---|---|
+| [CVE-ID] | [score] | [score] | [delta] | [percent] | [status] | [Surging/Rising/Low-baseline Monitor/Insufficient History] | [Action] |
 
 ### Prioritized Patch Schedule
 
@@ -370,9 +385,11 @@ Known Exploited Vulnerabilities catalog maintained by CISA. Contains CVEs with c
 
 3. **Allowing risk exceptions to auto-renew without review.** Risk acceptances that roll over indefinitely create a shadow backlog of unpatched vulnerabilities. Every exception must have a hard expiration date and mandatory re-evaluation. Track exception aging as a KPI and report to leadership quarterly.
 
-4. **Ignoring EPSS trend direction.** A CVE with a low absolute EPSS score but a rapidly rising trend (e.g., from 0.02 to 0.15 in two weeks) signals that exploit development is progressing. Treating EPSS as a static snapshot rather than a time series misses emerging threats. Always evaluate 7/30/90-day trends.
+4. **Ignoring EPSS trend direction.** A CVE with a meaningful absolute EPSS increase and rising percentile (e.g., from 0.02 to 0.15 in two weeks) signals that exploit development may be progressing. Treating EPSS as a static snapshot rather than a time series misses emerging threats. Always evaluate 7/30/90-day trends.
 
-5. **Scheduling patches without rollback plans.** Patch deployment failures without rollback procedures cause unplanned outages that erode trust in the patching program. Every patch window must include a validated rollback procedure, tested in a non-production environment where possible.
+5. **Overreacting to near-zero EPSS baselines.** A CVE can increase by hundreds of percent when the prior probability was close to zero while still remaining operationally low probability. Do not classify undefined, zero-baseline, or low-absolute-delta relative movement as Surging. Record source freshness, current probability, absolute delta, relative delta, percentile movement, and history status before changing an SLA.
+
+6. **Scheduling patches without rollback plans.** Patch deployment failures without rollback procedures cause unplanned outages that erode trust in the patching program. Every patch window must include a validated rollback procedure, tested in a non-production environment where possible.
 
 ---
 
@@ -391,6 +408,8 @@ Known Exploited Vulnerabilities catalog maintained by CISA. Contains CVEs with c
 - SSVC 2.1 (CERT/CC): https://certcc.github.io/SSVC/
 - SSVC GitHub Repository: https://github.com/CERTCC/SSVC
 - EPSS v3 (FIRST.org): https://www.first.org/epss/
+- EPSS User Guide: https://www.first.org/epss/user-guide.html
+- EPSS Model: https://www.first.org/epss/model
 - EPSS API Documentation: https://api.first.org/data/v1/epss
 - EPSS Data Portal: https://epss.cyentia.com/
 - CISA KEV Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog

--- a/skills/vuln-management/patch-prioritization/tests/benign/meaningful-epss-surge.md
+++ b/skills/vuln-management/patch-prioritization/tests/benign/meaningful-epss-surge.md
@@ -1,0 +1,36 @@
+# Benign: meaningful EPSS trend qualifies for Surging review
+
+This fixture should not be suppressed as a low-baseline artifact. The absolute
+delta is meaningful, current EPSS is above the default Surging floor, and the
+finding has exposure and exploitability context that can support out-of-cycle
+patching when SSVC agrees.
+
+```yaml
+finding:
+  cve: CVE-2099-0002
+  asset: customer-api-01
+  environment: production
+  exposure: internet-facing
+  business_criticality: high
+  cisa_kev: false
+  public_poc: true
+  active_exploitation_evidence: false
+  ssvc_decision: Out-of-Cycle
+  epss:
+    source_date: 2099-03-01
+    score_30_days_ago: 0.06
+    current_score: 0.31
+    absolute_delta_30d: 0.25
+    relative_delta_30d: 416.7
+    current_percentile: high
+    percentile_movement: rising
+    history_status: complete
+```
+
+Expected handling:
+
+- Trend: `Surging`
+- SLA impact: recommend out-of-cycle review only with SSVC, exposure, exploit
+  intelligence, asset criticality, or local policy support
+- Report note: current probability and absolute delta meet the default trend
+  floor, so this is not a near-zero relative-growth artifact.

--- a/skills/vuln-management/patch-prioritization/tests/vulnerable/near-zero-relative-epss-surge.md
+++ b/skills/vuln-management/patch-prioritization/tests/vulnerable/near-zero-relative-epss-surge.md
@@ -1,0 +1,35 @@
+# Vulnerable: near-zero relative EPSS spike escalated as Surging
+
+This fixture should be flagged by the skill because the relative EPSS increase is
+large but the current probability and absolute delta remain below the default
+trend policy floors. A review should classify this as `Low-baseline Monitor`,
+not `Surging`, and should not change the SSVC-driven SLA from trend alone.
+
+```yaml
+finding:
+  cve: CVE-2099-0001
+  asset: dev-mirror-02
+  environment: development
+  exposure: internal
+  business_criticality: low
+  cisa_kev: false
+  public_poc: false
+  active_exploitation_evidence: false
+  ssvc_decision: Scheduled
+  epss:
+    source_date: 2099-03-01
+    score_30_days_ago: 0.0005
+    current_score: 0.0016
+    absolute_delta_30d: 0.0011
+    relative_delta_30d: 220
+    current_percentile: low
+    percentile_movement: minimal
+    history_status: complete
+```
+
+Expected handling:
+
+- Trend: `Low-baseline Monitor`
+- SLA impact: keep the existing SSVC-driven SLA
+- Report note: relative EPSS change is high, but current probability, absolute
+  delta, and percentile movement remain below policy floors.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

/claim #1210

### Skill Modified
**Skill name:** `patch-prioritization`
**Skill path:** `skills/vuln-management/patch-prioritization/`

### What Was Wrong
The existing EPSS trend classifier treated a 30-day increase of `>= 200%` as `Surging` even when the baseline was near zero. That can turn mathematical noise into out-of-cycle patch urgency: a CVE moving from `0.0005` to `0.0016` crosses the relative threshold while remaining very low probability with a tiny absolute delta.

The skill also did not have an explicit state for missing, zero, stale, or first-seen EPSS history, so relative change could become undefined or misleading.

### What This PR Fixes
- Bumps `patch-prioritization` to version `1.0.1`.
- Adds default trend policy floors before relative EPSS growth can classify as `Surging` or `Rising`.
- Adds `Low-baseline Monitor` for large relative movement that stays below current-probability, absolute-delta, or percentile-movement floors.
- Adds `Insufficient History` for missing, zero, stale, or first-seen 30-day EPSS history.
- Requires trend reports to show current EPSS, absolute delta, relative delta, percentile movement, history status, source freshness, and rationale.
- Clarifies that relative movement alone should not change an SLA tier without SSVC, exposure, exploit intelligence, KEV status, asset criticality, or local policy support.
- Adds vulnerable and benign calibration fixtures for near-zero relative growth and meaningful EPSS surge cases.

### Evidence

**Before (false escalation risk):**
```yaml
epss:
  score_30_days_ago: 0.0005
  current_score: 0.0016
  absolute_delta_30d: 0.0011
  relative_delta_30d: 220
  current_percentile: low
```

This could be classified as `Surging` because the relative threshold is crossed.

**After (now handled):**
```text
Trend: Low-baseline Monitor
SLA impact: keep the SSVC-driven SLA; monitor for continued growth.
```

The skill now requires the relative growth to meet current-probability and absolute-delta floors before it can qualify as `Surging` or `Rising`.

### Test Cases Added/Updated
- [x] Added vulnerable test case:
  - `skills/vuln-management/patch-prioritization/tests/vulnerable/near-zero-relative-epss-surge.md`
- [x] Added benign test case:
  - `skills/vuln-management/patch-prioritization/tests/benign/meaningful-epss-surge.md`
- [x] Existing validation checks pass.

### Validation
- `git diff --check origin/main...HEAD` -> clean.
- Markdown fence-balance check:
  - `skills/vuln-management/patch-prioritization/SKILL.md` -> 12 fences, balanced.
  - both calibration fixtures -> 2 fences each, balanced.
- Content marker checks passed for version `1.0.1`, `Low-baseline Monitor`, `Insufficient History`, `Surging relative floor`, `Rising relative floor`, `History Status`, `Absolute Delta`, `Relative Delta`, EPSS User Guide, and EPSS Model.
- Prohibited-pattern scan over touched files passed.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `abd4c9195ded1a3eec3ec67a091a15bb569c317d`.
- Reference checks returned HTTP 200 for FIRST EPSS User Guide, FIRST EPSS Model, FIRST EPSS API, and SSVC. The existing CISA KEV URL was not revalidated in this environment due a local TLS request failure, and this PR does not modify that existing reference.

### Primary Sources Checked
- FIRST EPSS User Guide: https://www.first.org/epss/user-guide.html
- FIRST EPSS Model: https://www.first.org/epss/model
- FIRST EPSS API: https://api.first.org/data/v1/epss
- SSVC reference: https://certcc.github.io/SSVC/

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage and false-positive reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the `CONTRIBUTING.md` bounty terms.
- **Preferred payment method:** Payment details can be provided privately after maintainer acceptance.
