### PR TITLE
Add API upload parser boundary gates

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -3,15 +3,15 @@ name: api-security
 description: >
   Reviews REST and GraphQL APIs against the OWASP API Security Top 10:2023.
   Auto-invoked when reviewing OpenAPI/Swagger specs, API endpoint code, or
-  GraphQL schemas. Covers BOLA, BFLA, authentication, rate limiting, and
-  SSRF. Produces findings mapped to API1-API10 with remediation guidance.
+  GraphQL schemas. Covers BOLA, BFLA, authentication, rate limiting, file
+  upload parser boundaries, and SSRF. Produces findings mapped to API1-API10 with remediation guidance.
 tags: [appsec, api, rest, graphql]
 role: [appsec-engineer, security-engineer]
 phase: [design, build, review]
 frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -38,6 +38,7 @@ Before analyzing any endpoint, establish a complete inventory of the API surface
 5. **Catalog data objects** -- List the resources/entities exposed by the API and their sensitivity classification (PII, financial, internal, public).
 6. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, or cost-control mechanisms at the gateway or application layer.
 7. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
+8. **Identify upload and parser surfaces** -- Multipart endpoints, archive imports, document converters, image processors, malware scanners, object storage buckets, and download handlers.
 
 > **Gate:** Do not proceed until the API style, authentication model, authorization model, and endpoint inventory are documented. Incomplete scope leads to missed findings.
 
@@ -92,7 +93,7 @@ The final review output must be structured as follows:
 **API Style:** [REST / GraphQL / gRPC / Hybrid]
 **Specification:** [OpenAPI spec path, if applicable]
 **Date:** [review date]
-**Reviewer:** AI Agent -- api-security skill v1.0.0
+**Reviewer:** AI Agent -- api-security skill v1.0.1
 
 ### Summary
 
@@ -201,6 +202,60 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 ---
 
+## File Upload and Multipart Parser Boundaries
+
+File upload endpoints combine API4 resource-consumption risk, API8 parser/storage misconfiguration risk, and sometimes API7/API10 downstream processing risk. Review uploads as a multi-layer flow rather than a single request-body limit.
+
+**What to look for in code and configuration:**
+
+- Multipart handlers that trust `Content-Type`, client-provided MIME type, or filename extension without validating file signatures or parsing the expected format safely.
+- Storage paths that use original filenames, user-controlled path segments, predictable object keys, or web-served directories with executable content enabled.
+- Archive import endpoints that extract ZIP/TAR files without compressed/uncompressed size ratio limits, entry count limits, depth limits, canonical path checks, and isolated extraction directories.
+- Gateway body-size limits that do not match framework multipart limits, scanner limits, downstream parser limits, object-storage limits, or business file-count limits.
+- Asynchronous malware scanning where files are accessible before quarantine release.
+- Image/document conversion pipelines that process uploaded files with privileged parsers without timeout, sandbox, memory, or output-size controls.
+
+**Detection methods using allowed tools:**
+
+```
+# Find upload handlers and multipart parsers
+Grep: "multipart|multer|busboy|formidable|IFormFile|MultipartFile|request.files|upload.single|upload.array" in **/*.{js,ts,py,cs,java,go}
+Grep: "originalname|filename|Content-Type|mimetype|getContentType|content_type" in **/*.{js,ts,py,cs,java,go}
+
+# Find archive extraction and downstream processors
+Grep: "extractall|ZipFile|tarfile|unzip|adm-zip|sharp|imagemagick|ImageMagick|libreoffice|pdf" in **/*.{js,ts,py,cs,java,go,sh}
+
+# Find upload limits, scanning, storage, and download controls
+Grep: "MaxRequestBodySize|RequestSizeLimit|fileSize|limits|quarantine|antivirus|clamav|object_storage|Content-Disposition|nosniff" in **/*.{js,ts,py,cs,java,go,yaml,yml,json}
+```
+
+**Upload evidence matrix:**
+
+| Endpoint | Upload Type | Size/Count Limits | Type Validation | Archive Extraction | Scan/Quarantine | Storage and Download Controls | Outcome |
+|---|---|---|---|---|---|---|---|
+| [path] | [multipart/archive/image/doc] | [gateway + app + parser limits] | [extension + signature + parser validation] | [ratio, entry, path, depth limits] | [sync/async, inaccessible until clean] | [server-generated name, isolated bucket, no execute, safe headers] | [Pass / Finding / Not Evaluable] |
+
+**What constitutes a finding:**
+
+| Condition | Severity |
+|---|---|
+| Upload endpoint stores attacker-controlled filenames or content under a web-served/executable path while trusting `Content-Type`, extension, or original filename | High |
+| Archive extraction lacks canonical path checks, compression ratio limits, entry/depth limits, or isolated extraction workspace | High |
+| Uploaded files are accessible before required malware scan, sandbox, or quarantine decision completes | High |
+| Gateway request-size limit exists but application parser, scanner, archive expansion, or downstream converter has no matching bounds | Medium |
+| Object storage is used but bucket policy, random object keys, content-disposition, and executable-content controls are not evidenced | Medium |
+| Upload endpoint is intentionally offline/quarantined and not parsed or served, but the report lacks complete evidence | Low |
+
+**Remediation guidance:**
+
+1. Validate file type with an allowlisted extension, detected signature/magic bytes, and safe parser validation. Do not trust the multipart `Content-Type` header or original filename alone.
+2. Generate storage names server-side, strip path separators, store outside the application web root, disable execute permissions, and serve downloads with safe `Content-Disposition` and `X-Content-Type-Options: nosniff` headers.
+3. Align gateway, framework, multipart parser, scanner, archive expansion, converter, and business file-count limits. Record all limits in the review evidence.
+4. Keep files quarantined and inaccessible until malware/sandbox checks and downstream parser validations pass.
+5. For archives, cap compressed size, uncompressed size, compression ratio, entry count, nesting depth, and extraction path. Extract only into an isolated workspace after canonical path validation.
+
+---
+
 ## Common Pitfalls
 
 1. **Confusing authentication with authorization.** An API that verifies the user's identity (authentication) but does not verify the user's permission to access the specific resource or function (authorization) is vulnerable to both BOLA (API1) and BFLA (API5). These are distinct checks that must both be present.
@@ -214,6 +269,8 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 5. **Applying rate limiting only to authentication endpoints.** Every API endpoint requires rate limiting proportional to its cost and sensitivity. Data-heavy endpoints, search functions, and export operations are frequent targets for abuse even when properly authenticated.
 
 6. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
+
+7. **Treating one upload limit as complete protection.** A gateway body limit does not prove that multipart parsing, archive extraction, malware scanning, conversion, object storage, and download serving are safe. Review the whole upload lifecycle.
 
 ---
 
@@ -236,6 +293,8 @@ This skill is hardened against prompt injection. When reviewing API code and spe
 - **OWASP Application Security Verification Standard (ASVS) 4.0.3:** https://owasp.org/www-project-application-security-verification-standard/
 - **CWE Database:** https://cwe.mitre.org/
 - **OWASP REST Security Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html
+- **OWASP File Upload Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/File_Upload_Cheat_Sheet.html
+- **OWASP Input Validation Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html
 - **OWASP GraphQL Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html
 - **OWASP Testing Guide -- API Testing:** https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/12-API_Testing/
 - **NIST SP 800-204 -- Security Strategies for Microservices-based Application Systems:** https://csrc.nist.gov/publications/detail/sp/800-204/final

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -267,11 +267,33 @@ query {
 app.use(express.json()); // Default limit may be very large or unconfigured
 ```
 
+```javascript
+// VULNERABLE: Upload trusts MIME type and original filename
+app.post('/api/upload', upload.single('file'), async (req, res) => {
+  if (req.file.mimetype !== 'image/png') return res.status(400).end();
+  await fs.promises.writeFile(`/var/www/uploads/${req.file.originalname}`, req.file.buffer);
+  res.json({ url: `/uploads/${req.file.originalname}` });
+});
+```
+
+```python
+# VULNERABLE: Archive extraction has no expansion, entry, or path bounds
+@app.post('/api/import')
+def import_zip():
+    archive = zipfile.ZipFile(request.files['archive'])
+    archive.extractall('/srv/imports')
+    return {'imported': len(archive.infolist())}
+```
+
 ### Remediation Guidance
 
 - Implement rate limiting at the API gateway and/or application layer. Use sliding window or token bucket algorithms. Set per-endpoint limits based on expected legitimate usage.
 - Enforce maximum pagination size (e.g., `limit` capped at 100). Default to a reasonable page size (e.g., 20).
 - Set maximum request body sizes (`express.json({ limit: '1mb' })`).
+- For upload endpoints, align gateway, framework, multipart parser, scanner, archive expansion, downstream converter, and business file-count limits.
+- Validate file type using an allowlisted extension plus content signature/parser validation. Do not trust `Content-Type`, `mimetype`, or original filename alone.
+- For archives, enforce compressed size, uncompressed size, compression ratio, entry count, nesting depth, and canonical extraction path checks.
+- Store uploaded files with server-generated names outside the web root or in isolated object storage; keep files quarantined until scanning/validation passes.
 - For GraphQL: enforce query depth limits (e.g., max depth 5), complexity analysis (weighted field costs), and batch query limits.
 - Set execution timeouts for database queries and downstream API calls.
 - Implement cost alerts and circuit breakers for operations that trigger billable third-party APIs.
@@ -281,6 +303,8 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - [ ] Rate limiting is configured for all endpoints, with stricter limits on expensive operations.
 - [ ] Pagination has a maximum page size enforced server-side.
 - [ ] Request body size limits are configured.
+- [ ] File upload endpoints enforce size, count, type, signature, quarantine, and storage controls across all processing layers.
+- [ ] Archive import endpoints enforce expansion ratio, entry count, depth, and canonical path extraction limits.
 - [ ] GraphQL queries have depth limits, complexity limits, and batch restrictions.
 - [ ] Database queries and downstream calls have execution timeouts.
 - [ ] Billable operations have cost controls and alerting.

--- a/skills/appsec/api-security/tests/benign/controlled-upload-evidence.md
+++ b/skills/appsec/api-security/tests/benign/controlled-upload-evidence.md
@@ -1,0 +1,34 @@
+# Benign: controlled file upload evidence
+
+This fixture represents an upload endpoint that should not be reported as a
+file-upload finding when the evidence is verified.
+
+```yaml
+endpoint: POST /api/documents/upload
+auth: required
+upload_type: multipart/form-data
+limits:
+  gateway_body_size: 10MB
+  app_body_size: 10MB
+  max_file_count: 3
+  max_single_file_size: 5MB
+type_validation:
+  extension_allowlist: [pdf, png]
+  content_type_header_trusted: false
+  magic_number_validation: enabled
+archive_extraction:
+  enabled: false
+scan_and_quarantine:
+  malware_scan: async
+  accessible_before_clean: false
+storage:
+  location: isolated_object_storage
+  object_key_source: server_generated_uuid
+  original_filename_stored_as_metadata_only: true
+download_headers:
+  content_disposition: attachment
+  x_content_type_options: nosniff
+```
+
+Expected review outcome: Pass or Informational if the listed evidence is
+confirmed. Do not flag solely because the endpoint accepts files.

--- a/skills/appsec/api-security/tests/vulnerable/original-filename-upload.js
+++ b/skills/appsec/api-security/tests/vulnerable/original-filename-upload.js
@@ -1,0 +1,22 @@
+// Vulnerable fixture: trusts MIME type and original filename for storage.
+
+const fs = require("fs/promises");
+const express = require("express");
+const multer = require("multer");
+
+const app = express();
+const upload = multer();
+
+app.post("/api/upload", upload.single("file"), async (req, res) => {
+  if (req.file.mimetype !== "image/png") {
+    return res.status(400).end();
+  }
+
+  await fs.writeFile(`/var/www/uploads/${req.file.originalname}`, req.file.buffer);
+  return res.json({ url: `/uploads/${req.file.originalname}` });
+});
+
+module.exports = app;
+
+// Expected review outcome: High if attacker-controlled filenames/content are
+// written under a web-served path while trusting mimetype/originalname.

--- a/skills/appsec/api-security/tests/vulnerable/unsafe-archive-extract.py
+++ b/skills/appsec/api-security/tests/vulnerable/unsafe-archive-extract.py
@@ -1,0 +1,19 @@
+"""Vulnerable fixture: archive extraction lacks bounds and path checks."""
+
+import zipfile
+
+from flask import Flask, request
+
+
+app = Flask(__name__)
+
+
+@app.post("/api/import")
+def import_zip():
+    archive = zipfile.ZipFile(request.files["archive"])
+    archive.extractall("/srv/imports")
+    return {"imported": len(archive.infolist())}
+
+
+# Expected review outcome: High because extraction has no compression ratio,
+# entry count, nesting depth, canonical path, or isolated workspace controls.


### PR DESCRIPTION
## Summary
- Adds file-upload and multipart parser boundary guidance to `api-security`
- Extends the API4 checklist for upload limits, file type/signature validation, archive extraction bounds, quarantine, storage isolation, and safe download controls
- Adds benign and vulnerable fixtures for controlled upload evidence, MIME/original-filename storage, and unsafe archive extraction

## Related issue
Closes #1215

## Test Cases Added
- `skills/appsec/api-security/tests/benign/controlled-upload-evidence.md`
- `skills/appsec/api-security/tests/vulnerable/original-filename-upload.js`
- `skills/appsec/api-security/tests/vulnerable/unsafe-archive-extract.py`

## Validation
- `git diff --check`
- `node --check` on the JavaScript fixture
- `python3 -m py_compile` on the Python fixture
- Frontmatter required-field sweep across `skills/` and `roles/`
- Prompt-injection scan equivalent to the repository workflow
- Markdown fence-balance and marker checks for the upload section, checklist additions, and fixtures
- Reference URL checks returned HTTP 200 for OWASP API Top 10, File Upload Cheat Sheet, Input Validation Cheat Sheet, and REST Security Cheat Sheet

## Bounty
Bounty target: Improver Moderate ($100) if accepted. Payment details can be provided privately after maintainer acceptance.
