### PR TITLE
Add API upload parser evidence gates

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -55,7 +55,7 @@ skills:
 
   - id: api-security
     name: "API Security Review"
-    tags: [appsec, api, rest, graphql]
+    tags: [appsec, api, rest, graphql, file-upload]
     role: [appsec-engineer, security-engineer]
     phase: [design, build, review]
     activity: [review, test]

--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -3,15 +3,16 @@ name: api-security
 description: >
   Reviews REST and GraphQL APIs against the OWASP API Security Top 10:2023.
   Auto-invoked when reviewing OpenAPI/Swagger specs, API endpoint code, or
-  GraphQL schemas. Covers BOLA, BFLA, authentication, rate limiting, and
-  SSRF. Produces findings mapped to API1-API10 with remediation guidance.
-tags: [appsec, api, rest, graphql]
+  GraphQL schemas. Covers BOLA, BFLA, authentication, rate limiting, file
+  upload parser boundaries, and SSRF. Produces findings mapped to API1-API10
+  with remediation guidance.
+tags: [appsec, api, rest, graphql, file-upload]
 role: [appsec-engineer, security-engineer]
 phase: [design, build, review]
 frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -21,7 +22,7 @@ argument-hint: "[target-file-or-directory]"
 
 # API Security Review -- OWASP API Security Top 10:2023
 
-A structured, repeatable process for reviewing REST and GraphQL APIs against the OWASP API Security Top 10:2023. This skill produces findings mapped to API1 through API10 with associated CWE identifiers, severity ratings, and actionable remediation guidance. It applies to OpenAPI/Swagger specifications, API endpoint source code, GraphQL schemas, and API gateway configurations.
+A structured, repeatable process for reviewing REST and GraphQL APIs against the OWASP API Security Top 10:2023. This skill produces findings mapped to API1 through API10 with associated CWE identifiers, severity ratings, and actionable remediation guidance. It applies to OpenAPI/Swagger specifications, API endpoint source code, GraphQL schemas, file upload endpoints, archive import flows, and API gateway configurations.
 
 ---
 
@@ -37,9 +38,10 @@ Before analyzing any endpoint, establish a complete inventory of the API surface
 4. **Identify authorization models** -- RBAC, ABAC, ownership-based, or no authorization. Document how object-level and function-level access control decisions are made.
 5. **Catalog data objects** -- List the resources/entities exposed by the API and their sensitivity classification (PII, financial, internal, public).
 6. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, or cost-control mechanisms at the gateway or application layer.
-7. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
+7. **Catalog upload and parser boundaries** -- Identify endpoints that accept `multipart/form-data`, raw file bodies, GraphQL uploads, archives, import bundles, image/document conversion inputs, or signed upload callbacks. Record maximum body size, file count, content-signature validation, archive extraction behavior, quarantine/scanning, storage location, download path, and downstream processors.
+8. **Identify downstream dependencies** -- Third-party APIs, internal microservices, scanners, conversion workers, object storage, or webhooks that the API consumes.
 
-> **Gate:** Do not proceed until the API style, authentication model, authorization model, and endpoint inventory are documented. Incomplete scope leads to missed findings.
+> **Gate:** Do not proceed until the API style, authentication model, authorization model, endpoint inventory, and any upload/parser boundaries are documented. Incomplete scope leads to missed findings.
 
 ---
 
@@ -48,6 +50,36 @@ Before analyzing any endpoint, establish a complete inventory of the API surface
 Evaluate the API against all ten OWASP API Security Top 10:2023 risk categories: Broken Object Level Authorization (BOLA), Broken Authentication, Broken Object Property Level Authorization, Unrestricted Resource Consumption, Broken Function Level Authorization (BFLA), Unrestricted Access to Sensitive Business Flows, Server Side Request Forgery (SSRF), Security Misconfiguration, Improper Inventory Management, and Unsafe Consumption of APIs.
 
 For detailed checklist items with vulnerable code patterns, remediation examples, and review checklists for all ten API risk categories (API1:2023 through API10:2023), see [api-top10-checklist.md](api-top10-checklist.md) in this skill directory.
+
+---
+
+## File Upload and Multipart Parser Boundary Gate
+
+File upload endpoints are API surfaces even when the application later hands the file to object storage, an antivirus scanner, a document converter, or an offline import job. Treat upload evidence as a cross-layer gate that usually maps to API4:2023 (resource consumption) and API8:2023 (security misconfiguration), with API9:2023 inventory impact when upload routes are undocumented.
+
+### Required Evidence
+
+For each upload, import, or archive endpoint, record:
+
+| Evidence Area | Required Questions |
+|---|---|
+| **Endpoint and parser** | Which route accepts the file? Which framework parser, gateway, proxy, or GraphQL upload middleware parses it? Are gateway and application limits consistent? |
+| **Size, count, and rate limits** | Are request size, per-file size, file count, part count, stream timeout, per-user rate, and storage quota enforced before expensive processing? |
+| **Type validation** | Is the user-controlled `Content-Type` header treated as advisory only? Are extension allowlists paired with magic-number or content-signature validation? |
+| **Filename and path handling** | Are object keys or filenames server-generated? Are original filenames sanitized, never used as filesystem paths, and excluded from overwrite decisions? |
+| **Storage and download controls** | Are uploaded files stored outside the app web root or in private object storage? Are downloads served with safe `Content-Disposition`, `Content-Type`, and `X-Content-Type-Options: nosniff` headers? |
+| **Quarantine and scanning** | If malware scanning is asynchronous, is the file inaccessible until scan completion? Are scan failures fail-closed and logged? |
+| **Archive extraction** | Are compressed/uncompressed size ratio, total extracted size, entry count, nesting depth, symlink/device entries, and canonical output paths bounded before extraction? |
+| **Downstream processors** | Are image resizers, document converters, OCR jobs, import workers, and AV scanners covered by the same limits and isolation assumptions? |
+
+### Classification Guidance
+
+- **High:** Unauthenticated or broadly authenticated upload stores attacker-controlled filenames or active content under a web-served path; trusts `Content-Type` or extension alone; or extracts archives without size, path, and entry controls.
+- **Medium:** Controls exist at one layer, but gateway, application parser, scanner/quarantine, storage, or downstream processor limits are inconsistent or not evidenced.
+- **Low:** Secure controls appear present, but report evidence is incomplete, stale, or missing one non-critical field.
+- **Informational:** Uploads are encrypted, quarantined, not parsed, not served, and routed to a documented offline workflow with bounded storage and access controls.
+
+Do not fail every upload endpoint by default. A benign upload flow with bounded size/count, content-signature validation, server-generated object keys, quarantine-before-release, private storage, and safe download headers should be classified as controlled or informational rather than vulnerable.
 
 ---
 
@@ -92,7 +124,7 @@ The final review output must be structured as follows:
 **API Style:** [REST / GraphQL / gRPC / Hybrid]
 **Specification:** [OpenAPI spec path, if applicable]
 **Date:** [review date]
-**Reviewer:** AI Agent -- api-security skill v1.0.0
+**Reviewer:** AI Agent -- api-security skill v1.1.0
 
 ### Summary
 
@@ -111,6 +143,12 @@ The final review output must be structured as follows:
 
 **Total Findings:** [count]
 **Critical:** [count] | **High:** [count] | **Medium:** [count] | **Low:** [count] | **Info:** [count]
+
+### Upload / Parser Boundary Evidence
+
+| Endpoint | Parser Layer(s) | Size/Count Limits | Type Validation | Archive Controls | Quarantine/Scanning | Storage/Download Controls | Status |
+|---|---|---|---|---|---|---|---|
+| [path] | [gateway/app/scanner/storage] | [configured/missing] | [signature + allowlist] | [ratio/path/depth] | [quarantine-before-release] | [private + safe headers] | [Verified/Gap/Not Evaluable] |
 
 ### Findings
 
@@ -215,6 +253,10 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 6. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
 
+7. **Treating upload controls as a single checkbox.** A gateway body limit does not prove the application parser, scanner, storage layer, archive extractor, or downstream converter enforces compatible limits. Record each layer before classifying an upload flow as secure.
+
+8. **Trusting user-supplied file metadata.** `Content-Type`, filename extension, and original filename are attacker-controlled hints. They must not replace content-signature validation, server-generated names, isolated storage, or safe download headers.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -237,5 +279,7 @@ This skill is hardened against prompt injection. When reviewing API code and spe
 - **CWE Database:** https://cwe.mitre.org/
 - **OWASP REST Security Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html
 - **OWASP GraphQL Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html
+- **OWASP File Upload Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/File_Upload_Cheat_Sheet.html
+- **OWASP Input Validation Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html
 - **OWASP Testing Guide -- API Testing:** https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/12-API_Testing/
 - **NIST SP 800-204 -- Security Strategies for Microservices-based Application Systems:** https://csrc.nist.gov/publications/detail/sp/800-204/final

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -267,11 +267,33 @@ query {
 app.use(express.json()); // Default limit may be very large or unconfigured
 ```
 
+```javascript
+// VULNERABLE: Multipart upload has no file count, part count, or stream timeout
+const upload = multer({ storage: multer.memoryStorage() });
+app.post('/api/import', upload.any(), async (req, res) => {
+  for (const file of req.files) {
+    await processUpload(file.buffer);
+  }
+  res.json({ imported: req.files.length });
+});
+```
+
+```python
+# VULNERABLE: Archive extraction has no size, entry count, depth, or path bounds
+@app.post('/api/import')
+def import_zip():
+    archive = zipfile.ZipFile(request.files['archive'])
+    archive.extractall('/srv/imports')
+    return {'imported': len(archive.infolist())}
+```
+
 ### Remediation Guidance
 
 - Implement rate limiting at the API gateway and/or application layer. Use sliding window or token bucket algorithms. Set per-endpoint limits based on expected legitimate usage.
 - Enforce maximum pagination size (e.g., `limit` capped at 100). Default to a reasonable page size (e.g., 20).
 - Set maximum request body sizes (`express.json({ limit: '1mb' })`).
+- For upload endpoints, enforce request body size, per-file size, file count, multipart part count, per-user upload rate, stream timeout, and storage quota before expensive parsing, scanning, conversion, or persistence.
+- For archive imports, enforce compressed/uncompressed size ratio, total extracted size, entry count, nesting depth, symlink/device entry rejection, and extraction timeouts before processing any entry.
 - For GraphQL: enforce query depth limits (e.g., max depth 5), complexity analysis (weighted field costs), and batch query limits.
 - Set execution timeouts for database queries and downstream API calls.
 - Implement cost alerts and circuit breakers for operations that trigger billable third-party APIs.
@@ -281,6 +303,9 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - [ ] Rate limiting is configured for all endpoints, with stricter limits on expensive operations.
 - [ ] Pagination has a maximum page size enforced server-side.
 - [ ] Request body size limits are configured.
+- [ ] Upload endpoints enforce per-file size, file count, multipart part count, stream timeout, and storage quota limits.
+- [ ] Archive extraction enforces size ratio, total extracted size, entry count, nesting depth, safe entry types, and extraction time limits.
+- [ ] Gateway, framework parser, scanner/quarantine, storage, and downstream processor limits are consistent.
 - [ ] GraphQL queries have depth limits, complexity limits, and batch restrictions.
 - [ ] Database queries and downstream calls have execution timeouts.
 - [ ] Billable operations have cost controls and alerting.
@@ -450,6 +475,18 @@ DocumentBuilder builder = factory.newDocumentBuilder();
 Document doc = builder.parse(request.getInputStream());
 ```
 
+```javascript
+// VULNERABLE: Trusts Content-Type and writes attacker-controlled filenames under web root
+app.post('/api/upload', upload.single('file'), async (req, res) => {
+  if (req.file.mimetype !== 'image/png') {
+    return res.status(400).end();
+  }
+  const output = `/var/www/uploads/${req.file.originalname}`;
+  await fs.promises.writeFile(output, req.file.buffer);
+  res.json({ url: `/uploads/${req.file.originalname}` });
+});
+```
+
 ### Remediation Guidance
 
 - Configure CORS with an explicit allowlist of permitted origins. Never use `*` with `credentials: true`.
@@ -462,6 +499,24 @@ Document doc = builder.parse(request.getInputStream());
 - Disable XML External Entity processing: set `factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)`.
 - Enforce TLS 1.2+ with strong cipher suites. Disable TLS 1.0 and 1.1.
 - Automate configuration scanning in CI/CD to detect drift from security baselines.
+- Treat upload metadata as untrusted: validate content signatures/magic numbers, use extension allowlists only as secondary evidence, generate server-side object keys, and never use original filenames as filesystem paths.
+- Store uploaded files outside the application web root or in private object storage. Serve downloads through an authorization-checked handler with safe `Content-Disposition`, explicit `Content-Type`, and `X-Content-Type-Options: nosniff`.
+- Keep asynchronously scanned files quarantined and inaccessible until the scan succeeds. Fail closed on scanner errors or timeouts.
+- For archive extraction, canonicalize each output path and verify it remains inside an isolated workspace before writing. Reject absolute paths, `..` traversal, symlinks, device entries, and overwrite attempts.
+
+### File Upload and Parser Boundary Checks
+
+Use this cross-layer checklist for `multipart/form-data`, raw file uploads, GraphQL uploads, archive imports, image/document conversion inputs, and signed upload callbacks:
+
+| Area | Evidence to Require | Common Gap |
+|---|---|---|
+| **Parser limits** | Gateway and application parser body size, per-file size, file count, part count, and timeout settings | Gateway limit exists, but application parser buffers unlimited parts |
+| **Type validation** | Magic-number/content-signature checks plus extension allowlist | `Content-Type` or filename extension trusted alone |
+| **Filename handling** | Server-generated key, sanitized display name, no overwrite behavior | `originalname` used in filesystem path or public URL |
+| **Storage isolation** | Private bucket, non-executable filesystem, no direct app-origin serving | Uploaded active content served from `/uploads` |
+| **Quarantine/scanning** | File inaccessible until malware scan/conversion succeeds; fail-closed error handling | Async scan starts after file is already downloadable |
+| **Archive safety** | Ratio, extracted size, entry count, depth, canonical path, and safe entry-type checks | `extractall` or equivalent with untrusted archives |
+| **Downstream processors** | Image/document converter, OCR, AV, or import worker limits match API limits | Scanner checks first part only, but business logic processes all parts |
 
 ### Review Checklist
 
@@ -472,6 +527,11 @@ Document doc = builder.parse(request.getInputStream());
 - [ ] TLS 1.2+ is enforced with strong cipher suites.
 - [ ] XML parsers disable external entity processing and DTD loading.
 - [ ] Default credentials are changed or removed on all infrastructure components.
+- [ ] File upload endpoints do not trust `Content-Type`, extension, or original filename as security evidence.
+- [ ] Uploaded files are stored outside the app web root or in private object storage and served through authorization-checked download handlers.
+- [ ] Asynchronous malware scanning or conversion keeps files quarantined until success and fails closed on scanner errors.
+- [ ] Archive extraction uses canonical path checks, safe entry-type filtering, isolated workspaces, and overwrite protection.
+- [ ] Safe download headers prevent active content sniffing or inline execution where not explicitly required.
 
 ---
 

--- a/skills/appsec/api-security/tests/benign/quarantined-upload-controls.md
+++ b/skills/appsec/api-security/tests/benign/quarantined-upload-controls.md
@@ -1,0 +1,41 @@
+# Benign: upload flow has layered parser and storage controls
+
+This fixture should be classified as controlled or informational unless other evidence contradicts it.
+
+```yaml
+endpoint: POST /api/documents/upload
+request:
+  content_type: multipart/form-data
+controls:
+  gateway:
+    max_request_body_size: 10MB
+    per_user_rate: 30/hour
+  parser:
+    max_file_size: 5MB
+    max_file_count: 3
+    max_part_count: 8
+    stream_timeout: 30s
+  validation:
+    extension_allowlist: [pdf, png]
+    magic_number_validation: enabled
+    content_type_header_trusted: false
+  archive_extraction: disabled
+  storage:
+    location: private_object_storage
+    object_key_source: server_generated_uuid
+    executable_permissions: false
+    direct_public_url: false
+  malware_scan:
+    mode: async
+    release_policy: quarantine_until_clean
+    scanner_error_behavior: fail_closed
+  download:
+    authorization_checked: true
+    content_disposition: attachment
+    x_content_type_options: nosniff
+```
+
+Expected classification:
+
+- Upload evidence is complete enough to avoid reporting every upload as unsafe by default.
+- Remaining findings should be based on missing or contradicted controls, not on the mere presence of a file upload endpoint.

--- a/skills/appsec/api-security/tests/vulnerable/multipart-originalname-webroot.md
+++ b/skills/appsec/api-security/tests/vulnerable/multipart-originalname-webroot.md
@@ -1,0 +1,26 @@
+# Vulnerable: multipart upload trusts metadata and serves from web root
+
+This fixture should trigger API8:2023 and API4:2023 concerns.
+
+```javascript
+const multer = require('multer');
+const fs = require('fs');
+const upload = multer({ storage: multer.memoryStorage() });
+
+app.post('/api/upload', upload.single('file'), async (req, res) => {
+  if (req.file.mimetype !== 'image/png') {
+    return res.status(400).end();
+  }
+
+  const output = `/var/www/uploads/${req.file.originalname}`;
+  await fs.promises.writeFile(output, req.file.buffer);
+  res.json({ url: `/uploads/${req.file.originalname}` });
+});
+```
+
+Expected findings:
+
+- User-controlled `Content-Type` is treated as the file-type decision.
+- `originalname` is used as a filesystem path and public URL component.
+- Uploaded content is served from the application origin.
+- No evidence of file count, per-file size, server-generated object key, magic-number validation, quarantine, or safe download headers.

--- a/skills/appsec/api-security/tests/vulnerable/zip-extractall-unbounded.md
+++ b/skills/appsec/api-security/tests/vulnerable/zip-extractall-unbounded.md
@@ -1,0 +1,21 @@
+# Vulnerable: archive import extracts untrusted entries without bounds
+
+This fixture should trigger API4:2023 and API8:2023 concerns.
+
+```python
+import zipfile
+from flask import request
+
+@app.post('/api/import')
+def import_zip():
+    archive = zipfile.ZipFile(request.files['archive'])
+    archive.extractall('/srv/imports')
+    return {'imported': len(archive.infolist())}
+```
+
+Expected findings:
+
+- No compressed/uncompressed size ratio or total extracted size limit.
+- No entry count, nesting depth, or extraction timeout.
+- No canonical path check to keep entries inside the workspace.
+- No rejection of absolute paths, `..` traversal, symlinks, device entries, or overwrite attempts.


### PR DESCRIPTION
/claim #1215

## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** api-security
**Skill path:** `skills/appsec/api-security/`

Closes #1215.

### What Was Wrong
The API security skill mapped API4 resource consumption and API8 security misconfiguration well, but upload endpoints did not have a first-class evidence path. That could create both false positives and missed findings:

- safe upload flows could be over-reported just because they accept files;
- unsafe multipart handlers could trust `Content-Type`, filename extensions, or original filenames;
- archive imports could miss ZIP expansion, traversal, overwrite, symlink, and extraction-bound risks;
- gateway limits could be accepted even when framework parsers, scanners, storage, or downstream processors used different limits.

### What This PR Fixes
- Adds a File Upload and Multipart Parser Boundary Gate to the main API review workflow.
- Adds upload/parser boundary fields to the report output.
- Expands API4 guidance for upload size, file count, multipart part count, stream timeout, storage quota, archive size ratio, entry count, depth, and extraction time limits.
- Expands API8 guidance for content-signature validation, server-generated filenames, private storage, quarantine-before-release, safe download headers, canonical archive paths, and downstream processor consistency.
- Adds focused vulnerable and benign fixtures for original filename web-root storage, unbounded archive extraction, and a controlled quarantined upload flow.
- Adds `file-upload` discoverability to the API security skill metadata and index entry.

### Evidence

**Before (skill misses this / false positive on this):**
```javascript
app.post('/api/upload', upload.single('file'), async (req, res) => {
  if (req.file.mimetype !== 'image/png') return res.status(400).end();
  await fs.promises.writeFile(`/var/www/uploads/${req.file.originalname}`, req.file.buffer);
  res.json({ url: `/uploads/${req.file.originalname}` });
});
```

**After (now correctly handled):**
```text
The skill now requires evidence for parser layers, size/count/rate limits, content-signature validation, server-generated object keys, quarantine/scanning, storage/download controls, archive extraction safety, and downstream processor consistency before classifying upload flows.
```

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing validation checks pass

Added fixtures:
- `skills/appsec/api-security/tests/vulnerable/multipart-originalname-webroot.md`
- `skills/appsec/api-security/tests/vulnerable/zip-extractall-unbounded.md`
- `skills/appsec/api-security/tests/benign/quarantined-upload-controls.md`

### Validation
- `git diff --cached --check`
- Required frontmatter field check for `skills/**/SKILL.md` and `roles/**/SKILL.md`
- Indexed-file existence check for `index.yaml`
- Markdown fence-balance check for changed files and new fixtures
- Content marker checks for upload/parser, archive, quarantine, and fixture coverage
- Prompt-injection pattern scan over `skills/` and `roles/`
- ASCII check for changed Markdown files

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Payment details can be provided privately after maintainer acceptance.