### PR TITLE
Add API gRPC and webhook evidence gates

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: api-security
 description: >
-  Reviews REST and GraphQL APIs against the OWASP API Security Top 10:2023.
+  Reviews REST, GraphQL, and gRPC APIs against the OWASP API Security Top 10:2023.
   Auto-invoked when reviewing OpenAPI/Swagger specs, API endpoint code, or
-  GraphQL schemas. Covers BOLA, BFLA, authentication, rate limiting, and
-  SSRF. Produces findings mapped to API1-API10 with remediation guidance.
-tags: [appsec, api, rest, graphql]
+  GraphQL schemas. Covers BOLA, BFLA, authentication, rate limiting, gRPC
+  service boundaries, webhook receivers, and SSRF. Produces findings mapped to
+  API1-API10 with remediation guidance.
+tags: [appsec, api, rest, graphql, grpc]
 role: [appsec-engineer, security-engineer]
 phase: [design, build, review]
 frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -21,7 +22,7 @@ argument-hint: "[target-file-or-directory]"
 
 # API Security Review -- OWASP API Security Top 10:2023
 
-A structured, repeatable process for reviewing REST and GraphQL APIs against the OWASP API Security Top 10:2023. This skill produces findings mapped to API1 through API10 with associated CWE identifiers, severity ratings, and actionable remediation guidance. It applies to OpenAPI/Swagger specifications, API endpoint source code, GraphQL schemas, and API gateway configurations.
+A structured, repeatable process for reviewing REST, GraphQL, and gRPC APIs against the OWASP API Security Top 10:2023. This skill produces findings mapped to API1 through API10 with associated CWE identifiers, severity ratings, and actionable remediation guidance. It applies to OpenAPI/Swagger specifications, API endpoint source code, GraphQL schemas, protobuf service definitions, webhook receivers, and API gateway configurations.
 
 ---
 
@@ -32,14 +33,42 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 Before analyzing any endpoint, establish a complete inventory of the API surface under review.
 
 1. **Identify the API style** -- REST (OpenAPI/Swagger), GraphQL, gRPC, or hybrid. Each style has distinct attack patterns.
-2. **Catalog all endpoints and operations** -- For REST, list every path and HTTP method. For GraphQL, list all queries, mutations, and subscriptions.
+2. **Catalog all endpoints and operations** -- For REST, list every path and HTTP method. For GraphQL, list all queries, mutations, and subscriptions. For gRPC, list every package, service, method, streaming mode, and reflected service exposure.
 3. **Map authentication mechanisms** -- OAuth 2.0 flows, API keys, JWTs, session cookies, mTLS, or custom tokens. Note which endpoints require authentication and which are public.
 4. **Identify authorization models** -- RBAC, ABAC, ownership-based, or no authorization. Document how object-level and function-level access control decisions are made.
 5. **Catalog data objects** -- List the resources/entities exposed by the API and their sensitivity classification (PII, financial, internal, public).
 6. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, or cost-control mechanisms at the gateway or application layer.
 7. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
+8. **Identify deployment-layer evidence** -- API gateway, WAF, ingress, service mesh, identity provider, and Terraform/Helm/Kubernetes policy that may enforce controls outside application code.
+9. **Identify callback and webhook boundaries** -- Receiver endpoints, raw-body handling, signature algorithms, replay windows, event IDs, provider IP allowlists, and idempotency storage.
 
 > **Gate:** Do not proceed until the API style, authentication model, authorization model, and endpoint inventory are documented. Incomplete scope leads to missed findings.
+
+---
+
+## Discovery Patterns
+
+Use Glob and Grep to build an evidence inventory before reporting findings.
+
+```
+# REST, OpenAPI, and gateway evidence
+Glob: **/*openapi*.{yaml,yml,json}, **/*swagger*.{yaml,yml,json}
+Glob: **/*gateway*.{yaml,yml,json,tf}, **/*kong*.{yaml,yml,json}, **/*envoy*.{yaml,yml,json}
+Glob: **/*ingress*.{yaml,yml}, **/*httproute*.{yaml,yml}, **/*apigee*, **/*cloudflare*.tf
+
+# GraphQL evidence
+Glob: **/*schema*.graphql, **/*.graphql, **/*resolver*.{js,ts,py,go,java,kt,cs}
+Grep: "introspection|persisted|complexity|depthLimit|NoSchemaIntrospectionCustomRule|ApolloServer"
+
+# gRPC evidence
+Glob: **/*.proto, **/buf.yaml, **/buf.gen.yaml, **/prototool.yaml
+Grep: "grpc|Interceptor|UnaryInterceptor|StreamInterceptor|ServerInterceptor|reflection.Register|MaxReceiveMessageSize|MaxSendMessageSize|deadline" in **/*.{go,java,kt,cs,py,ts,js}
+
+# Webhook and upstream callback evidence
+Grep: "webhook|signature|hmac|rawBody|raw body|event_id|idempotency|timestamp|replay" in **/*.{js,ts,py,go,java,kt,cs,rb,php}
+```
+
+Record missing layers as `Not Evaluable` instead of treating absent code-level evidence as a confirmed failure.
 
 ---
 
@@ -92,7 +121,7 @@ The final review output must be structured as follows:
 **API Style:** [REST / GraphQL / gRPC / Hybrid]
 **Specification:** [OpenAPI spec path, if applicable]
 **Date:** [review date]
-**Reviewer:** AI Agent -- api-security skill v1.0.0
+**Reviewer:** AI Agent -- api-security skill v1.0.1
 
 ### Summary
 
@@ -111,6 +140,16 @@ The final review output must be structured as follows:
 
 **Total Findings:** [count]
 **Critical:** [count] | **High:** [count] | **Medium:** [count] | **Low:** [count] | **Info:** [count]
+
+### Evidence Coverage
+
+| Layer | Evidence reviewed | Missing evidence | Impact |
+|---|---|---|---|
+| Application code | [routes/resolvers/services/interceptors] | [none or missing files] | [confirmed findings / partial confidence] |
+| Gateway or ingress | [Kong/Envoy/API Gateway/Ingress/IaC] | [rate limits/JWT/body limits] | [API2/API4 not fully evaluable] |
+| Identity provider | [issuer/audience/client config] | [tenant/realm/azp policy] | [API2 not fully evaluable] |
+| Service mesh | [mTLS/retries/timeouts] | [deadlines/circuit breakers] | [API4/API8 not fully evaluable] |
+| Webhook provider | [signature docs/test events/logs] | [raw body/replay evidence] | [API2/API10 not fully evaluable] |
 
 ### Findings
 
@@ -171,7 +210,7 @@ GraphQL APIs share all ten OWASP API risks with REST but introduce additional at
 }
 ```
 
-**Mitigation:** Disable introspection in production. If introspection is required for internal tooling, restrict it to authenticated internal consumers.
+**Mitigation:** Report unauthenticated public production introspection as a finding. If introspection is authenticated, internal-only, tied to persisted queries, or intentionally public because the schema is already documented, downgrade to informational or no finding based on exposure and compensating controls.
 
 ### Query Depth and Complexity Attacks
 
@@ -201,11 +240,84 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 ---
 
+## gRPC-Specific Considerations
+
+gRPC APIs share OWASP API Top 10 risks but hide them behind protobuf service definitions, generated stubs, interceptors, and service-mesh controls. Do not rely only on HTTP route discovery.
+
+### gRPC Inventory Gates
+
+- List every `.proto` service and method, including unary, client-streaming, server-streaming, and bidirectional-streaming methods.
+- Map each method to an authentication interceptor, authorization policy, and data object or privilege boundary.
+- Confirm whether gRPC reflection is enabled in production and whether it is restricted to authenticated internal users.
+- Record gateway, service mesh, and mTLS evidence separately from application interceptor evidence.
+
+### gRPC Findings to Report
+
+| Condition | OWASP API Risk | Typical Severity |
+|---|---|---|
+| Service methods rely on network location only and have no authn/authz interceptor | API2/API5 | High |
+| Object identifiers in protobuf requests are fetched without caller relationship checks | API1 | High |
+| Reflection is exposed to unauthenticated public clients | API9/API8 | Medium to High |
+| No request/message size limits, stream limits, deadlines, or cancellation handling | API4 | Medium to High |
+| Error details expose stack traces, SQL errors, or internal service names | API8 | Medium |
+| Internal/admin protobuf fields are returned without field-level filtering | API3 | High |
+
+### gRPC Remediation
+
+- Enforce authentication and authorization through unary and stream interceptors, not only through gateway routing.
+- Require mTLS or workload identity for service-to-service APIs and validate caller identity before method execution.
+- Set maximum receive/send message sizes, stream concurrency limits, deadlines, and cancellation handling.
+- Disable or restrict reflection in production.
+- Return sanitized status codes and structured errors without internal stack traces or implementation details.
+
+---
+
+## Webhook Receiver Security
+
+Webhook receivers are API boundaries even when the organization did not initiate the request. Treat provider callbacks as untrusted until integrity, freshness, and idempotency are proven.
+
+### Webhook Evidence Gates
+
+- Receiver preserves the exact raw request body used by the provider signature algorithm.
+- HMAC, asymmetric signature, mTLS, or equivalent provider authentication is verified before processing.
+- Timestamp freshness is enforced with a small replay window.
+- Event IDs are deduplicated in durable storage before side effects occur.
+- Provider IP allowlists, if used, are supplemental and not the only authentication control.
+- Malformed, unsigned, stale, duplicate, or unknown-event requests fail closed.
+
+### Webhook Findings to Report
+
+| Condition | OWASP API Risk | Typical Severity |
+|---|---|---|
+| State-changing webhook accepts JSON body with no signature or mTLS verification | API2/API10 | High |
+| Signature verification runs after JSON parsing that mutates the raw body | API2/API10 | Medium to High |
+| No timestamp/replay window or event ID deduplication before side effects | API6/API10 | High |
+| Provider IP allowlist is treated as the only proof of event authenticity | API8/API10 | Medium |
+| Unknown event types are processed by a permissive default branch | API10 | Medium |
+
+---
+
+## Gateway and Service-Mesh Evidence Model
+
+Some controls are intentionally enforced outside application code. Avoid false positives by recording which layer was reviewed and what proof was available.
+
+| Control | Application Evidence | Gateway/Mesh/IdP Evidence | Reporting Rule |
+|---|---|---|---|
+| Rate limits and quotas | Middleware, decorators, resolver cost limits | Kong/Envoy/API Gateway/Cloudflare/Istio policy | `Confirmed missing` only after all relevant layers are reviewed |
+| JWT validation | Library config, middleware, issuer/audience checks | Gateway JWT plugin, IdP app policy | `Not Evaluable` if only code is visible and gateway terminates auth |
+| Request/body/message limits | Parser limits, gRPC max message size | Gateway body limits, mesh circuit breakers | Confirm limit alignment across layers before marking pass |
+| CORS and PNA | App headers | Gateway response-header policy | Gateway-only evidence can be valid if clients cannot bypass it |
+| mTLS | App client cert handling | Mesh policy, workload identity, SPIFFE/SPIRE | Record which callers and namespaces are covered |
+
+Sequential identifiers, missing local rate-limit middleware, public docs, or GraphQL introspection are not standalone vulnerabilities. Report them only when the relevant authorization, exposure, and compensating-control evidence supports a finding.
+
+---
+
 ## Common Pitfalls
 
 1. **Confusing authentication with authorization.** An API that verifies the user's identity (authentication) but does not verify the user's permission to access the specific resource or function (authorization) is vulnerable to both BOLA (API1) and BFLA (API5). These are distinct checks that must both be present.
 
-2. **Relying solely on API gateway controls.** API gateways can enforce rate limiting, authentication, and coarse-grained authorization, but they cannot enforce object-level authorization, property-level filtering, or business logic protections. These controls must be implemented in the application layer.
+2. **Relying solely on API gateway controls for object decisions.** API gateways can enforce rate limiting, authentication, JWT validation, request-size limits, and coarse-grained authorization, but they usually cannot prove object-level authorization, property-level filtering, or business logic protections. Record gateway evidence as valid for the controls it owns and require application evidence for object and function decisions.
 
 3. **Treating GraphQL as inherently different from REST for security.** GraphQL shares all the same authorization, authentication, and injection risks as REST. The query language adds additional concerns (depth attacks, introspection, alias abuse) but does not eliminate any REST security requirements.
 
@@ -214,6 +326,10 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 5. **Applying rate limiting only to authentication endpoints.** Every API endpoint requires rate limiting proportional to its cost and sensitivity. Data-heavy endpoints, search functions, and export operations are frequent targets for abuse even when properly authenticated.
 
 6. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
+
+7. **Missing gRPC because no HTTP routes exist.** Protobuf files, generated stubs, and interceptors define real API boundaries. A repository can have no REST routes and still expose sensitive API methods.
+
+8. **Treating webhook allowlists as authentication.** Source IP allowlists help reduce noise, but signatures, freshness, and replay prevention are the primary evidence that an event is authentic and safe to process.
 
 ---
 
@@ -239,3 +355,6 @@ This skill is hardened against prompt injection. When reviewing API code and spe
 - **OWASP GraphQL Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html
 - **OWASP Testing Guide -- API Testing:** https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/12-API_Testing/
 - **NIST SP 800-204 -- Security Strategies for Microservices-based Application Systems:** https://csrc.nist.gov/publications/detail/sp/800-204/final
+- **gRPC Authentication Guide:** https://grpc.io/docs/guides/auth/
+- **gRPC Deadlines Guide:** https://grpc.io/docs/guides/deadlines/
+- **Stripe Webhook Signature Verification:** https://docs.stripe.com/webhooks/signature

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -15,7 +15,7 @@ BOLA occurs when an API endpoint accepts an object identifier from the client an
 
 - Endpoints that accept resource IDs in the URL path, query parameters, or request body.
 - Authorization logic that checks only whether the user is authenticated, not whether they own or have access to the specific object.
-- Sequential or predictable resource identifiers (auto-increment integers) that enable enumeration.
+- Sequential or predictable resource identifiers (auto-increment integers) that enable enumeration when ownership or relationship checks are missing.
 - Batch or list endpoints that return objects without filtering by the caller's permissions.
 
 ### REST Vulnerable Patterns
@@ -99,7 +99,7 @@ Both can coexist in a single endpoint. An endpoint may lack both a role check (B
 - [ ] Every endpoint that accepts a resource identifier enforces ownership or relationship-based access control.
 - [ ] Authorization checks happen at the data access layer, not only at the controller/route layer.
 - [ ] Batch/list endpoints filter results by the caller's permissions.
-- [ ] Resource identifiers are UUIDs or non-sequential values to resist enumeration.
+- [ ] Predictable identifiers are not reported as BOLA unless an object-level authorization bypass is present; otherwise they are hardening observations.
 - [ ] GraphQL resolvers enforce authorization on every field that returns sensitive data.
 
 ---
@@ -119,6 +119,8 @@ APIs are particularly susceptible to authentication flaws because they expose ma
 - Missing or weak token rotation -- refresh tokens that never expire or are not rotated on use.
 - Password reset or account recovery flows that leak tokens or allow enumeration.
 - Micro-service-to-service communication without authentication (implicit trust based on network location).
+- gRPC services or methods that rely on private networking but have no unary or stream authentication interceptor.
+- JWT/OAuth token confusion: accepting ID tokens where access tokens are required, accepting tokens from the wrong tenant/environment, or trusting `jku`/`x5u` headers without allowlisting.
 
 ### Vulnerable Patterns
 
@@ -157,6 +159,8 @@ paths:
 - Implement token expiration: access tokens (5-15 minutes), refresh tokens (hours to days with rotation).
 - Use `bcrypt`, `scrypt`, or `Argon2id` for password storage.
 - Authenticate service-to-service calls with mTLS or signed tokens, not network-based trust.
+- For gRPC, enforce authentication in both unary and stream interceptors and verify caller identity before dispatching service methods.
+- Validate OAuth/JWT issuer, audience, authorized party/client, tenant/realm, token type, key source, algorithm, and JWKS cache failure behavior.
 
 ### Review Checklist
 
@@ -166,6 +170,8 @@ paths:
 - [ ] API keys and tokens are transmitted in headers, not query strings.
 - [ ] Refresh tokens are rotated on each use and revocable.
 - [ ] Service-to-service communication is explicitly authenticated.
+- [ ] gRPC unary and stream methods have authentication interceptors or equivalent service-mesh identity enforcement.
+- [ ] OAuth/JWT validation rejects wrong token type, wrong tenant/environment, untrusted `jku`/`x5u`, and fail-open JWKS behavior.
 
 ---
 
@@ -267,12 +273,20 @@ query {
 app.use(express.json()); // Default limit may be very large or unconfigured
 ```
 
+```go
+// VULNERABLE: gRPC server has no message size or deadline enforcement
+s := grpc.NewServer()
+pb.RegisterExportServiceServer(s, &exportServer{})
+```
+
 ### Remediation Guidance
 
 - Implement rate limiting at the API gateway and/or application layer. Use sliding window or token bucket algorithms. Set per-endpoint limits based on expected legitimate usage.
 - Enforce maximum pagination size (e.g., `limit` capped at 100). Default to a reasonable page size (e.g., 20).
 - Set maximum request body sizes (`express.json({ limit: '1mb' })`).
 - For GraphQL: enforce query depth limits (e.g., max depth 5), complexity analysis (weighted field costs), and batch query limits.
+- For gRPC: enforce maximum receive/send message sizes, stream concurrency limits, server-side deadlines/timeouts, and cancellation handling.
+- Treat gateway-enforced limits as valid evidence only when the gateway cannot be bypassed and its route mapping covers the reviewed API operations.
 - Set execution timeouts for database queries and downstream API calls.
 - Implement cost alerts and circuit breakers for operations that trigger billable third-party APIs.
 
@@ -282,6 +296,8 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - [ ] Pagination has a maximum page size enforced server-side.
 - [ ] Request body size limits are configured.
 - [ ] GraphQL queries have depth limits, complexity limits, and batch restrictions.
+- [ ] gRPC methods have message-size, stream, deadline, and cancellation limits.
+- [ ] Gateway, service-mesh, and application limits are aligned; missing local middleware is not a confirmed finding when gateway evidence proves coverage.
 - [ ] Database queries and downstream calls have execution timeouts.
 - [ ] Billable operations have cost controls and alerting.
 
@@ -316,12 +332,21 @@ const resolvers = {
 };
 ```
 
+```javascript
+// VULNERABLE: gRPC method has no method-level authorization
+function deleteUser(call, callback) {
+  users.delete(call.request.userId);
+  callback(null, { deleted: true });
+}
+```
+
 ### Remediation Guidance
 
 - Implement a centralized authorization middleware or policy engine that enforces role/permission checks consistently across all endpoints.
 - Deny by default: every endpoint should require explicit permission grants. Do not rely on "security through obscurity" of admin URL paths.
 - Enforce authorization on every HTTP method independently. A user authorized to `GET` a resource is not automatically authorized to `DELETE` it.
 - In GraphQL, use directive-based or middleware-based authorization on mutations (`@hasRole(role: ADMIN)`).
+- In gRPC, enforce method-level authorization in unary and stream interceptors before dispatching handlers.
 - Regularly audit the endpoint inventory against the authorization policy matrix to detect gaps.
 
 ### Review Checklist
@@ -330,6 +355,7 @@ const resolvers = {
 - [ ] Authorization middleware is centralized and applied consistently.
 - [ ] Each HTTP method on each endpoint has an independent authorization check.
 - [ ] GraphQL mutations enforce role/permission checks in resolvers or directives.
+- [ ] gRPC service methods enforce method-level roles, scopes, and object relationships before side effects.
 - [ ] The authorization policy is deny-by-default; endpoints are inaccessible unless explicitly permitted.
 
 ---
@@ -544,11 +570,22 @@ const data = await enrichmentData.json();
 res.send(`<div class="bio">${data.biography}</div>`);  // Stored XSS via third party
 ```
 
+```javascript
+// VULNERABLE: Webhook updates state before authenticating the event
+app.post('/webhooks/payment', express.json(), async (req, res) => {
+  await markInvoicePaid(req.body.invoice_id);
+  res.sendStatus(204);
+});
+```
+
 ### Remediation Guidance
 
 - Treat all data from external and internal APIs as untrusted input. Validate and sanitize before use.
 - Always enforce TLS certificate validation on outbound connections. Never set `verify=False` or `rejectUnauthorized: false` in production.
 - Validate response schemas from upstream APIs using a schema validator (JSON Schema, Pydantic, Zod).
+- Verify webhook signatures or mTLS before parsing side effects. Preserve the raw request body when the provider signature covers exact bytes.
+- Enforce webhook timestamp freshness and durable event ID deduplication before state changes.
+- Treat provider IP allowlists as supplemental evidence, not a replacement for event authenticity.
 - Implement timeouts, retry limits with backoff, and circuit breakers on all outbound API calls.
 - Restrict redirects on outbound calls. If following redirects, re-validate the destination URL.
 - Use parameterized queries when inserting data from any source, including trusted internal APIs.
@@ -558,5 +595,7 @@ res.send(`<div class="bio">${data.biography}</div>`);  // Stored XSS via third p
 - [ ] Data from all upstream APIs is validated and sanitized before use in queries, rendering, or commands.
 - [ ] TLS certificate validation is enabled on all outbound API calls.
 - [ ] Response schemas from third-party APIs are validated before processing.
+- [ ] Webhook receivers verify signatures/mTLS, timestamp freshness, and event ID deduplication before side effects.
+- [ ] Raw request body handling preserves provider signature semantics.
 - [ ] Outbound calls have timeouts, retry limits, and circuit breakers.
 - [ ] Redirect following is disabled or restricted on outbound HTTP calls.

--- a/skills/appsec/api-security/tests/benign/gateway-rate-limit-evidence.md
+++ b/skills/appsec/api-security/tests/benign/gateway-rate-limit-evidence.md
@@ -1,0 +1,14 @@
+# Gateway Rate Limit Evidence
+
+This fixture should not be reported as confirmed API4 solely because the
+application code lacks local rate-limit middleware.
+
+| Layer | Evidence | Result |
+| --- | --- | --- |
+| Application | Routes call authenticated handlers only | Rate limit not local |
+| Gateway | Kong route `orders-list` enforces `60 requests/minute/user` | Protected at edge |
+| Deployment | Kubernetes NetworkPolicy only permits traffic from Kong to app pods | Gateway bypass not evidenced |
+
+Expected classification: `Present at Gateway`, not a confirmed missing rate
+limit. If gateway bypass is possible or route mapping is incomplete, classify
+the missing evidence explicitly instead of reporting a confirmed finding.

--- a/skills/appsec/api-security/tests/benign/graphql-private-persisted-introspection.md
+++ b/skills/appsec/api-security/tests/benign/graphql-private-persisted-introspection.md
@@ -1,0 +1,16 @@
+# Private Persisted GraphQL Introspection Evidence
+
+This fixture should not be reported as a high-severity GraphQL introspection
+finding.
+
+| Control | Evidence |
+| --- | --- |
+| Exposure | GraphQL endpoint is reachable only through internal VPN and mTLS |
+| Authentication | Developer role is required before introspection is enabled |
+| Query shape | Production clients use persisted queries only |
+| Abuse controls | Depth, complexity, and alias limits are enforced |
+| Documentation | Public schema documentation already exposes non-sensitive types |
+
+Expected classification: informational or no finding, depending on the reviewed
+environment. Resolver-level authorization and sensitive field exposure must
+still be reviewed separately.

--- a/skills/appsec/api-security/tests/vulnerable/graphql-public-introspection-no-limits.js
+++ b/skills/appsec/api-security/tests/vulnerable/graphql-public-introspection-no-limits.js
@@ -1,0 +1,28 @@
+const { ApolloServer, gql } = require("apollo-server");
+
+const typeDefs = gql`
+  type User {
+    id: ID!
+    email: String!
+    role: String!
+  }
+
+  type Query {
+    user(id: ID!): User
+  }
+`;
+
+const resolvers = {
+  Query: {
+    user: (_parent, args, context) => context.db.users.findById(args.id),
+  },
+};
+
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+  introspection: true,
+  playground: true,
+});
+
+server.listen();

--- a/skills/appsec/api-security/tests/vulnerable/grpc-admin-service-no-interceptor.js
+++ b/skills/appsec/api-security/tests/vulnerable/grpc-admin-service-no-interceptor.js
@@ -1,0 +1,18 @@
+const grpc = require("@grpc/grpc-js");
+const protoLoader = require("@grpc/proto-loader");
+
+const packageDefinition = protoLoader.loadSync("admin.proto");
+const adminProto = grpc.loadPackageDefinition(packageDefinition).admin;
+
+const users = new Map();
+
+function deleteUser(call, callback) {
+  users.delete(call.request.userId);
+  callback(null, { deleted: true });
+}
+
+const server = new grpc.Server();
+server.addService(adminProto.AdminService.service, { deleteUser });
+server.bindAsync("0.0.0.0:50051", grpc.ServerCredentials.createInsecure(), () => {
+  server.start();
+});

--- a/skills/appsec/api-security/tests/vulnerable/webhook-without-signature.js
+++ b/skills/appsec/api-security/tests/vulnerable/webhook-without-signature.js
@@ -1,0 +1,15 @@
+const express = require("express");
+
+const app = express();
+app.use(express.json());
+
+async function markInvoicePaid(invoiceId) {
+  console.log(`paid ${invoiceId}`);
+}
+
+app.post("/webhooks/payment", async (req, res) => {
+  await markInvoicePaid(req.body.invoice_id);
+  res.sendStatus(204);
+});
+
+module.exports = app;


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** api-security
**Skill path:** `skills/appsec/api-security/`

### What Was Wrong

Issue #1115 identified four accuracy/coverage gaps in the API security skill:

- gRPC was listed in scope, but the main skill had no gRPC-first discovery, inventory, or interceptor evidence model.
- Webhook receiver authentication and replay protection were under-covered.
- Gateway/service-mesh controls could be misclassified as missing when evidence lived outside application code.
- GraphQL introspection guidance could create false positives for authenticated/internal or persisted-query deployments.

### What This PR Fixes

- Adds main-skill discovery patterns for REST/OpenAPI, GraphQL, gRPC, gateway/ingress, service-mesh, and webhook evidence.
- Adds an `Evidence Coverage` output table so missing gateway, IdP, mesh, or webhook provider evidence is marked `Not Evaluable` instead of overreported.
- Adds gRPC inventory gates and findings for missing authn/authz interceptors, reflection exposure, message/deadline limits, and error leakage.
- Adds webhook receiver gates for raw-body signature verification, timestamp freshness, event ID dedupe, fail-closed handling, and IP allowlist limitations.
- Refines GraphQL introspection and sequential-ID guidance to reduce false positives.
- Expands API2/API4/API5/API10 checklist coverage for JWT/OAuth token confusion, gRPC limits/authz, and webhook authentication/replay controls.

Closes #1115.

### Evidence

**Before:** gRPC and webhook evidence were mostly absent from the main workflow; missing local middleware could be treated as a confirmed issue even when gateway evidence handled the control.

**After:** the skill requires explicit layer evidence and includes concrete vulnerable/benign calibration fixtures:

- `tests/vulnerable/grpc-admin-service-no-interceptor.js`
- `tests/vulnerable/webhook-without-signature.js`
- `tests/vulnerable/graphql-public-introspection-no-limits.js`
- `tests/benign/gateway-rate-limit-evidence.md`
- `tests/benign/graphql-private-persisted-introspection.md`

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing validation still passes

### Validation

- `git diff --check`
- `git diff --cached --check`
- `node --check` on all new JavaScript fixtures
- Required frontmatter sweep across `skills/` and `roles/`
- Markdown fence-balance check across skills/roles and repo docs
- Prompt-injection scan equivalent to repo workflow
- ASCII check for the changed api-security files and fixtures
- Content marker checks for gRPC, webhook, Evidence Coverage, Not Evaluable, introspection, gateway, service mesh, replay, and signature coverage
- Reference URL checks returned HTTP 200 for OWASP API Top 10, OWASP GraphQL Cheat Sheet, gRPC auth/deadlines, and Stripe webhook signature docs

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Payment details can be provided privately after maintainer acceptance.