### PR TITLE
Improve CVE package status gates

### DIFF
--- a/skills/vuln-management/cve-triage/SKILL.md
+++ b/skills/vuln-management/cve-triage/SKILL.md
@@ -12,7 +12,7 @@ phase: [operate, respond]
 frameworks: [CVSS-4.0, SSVC-2.1, CISA-KEV, EPSS]
 difficulty: intermediate
 time_estimate: "10-20min per CVE"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob, WebFetch
@@ -81,6 +81,43 @@ CVE Context Summary:
 - Patch Available:     [Yes (vX.Y.Z+) | No | Workaround Only]
 - Known Aliases:       [Common names, e.g., "Log4Shell", "Heartbleed"]
 ```
+
+### Step 1.5: Vendor Package Status and Backport Evidence
+
+Before assigning an SLA for OS packages, container base images, or distro-managed
+software, verify vendor package status. Do not treat an older upstream version
+string as proof of exposure when the vendor may have backported a security fix.
+
+For each affected package or image, record:
+
+| Evidence field | Required analysis |
+|----------------|-------------------|
+| OS / distro release | Distribution, release, codename, and architecture, such as RHEL 9 x86_64, Ubuntu 22.04, or Debian bookworm. |
+| Source package | Vendor-tracked source package name when different from the scanner's binary package name. |
+| Binary package | Installed binary package name from rpm/dpkg/apk or SBOM evidence. |
+| Installed version | Full version including epoch, release suffix, module stream, and architecture. |
+| Repository origin | Signed vendor security repository, third-party repo, pinned mirror, container base image, or vendored bundle. |
+| Vendor status | Fixed, not affected, vulnerable/needed, deferred/ignored, under investigation, or unknown. |
+| Fixed package / advisory | Fixed version, advisory ID, OVAL/CSAF/VEX reference, and data date. |
+| Asset evidence | Host package database, scanner package record, SBOM component, image digest, or runtime inventory proving what is installed. |
+
+**Backport rule:** A vendor-fixed package with an older upstream version is not
+automatically vulnerable. Accept the fixed status only when the advisory/tracker
+matches the distro release, source package, binary package or product, installed
+epoch/release, and architecture.
+
+**Container rule:** Separate these states before closing or de-escalating a
+container finding:
+
+1. Vendor package status is fixed for the base distro release.
+2. The base image digest contains the fixed package.
+3. The application image was rebuilt from that fixed base image.
+4. The rebuilt image digest is deployed to the runtime environment.
+
+If the vendor fixed the package but the image or host still contains the old
+package release, keep the finding open. If vendor status is unknown or release
+mapping is ambiguous, mark the package-status gate as **Not Evaluable** and do
+not downgrade solely on upstream version comparisons.
 
 ### Step 2: CVSS 4.0 Assessment
 
@@ -302,6 +339,7 @@ The following conditions may justify a longer SLA (document the justification):
 - Affected component is disabled or not deployed in your environment
 - Network segmentation prevents attacker access to the vulnerable system
 - VEX (Vulnerability Exploitability eXchange) status is "not_affected" or "fixed"
+- Vendor package status confirms a fixed or not-affected distro package for the exact OS release, package identity, installed epoch/release, and architecture
 
 ---
 
@@ -312,7 +350,7 @@ Produce a structured report with these exact sections:
 ```markdown
 ## CVE Triage Report: [CVE-YYYY-NNNNN]
 **Date:** [YYYY-MM-DD]
-**Skill:** cve-triage v1.0.0
+**Skill:** cve-triage v1.1.0
 **Frameworks:** CVSS 4.0, SSVC 2.1, EPSS, CISA KEV
 **Reviewer:** AI-assisted (human review required for Immediate/Out-of-Cycle findings)
 
@@ -328,6 +366,19 @@ recommended SLA tier. Lead with the most critical fact.]
 | Affected Software | [Product vX.Y.Z] |
 | Affected Component | [Component] |
 | Patch Available | [Yes/No/Workaround] |
+
+### Vendor Package Status
+| Field | Value |
+|---|---|
+| OS / Distro Release | [Distro release, codename, architecture] |
+| Source Package | [Source package or N/A] |
+| Binary Package | [Binary package or N/A] |
+| Installed Version | [Full version including epoch/release/arch] |
+| Repository Origin | [Vendor security repo / third-party / image / vendored] |
+| Vendor Status | [Fixed / Not affected / Vulnerable-needed / Deferred / Unknown] |
+| Fixed Package / Advisory | [Fixed version, advisory, OVAL/CSAF/VEX URL, data date] |
+| Asset Evidence | [Package DB / SBOM / image digest / runtime inventory] |
+| Package-Status Gate | [Pass / Fail / Not Evaluable] |
 
 ### CVSS 4.0 Assessment
 | Metric Group | Score | Severity |
@@ -368,6 +419,7 @@ recommended SLA tier. Lead with the most critical fact.]
 - **Escalation Factors:** [List any factors that elevated the SLA tier]
 - **De-escalation Factors:** [List any compensating controls or mitigating factors]
 - **Assumptions Made:** [List any assumptions due to missing context]
+- **Package/Image State:** [Vendor fixed / host fixed / image rebuilt / runtime deployed / not evaluable]
 
 ### Risk Acceptance (If Deferring)
 [If the recommendation is Scheduled or Defer, include a risk acceptance template:]
@@ -387,7 +439,10 @@ recommended SLA tier. Lead with the most critical fact.]
 
 ## Batch Triage Mode
 
-When triaging multiple CVEs (e.g., from a scan report), produce a summary table first, then full assessments for Critical and High items only:
+When triaging multiple CVEs (e.g., from a scan report), produce a summary table
+first, then full assessments for Critical and High items only. Split rows by
+distro release, source package, binary package, image digest, and runtime
+deployment when one CVE spans multiple package states.
 
 ```markdown
 ## Vulnerability Triage Summary
@@ -395,18 +450,35 @@ When triaging multiple CVEs (e.g., from a scan report), produce a summary table 
 **Date:** [YYYY-MM-DD]
 **Total CVEs:** [N]
 
-| CVE ID | CVSS 4.0 | EPSS | KEV | SSVC Decision | SLA | Affected System |
-|---|---|---|---|---|---|---|
-| CVE-YYYY-NNNNN | 9.8 Critical | 0.95 | Yes | Immediate | 24h | [System] |
-| CVE-YYYY-NNNNN | 7.5 High | 0.15 | No | Out-of-Cycle | 72h | [System] |
-| CVE-YYYY-NNNNN | 5.3 Medium | 0.02 | No | Scheduled | 30d | [System] |
-| CVE-YYYY-NNNNN | 3.1 Low | 0.001 | No | Defer | 90d | [System] |
+| CVE ID | Package / Image | Vendor Status | Installed / Fixed Version | CVSS 4.0 | EPSS | KEV | SSVC Decision | SLA | Affected System |
+|---|---|---|---|---|---|---|---|---|---|
+| CVE-YYYY-NNNNN | openssh-server / RHEL 9 | Fixed | installed fixed erratum | 9.8 Critical | 0.95 | Yes | Out-of-Cycle | 72h | [System] |
+| CVE-YYYY-NNNNN | app image digest | Vendor fixed, image not rebuilt | old package in runtime image | 7.5 High | 0.15 | No | Out-of-Cycle | 72h | [System] |
+| CVE-YYYY-NNNNN | openssl / Ubuntu 24.04 | Not affected | N/A | 5.3 Medium | 0.02 | No | Defer | 90d | [System] |
 
 ### Priority Order
 1. [CVE with Immediate SLA -- full assessment below]
 2. [CVE with Out-of-Cycle SLA -- full assessment below]
 3. [Remaining CVEs -- scheduled per standard patch cycle]
 ```
+
+---
+
+## Triage Pitfalls
+
+1. **Version-only scanner conclusions.** Enterprise vendors often backport
+security fixes without changing the upstream version. Require vendor advisory,
+OVAL, CSAF, VEX, or distro tracker evidence before marking a distro package
+vulnerable solely because its upstream version appears old.
+
+2. **Ignoring package identity mismatches.** Debian and Ubuntu trackers may use
+source package names while scanners report binary package names. RPM packages
+may include epoch, release suffix, module stream, and architecture. Bind vendor
+status to the exact package identity before de-escalating.
+
+3. **Closing container findings after vendor fix only.** A vendor-fixed base
+package does not remediate an application image until the base image is updated,
+the application image is rebuilt, and the rebuilt digest is deployed.
 
 ---
 
@@ -431,3 +503,14 @@ When triaging multiple CVEs (e.g., from a scan report), produce a summary table 
 - EPSS (FIRST.org): https://www.first.org/epss/
 - EPSS Data & API: https://epss.cyentia.com/
 - NVD (NIST): https://nvd.nist.gov/
+- Red Hat Backporting Security Fixes: https://access.redhat.com/security/updates/backporting/
+- Ubuntu VEX and CVE Status Mapping: https://documentation.ubuntu.com/security/docs/security-updates/vex/
+- Ubuntu CVE Search: https://ubuntu.com/security/cve
+- Debian Security Tracker: https://security-tracker.debian.org/
+
+---
+
+## Changelog
+
+- **1.1.0** -- Added vendor package-status and backport evidence gates for distro-managed packages and container base images.
+- **1.0.0** -- Initial release. CVE triage using CVSS 4.0, SSVC 2.1, EPSS, CISA KEV, SLA assignment, and batch mode.

--- a/skills/vuln-management/cve-triage/tests/benign/rhel-backported-fixed-package.txt
+++ b/skills/vuln-management/cve-triage/tests/benign/rhel-backported-fixed-package.txt
@@ -1,0 +1,8 @@
+CVE: CVE-2024-6387
+Asset: rhel-web-01
+Scanner reason: upstream OpenSSH version appears lower than upstream fixed version
+OS release: Red Hat Enterprise Linux 9
+Installed package: openssh-server-8.7p1-38.el9_4.4.x86_64
+Repository origin: signed RHEL security repository
+Vendor status: fixed by Red Hat advisory
+Expected triage: do not prioritize solely from upstream version string; verify advisory and installed package release.

--- a/skills/vuln-management/cve-triage/tests/vulnerable/container-vendor-fixed-image-not-rebuilt.txt
+++ b/skills/vuln-management/cve-triage/tests/vulnerable/container-vendor-fixed-image-not-rebuilt.txt
@@ -1,0 +1,7 @@
+CVE: CVE-2026-12345
+Image: registry.example.com/app:2026-06-05
+Base image: ubuntu:24.04
+Package: libssl3
+Vendor status: fixed package available in Ubuntu security repository
+Runtime evidence: deployed image digest still contains the old vulnerable package
+Expected triage: keep finding open until base image, application image, and runtime deployment all contain the fixed package.


### PR DESCRIPTION
## Summary

Fixes #1118.

This improves `skills/vuln-management/cve-triage` by adding a vendor package-status gate before SLA assignment for distro-managed packages and container image findings.

Changes included:
- Add Vendor Package Status and Backport Evidence before CVSS/SSVC/SLA decisions.
- Require OS/distro release, source package, binary package, installed version including epoch/release/architecture, repository origin, vendor status, fixed package/advisory, and asset evidence.
- Add backport handling so older upstream versions are not treated as vulnerable without vendor-status evidence.
- Add container-state handling that separates vendor fixed, base image fixed, application image rebuilt, and runtime deployed.
- Extend output and batch triage templates with package/image state and package-status gates.
- Add triage pitfalls for version-only scanner conclusions, package identity mismatches, and closing container findings before rebuild/deploy evidence.
- Add fixtures for a benign RHEL backported fixed package and a vulnerable container where the vendor fixed the package but the deployed image was not rebuilt.

## Validation

- Red-first marker check failed before edits for the new package-status gate terms.
- `rg -n "Vendor Package Status|Backport rule|Container rule|Package-Status Gate|Vendor package status|Version-only scanner conclusions|source package|binary package|image rebuilt" skills/vuln-management/cve-triage/SKILL.md skills/vuln-management/cve-triage/tests -S`
- `git diff --check`
- `git diff --cached --check`
- Required frontmatter sweep across `skills/**/SKILL.md`
- Markdown fence balance check for cve-triage markdown
- ASCII byte scan for changed and untracked files
- Prompt-injection phrase scan for changed cve-triage files
- Source URL checks returned 200 for Red Hat backporting, Ubuntu VEX/status docs, Ubuntu CVE search, and Debian Security Tracker

## Bounty

- Requested bounty tier: Improver Moderate ($100) if accepted.
- Preferred payment method: GitHub Sponsors; PayPal can be provided privately if preferred.
