### PR TITLE
Improve AWS ECR evidence gates

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-AWS-v3.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -103,6 +103,31 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 Produce the final report using the structure defined in the Output Format section.
 
+### Step 8: AWS Container Registry Evidence Gates
+
+If the environment uses Amazon ECR, evaluate repository mutability, scanning, and
+image evidence separately from the CIS Foundations score. CIS AWS Foundations
+does not fully cover ECR supply-chain controls, but these gates materially affect
+deployment integrity and vulnerability visibility.
+
+For each ECR repository, record:
+
+| Evidence field | Required review |
+|----------------|-----------------|
+| Tag mutability | `image_tag_mutability` is `IMMUTABLE`, or mutable tags are justified for a tightly scoped non-production workflow. |
+| Exclusion filters | Any `image_tag_mutability_exclusion_filter` or equivalent exception is documented with owner, scope, and expiry. |
+| Scan on push | Repository-level `scan_on_push` or registry-level scanning rules cover the repository. |
+| Enhanced scanning | Amazon Inspector enhanced ECR scanning is enabled for production repositories, with repository filters reviewed. |
+| Scan freshness | Last image scan completed after the image digest was pushed or rebuilt. |
+| Image digest evidence | Deployments pin immutable image digests, or release evidence binds tags to digests before promotion. |
+| Lifecycle policy | Lifecycle policy retains required forensic rollback images and does not delete the latest fixed digest before deployment. |
+
+**Finding classification:** Mutable production image tags without digest-pinned
+deployment evidence are **High**. No ECR scanning on production repositories is
+**High**. Basic scan-on-push without enhanced scanning is **Medium** for
+production unless risk acceptance documents another scanner. Missing digest or
+scan-freshness evidence is **Medium**.
+
 ---
 
 ## Findings Classification
@@ -145,6 +170,12 @@ Produce the final report using the structure defined in the Output Format sectio
 | 3 | Logging | X/11 | Y | Z | nn% |
 | 4 | Monitoring | X/16 | Y | Z | nn% |
 | 5 | Networking | X/6 | Y | Z | nn% |
+
+### ECR Repository Evidence
+
+| Repository | Tag Mutability | Scan Coverage | Enhanced Scanning | Latest Digest Evidence | Scan Freshness | Lifecycle / Retention | Finding |
+|------------|----------------|---------------|-------------------|------------------------|----------------|-----------------------|---------|
+| [repo] | [Immutable/Mutable/Exception] | [On push/Registry rule/External/None] | [Enabled/Disabled/N/A] | [Digest or release evidence] | [Fresh/Stale/Unknown] | [Policy summary] | [Pass/Finding ID] |
 
 ### Detailed Findings
 
@@ -201,6 +232,15 @@ Produce the final report using the structure defined in the Output Format sectio
 5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
 6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
 
+7. **Assuming ECR tags are immutable by convention.** Docker tags are labels, not
+content identities. Without ECR tag immutability or digest-pinned deployments, a
+previously approved `latest` or release tag can be overwritten after scanning.
+
+8. **Treating scan-on-push as complete vulnerability coverage.** Basic ECR
+scan-on-push can miss repository-wide coverage, stale images, or findings from
+enhanced Inspector scanning. Record whether the scan result is tied to the
+deployed image digest and whether the scan completed after the digest was built.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -225,10 +265,14 @@ Produce the final report using the structure defined in the Output Format sectio
 - AWS CloudTrail Documentation: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/
 - AWS Security Hub: https://docs.aws.amazon.com/securityhub/latest/userguide/
 - AWS VPC Security: https://docs.aws.amazon.com/vpc/latest/userguide/security.html
+- Amazon ECR Image Tag Mutability: https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-tag-mutability.html
+- Amazon ECR Image Scanning: https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html
+- Amazon Inspector ECR Scanning: https://docs.aws.amazon.com/inspector/latest/user/scanning-ecr.html
 - Terraform AWS Provider Documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 
 ---
 
 ## Changelog
 
+- **1.1.0** -- Added ECR tag immutability, repository scanning, enhanced Inspector scanning, image digest, scan freshness, and lifecycle retention evidence gates.
 - **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 (62 recommendations).

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -262,6 +262,71 @@ encrypted = true
 
 ---
 
+## AWS Container Registry Extension -- ECR Evidence Gates
+
+These checks supplement the CIS Foundations benchmark when Amazon ECR
+repositories or container-image deployment evidence are in scope.
+
+### ECR-1 -- Ensure production repositories use tag immutability
+
+**What to look for:**
+
+```hcl
+resource "aws_ecr_repository" "app" {
+  image_tag_mutability = "IMMUTABLE"
+}
+```
+
+Flag production repositories with `image_tag_mutability = "MUTABLE"` unless an
+exception filter, owner, expiry, and release-control rationale are documented.
+
+### ECR-2 -- Ensure repository scanning covers pushed images
+
+**What to look for:**
+
+```hcl
+resource "aws_ecr_repository" "app" {
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+```
+
+Also inspect registry-level scanning configuration:
+
+```hcl
+resource "aws_ecr_registry_scanning_configuration" "registry" {
+  scan_type = "ENHANCED"
+}
+```
+
+### ECR-3 -- Bind scan results to immutable image digests
+
+Require evidence that the image digest deployed to ECS, EKS, Lambda, or another
+runtime was scanned after build. Tags alone are not sufficient for production
+release evidence.
+
+**Grep patterns:**
+
+```
+image_digest
+imageDigest
+sha256:
+aws_ecr_image
+aws_ecr_lifecycle_policy
+image_tag_mutability
+scan_on_push
+aws_ecr_registry_scanning_configuration
+```
+
+### ECR-4 -- Review lifecycle policy retention for rollback and forensics
+
+Lifecycle policies should remove stale images without deleting the latest fixed
+digest needed for deployment rollback, incident response, or forensic
+reconstruction.
+
+---
+
 ## Section 3 -- Logging
 
 Evaluate logging configurations against Section 3 recommendations.

--- a/skills/cloud/aws-review/tests/benign/ecr-immutable-enhanced-scanning.tf
+++ b/skills/cloud/aws-review/tests/benign/ecr-immutable-enhanced-scanning.tf
@@ -1,0 +1,25 @@
+resource "aws_ecr_repository" "app" {
+  name                 = "prod/app"
+  image_tag_mutability = "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_registry_scanning_configuration" "registry" {
+  scan_type = "ENHANCED"
+
+  rule {
+    scan_frequency = "CONTINUOUS_SCAN"
+
+    repository_filter {
+      filter      = "prod/*"
+      filter_type = "WILDCARD"
+    }
+  }
+}
+
+locals {
+  release_image_digest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+}

--- a/skills/cloud/aws-review/tests/vulnerable/ecr-mutable-unscanned-production.tf
+++ b/skills/cloud/aws-review/tests/vulnerable/ecr-mutable-unscanned-production.tf
@@ -1,0 +1,19 @@
+resource "aws_ecr_repository" "app" {
+  name                 = "prod/app"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+}
+
+resource "aws_ecs_task_definition" "app" {
+  family = "prod-app"
+
+  container_definitions = jsonencode([
+    {
+      name  = "app"
+      image = "${aws_ecr_repository.app.repository_url}:latest"
+    }
+  ])
+}


### PR DESCRIPTION
## Summary

Fixes #1204.

This improves `skills/cloud/aws-review` by adding Amazon ECR tag immutability, image scanning, enhanced Inspector scanning, image digest, scan freshness, and lifecycle retention evidence gates.

Changes included:
- Add an AWS Container Registry Evidence Gates step for ECR repositories.
- Add ECR Repository Evidence output fields for tag mutability, scan coverage, enhanced scanning, digest evidence, scan freshness, lifecycle/retention, and findings.
- Add findings classification for mutable production tags, missing scanning, missing digest evidence, and stale scan evidence.
- Extend `benchmark-checklist.md` with ECR-1 through ECR-4 checks.
- Add fixtures for a benign immutable/enhanced-scanning repository and a vulnerable mutable/unscanned production repository deployed by tag.
- Add official AWS ECR and Inspector references.

## Validation

- Red-first marker check failed before edits for the new ECR gate terms.
- `rg -n "ECR Repository Evidence|AWS Container Registry Evidence Gates|image_tag_mutability|scan_on_push|ENHANCED|Inspector enhanced|image digest evidence|scan freshness|lifecycle policy" skills/cloud/aws-review -S`
- `git diff --check`
- `git diff --cached --check`
- Required frontmatter sweep across `skills/**/SKILL.md`
- Markdown fence balance check for aws-review markdown
- ASCII byte scan for changed and untracked files
- Prompt-injection phrase scan for changed aws-review files
- Source URL checks returned 200 for AWS ECR tag mutability, AWS ECR image scanning, and Amazon Inspector ECR scanning docs

## Bounty

- Requested bounty tier: Improver Moderate ($100) if accepted.
- Preferred payment method: GitHub Sponsors; PayPal can be provided privately if preferred.
