### PR TITLE
Improve GCP Cloud Run evidence gates

### DIFF
--- a/skills/cloud/gcp-review/SKILL.md
+++ b/skills/cloud/gcp-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-GCP-v2.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -93,6 +93,32 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 Produce the final report using the structure defined in the Output Format section.
 
+### Step 10: Cloud Run Ingress and Identity Evidence
+
+If Cloud Run services or jobs are present, evaluate them as supplemental
+serverless controls outside the CIS score. Cloud Run exposure depends on both
+network ingress and IAM invoker policy, so record both before classifying a
+service as public or private.
+
+For each Cloud Run service, record:
+
+| Evidence field | Required review |
+|----------------|-----------------|
+| Ingress mode | `INGRESS_TRAFFIC_ALL`, `INGRESS_TRAFFIC_INTERNAL_ONLY`, or `INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER` / equivalent annotation. |
+| Invoker IAM | `roles/run.invoker` bindings, especially `allUsers` or `allAuthenticatedUsers`, with intended-public justification. |
+| Service identity | User-managed runtime service account; avoid default compute service account unless least-privilege evidence exists. |
+| VPC egress | Direct VPC egress or Serverless VPC Access connector settings, egress mode, Shared VPC permissions, firewall, and Cloud NAT evidence. |
+| Image provenance | Artifact Registry image digest, vulnerability scan, Binary Authorization policy, and breakglass audit evidence where used. |
+| Edge controls | Load balancer, serverless NEG, IAP, Cloud Armor, CDN, or API gateway evidence for public paths. |
+| Audit evidence | Admin Activity/Data Access logs or deployment audit entries showing who changed ingress, IAM, image, or service identity. |
+
+**Finding classification:** Public `INGRESS_TRAFFIC_ALL` on admin/internal
+services is **High**. `roles/run.invoker` granted to `allUsers` without an
+intended-public decision is **High**. Default or broadly privileged runtime
+service identity is **High** for production. Missing image digest/provenance or
+Binary Authorization evidence is **Medium**. Missing VPC egress evidence for
+private dependencies is **Medium**.
+
 ---
 
 ## Findings Classification
@@ -137,6 +163,12 @@ Produce the final report using the structure defined in the Output Format sectio
 | 5 | Storage | X | Y | Z | nn% |
 | 6 | Cloud SQL | X | Y | Z | nn% |
 | 7 | BigQuery | X | Y | Z | nn% |
+
+### Cloud Run Evidence
+
+| Service | Region | Ingress | Invoker IAM | Service Identity | VPC Egress | Image Provenance | Edge Controls | Audit Evidence | Finding |
+|---------|--------|---------|-------------|------------------|------------|------------------|---------------|----------------|---------|
+| [service] | [region] | [All/Internal/Internal+LB] | [private/allUsers/other] | [service account] | [connector/direct/none] | [digest/Binauthz/scan] | [LB/IAP/Armor/N/A] | [logs] | [Pass/Finding ID] |
 
 ### Detailed Findings
 
@@ -195,6 +227,16 @@ Produce the final report using the structure defined in the Output Format sectio
 5. **BigQuery dataset-level vs. table-level CMEK.** CIS 7.2 checks table-level encryption, while CIS 7.3 checks the dataset default. Both should be evaluated independently.
 6. **Default compute service account identification.** The default SA follows the pattern `PROJECT_NUMBER-compute@developer.gserviceaccount.com`. Grep for this pattern, not just the string "default."
 
+7. **Treating Cloud Run ingress and IAM as one control.** A service can be
+internet-routable but still require IAM, or internal/load-balancer ingress can
+front an intended public API through edge controls. Review ingress, invoker IAM,
+service identity, and edge path together before assigning severity.
+
+8. **Missing serverless release provenance.** Cloud Run can deploy mutable image
+tags. Production reviews should bind service revisions to immutable image
+digests, vulnerability scan results, Binary Authorization policy, and breakglass
+audit evidence where applicable.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -219,10 +261,16 @@ Produce the final report using the structure defined in the Output Format sectio
 - Google Cloud Audit Logs: https://cloud.google.com/logging/docs/audit
 - Google Cloud VPC Documentation: https://cloud.google.com/vpc/docs
 - Google Cloud SQL Security: https://cloud.google.com/sql/docs/mysql/configure-ssl-instance
+- Cloud Run Ingress Controls: https://cloud.google.com/run/docs/securing/ingress
+- Cloud Run IAM Access Control: https://cloud.google.com/run/docs/securing/managing-access
+- Cloud Run Service Identity: https://cloud.google.com/run/docs/securing/service-identity
+- Cloud Run Direct VPC Egress: https://cloud.google.com/run/docs/configuring/vpc-direct-vpc
+- Cloud Run Binary Authorization: https://cloud.google.com/run/docs/securing/binary-authorization
 - Terraform Google Provider Documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs
 
 ---
 
 ## Changelog
 
+- **1.1.0** -- Added Cloud Run ingress, invoker IAM, service identity, VPC egress, image provenance, Binary Authorization, edge-control, and audit evidence gates.
 - **1.0.0** -- Initial release. Full coverage of CIS Google Cloud Platform Foundation Benchmark v2.0.0 sections 1 through 7.

--- a/skills/cloud/gcp-review/benchmark-checklist.md
+++ b/skills/cloud/gcp-review/benchmark-checklist.md
@@ -259,6 +259,58 @@ Filter: `resource.type="gcs_bucket" AND protoPayload.methodName="storage.setIamP
 
 Filter: `protoPayload.methodName="cloudsql.instances.update" OR protoPayload.methodName="cloudsql.instances.create" OR protoPayload.methodName="cloudsql.instances.delete"`
 
+---
+
+## Cloud Run Supplemental Checklist -- Ingress and Identity
+
+These checks supplement CIS GCP when Cloud Run services or jobs are in scope.
+
+### GCP-RUN-1 -- Record Cloud Run ingress mode and public path
+
+**Terraform patterns:**
+
+```hcl
+resource "google_cloud_run_v2_service" "api" {
+  ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+}
+```
+
+Flag `INGRESS_TRAFFIC_ALL` on admin, worker, or internal services unless the
+service is explicitly intended to be public and edge controls are documented.
+
+### GCP-RUN-2 -- Review invoker IAM separately from ingress
+
+**Grep patterns:**
+
+```
+roles/run.invoker
+member = "allUsers"
+member = "allAuthenticatedUsers"
+google_cloud_run_service_iam_member
+google_cloud_run_v2_service_iam_member
+```
+
+Public `roles/run.invoker` bindings require an intended-public decision,
+service owner, data classification, and compensating edge controls.
+
+### GCP-RUN-3 -- Require least-privilege service identity
+
+Cloud Run services should use a user-managed service account with only required
+roles. Missing `service_account` should be reviewed for default compute service
+account use and inherited broad permissions.
+
+### GCP-RUN-4 -- Validate private dependency egress
+
+Record Direct VPC egress or Serverless VPC Access connector settings, egress
+mode, Shared VPC permissions, firewall rules, and Cloud NAT for services that
+reach private databases, queues, or internal APIs.
+
+### GCP-RUN-5 -- Bind deployment to image provenance
+
+Production services should use immutable Artifact Registry image digests or
+release evidence binding tags to digests. Record vulnerability scan status,
+Binary Authorization policy, and any breakglass justification.
+
 **For each metric (CIS 2.4 through 2.11), also verify an alerting policy exists:**
 
 ```hcl

--- a/skills/cloud/gcp-review/tests/benign/cloud-run-public-via-lb-with-identity.tf
+++ b/skills/cloud/gcp-review/tests/benign/cloud-run-public-via-lb-with-identity.tf
@@ -1,0 +1,30 @@
+resource "google_service_account" "public_api" {
+  account_id   = "public-api"
+  display_name = "Public API runtime identity"
+}
+
+resource "google_cloud_run_v2_service" "public_api" {
+  name     = "public-api"
+  location = "us-central1"
+  ingress  = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+
+  template {
+    service_account = google_service_account.public_api.email
+
+    containers {
+      image = "us-docker.pkg.dev/example/prod/public-api@sha256:def456"
+    }
+
+    vpc_access {
+      egress = "PRIVATE_RANGES_ONLY"
+    }
+  }
+}
+
+resource "google_cloud_run_v2_service_iam_member" "public_invoker" {
+  project  = google_cloud_run_v2_service.public_api.project
+  location = google_cloud_run_v2_service.public_api.location
+  name     = google_cloud_run_v2_service.public_api.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}

--- a/skills/cloud/gcp-review/tests/vulnerable/cloud-run-public-default-identity.tf
+++ b/skills/cloud/gcp-review/tests/vulnerable/cloud-run-public-default-identity.tf
@@ -1,0 +1,19 @@
+resource "google_cloud_run_v2_service" "admin_api" {
+  name     = "admin-api"
+  location = "us-central1"
+  ingress  = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/example/prod/admin-api:latest"
+    }
+  }
+}
+
+resource "google_cloud_run_v2_service_iam_member" "admin_public_invoker" {
+  project  = google_cloud_run_v2_service.admin_api.project
+  location = google_cloud_run_v2_service.admin_api.location
+  name     = google_cloud_run_v2_service.admin_api.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}


### PR DESCRIPTION
## Summary

Fixes #1208.

This improves `skills/cloud/gcp-review` by adding supplemental Cloud Run ingress, invoker IAM, service identity, VPC egress, image provenance, Binary Authorization, edge-control, and audit evidence gates.

Changes included:
- Add Cloud Run Ingress and Identity Evidence as a supplemental GCP review step.
- Add Cloud Run Evidence output fields for service, region, ingress, invoker IAM, service identity, VPC egress, image provenance, edge controls, audit evidence, and findings.
- Add findings classification for public `INGRESS_TRAFFIC_ALL`, unauthenticated `roles/run.invoker`, default/broad runtime identities, missing image provenance, missing Binary Authorization evidence, and missing VPC egress evidence.
- Extend `benchmark-checklist.md` with GCP-RUN-1 through GCP-RUN-5 checks.
- Add fixtures for a benign public API routed through internal load balancer ingress with user-managed service identity and a vulnerable public admin API using default identity and mutable tag.
- Add official Cloud Run references for ingress, IAM access control, service identity, Direct VPC egress, and Binary Authorization.

## Validation

- Red-first marker check failed before edits for the new Cloud Run gate terms.
- `rg -n "Cloud Run Evidence|GCP-RUN|INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER|roles/run.invoker|service identity|Binary Authorization|Direct VPC egress|VPC connector|allUsers" skills/cloud/gcp-review -S`
- `git diff --check`
- `git diff --cached --check`
- Required frontmatter sweep across `skills/**/SKILL.md`
- Markdown fence balance check for gcp-review markdown
- ASCII byte scan for changed and untracked files
- Prompt-injection phrase scan for changed gcp-review files
- Source URL checks returned 200 for Cloud Run ingress, IAM access control, service identity, Direct VPC egress, and Binary Authorization docs

## Bounty

- Requested bounty tier: Improver Moderate ($100) if accepted.
- Preferred payment method: GitHub Sponsors; PayPal can be provided privately if preferred.
