### PR TITLE
Improve Azure ACR evidence gates

### DIFF
--- a/skills/cloud/azure-review/SKILL.md
+++ b/skills/cloud/azure-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-Azure-v2.1.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -95,6 +95,32 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, Bic
 
 Produce the final report using the structure defined in the Output Format section.
 
+### Step 12: Azure Container Registry Evidence Gates
+
+If Azure Container Registry (ACR) resources are present, evaluate registry
+authentication, network exposure, private endpoint reachability, scanning, and
+token scope as supplemental controls outside the CIS score.
+
+For each registry, record:
+
+| Evidence field | Required review |
+|----------------|-----------------|
+| Admin account | `admin_enabled = false`, or documented exception with owner, expiry, and migration plan. |
+| Public network access | `public_network_access_enabled = false` with Private Link, or public endpoint with default-deny firewall and explicit allowed IP ranges. |
+| Trusted services bypass | `network_rule_bypass_option` / trusted services access is documented for Defender, build, or import workflows. |
+| Private endpoint evidence | Private endpoint, subresource `registry`, private DNS zone/link, and build-agent or AKS reachability evidence. |
+| Identity and RBAC scope | Managed identity, service principal, or workload identity has only required `AcrPull`/`AcrPush` scope at the registry or repository boundary. |
+| Repository-scoped tokens | Scope maps list allowed actions, owner, rotation, and expiry for non-Entra clients. |
+| Defender image scanning | Defender for Containers or equivalent scanner covers the registry after network restrictions are applied. |
+| Retention and controls | Retention, quarantine, soft delete, export policy, and content trust are calibrated to workload sensitivity. |
+
+**Finding classification:** Enabled production ACR admin account is **High**.
+Public network access without firewall default-deny or private endpoint evidence
+is **High**. Broad `AcrPush`/`AcrDelete` at subscription or resource-group scope
+is **High**. Missing Defender image scanning evidence for production registries
+is **Medium**. Missing private DNS or build-agent reachability evidence for a
+private registry is **Medium**.
+
 ---
 
 ## Findings Classification
@@ -141,6 +167,12 @@ Produce the final report using the structure defined in the Output Format sectio
 | 7 | Virtual Machines | X | Y | Z | nn% |
 | 8 | Key Vault | X | Y | Z | nn% |
 | 9 | App Service | X | Y | Z | nn% |
+
+### Azure Container Registry Evidence
+
+| Registry | Admin Account | Network Access | Private Endpoint / DNS | Identity / RBAC | Token Scope | Scanning Coverage | Retention / Export Controls | Finding |
+|----------|---------------|----------------|------------------------|-----------------|-------------|-------------------|-----------------------------|---------|
+| [registry] | [Disabled/Enabled/Exception] | [Private/Public restricted/Public all] | [Evidence] | [AcrPull/AcrPush scope] | [Scope map/None] | [Defender/External/None] | [Policy summary] | [Pass/Finding ID] |
 
 ### Detailed Findings
 
@@ -201,6 +233,16 @@ Produce the final report using the structure defined in the Output Format sectio
 5. **Key Vault purge protection is irreversible.** CIS 8.5 requires `purge_protection_enabled = true`. Note this cannot be disabled once enabled -- flag this for awareness during remediation.
 6. **App Service TLS version on both Linux and Windows.** Check `azurerm_linux_web_app` and `azurerm_windows_web_app` resources separately.
 
+7. **Treating ACR admin credentials as ordinary app secrets.** The ACR admin
+account is a shared registry credential. Production registries should use Entra
+identities, managed identities, service principals, workload identity, or
+repository-scoped tokens with narrow scope and rotation evidence.
+
+8. **Assuming private endpoint presence proves registry privacy.** A private
+endpoint must be paired with disabled or restricted public network access,
+private DNS, and build-agent/AKS reachability evidence. Otherwise teams may
+break scanning or still leave public pull paths available.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -225,10 +267,16 @@ Produce the final report using the structure defined in the Output Format sectio
 - Azure Storage Security: https://learn.microsoft.com/en-us/azure/storage/common/storage-security-guide
 - Azure Key Vault Best Practices: https://learn.microsoft.com/en-us/azure/key-vault/general/best-practices
 - Azure App Service Security: https://learn.microsoft.com/en-us/azure/app-service/overview-security
+- Azure Container Registry Authentication: https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication
+- Azure Container Registry Private Link: https://learn.microsoft.com/en-us/azure/container-registry/container-registry-private-endpoints
+- Azure Container Registry Public Network Rules: https://learn.microsoft.com/en-us/azure/container-registry/container-registry-access-selected-networks
+- Azure Container Registry Token Permissions: https://learn.microsoft.com/en-us/azure/container-registry/container-registry-token-based-repository-permissions
+- Defender Image Scanning for ACR: https://learn.microsoft.com/en-us/azure/container-registry/scan-images-defender
 - Terraform AzureRM Provider Documentation: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
 
 ---
 
 ## Changelog
 
+- **1.1.0** -- Added Azure Container Registry admin account, private network, private endpoint/DNS, RBAC, repository-scoped token, Defender scanning, and retention evidence gates.
 - **1.0.0** -- Initial release. Full coverage of CIS Microsoft Azure Foundations Benchmark v2.1.0 sections 1 through 9.

--- a/skills/cloud/azure-review/benchmark-checklist.md
+++ b/skills/cloud/azure-review/benchmark-checklist.md
@@ -266,6 +266,68 @@ resource "azurerm_storage_account" {
 }
 ```
 
+---
+
+## Azure Container Registry Supplemental Checklist
+
+These controls supplement CIS Azure when Azure Container Registry resources are
+in scope.
+
+### ACR-REG-1 -- Disable the registry admin account
+
+**Terraform pattern:**
+
+```hcl
+resource "azurerm_container_registry" "prod" {
+  admin_enabled = false
+}
+```
+
+Flag `admin_enabled = true` for production unless there is a documented
+exception with owner, expiry, and migration to Entra identity or scoped tokens.
+
+### ACR-REG-2 -- Restrict public network access or require default-deny rules
+
+**Terraform patterns:**
+
+```hcl
+resource "azurerm_container_registry" "prod" {
+  sku                           = "Premium"
+  public_network_access_enabled = false
+  network_rule_bypass_option    = "AzureServices"
+}
+```
+
+For public endpoints, require default-deny network rules and exact allowed IP
+ranges. Document trusted-services bypass when required for Defender or build
+workflows.
+
+### ACR-REG-3 -- Verify Private Link, DNS, and build-agent reachability
+
+```hcl
+resource "azurerm_private_endpoint" "acr" {
+  private_service_connection {
+    private_connection_resource_id = azurerm_container_registry.prod.id
+    subresource_names              = ["registry"]
+  }
+}
+```
+
+Require private DNS zone/link evidence and AKS, build-agent, or deployment
+runner reachability tests for private registries.
+
+### ACR-REG-4 -- Scope registry identities and repository tokens
+
+Review `AcrPull`, `AcrPush`, `AcrDelete`, scope maps, and tokens. Broad write or
+delete rights at subscription/resource-group scope should be treated as high
+risk for production registries.
+
+### ACR-REG-5 -- Preserve Defender image scanning coverage
+
+Network-restricted registries still need Defender for Containers or equivalent
+image scanning evidence. Record scan source, last successful scan time, and
+whether trusted-services access is needed after public access is disabled.
+
 ### CIS 3.12 -- Ensure Storage for Critical Data are Encrypted with Customer Managed Keys
 
 Check for CMK encryption on storage accounts containing sensitive data:

--- a/skills/cloud/azure-review/tests/benign/acr-private-admin-disabled.tf
+++ b/skills/cloud/azure-review/tests/benign/acr-private-admin-disabled.tf
@@ -1,0 +1,29 @@
+resource "azurerm_container_registry" "prod" {
+  name                          = "prodacr"
+  resource_group_name           = azurerm_resource_group.prod.name
+  location                      = azurerm_resource_group.prod.location
+  sku                           = "Premium"
+  admin_enabled                 = false
+  public_network_access_enabled = false
+  network_rule_bypass_option    = "AzureServices"
+}
+
+resource "azurerm_private_endpoint" "acr" {
+  name                = "prod-acr-pe"
+  resource_group_name = azurerm_resource_group.prod.name
+  location            = azurerm_resource_group.prod.location
+  subnet_id           = azurerm_subnet.private_endpoints.id
+
+  private_service_connection {
+    name                           = "prod-acr"
+    is_manual_connection           = false
+    private_connection_resource_id = azurerm_container_registry.prod.id
+    subresource_names              = ["registry"]
+  }
+}
+
+resource "azurerm_role_assignment" "aks_can_pull_acr" {
+  scope                = azurerm_container_registry.prod.id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_user_assigned_identity.aks_pull.principal_id
+}

--- a/skills/cloud/azure-review/tests/vulnerable/acr-admin-public-broad-push.tf
+++ b/skills/cloud/azure-review/tests/vulnerable/acr-admin-public-broad-push.tf
@@ -1,0 +1,14 @@
+resource "azurerm_container_registry" "prod" {
+  name                          = "prodacr"
+  resource_group_name           = azurerm_resource_group.prod.name
+  location                      = azurerm_resource_group.prod.location
+  sku                           = "Premium"
+  admin_enabled                 = true
+  public_network_access_enabled = true
+}
+
+resource "azurerm_role_assignment" "ci_push_all" {
+  scope                = azurerm_resource_group.prod.id
+  role_definition_name = "AcrPush"
+  principal_id         = azuread_service_principal.ci.object_id
+}


### PR DESCRIPTION
## Summary

Fixes #1206.

This improves `skills/cloud/azure-review` by adding supplemental Azure Container Registry gates for admin account state, public/private network posture, Private Link/DNS evidence, identity/RBAC scope, repository-scoped tokens, Defender image scanning, and retention controls.

Changes included:
- Add Azure Container Registry Evidence Gates as a supplemental Azure review step.
- Add Azure Container Registry Evidence output fields for admin account, network access, private endpoint/DNS, identity/RBAC, token scope, scanning coverage, retention/export controls, and findings.
- Add findings classification for enabled production admin account, unrestricted public access, broad `AcrPush`/`AcrDelete`, missing Defender scanning evidence, and missing private DNS/build-agent reachability evidence.
- Extend `benchmark-checklist.md` with ACR-REG-1 through ACR-REG-5 checks.
- Add fixtures for a benign private/admin-disabled registry with scoped `AcrPull` and a vulnerable public/admin-enabled registry with broad `AcrPush`.
- Add official Microsoft references for ACR authentication, Private Link, selected networks, token permissions, and Defender image scanning.

## Validation

- Red-first marker check failed before edits for the new ACR gate terms.
- `rg -n "ACR Evidence|ACR-REG|azurerm_container_registry|admin_enabled|network_rule_bypass_option|repository-scoped token|Defender image scanning|Container Registry Private Link|AcrPush" skills/cloud/azure-review -S`
- `git diff --check`
- `git diff --cached --check`
- Required frontmatter sweep across `skills/**/SKILL.md`
- Markdown fence balance check for azure-review markdown
- ASCII byte scan for changed and untracked files
- Prompt-injection phrase scan for changed azure-review files
- Source URL checks returned 200 for ACR authentication, Private Link, selected networks, token permissions, and Defender image scanning docs

## Bounty

- Requested bounty tier: Improver Moderate ($100) if accepted.
- Preferred payment method: GitHub Sponsors; PayPal can be provided privately if preferred.
