### PR TITLE
Improve container debug evidence gates

### DIFF
--- a/skills/cloud/container-security/SKILL.md
+++ b/skills/cloud/container-security/SKILL.md
@@ -13,7 +13,7 @@ phase: [build, deploy, operate]
 frameworks: [CIS-Docker-v1.6.0, CIS-Kubernetes-v1.9.0, NIST-SP-800-190]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -120,6 +120,30 @@ For detailed CIS benchmark checklist items, NIST SP 800-190 countermeasure table
 
 Produce the final report using the structure defined in the Output Format section.
 
+### Step 8: Ephemeral Debug Container Evidence
+
+Kubernetes Pod Security Standards apply to regular containers, init containers,
+and `spec.ephemeralContainers[*]`. Inventory all three container arrays before
+declaring a workload Baseline or Restricted compliant.
+
+For each workload or live pod, record:
+
+| Evidence field | Required review |
+|----------------|-----------------|
+| Container coverage | `containers`, `initContainers`, and `ephemeralContainers` were all checked. |
+| PSS parity | Ephemeral containers meet the same Restricted controls: no privileged mode, no privilege escalation, drop capabilities, non-root, seccomp, and approved volume use. |
+| Debug image policy | Debug images are approved, pinned by digest, scanned, and pulled from trusted registries. |
+| RBAC subresource | `pods/ephemeralcontainers` create/update/patch permissions are limited to approved breakglass or SRE roles. |
+| Admission coverage | Pod Security Admission, Kyverno, Gatekeeper, or equivalent policies cover the `pods/ephemeralcontainers` subresource. |
+| Audit evidence | Kubernetes audit logs capture updates to `pods/ephemeralcontainers`, including actor, namespace, pod, image, and justification. |
+
+**Finding classification:** Privileged or root ephemeral debug containers in
+production are **Critical** when paired with host namespace, hostPath, or
+dangerous capabilities, otherwise **High**. Missing RBAC/admission/audit evidence
+for runtime debug containers is **Medium**. A Restricted-compliant debug workflow
+with approved pinned images and audited breakglass access can pass with
+documentation.
+
 ---
 
 ## Findings Classification
@@ -163,6 +187,18 @@ Produce the final report using the structure defined in the Output Format sectio
 | Secrets Management | CIS K8s 5.4.x | X | X | X | X | X |
 | Runtime Hardening | NIST 800-190 | X | X | X | X | X |
 | Control Plane | CIS K8s 1.x-4.x | X | X | X | X | X |
+
+### Container Coverage Matrix
+
+| Workload | Namespace | Regular Containers | Init Containers | Ephemeral Containers | Coverage Status |
+|----------|-----------|--------------------|-----------------|----------------------|-----------------|
+| [workload] | [namespace] | [N checked] | [N checked / N/A] | [N checked / runtime evidence / Not Evaluable] | [Complete/Partial] |
+
+### Ephemeral Debug Container Evidence
+
+| Workload / Pod | Namespace | Debug Image | PSS Controls | RBAC Subresource | Admission Coverage | Audit Evidence | Finding |
+|----------------|-----------|-------------|--------------|------------------|--------------------|----------------|---------|
+| [pod] | [namespace] | [image digest] | [Restricted/Baseline/Fail] | [role evidence] | [policy evidence] | [audit event] | [Pass/Finding ID] |
 
 ### Detailed Findings
 
@@ -258,6 +294,16 @@ Produce the final report using the structure defined in the Output Format sectio
 6. **Network policies are additive, not subtractive.** A default-deny policy must be explicitly created. Without it, all pod-to-pod traffic is allowed regardless of other NetworkPolicy resources.
 7. **Distroless images have no shell.** While this is excellent for security, note that debugging requires ephemeral containers (`kubectl debug`). Flag this as a consideration, not a problem.
 
+8. **Reviewing only `containers` and `initContainers`.** Ephemeral containers can
+be added after pod creation through the `pods/ephemeralcontainers` subresource.
+PSS checks, RBAC, admission policy, and audit logging must cover that runtime
+debug path.
+
+9. **Treating all debug workflows as privileged.** A distroless workload may have
+a legitimate debug-container process. The review should require approved pinned
+debug images, Restricted security context, scoped RBAC, admission controls, and
+audit evidence instead of blanket-failing all ephemeral containers.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -283,6 +329,7 @@ Produce the final report using the structure defined in the Output Format sectio
 - NIST SP 800-190 Application Container Security Guide: https://csrc.nist.gov/publications/detail/sp/800-190/final
 - Kubernetes Pod Security Standards: https://kubernetes.io/docs/concepts/security/pod-security-standards/
 - Kubernetes Pod Security Admission: https://kubernetes.io/docs/concepts/security/pod-security-admission/
+- Kubernetes Ephemeral Containers: https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/
 - Kubernetes Network Policies: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 - Kubernetes RBAC: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 - Docker Security Best Practices: https://docs.docker.com/develop/security-best-practices/
@@ -293,4 +340,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.1.0** -- Added ephemeral debug container PSS coverage, RBAC/admission/audit evidence gates, container coverage matrix, and benign/vulnerable debug-container fixtures.
 - **1.0.0** -- Initial release. Full coverage of CIS Docker Benchmark v1.6.0 Section 4-5, CIS Kubernetes Benchmark v1.9.0 Sections 1-5, and NIST SP 800-190 countermeasures across all five risk categories.

--- a/skills/cloud/container-security/cis-benchmarks.md
+++ b/skills/cloud/container-security/cis-benchmarks.md
@@ -264,6 +264,16 @@ Evaluate workload configurations against Kubernetes Pod Security Standards. The 
 | **Baseline** | Minimally restrictive. Prevents known privilege escalations. | Standard workloads |
 | **Restricted** | Heavily restricted. Follows current hardening best practices. | Security-sensitive and untrusted workloads |
 
+**Container coverage requirement:** Apply every Pod Security Standards check to:
+
+- `spec.containers[*]`
+- `spec.initContainers[*]`
+- `spec.ephemeralContainers[*]`
+
+If only workload manifests are available and runtime ephemeral-container
+evidence is missing, mark ephemeral debug container coverage as **Not
+Evaluable** rather than passing the workload.
+
 #### CIS 5.2.1 -- Ensure that the cluster has at least one active policy control mechanism installed
 
 Check for Pod Security Admission labels on namespaces:
@@ -294,6 +304,15 @@ spec:
 ```
 
 **Grep pattern:** `privileged: true`
+
+Also check `ephemeralContainers`:
+
+```yaml
+ephemeralContainers:
+  - name: debug
+    securityContext:
+      privileged: true  # CRITICAL/HIGH FAIL
+```
 
 #### CIS 5.2.3 -- Minimize the admission of containers wishing to share the host process ID namespace
 
@@ -331,6 +350,8 @@ spec:
 ```
 
 **Grep pattern:** Check for absence of `allowPrivilegeEscalation: false` on all containers.
+
+Include `spec.ephemeralContainers[*].securityContext.allowPrivilegeEscalation`.
 
 #### CIS 5.2.7 -- Minimize the admission of root containers
 
@@ -377,6 +398,33 @@ securityContext:
   capabilities:
     drop: ["ALL"]
     add: ["NET_BIND_SERVICE"]  # Only if needed for ports < 1024
+```
+
+Ephemeral debug containers must not add broad capabilities such as `SYS_ADMIN`,
+`SYS_PTRACE`, or `NET_ADMIN` unless a documented breakglass exception, admission
+approval, and audit trail exist.
+
+### CIS 5.2 Debug Container Evidence Gate
+
+Review ephemeral containers and runtime debug paths:
+
+| Evidence | Pass condition |
+|----------|----------------|
+| Static manifests | `spec.ephemeralContainers` absent or Restricted-compliant when present. |
+| RBAC | `pods/ephemeralcontainers` update/patch rights limited to approved operational roles. |
+| Admission | PSA/Kyverno/Gatekeeper policies cover ephemeral container subresource updates. |
+| Audit | Audit policy logs `pods/ephemeralcontainers` changes with actor, namespace, pod, image, and reason. |
+| Debug images | Images are approved, scanned, and pinned by digest. |
+
+**Grep patterns:**
+
+```
+ephemeralContainers:
+pods/ephemeralcontainers
+kubectl debug
+SYS_ADMIN
+allowPrivilegeEscalation: true
+privileged: true
 ```
 
 #### CIS 5.2.11 -- Minimize the admission of Windows HostProcess containers

--- a/skills/cloud/container-security/tests/benign/restricted-ephemeral-debug.yaml
+++ b/skills/cloud/container-security/tests/benign/restricted-ephemeral-debug.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: checkout-api
+  namespace: production
+spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: app
+      image: registry.example.com/checkout-api@sha256:1111111111111111111111111111111111111111111111111111111111111111
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        capabilities:
+          drop: ["ALL"]
+        seccompProfile:
+          type: RuntimeDefault
+  ephemeralContainers:
+    - name: node-debug
+      image: registry.example.com/debug-tools@sha256:2222222222222222222222222222222222222222222222222222222222222222
+      targetContainerName: app
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 1000
+        capabilities:
+          drop: ["ALL"]
+        seccompProfile:
+          type: RuntimeDefault

--- a/skills/cloud/container-security/tests/vulnerable/privileged-ephemeral-debug.yaml
+++ b/skills/cloud/container-security/tests/vulnerable/privileged-ephemeral-debug.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: checkout-api
+  namespace: production
+spec:
+  containers:
+    - name: app
+      image: registry.example.com/checkout-api@sha256:3333333333333333333333333333333333333333333333333333333333333333
+      securityContext:
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        seccompProfile:
+          type: RuntimeDefault
+  ephemeralContainers:
+    - name: node-debug
+      image: busybox:1.36
+      targetContainerName: app
+      securityContext:
+        privileged: true
+        runAsUser: 0
+        allowPrivilegeEscalation: true
+        capabilities:
+          add: ["SYS_ADMIN"]


### PR DESCRIPTION
Fixes #1191

## Summary
- add an ephemeral debug container evidence step to the container-security skill
- require PSS coverage across `containers`, `initContainers`, and `ephemeralContainers`
- add RBAC, admission, audit, and debug image evidence gates for `pods/ephemeralcontainers`
- extend CIS benchmark guidance with a debug-container evidence gate and grep patterns
- add benign and vulnerable Kubernetes fixtures for restricted and privileged ephemeral debug workflows

## Validation
- red-first marker check before edits confirmed the evidence gate was absent
- `rg -n "Ephemeral Debug Container Evidence|pods/ephemeralcontainers|ephemeralContainers\[\*\]|debug image policy|ephemeral container|Container Coverage Matrix|SYS_ADMIN" skills/cloud/container-security -S`
- `git diff --check`
- frontmatter sweep across `skills/**/SKILL.md`
- Markdown fence balance check for `skills/cloud/container-security/**/*.md`
- ASCII scan for changed and untracked files
- prompt-injection phrase scan for changed container-security files
- official reference checks returned HTTP 200 for Kubernetes Pod Security Standards and Kubernetes Ephemeral Containers

## Bounty
Requested as an Improver Moderate submission for the $100 bounty. Preferred payment method: GitHub Sponsors.
