### PR TITLE
fix(skill): add JWT JOSE validation evidence gates

### DIFF
--- a/skills/appsec/secure-code-review/SKILL.md
+++ b/skills/appsec/secure-code-review/SKILL.md
@@ -173,6 +173,71 @@ Remediation: Use the framework's built-in session management (e.g., `HttpSession
 - [ ] Brute-force protections (rate limiting, account lockout, CAPTCHA) are in place for login.
 - [ ] Password storage uses a memory-hard hash (bcrypt, scrypt, or Argon2id).
 
+### 3.4 JWT/JOSE Token Validation
+
+JWTs are often used as authentication, authorization, session, API, and service-to-service tokens. Treat a JWT library call as a security boundary only after verifying both the cryptographic validation and the claim-validation rules used by the application.
+
+**Controls to verify:**
+
+- Signature verification happens before any JWT claim is trusted for authentication, authorization, tenant selection, account lookup, or role assignment.
+- Accepted algorithms are explicitly pinned per issuer and key. Reject `none`, and do not mix symmetric (`HS*`) and asymmetric (`RS*`, `ES*`, `EdDSA`) algorithms for the same verifier/key selection path.
+- Claims are validated for the token type and trust context: `iss`, `aud`, `exp`, `nbf`, and `iat`. For OpenID Connect ID tokens, validate `nonce` when it was sent in the authentication request.
+- The key source is trusted. Do not fetch `jku` or `x5u` from arbitrary token headers; use configured or allowlisted JWKS endpoints for trusted issuers.
+- `kid` is validated or sanitized before database, filesystem, cache, or LDAP lookup. Do not concatenate raw `kid` values into paths or queries.
+- ID tokens, access tokens, refresh tokens, session JWTs, and service tokens have mutually exclusive validation rules so one token type cannot be replayed in another context.
+
+**Vulnerable patterns by language:**
+
+**JavaScript -- Unverified JWT Claims**
+```javascript
+// VULNERABLE: decoded claims are trusted without verification
+app.get("/admin", (req, res) => {
+  const raw = req.headers.authorization?.replace("Bearer ", "");
+  const claims = jwt.decode(raw);
+
+  if (claims.role === "admin") {
+    return res.json({ secret: process.env.ADMIN_DATA });
+  }
+
+  res.status(403).end();
+});
+```
+Remediation: Use `jwt.verify()` or framework middleware that validates signature, issuer, audience, expiry, and allowed algorithms before exposing claims to route handlers.
+
+**JavaScript -- Attacker-Controlled Key Selection**
+```javascript
+// VULNERABLE: token header controls remote key fetch and local key lookup
+jwt.verify(token, getKeyFromHeader, { algorithms: ["HS256", "RS256"] });
+
+function getKeyFromHeader(header, callback) {
+  if (header.jku) {
+    return fetch(header.jku)
+      .then((response) => response.json())
+      .then((jwks) => callback(null, jwks.keys[0]));
+  }
+
+  return fs.readFile(`/keys/${header.kid}.pem`, "utf8", callback);
+}
+```
+Remediation: Resolve keys from trusted issuer configuration only, allowlist JWKS URLs, pin algorithms per issuer/key, and validate `kid` before lookup.
+
+**Python -- Verification Disabled**
+```python
+# VULNERABLE: claims are later trusted after signature verification is disabled
+claims = jwt.decode(token, options={"verify_signature": False})
+user = db.users.find_one({"email": claims["email"]})
+```
+Remediation: Decode with a trusted key and explicit options such as expected issuer, audience, and algorithms before using claims in trust decisions.
+
+**Review checklist:**
+
+- [ ] No code path uses `jwt.decode`, `verify_signature: false`, or equivalent unverified parsing for a trust decision.
+- [ ] Token validation pins algorithms and does not allow algorithm confusion between HMAC and asymmetric algorithms.
+- [ ] `iss`, `aud`, expiry, not-before, and issued-at claims are checked according to token type.
+- [ ] OIDC ID token validation includes nonce validation where applicable.
+- [ ] `jku`, `x5u`, `jwk`, `kid`, and similar JOSE header values cannot redirect key lookup to attacker-controlled network or filesystem locations.
+- [ ] Multi-issuer or multi-tenant token validation uses issuer-specific JWKS, audiences, algorithms, and token-type rules.
+
 ---
 
 ## Step 4: Authorization Review

--- a/skills/appsec/secure-code-review/SKILL.md
+++ b/skills/appsec/secure-code-review/SKILL.md
@@ -177,12 +177,15 @@ Remediation: Use the framework's built-in session management (e.g., `HttpSession
 
 JWTs are often used as authentication, authorization, session, API, and service-to-service tokens. Treat a JWT library call as a security boundary only after verifying both the cryptographic validation and the claim-validation rules used by the application.
 
+**ASVS Reference:** V2 -- Authentication, V3 -- Session Management, V4 -- Access Control, V13 -- API and Web Service
+**CWE Coverage:** CWE-287 (Improper Authentication), CWE-345 (Insufficient Verification of Data Authenticity), CWE-347 (Improper Verification of Cryptographic Signature), CWE-639 (Authorization Bypass Through User-Controlled Key)
+
 **Controls to verify:**
 
 - Signature verification happens before any JWT claim is trusted for authentication, authorization, tenant selection, account lookup, or role assignment.
 - Accepted algorithms are explicitly pinned per issuer and key. Reject `none`, and do not mix symmetric (`HS*`) and asymmetric (`RS*`, `ES*`, `EdDSA`) algorithms for the same verifier/key selection path.
 - Claims are validated for the token type and trust context: `iss`, `aud`, `exp`, `nbf`, and `iat`. For OpenID Connect ID tokens, validate `nonce` when it was sent in the authentication request.
-- The key source is trusted. Do not fetch `jku` or `x5u` from arbitrary token headers; use configured or allowlisted JWKS endpoints for trusted issuers.
+- The key source is trusted. Do not fetch `jku` or `x5u` from arbitrary token headers, and do not trust embedded `jwk` values from attacker-controlled tokens; use configured or allowlisted JWKS endpoints for trusted issuers.
 - `kid` is validated or sanitized before database, filesystem, cache, or LDAP lookup. Do not concatenate raw `kid` values into paths or queries.
 - ID tokens, access tokens, refresh tokens, session JWTs, and service tokens have mutually exclusive validation rules so one token type cannot be replayed in another context.
 
@@ -237,6 +240,16 @@ Remediation: Decode with a trusted key and explicit options such as expected iss
 - [ ] OIDC ID token validation includes nonce validation where applicable.
 - [ ] `jku`, `x5u`, `jwk`, `kid`, and similar JOSE header values cannot redirect key lookup to attacker-controlled network or filesystem locations.
 - [ ] Multi-issuer or multi-tenant token validation uses issuer-specific JWKS, audiences, algorithms, and token-type rules.
+
+**Finding classification:**
+
+| Finding | Severity | Rationale |
+|---|---|---|
+| JWT claims are trusted after unverified parsing (`decode`, disabled signature verification, or `none` algorithm accepted) | **Critical** | Enables authentication or authorization bypass if claims drive identity, tenant, roles, or account lookup |
+| Verifier allows algorithm confusion or mixes HMAC and asymmetric algorithms on the same key-selection path | **High** | Can allow signature bypass when key material or verifier assumptions are misused |
+| Token header controls remote JWKS, embedded JWK, filesystem, SQL, cache, or LDAP key lookup without an allowlist | **High** | Enables attacker-controlled key selection, SSRF, path traversal, or lookup injection |
+| Issuer, audience, token type, nonce, or expiry rules are missing or shared across contexts | **High** | Enables token substitution across tenants, APIs, clients, or OIDC sessions |
+| Clock skew, `iat`, `nbf`, or key rotation behavior is undocumented but signature and issuer/audience checks exist | **Medium** | Weakens resilience and incident response without immediate standalone bypass |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a focused JWT/JOSE token validation subsection to `secure-code-review`.
- Covers signature verification, algorithm pinning, issuer/audience/expiry checks, OIDC nonce validation, unsafe `jku`/`x5u` fetching, unsafe `kid` lookup, and cross-token confusion.
- Includes JavaScript and Python vulnerable examples, review checklist, ASVS/CWE mapping, and severity classification guidance.

## Review Link

Closes #1247

## Verification

- Local marker check: `rg -n "JWT/JOSE|jku|x5u|verify_signature|algorithm confusion|Finding classification|CWE-347" skills/appsec/secure-code-review/SKILL.md`
- Scope is documentation-only; no runtime tests are applicable.

## Bounty Info

- Preferred payment method: GitHub Sponsors, or PayPal/crypto details to be confirmed privately if accepted.
