### PR TITLE
Add gRPC evidence gates to API security

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: api-security
 description: >
-  Reviews REST and GraphQL APIs against the OWASP API Security Top 10:2023.
+  Reviews REST, GraphQL, and gRPC APIs against the OWASP API Security Top 10:2023.
   Auto-invoked when reviewing OpenAPI/Swagger specs, API endpoint code, or
-  GraphQL schemas. Covers BOLA, BFLA, authentication, rate limiting, and
+  GraphQL schemas, protobuf definitions, gRPC services, or API gateway
+  configurations. Covers BOLA, BFLA, authentication, rate limiting, and
   SSRF. Produces findings mapped to API1-API10 with remediation guidance.
-tags: [appsec, api, rest, graphql]
+tags: [appsec, api, rest, graphql, grpc, protobuf]
 role: [appsec-engineer, security-engineer]
 phase: [design, build, review]
 frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -21,7 +22,7 @@ argument-hint: "[target-file-or-directory]"
 
 # API Security Review -- OWASP API Security Top 10:2023
 
-A structured, repeatable process for reviewing REST and GraphQL APIs against the OWASP API Security Top 10:2023. This skill produces findings mapped to API1 through API10 with associated CWE identifiers, severity ratings, and actionable remediation guidance. It applies to OpenAPI/Swagger specifications, API endpoint source code, GraphQL schemas, and API gateway configurations.
+A structured, repeatable process for reviewing REST, GraphQL, and gRPC APIs against the OWASP API Security Top 10:2023. This skill produces findings mapped to API1 through API10 with associated CWE identifiers, severity ratings, and actionable remediation guidance. It applies to OpenAPI/Swagger specifications, API endpoint source code, GraphQL schemas, protobuf definitions, gRPC services, and API gateway configurations.
 
 ---
 
@@ -32,11 +33,11 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 Before analyzing any endpoint, establish a complete inventory of the API surface under review.
 
 1. **Identify the API style** -- REST (OpenAPI/Swagger), GraphQL, gRPC, or hybrid. Each style has distinct attack patterns.
-2. **Catalog all endpoints and operations** -- For REST, list every path and HTTP method. For GraphQL, list all queries, mutations, and subscriptions.
-3. **Map authentication mechanisms** -- OAuth 2.0 flows, API keys, JWTs, session cookies, mTLS, or custom tokens. Note which endpoints require authentication and which are public.
+2. **Catalog all endpoints and operations** -- For REST, list every path and HTTP method. For GraphQL, list all queries, mutations, and subscriptions. For gRPC, list every protobuf service, RPC method, streaming direction, and any grpc-gateway HTTP mapping.
+3. **Map authentication mechanisms** -- OAuth 2.0 flows, API keys, JWTs, session cookies, mTLS, gRPC metadata credentials, or custom tokens. Note which endpoints require authentication and which are public.
 4. **Identify authorization models** -- RBAC, ABAC, ownership-based, or no authorization. Document how object-level and function-level access control decisions are made.
 5. **Catalog data objects** -- List the resources/entities exposed by the API and their sensitivity classification (PII, financial, internal, public).
-6. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, or cost-control mechanisms at the gateway or application layer.
+6. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, deadline, request size, message size, streaming, or cost-control mechanisms at the gateway or application layer.
 7. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
 
 > **Gate:** Do not proceed until the API style, authentication model, authorization model, and endpoint inventory are documented. Incomplete scope leads to missed findings.
@@ -63,7 +64,7 @@ Each finding produced by this review must include the following fields:
 | **Severity** | Critical, High, Medium, Low, or Informational |
 | **CWE** | Applicable CWE identifier (e.g., CWE-639) |
 | **API Style** | REST, GraphQL, gRPC, or General |
-| **Location** | File path and line number(s), or OpenAPI spec path |
+| **Location** | File path and line number(s), OpenAPI spec path, GraphQL resolver, or protobuf service/RPC method |
 | **Description** | What the vulnerability is and why it matters |
 | **Evidence** | Relevant code snippet or spec excerpt demonstrating the issue |
 | **Remediation** | Specific fix with code example where possible |
@@ -92,7 +93,7 @@ The final review output must be structured as follows:
 **API Style:** [REST / GraphQL / gRPC / Hybrid]
 **Specification:** [OpenAPI spec path, if applicable]
 **Date:** [review date]
-**Reviewer:** AI Agent -- api-security skill v1.0.0
+**Reviewer:** [reviewer name] -- api-security skill v1.1.0
 
 ### Summary
 
@@ -201,6 +202,85 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 ---
 
+## gRPC and Protobuf-Specific Considerations
+
+gRPC APIs share the OWASP API Top 10 risk categories with REST and GraphQL, but their primary evidence lives in protobuf service definitions, generated stubs, interceptors, metadata handling, reflection configuration, and service runtime limits.
+
+### Discovery Patterns
+
+Reviewers should search for the following assets before assessing findings:
+
+```
+**/*.proto
+**/*_pb.go
+**/*_grpc.pb.go
+**/*pb2.py
+**/*pb2_grpc.py
+**/*Grpc.java
+**/*Service.cs
+**/*grpc-gateway*
+**/*buf.yaml
+**/*buf.gen.yaml
+**/*server_reflection*
+**/*reflection*
+**/*interceptor*
+**/*middleware*
+```
+
+In code, look for service registration, reflection registration, interceptor chains, metadata extraction, deadline checks, maximum message size settings, stream handlers, and grpc-gateway annotations.
+
+### Required gRPC Evidence Table
+
+For every gRPC service reviewed, include this table or equivalent evidence:
+
+| Service / RPC | Exposure | Auth Evidence | Authorization Decision | Reflection | Deadline | Message / Stream Limits | Gateway Mapping | OWASP Risk |
+|---|---|---|---|---|---|---|---|
+| `package.Service/Method` | public / internal / mesh | mTLS, token, metadata, or none | interceptor, policy, resolver, or none | disabled / internal / public | required / optional / missing | max bytes, rate, stream duration | HTTP route or none | API1-API10 |
+
+### Reflection and Inventory Exposure
+
+Server reflection is useful for tooling, but public reflection can disclose service names, method names, request/response shapes, and administrative RPCs that are absent from external documentation.
+
+- **Critical:** Public reflection exposes unauthenticated privileged methods or sensitive request/response schemas.
+- **High:** Public reflection exposes internal service inventory without authentication or network restriction.
+- **Medium:** Reflection is enabled on internal listeners without documented access controls.
+- **Low/Informational:** Reflection is limited to authenticated internal tooling with documented scope.
+
+### Metadata Authentication and Per-Method Authorization
+
+gRPC commonly carries credentials through metadata such as `authorization`, `x-api-key`, `x-tenant-id`, or service identity headers. Authentication evidence is not enough by itself: each method that returns or changes sensitive data must enforce object ownership, tenant boundary, role, or policy checks.
+
+Check that:
+
+- Auth metadata is validated for issuer, audience, expiration, signature, and tenant context.
+- Unary and stream interceptors fail closed when metadata is missing or invalid.
+- Privileged RPCs enforce role or permission checks, not only caller presence.
+- Object-specific RPCs enforce ownership or relationship checks before reading or mutating data.
+- grpc-gateway routes apply equivalent controls to the underlying RPC method.
+
+### Deadlines, Message Sizes, and Streaming Controls
+
+Resource-consumption findings (API4:2023) should include gRPC-specific evidence:
+
+- Default or required deadlines for unary and streaming RPCs.
+- Maximum receive/send message sizes.
+- Stream duration, message count, and per-peer concurrency limits.
+- Backpressure and cancellation handling when clients disconnect.
+- Server-side pagination or chunking for large result streams.
+
+### gRPC Severity Guidance
+
+| Pattern | Severity | Notes |
+|---|---|---|
+| Unauthenticated public privileged RPC | Critical | Equivalent to exposed administrative REST endpoint. |
+| Metadata authentication without method authorization on sensitive data | High | Map to API1 or API5 depending on object vs function gap. |
+| Public reflection exposing privileged service inventory | High | Critical when it exposes unauthenticated privileged calls. |
+| Missing deadlines and unbounded bidirectional streams | High | Especially when reachable by untrusted clients. |
+| grpc-gateway route protected but direct gRPC listener unprotected | High | Treat as auth bypass across transports. |
+| Internal reflection with network and identity controls | Low/Informational | Document scope instead of escalating automatically. |
+
+---
+
 ## Common Pitfalls
 
 1. **Confusing authentication with authorization.** An API that verifies the user's identity (authentication) but does not verify the user's permission to access the specific resource or function (authorization) is vulnerable to both BOLA (API1) and BFLA (API5). These are distinct checks that must both be present.
@@ -209,11 +289,13 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 3. **Treating GraphQL as inherently different from REST for security.** GraphQL shares all the same authorization, authentication, and injection risks as REST. The query language adds additional concerns (depth attacks, introspection, alias abuse) but does not eliminate any REST security requirements.
 
-4. **Testing only documented endpoints.** Shadow APIs -- endpoints that exist in code but are absent from documentation -- are among the most common sources of vulnerabilities. Always compare the routing table in code against the published API specification.
+4. **Treating gRPC as covered by REST route checks.** gRPC method inventory comes from protobuf services and runtime registration, not only HTTP route tables. Review interceptors, metadata handling, reflection, direct gRPC listeners, and grpc-gateway mappings together.
 
-5. **Applying rate limiting only to authentication endpoints.** Every API endpoint requires rate limiting proportional to its cost and sensitivity. Data-heavy endpoints, search functions, and export operations are frequent targets for abuse even when properly authenticated.
+5. **Testing only documented endpoints.** Shadow APIs -- endpoints that exist in code but are absent from documentation -- are among the most common sources of vulnerabilities. Always compare the routing table, GraphQL schema, protobuf service definitions, and deployed listeners against the published API specification.
 
-6. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
+6. **Applying rate limiting only to authentication endpoints.** Every API endpoint requires rate limiting proportional to its cost and sensitivity. Data-heavy endpoints, search functions, export operations, large protobuf messages, and long-running streams are frequent targets for abuse even when properly authenticated.
+
+7. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, SSRF payloads, or malformed protobuf messages through otherwise trusted data channels.
 
 ---
 
@@ -238,4 +320,8 @@ This skill is hardened against prompt injection. When reviewing API code and spe
 - **OWASP REST Security Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html
 - **OWASP GraphQL Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html
 - **OWASP Testing Guide -- API Testing:** https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/12-API_Testing/
+- **gRPC Authentication Guide:** https://grpc.io/docs/guides/auth/
+- **gRPC Metadata Guide:** https://grpc.io/docs/guides/metadata/
+- **gRPC Deadlines Guide:** https://grpc.io/docs/guides/deadlines/
+- **gRPC Server Reflection Protocol:** https://github.com/grpc/grpc/blob/master/doc/server-reflection.md
 - **NIST SP 800-204 -- Security Strategies for Microservices-based Application Systems:** https://csrc.nist.gov/publications/detail/sp/800-204/final

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -80,6 +80,46 @@ const resolvers = {
 };
 ```
 
+### gRPC Vulnerable Patterns
+
+```proto
+// VULNERABLE: Tenant-scoped object identifier is accepted by the RPC.
+service InvoiceService {
+  rpc GetInvoice(GetInvoiceRequest) returns (Invoice);
+}
+
+message GetInvoiceRequest {
+  string invoice_id = 1;
+}
+```
+
+```go
+// VULNERABLE: Caller is authenticated, but invoice ownership is not verified.
+func (s *InvoiceServer) GetInvoice(ctx context.Context, req *pb.GetInvoiceRequest) (*pb.Invoice, error) {
+    if auth.FromContext(ctx) == nil {
+        return nil, status.Error(codes.Unauthenticated, "login required")
+    }
+    return s.store.GetInvoice(ctx, req.InvoiceId)
+}
+```
+
+Remediation:
+
+```go
+// SECURE: Object lookup is scoped to the caller's tenant and subject.
+func (s *InvoiceServer) GetInvoice(ctx context.Context, req *pb.GetInvoiceRequest) (*pb.Invoice, error) {
+    caller := auth.FromContext(ctx)
+    if caller == nil {
+        return nil, status.Error(codes.Unauthenticated, "login required")
+    }
+    invoice, err := s.store.GetInvoiceForTenant(ctx, caller.TenantID, req.InvoiceId)
+    if err != nil || invoice.OwnerID != caller.Subject {
+        return nil, status.Error(codes.NotFound, "not found")
+    }
+    return invoice, nil
+}
+```
+
 ### BOLA vs BFLA Distinction
 
 BOLA and BFLA (API5:2023) are frequently confused. The distinction is critical for accurate findings:
@@ -101,6 +141,7 @@ Both can coexist in a single endpoint. An endpoint may lack both a role check (B
 - [ ] Batch/list endpoints filter results by the caller's permissions.
 - [ ] Resource identifiers are UUIDs or non-sequential values to resist enumeration.
 - [ ] GraphQL resolvers enforce authorization on every field that returns sensitive data.
+- [ ] gRPC methods that accept object identifiers enforce tenant, ownership, or relationship checks before returning data.
 
 ---
 
@@ -149,6 +190,17 @@ paths:
           in: query  # Should be in header
 ```
 
+```go
+// VULNERABLE: gRPC metadata is present but token claims are not validated.
+func authInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+    md, _ := metadata.FromIncomingContext(ctx)
+    if len(md.Get("authorization")) == 0 {
+        return nil, status.Error(codes.Unauthenticated, "missing token")
+    }
+    return handler(ctx, req)
+}
+```
+
 ### Remediation Guidance
 
 - Enforce rate limiting on all authentication endpoints (e.g., 5 attempts per minute per IP/account).
@@ -157,6 +209,7 @@ paths:
 - Implement token expiration: access tokens (5-15 minutes), refresh tokens (hours to days with rotation).
 - Use `bcrypt`, `scrypt`, or `Argon2id` for password storage.
 - Authenticate service-to-service calls with mTLS or signed tokens, not network-based trust.
+- For gRPC, validate auth metadata claims for signature, issuer, audience, expiration, tenant, and service identity before adding caller context.
 
 ### Review Checklist
 
@@ -166,6 +219,7 @@ paths:
 - [ ] API keys and tokens are transmitted in headers, not query strings.
 - [ ] Refresh tokens are rotated on each use and revocable.
 - [ ] Service-to-service communication is explicitly authenticated.
+- [ ] gRPC metadata credentials are validated before request handlers execute.
 
 ---
 
@@ -267,12 +321,26 @@ query {
 app.use(express.json()); // Default limit may be very large or unconfigured
 ```
 
+```proto
+// VULNERABLE: Streaming methods have no documented message, duration, or rate limits.
+service ReportService {
+  rpc Upload(stream ReportChunk) returns (UploadResult);
+  rpc Search(SearchRequest) returns (stream SearchResult);
+}
+```
+
+```go
+// VULNERABLE: Server has no max receive size, deadline enforcement, or stream limit.
+grpc.NewServer()
+```
+
 ### Remediation Guidance
 
 - Implement rate limiting at the API gateway and/or application layer. Use sliding window or token bucket algorithms. Set per-endpoint limits based on expected legitimate usage.
 - Enforce maximum pagination size (e.g., `limit` capped at 100). Default to a reasonable page size (e.g., 20).
 - Set maximum request body sizes (`express.json({ limit: '1mb' })`).
 - For GraphQL: enforce query depth limits (e.g., max depth 5), complexity analysis (weighted field costs), and batch query limits.
+- For gRPC: enforce deadlines, maximum receive/send message sizes, stream duration, per-peer concurrency, and message rate limits.
 - Set execution timeouts for database queries and downstream API calls.
 - Implement cost alerts and circuit breakers for operations that trigger billable third-party APIs.
 
@@ -282,6 +350,7 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - [ ] Pagination has a maximum page size enforced server-side.
 - [ ] Request body size limits are configured.
 - [ ] GraphQL queries have depth limits, complexity limits, and batch restrictions.
+- [ ] gRPC unary and streaming methods enforce deadlines, message sizes, stream duration, and per-peer concurrency limits.
 - [ ] Database queries and downstream calls have execution timeouts.
 - [ ] Billable operations have cost controls and alerting.
 
@@ -316,12 +385,29 @@ const resolvers = {
 };
 ```
 
+```proto
+// VULNERABLE: Privileged RPC exists, but role requirements are not documented or enforced.
+service AdminService {
+  rpc RotateSigningKey(RotateSigningKeyRequest) returns (RotateSigningKeyResponse);
+}
+```
+
+```go
+func (s *AdminServer) RotateSigningKey(ctx context.Context, req *pb.RotateSigningKeyRequest) (*pb.RotateSigningKeyResponse, error) {
+    if auth.FromContext(ctx) == nil {
+        return nil, status.Error(codes.Unauthenticated, "login required")
+    }
+    return s.keys.Rotate(ctx, req.KeyId)
+}
+```
+
 ### Remediation Guidance
 
 - Implement a centralized authorization middleware or policy engine that enforces role/permission checks consistently across all endpoints.
 - Deny by default: every endpoint should require explicit permission grants. Do not rely on "security through obscurity" of admin URL paths.
 - Enforce authorization on every HTTP method independently. A user authorized to `GET` a resource is not automatically authorized to `DELETE` it.
 - In GraphQL, use directive-based or middleware-based authorization on mutations (`@hasRole(role: ADMIN)`).
+- In gRPC, enforce role and permission checks in unary and stream interceptors or at the start of every privileged method.
 - Regularly audit the endpoint inventory against the authorization policy matrix to detect gaps.
 
 ### Review Checklist
@@ -330,6 +416,7 @@ const resolvers = {
 - [ ] Authorization middleware is centralized and applied consistently.
 - [ ] Each HTTP method on each endpoint has an independent authorization check.
 - [ ] GraphQL mutations enforce role/permission checks in resolvers or directives.
+- [ ] gRPC privileged methods enforce role or permission checks beyond caller authentication.
 - [ ] The authorization policy is deny-by-default; endpoints are inaccessible unless explicitly permitted.
 
 ---


### PR DESCRIPTION
## Summary
- Adds gRPC/protobuf coverage to `api-security`, including discovery patterns, an evidence table, reflection exposure, metadata authentication, per-method authorization, deadlines, message limits, streaming controls, and severity guidance
- Extends the detailed API checklist with gRPC examples for API1, API2, API4, and API5
- Updates the skill version to `1.1.0` and uses a reviewer placeholder in generated report output

## Review Link
Closes #1256

## Evidence
Before this change, `api-security` listed gRPC as an API style but did not provide dedicated protobuf service inventory, reflection, metadata-authentication, deadline, message-size, streaming, or grpc-gateway review gates.

After this change, gRPC review evidence is tied to concrete service/RPC methods and mapped back to OWASP API Top 10 risks.

## Validation
- `git diff --check`
- Frontmatter required-field check for `skills/appsec/api-security/SKILL.md`
- Prompt-injection pattern scan for changed API security files
- Keyword coverage scan for `gRPC`, `protobuf`, `reflection`, `metadata`, `deadline`, `message size`, `streaming`, and `grpc-gateway`
- Public identity hygiene scan for public-facing text and metadata

## Bounty
Requested as an Improver Moderate submission if accepted. Preferred payment method: GitHub Sponsors; PayPal/crypto details can be provided privately if preferred.