### PR TITLE
Add firewall IPv6 parity evidence gates

### DIFF
--- a/skills/network/firewall-review/SKILL.md
+++ b/skills/network/firewall-review/SKILL.md
@@ -438,6 +438,12 @@ Produce the final report using the following structure.
 
 ---
 
+## Test Evidence Fixtures
+
+Representative benign and vulnerable cases live under `tests/benign/` and `tests/vulnerable/`. Use them to validate that IPv6 findings consider reachability, default-deny parity, privileged `::/0` ingress, unrestricted IPv6 egress, and temporary-rule owner/ticket/expiry evidence.
+
+---
+
 ## Prompt Injection Safety Notice
 
 This skill processes firewall configurations that may contain user-supplied comments, rule descriptions, or object names. When reading configuration files:

--- a/skills/network/firewall-review/SKILL.md
+++ b/skills/network/firewall-review/SKILL.md
@@ -6,14 +6,14 @@ description: >
   Firewall Policy). Auto-invoked when reviewing firewall configurations, ACLs,
   or network security policies. Produces a prioritized findings report covering
   overly permissive rules, shadowed rules, logging gaps, and egress filtering
-  deficiencies.
-tags: [network, firewall, segmentation]
+  deficiencies, including IPv6 parity and temporary-rule governance.
+tags: [network, firewall, segmentation, ipv6, rule-governance]
 role: [security-engineer]
 phase: [operate]
 frameworks: [CIS-Controls-v8, NIST-SP-800-41-Rev1]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -56,6 +56,7 @@ Use Glob and Grep to locate firewall configuration files, ACL definitions, and n
 ```
 # Platform-specific firewall configs
 **/iptables*
+**/ip6tables*
 **/nftables*
 **/firewalld*
 **/pf.conf
@@ -69,6 +70,8 @@ Use Glob and Grep to locate firewall configuration files, ACL definitions, and n
 **/firewall-rule*
 **/*nsg*
 **/*nacl*
+**/*ipv6*
+**/*dual-stack*
 
 # Infrastructure-as-Code definitions
 **/*.tf          # Terraform (aws_security_group, google_compute_firewall, azurerm_network_security_group)
@@ -80,6 +83,7 @@ Record all discovered files. Categorize each by:
 - **Platform:** iptables, nftables, pf, cloud security groups, Kubernetes NetworkPolicy, vendor-specific (Palo Alto, Fortinet, Cisco ASA).
 - **Direction:** Perimeter (north-south) vs. internal (east-west).
 - **Scope:** Server, endpoint, network segment.
+- **Address family:** IPv4, IPv6, dual-stack, or IPv6 not applicable with evidence.
 
 ---
 
@@ -96,6 +100,7 @@ The rule base MUST terminate with an explicit deny-all rule. Every traffic flow 
 - The last rule in every chain/policy is an explicit `deny all` or `drop all`.
 - No implicit allow rules override the default deny (e.g., cloud security groups that default to allow outbound).
 - Both inbound AND outbound directions enforce default deny.
+- IPv4 and IPv6 policies both enforce default deny, or IPv6 is explicitly disabled at the interface, subnet, and route level.
 
 **Patterns to check:**
 
@@ -105,14 +110,27 @@ The rule base MUST terminate with an explicit deny-all rule. Every traffic flow 
 :FORWARD DROP
 :OUTPUT DROP
 
-# Cloud security groups -- verify no 0.0.0.0/0 allow-all egress
+# ip6tables -- IPv6 default policy should match IPv4 policy
+:INPUT DROP
+:FORWARD DROP
+:OUTPUT DROP
+
+# nftables -- inet family covers both IPv4 and IPv6
+table inet filter {
+  chain input { type filter hook input priority 0; policy drop; }
+  chain forward { type filter hook forward priority 0; policy drop; }
+  chain output { type filter hook output priority 0; policy drop; }
+}
+
+# Cloud security groups -- verify no IPv4 or IPv6 allow-all egress
 egress: 0.0.0.0/0 allow all
+egress: ::/0 allow all
 
 # Terraform
 default_action = "Allow"    # BAD -- should be "Deny"
 ```
 
-**Finding classification:** Absence of explicit default deny is **Critical**.
+**Finding classification:** Absence of explicit default deny is **Critical**. IPv4 default deny with unmanaged IPv6 allow-all is **Critical** when IPv6 is routable and **High** when IPv6 reachability is unknown.
 
 ---
 
@@ -134,22 +152,34 @@ permit ip any any
 from_port: 0
 to_port: 65535
 cidr_blocks: ["0.0.0.0/0"]
+ipv6_cidr_blocks: ["::/0"]
 
 # Terraform AWS
 ingress {
-  from_port   = 0
-  to_port     = 0
-  protocol    = "-1"
-  cidr_blocks = ["0.0.0.0/0"]
+  from_port        = 0
+  to_port          = 0
+  protocol         = "-1"
+  cidr_blocks      = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
+}
+
+# Terraform AWS -- privileged IPv6 ingress
+ingress {
+  from_port        = 22
+  to_port          = 22
+  protocol         = "tcp"
+  ipv6_cidr_blocks = ["::/0"]
 }
 ```
 
 For each overly permissive rule, document:
 - Rule number/position.
 - Source, destination, port, and protocol.
+- Address family (`IPv4`, `IPv6`, or both) and whether IPv6 is routable.
 - Whether the rule has a documented business justification (comment/description).
+- Owner, change ticket, expiry date, and last review date for broad or temporary permits.
 
-**Finding classification:** Any/any rules are **Critical** for inbound, **High** for outbound.
+**Finding classification:** Any/any rules are **Critical** for inbound, **High** for outbound. Privileged ingress from `::/0` has the same severity as privileged ingress from `0.0.0.0/0`.
 
 ---
 
@@ -189,8 +219,9 @@ Rules with zero hit counts over an extended period (30+ days) indicate stale pol
 - Last-hit timestamps where available.
 - Rules referencing decommissioned IP addresses, subnets, or services.
 - Rules with comments referencing past projects or temporary access.
+- Owner, business justification, change ticket, creation date, expiry date, and last review date for time-bound or emergency permits.
 
-**Finding classification:** Unused rules present for 90+ days are **Medium**. Rules referencing decommissioned resources are **High** (may indicate orphaned access paths).
+**Finding classification:** Unused rules present for 90+ days are **Medium**. Rules referencing decommissioned resources are **High** (may indicate orphaned access paths). Expired temporary permits that still allow sensitive traffic are **High**; temporary permits without owner or expiry evidence are **Medium**.
 
 ---
 
@@ -249,8 +280,38 @@ Egress filtering prevents compromised internal hosts from establishing unrestric
 - Outbound HTTPS (TCP 443) is routed through a forward proxy where feasible.
 - Uncommon outbound protocols (SSH 22, RDP 3389, ICMP) are restricted or denied by default.
 - Outbound connections to known anonymization services (Tor exit nodes) are blocked.
+- IPv6 egress has equivalent restrictions to IPv4 egress, including DNS, SMTP, proxy routing, uncommon protocols, and deny-all cleanup.
 
-**Finding classification:** Unrestricted outbound egress (allow all) is **High**. Missing DNS egress restriction is **Medium**.
+**Finding classification:** Unrestricted outbound egress (allow all) is **High**. Missing DNS egress restriction is **Medium**. Unrestricted IPv6 egress with restricted IPv4 egress is **High** when IPv6 is routable.
+
+---
+
+#### 2.8 IPv6 Parity and Temporary Rule Governance
+
+IPv6 and temporary-rule evidence must be collected even when the primary rule base appears healthy.
+
+**IPv6 parity checks:**
+
+| Evidence | Pass | Fail / Follow-up |
+|---|---|---|
+| IPv6 enabled on interface/subnet/VPC | Document enabled scope | If unknown, mark IPv6 reachability as `Not Evaluable` |
+| IPv6 default deny | `ip6tables`, `nft inet`, cloud IPv6 policy denies by default | `ip6tables` policy `ACCEPT`, missing IPv6 cleanup rule, or `::/0` allow-all |
+| Privileged ingress | No `::/0` to SSH/RDP/database/management ports | `::/0` privileged ingress without narrow source or compensating control |
+| Egress parity | IPv6 egress restricted like IPv4 | IPv4 egress restricted but IPv6 egress `::/0` all protocols |
+| Not applicable proof | IPv6 disabled at host, subnet, and route table | Missing proof; do not assume IPv4-only |
+
+**Temporary rule governance fields:**
+
+| Rule ID | Owner | Justification | Change Ticket | Created | Expires | Last Hit | Last Reviewed | Exception Status |
+|---|---|---|---|---|---|---|---|---|
+| `<rule>` | `<team/person>` | `<business need>` | `<ticket>` | `<date>` | `<date>` | `<timestamp>` | `<date>` | active / expired / no expiry |
+
+**Severity guidance:**
+
+- **Critical:** Routable IPv6 permits unauthenticated privileged ingress from `::/0` to management services or sensitive data-plane services.
+- **High:** IPv6 policy is allow-all while IPv4 policy is default-deny; unrestricted routable IPv6 egress exists; expired temporary rule still permits sensitive traffic.
+- **Medium:** Temporary rule lacks owner, ticket, expiry, or last-review evidence; IPv6 reachability cannot be evaluated.
+- **Low/Informational:** IPv6 is demonstrably disabled, or a broad-looking IPv6 rule is narrow in practice because routing, proxy, and logging evidence prove the traffic path is controlled.
 
 ---
 
@@ -264,9 +325,9 @@ Produce the final report using the following structure.
 
 | Severity | Definition |
 |----------|-----------|
-| **Critical** | Missing default deny; any/any inbound rules. Immediate exploitation risk. |
-| **High** | Overly permissive outbound rules; shadowed deny rules; no logging on deny actions; missing anti-spoofing; unused rules to decommissioned resources. |
-| **Medium** | Shadowed permit rules; missing egress DNS restriction; unused rules (active resources); missing logging on sensitive permits; missing stealth rules. |
+| **Critical** | Missing default deny; any/any inbound rules; routable IPv6 privileged ingress from `::/0`. Immediate exploitation risk. |
+| **High** | Overly permissive outbound rules; IPv6 allow-all with IPv4 default-deny; unrestricted routable IPv6 egress; expired temporary permits to sensitive services; shadowed deny rules; no logging on deny actions; missing anti-spoofing; unused rules to decommissioned resources. |
+| **Medium** | Shadowed permit rules; missing egress DNS restriction; unused rules (active resources); temporary rules without owner/ticket/expiry evidence; IPv6 reachability not evaluable; missing logging on sensitive permits; missing stealth rules. |
 | **Low** | Rule documentation gaps; suboptimal rule ordering with no current security impact; cosmetic rule base issues. |
 
 ---
@@ -301,21 +362,33 @@ Produce the final report using the following structure.
 - **Remediation:** <concrete fix with example>
 
 ### Default Deny Status
-| Direction | Status | Evidence |
-|-----------|--------|----------|
-| Inbound   | Pass/Fail | <rule reference> |
-| Outbound  | Pass/Fail | <rule reference> |
+| Direction | Address Family | Status | Evidence |
+|-----------|----------------|--------|----------|
+| Inbound   | IPv4 | Pass/Fail | <rule reference> |
+| Inbound   | IPv6 | Pass/Fail/N/A/Not Evaluable | <rule or disablement evidence> |
+| Outbound  | IPv4 | Pass/Fail | <rule reference> |
+| Outbound  | IPv6 | Pass/Fail/N/A/Not Evaluable | <rule or disablement evidence> |
 
 ### Shadowed Rules Summary
 | Shadowed Rule | Position | Shadowing Rule | Position | Impact |
 |---------------|----------|----------------|----------|--------|
 
 ### Egress Filtering Status
-| Protocol/Port | Restricted | Authorized Destinations |
-|---------------|-----------|------------------------|
-| DNS (53)      | Yes/No    | <resolver IPs>         |
-| SMTP (25)     | Yes/No    | <mail server IPs>      |
-| HTTPS (443)   | Yes/No    | <proxy or direct>      |
+| Protocol/Port | Address Family | Restricted | Authorized Destinations |
+|---------------|----------------|-----------|------------------------|
+| DNS (53)      | IPv4/IPv6 | Yes/No    | <resolver IPs>         |
+| SMTP (25)     | IPv4/IPv6 | Yes/No    | <mail server IPs>      |
+| HTTPS (443)   | IPv4/IPv6 | Yes/No    | <proxy or direct>      |
+
+### IPv6 Parity Status
+| Scope | IPv6 Enabled | Default Deny | Broad Ingress | Broad Egress | Evidence |
+|-------|--------------|--------------|---------------|--------------|----------|
+| <firewall/resource> | Yes/No/Unknown | Pass/Fail/N/A | None/Present | None/Present | <rule, route, or disablement proof> |
+
+### Temporary Rule Governance
+| Rule ID | Owner | Justification | Change Ticket | Created | Expires | Last Hit | Last Reviewed | Status |
+|---------|-------|---------------|---------------|---------|---------|----------|---------------|--------|
+| <rule> | <owner> | <reason> | <ticket> | <date> | <date/none> | <timestamp> | <date> | active/expired/no-expiry |
 
 ### Prioritized Remediation Plan
 1. **[Critical]** <action item with control reference>
@@ -355,11 +428,13 @@ Produce the final report using the following structure.
 
 2. **Treating cloud security groups like traditional firewalls.** Cloud security groups are stateful and often default to allow-all egress. Each cloud provider has different implicit behaviors (AWS security groups allow all outbound by default; Azure NSGs do not). Document the platform's default behavior before auditing rules.
 
-3. **Ignoring IPv6 rules.** Many environments have parallel IPv4 and IPv6 rule bases (ip6tables, IPv6 security group rules). If IPv6 is not explicitly disabled at the interface level, an unmanaged IPv6 rule base can bypass all IPv4 firewall controls.
+3. **Ignoring IPv6 rules.** Many environments have parallel IPv4 and IPv6 rule bases (`ip6tables`, `nft inet`, IPv6 security group rules, `ipv6_cidr_blocks`). If IPv6 is not explicitly disabled at the interface, subnet, and route level, an unmanaged IPv6 rule base can bypass all IPv4 firewall controls.
 
 4. **Assuming hit count of zero means the rule is unused.** Hit counters reset on firewall reload or failover. Verify the counter baseline timestamp before recommending rule removal. Cross-reference with SIEM/flow data where available.
 
 5. **Conflating network ACLs with security groups in cloud environments.** In AWS, NACLs are stateless and operate at the subnet level; security groups are stateful and operate at the instance level. Both must be audited. A permissive NACL can undermine restrictive security group rules for responses.
+
+6. **Accepting "temporary" comments without expiry evidence.** A comment that says `temporary`, `incident`, or `vendor access` is not governance by itself. Require owner, change ticket, expiry, last review, and removal evidence before downgrading stale access.
 
 ---
 
@@ -386,4 +461,5 @@ This skill processes firewall configurations that may contain user-supplied comm
 
 ## Changelog
 
+- **1.1.0** -- Added IPv6 parity, `::/0` ingress/egress, and temporary-rule owner/ticket/expiry evidence gates.
 - **1.0.0** -- Initial release. Full coverage of CIS Controls v8 (4.4, 4.5) and NIST SP 800-41 Rev 1 firewall audit methodology.

--- a/skills/network/firewall-review/tests/README.md
+++ b/skills/network/firewall-review/tests/README.md
@@ -1,0 +1,15 @@
+# Firewall Review Evidence Fixtures
+
+These fixtures exercise the IPv6 parity and temporary-rule governance gates in `firewall-review`.
+
+Use the benign cases to verify false-positive reduction:
+
+- `benign/controlled-ipv6-egress-proxy.md` shows broad-looking IPv6 HTTPS egress that is acceptable only when proxy, routing, owner, ticket, logging, and expiry evidence are present.
+- `benign/ipv6-disabled-not-applicable.md` shows the evidence required before marking IPv6 checks as `Not Applicable`.
+
+Use the vulnerable cases to verify coverage expansion:
+
+- `vulnerable/ip6tables-default-accept.md` catches IPv4 default deny with IPv6 default allow.
+- `vulnerable/ssh-ipv6-anywhere.md` catches privileged `::/0` ingress in cloud security groups.
+- `vulnerable/unrestricted-ipv6-egress.md` catches IPv6 all-protocol egress when IPv4 egress is restricted.
+- `vulnerable/temporary-db-permit-no-expiry.md` catches temporary access without owner, ticket, expiry, or review evidence.

--- a/skills/network/firewall-review/tests/benign/controlled-ipv6-egress-proxy.md
+++ b/skills/network/firewall-review/tests/benign/controlled-ipv6-egress-proxy.md
@@ -1,0 +1,29 @@
+# Benign: Controlled IPv6 HTTPS Egress Through Proxy
+
+## Fixture
+
+```yaml
+rule_id: sg-https-egress-v6
+family: ipv6
+direction: egress
+protocol: tcp
+port: 443
+destination: "::/0"
+action: allow
+proxy_required: true
+proxy_address: 2001:db8:10:40::20
+subnet_ipv6_assignment: disabled
+direct_internet_route: false
+flow_logs_enabled: true
+owner: network-security
+change_ticket: CHG-2026-4421
+created_at: 2026-06-01
+expires_at: 2026-07-01
+last_reviewed: 2026-06-05
+```
+
+## Expected Result
+
+No finding when the review evidence proves IPv6 is not directly routable and HTTPS egress is forced through an inspected proxy with owner, ticket, logging, and expiry evidence.
+
+If any of `direct_internet_route: false`, `proxy_required: true`, `owner`, `change_ticket`, or `expires_at` is missing, downgrade only when compensating evidence is documented.

--- a/skills/network/firewall-review/tests/benign/ipv6-disabled-not-applicable.md
+++ b/skills/network/firewall-review/tests/benign/ipv6-disabled-not-applicable.md
@@ -1,0 +1,26 @@
+# Benign: IPv6 Disabled With Not Applicable Evidence
+
+## Fixture
+
+```yaml
+scope: prod-web-subnet-a
+ipv6_status:
+  host_interfaces:
+    eth0_accept_ra: 0
+    eth0_ipv6_addresses: []
+  subnet_ipv6_assignment: disabled
+  vpc_ipv6_cidr: null
+  route_table_ipv6_default_route: null
+  security_group_ipv6_rules: []
+evidence:
+  host_command: "sysctl net.ipv6.conf.eth0.disable_ipv6=1"
+  cloud_subnet: "assignIpv6AddressOnCreation=false"
+  route_table: "no ::/0 route"
+  reviewed_at: 2026-06-05
+```
+
+## Expected Result
+
+Report IPv6 as `Not Applicable`, not as a vulnerability, because host, subnet, and route-table evidence all prove IPv6 is disabled or unrouted.
+
+If any layer is unknown, report `Not Evaluable` instead of assuming IPv4-only coverage.

--- a/skills/network/firewall-review/tests/vulnerable/ip6tables-default-accept.md
+++ b/skills/network/firewall-review/tests/vulnerable/ip6tables-default-accept.md
@@ -1,0 +1,19 @@
+# Vulnerable: IPv4 Default Deny With IPv6 Default Accept
+
+## Fixture
+
+```bash
+iptables -P INPUT DROP
+iptables -P FORWARD DROP
+iptables -P OUTPUT DROP
+
+ip6tables -P INPUT ACCEPT
+ip6tables -P FORWARD ACCEPT
+ip6tables -P OUTPUT ACCEPT
+```
+
+## Expected Result
+
+Flag as `Critical` when IPv6 is routable. IPv4 default deny does not protect dual-stack hosts when the IPv6 rule base defaults to accept.
+
+If IPv6 reachability is unknown, flag as `High` or `Not Evaluable` according to the available routing and interface evidence.

--- a/skills/network/firewall-review/tests/vulnerable/ssh-ipv6-anywhere.md
+++ b/skills/network/firewall-review/tests/vulnerable/ssh-ipv6-anywhere.md
@@ -1,0 +1,30 @@
+# Vulnerable: Privileged IPv6 Ingress From Anywhere
+
+## Fixture
+
+```hcl
+resource "aws_security_group_rule" "ssh_ipv6_anywhere" {
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  ipv6_cidr_blocks  = ["::/0"]
+  security_group_id = aws_security_group.admin.id
+  description       = "temporary admin access"
+}
+
+resource "aws_security_group_rule" "ssh_ipv4_corp_only" {
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["203.0.113.0/24"]
+  security_group_id = aws_security_group.admin.id
+}
+```
+
+## Expected Result
+
+Flag as `Critical` when IPv6 is routable because SSH is exposed from `::/0` even though the IPv4 peer is limited to a corporate CIDR.
+
+The `temporary admin access` description must not reduce severity without owner, change-ticket, expiry, and review evidence.

--- a/skills/network/firewall-review/tests/vulnerable/temporary-db-permit-no-expiry.md
+++ b/skills/network/firewall-review/tests/vulnerable/temporary-db-permit-no-expiry.md
@@ -1,0 +1,27 @@
+# Vulnerable: Temporary Database Permit Without Governance Evidence
+
+## Fixture
+
+```yaml
+rule_id: TEMP-incident-db-allow
+direction: ingress
+family: ipv4
+source: 10.40.0.0/16
+destination: db-prod-01
+protocol: tcp
+port: 5432
+action: allow
+comment: temporary incident access
+owner: null
+change_ticket: null
+created_at: 2026-04-15
+expires_at: null
+last_hit: 2026-06-04T11:20:00Z
+last_reviewed: unknown
+```
+
+## Expected Result
+
+Flag as `High` when the rule still permits sensitive database access after the incident window without owner, ticket, expiry, or review evidence.
+
+At minimum, missing owner, ticket, expiry, or last review should be reported as a temporary-rule governance failure.

--- a/skills/network/firewall-review/tests/vulnerable/unrestricted-ipv6-egress.md
+++ b/skills/network/firewall-review/tests/vulnerable/unrestricted-ipv6-egress.md
@@ -1,0 +1,27 @@
+# Vulnerable: Unrestricted IPv6 Egress With Restricted IPv4
+
+## Fixture
+
+```hcl
+egress {
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
+  cidr_blocks = ["198.51.100.20/32"]
+  description = "approved HTTPS proxy"
+}
+
+egress {
+  from_port        = 0
+  to_port          = 0
+  protocol         = "-1"
+  ipv6_cidr_blocks = ["::/0"]
+  description      = "default IPv6 egress"
+}
+```
+
+## Expected Result
+
+Flag as `High` when IPv6 is routable. IPv4 egress is constrained to a proxy, but IPv6 allows all protocols to all destinations.
+
+The review should require IPv6 egress parity for DNS, SMTP, HTTPS proxy routing, uncommon protocols, and deny-all cleanup.


### PR DESCRIPTION
## Summary
- Adds IPv6 parity checks to `firewall-review`, covering `ip6tables`, `nft inet`, `::/0` privileged ingress, IPv6 default deny, and unrestricted IPv6 egress
- Adds temporary-rule governance evidence for owner, justification, change ticket, created date, expiry, last hit, last review, and exception status
- Adds benign and vulnerable fixtures for controlled IPv6 proxy egress, IPv6-disabled `Not Applicable` handling, IPv6 default-accept drift, privileged `::/0` ingress, unrestricted IPv6 egress, and temporary database access without governance evidence
- Extends severity guidance, output tables, common pitfalls, tags, version, changelog, and fixture pointers for the new evidence gates

## Review Link
Closes #1260

## Evidence
Before this change, IPv6 was mentioned as a common pitfall but was not represented in discovery patterns, default-deny checks, any/any examples, egress evidence, severity guidance, report tables, or test evidence.

After this change, IPv4/IPv6 parity and time-bound exception evidence are required before reviewers downgrade broad or temporary firewall rules. The fixtures under `skills/network/firewall-review/tests/` exercise both false-positive reduction and vulnerable edge cases.

## Validation
- `git diff --check`
- Frontmatter required-field check for `skills/network/firewall-review/SKILL.md`
- Markdown fence balance check for touched Markdown files
- Prompt-injection pattern scan for touched files
- ASCII check for added/touched files
- Keyword coverage scan for `IPv6`, `::/0`, `ip6tables`, `ipv6_cidr_blocks`, `temporary`, `expires_at`, `change_ticket`, `owner`, `Not Applicable`, and `Not Evaluable`
- Public identity hygiene scan for branch, commit message, staged diff, PR body, and author metadata

## Bounty
Requested as an Improver Moderate submission if accepted. Preferred payment method: GitHub Sponsors; PayPal/crypto details can be provided privately if preferred.