### PR TITLE
Add IPv6 and temporary rule firewall gates

### DIFF
--- a/skills/network/firewall-review/SKILL.md
+++ b/skills/network/firewall-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [operate]
 frameworks: [CIS-Controls-v8, NIST-SP-800-41-Rev1]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -56,7 +56,9 @@ Use Glob and Grep to locate firewall configuration files, ACL definitions, and n
 ```
 # Platform-specific firewall configs
 **/iptables*
+**/ip6tables*
 **/nftables*
+**/nft*
 **/firewalld*
 **/pf.conf
 **/ufw*
@@ -80,6 +82,8 @@ Record all discovered files. Categorize each by:
 - **Platform:** iptables, nftables, pf, cloud security groups, Kubernetes NetworkPolicy, vendor-specific (Palo Alto, Fortinet, Cisco ASA).
 - **Direction:** Perimeter (north-south) vs. internal (east-west).
 - **Scope:** Server, endpoint, network segment.
+- **Address family:** IPv4, IPv6, dual-stack, or not applicable with evidence.
+- **Exception metadata:** Rule owner, business justification, change ticket, created date, expiry date, and last review where available.
 
 ---
 
@@ -96,6 +100,8 @@ The rule base MUST terminate with an explicit deny-all rule. Every traffic flow 
 - The last rule in every chain/policy is an explicit `deny all` or `drop all`.
 - No implicit allow rules override the default deny (e.g., cloud security groups that default to allow outbound).
 - Both inbound AND outbound directions enforce default deny.
+- IPv4 and IPv6 policies are evaluated independently; do not infer IPv6 controls from IPv4 rules.
+- If IPv6 is out of scope, record evidence that IPv6 is disabled at the host interface, subnet, route table, and cloud/VPC level.
 
 **Patterns to check:**
 
@@ -105,14 +111,25 @@ The rule base MUST terminate with an explicit deny-all rule. Every traffic flow 
 :FORWARD DROP
 :OUTPUT DROP
 
-# Cloud security groups -- verify no 0.0.0.0/0 allow-all egress
+# ip6tables -- default policy should also be DROP when IPv6 is enabled
+:INPUT DROP
+:FORWARD DROP
+:OUTPUT DROP
+
+# nftables -- verify inet/ip6 chains and default policies
+table inet filter
+chain input { type filter hook input priority 0; policy drop; }
+chain output { type filter hook output priority 0; policy drop; }
+
+# Cloud security groups -- verify no 0.0.0.0/0 or ::/0 allow-all egress
 egress: 0.0.0.0/0 allow all
+egress: ::/0 allow all
 
 # Terraform
 default_action = "Allow"    # BAD -- should be "Deny"
 ```
 
-**Finding classification:** Absence of explicit default deny is **Critical**.
+**Finding classification:** Absence of explicit default deny is **Critical**. IPv4 default deny with IPv6 default allow is **Critical** when IPv6 is routed or reachable, and **Not Applicable** only when disabling evidence is captured.
 
 ---
 
@@ -134,6 +151,7 @@ permit ip any any
 from_port: 0
 to_port: 65535
 cidr_blocks: ["0.0.0.0/0"]
+ipv6_cidr_blocks: ["::/0"]
 
 # Terraform AWS
 ingress {
@@ -142,14 +160,32 @@ ingress {
   protocol    = "-1"
   cidr_blocks = ["0.0.0.0/0"]
 }
+
+# Terraform AWS -- IPv6 any/any exposure
+ingress {
+  from_port        = 0
+  to_port          = 0
+  protocol         = "-1"
+  ipv6_cidr_blocks = ["::/0"]
+}
+
+# Privileged IPv6 ingress
+ingress {
+  from_port        = 22
+  to_port          = 22
+  protocol         = "tcp"
+  ipv6_cidr_blocks = ["::/0"]
+}
 ```
 
 For each overly permissive rule, document:
 - Rule number/position.
+- Address family (IPv4, IPv6, or dual-stack) and whether the address family is internet-routable.
 - Source, destination, port, and protocol.
 - Whether the rule has a documented business justification (comment/description).
+- Whether routing, subnet assignment, host interface state, and proxy controls make the rule reachable.
 
-**Finding classification:** Any/any rules are **Critical** for inbound, **High** for outbound.
+**Finding classification:** Any/any rules are **Critical** for inbound, **High** for outbound. Privileged `::/0` ingress to SSH, RDP, database, management, or admin ports is **Critical** when reachable.
 
 ---
 
@@ -189,8 +225,16 @@ Rules with zero hit counts over an extended period (30+ days) indicate stale pol
 - Last-hit timestamps where available.
 - Rules referencing decommissioned IP addresses, subnets, or services.
 - Rules with comments referencing past projects or temporary access.
+- Temporary, break-fix, migration, vendor, or incident-response rules without owner, change ticket, expiry, and post-expiry removal evidence.
 
-**Finding classification:** Unused rules present for 90+ days are **Medium**. Rules referencing decommissioned resources are **High** (may indicate orphaned access paths).
+For each temporary or exception rule, document:
+- Rule ID or position.
+- Owner and approving team.
+- Business justification and change ticket.
+- Creation date, expiry date, last review date, and exception status.
+- Evidence that the rule was removed, renewed, or still required after expiry.
+
+**Finding classification:** Unused rules present for 90+ days are **Medium**. Rules referencing decommissioned resources are **High** (may indicate orphaned access paths). Expired temporary permits or temporary permits with no owner/ticket/expiry are **High** for privileged or production access and **Medium** otherwise.
 
 ---
 
@@ -249,8 +293,82 @@ Egress filtering prevents compromised internal hosts from establishing unrestric
 - Outbound HTTPS (TCP 443) is routed through a forward proxy where feasible.
 - Uncommon outbound protocols (SSH 22, RDP 3389, ICMP) are restricted or denied by default.
 - Outbound connections to known anonymization services (Tor exit nodes) are blocked.
+- IPv4 and IPv6 egress controls are equivalent unless IPv6 is explicitly disabled with evidence.
+- Broad IPv6 egress to `::/0` is tied to proxy, route, log, and reachability evidence before lowering severity.
 
-**Finding classification:** Unrestricted outbound egress (allow all) is **High**. Missing DNS egress restriction is **Medium**.
+**Patterns to check:**
+
+```
+# IPv6-only unrestricted egress
+egress {
+  from_port        = 0
+  to_port          = 0
+  protocol         = "-1"
+  cidr_blocks      = []
+  ipv6_cidr_blocks = ["::/0"]
+}
+
+# ip6tables unrestricted outbound
+-A OUTPUT -d ::/0 -j ACCEPT
+
+# nftables unrestricted outbound over IPv6
+ip6 daddr ::/0 accept
+```
+
+**Finding classification:** Unrestricted outbound egress (allow all) is **High**. Missing DNS egress restriction is **Medium**. IPv6 unrestricted egress with restrictive IPv4 egress is **High**, or **Not Applicable** only when IPv6 is proven disabled or unrouted.
+
+---
+
+#### 2.8 IPv4/IPv6 Parity and Reachability Gate
+
+Dual-stack environments require parity checks because IPv4 and IPv6 rule bases, routes, security groups, and host interfaces can be configured separately.
+
+**What to verify:**
+
+- IPv6 listener exposure matches the intended IPv4 exposure for privileged services.
+- IPv6 default policies are deny-by-default for inbound, forwarded, and outbound chains.
+- Cloud security group, firewall, route table, subnet, and host interface evidence agree on whether IPv6 is reachable.
+- Public `::/0` rules are not accepted as benign solely because IPv4 is restricted.
+- Link-local IPv6 findings are distinguished from internet-routable IPv6 exposure.
+
+**IPv6 Not Applicable evidence:**
+
+Use `Not Applicable` only when the report includes all relevant evidence for the platform:
+- Host interface IPv6 disabled or no global unicast address assigned.
+- Subnet/VPC IPv6 assignment disabled.
+- No IPv6 default route or internet gateway path.
+- Cloud firewall/security group lacks IPv6 peers for the reviewed asset.
+
+**Finding classification:** Reachable privileged `::/0` ingress is **Critical**. Unmanaged IPv6 default allow is **Critical**. Missing IPv6 reachability evidence is **Medium** when IPv6 appears enabled but exposure is uncertain.
+
+---
+
+#### 2.9 Temporary Rule and Exception Governance Gate
+
+Temporary rules are valid during incidents, migrations, or vendor maintenance only when they are managed as time-bound exceptions.
+
+**What to verify:**
+
+- Each temporary rule has an owner, business justification, approving team, and change ticket.
+- Each rule has `created_at`, `expires_at`, and `last_reviewed` or equivalent evidence.
+- Expired rules are removed or renewed through a documented exception workflow.
+- Hit count, flow log, or SIEM evidence supports continued need.
+- Privileged access, production database access, and management-plane access have stronger expiry and review requirements.
+
+**Patterns to check:**
+
+```
+comment: temporary
+comment: break-fix
+comment: incident
+comment: vendor
+expires_at: null
+owner: null
+change_ticket: null
+last_reviewed: unknown
+```
+
+**Finding classification:** Expired temporary production or privileged access is **High**. Missing owner, ticket, or expiry on a temporary rule is **High** for privileged access and **Medium** for lower-risk access.
 
 ---
 
@@ -264,9 +382,9 @@ Produce the final report using the following structure.
 
 | Severity | Definition |
 |----------|-----------|
-| **Critical** | Missing default deny; any/any inbound rules. Immediate exploitation risk. |
-| **High** | Overly permissive outbound rules; shadowed deny rules; no logging on deny actions; missing anti-spoofing; unused rules to decommissioned resources. |
-| **Medium** | Shadowed permit rules; missing egress DNS restriction; unused rules (active resources); missing logging on sensitive permits; missing stealth rules. |
+| **Critical** | Missing default deny; any/any inbound rules; reachable privileged `::/0` ingress; unmanaged IPv6 default allow. Immediate exploitation risk. |
+| **High** | Overly permissive outbound rules; unrestricted IPv6 egress; shadowed deny rules; no logging on deny actions; missing anti-spoofing; unused rules to decommissioned resources; expired temporary privileged access. |
+| **Medium** | Shadowed permit rules; missing egress DNS restriction; unused rules (active resources); missing IPv6 reachability evidence; missing logging on sensitive permits; missing stealth rules; incomplete temporary-rule metadata for lower-risk access. |
 | **Low** | Rule documentation gaps; suboptimal rule ordering with no current security impact; cosmetic rule base issues. |
 
 ---
@@ -301,21 +419,31 @@ Produce the final report using the following structure.
 - **Remediation:** <concrete fix with example>
 
 ### Default Deny Status
-| Direction | Status | Evidence |
-|-----------|--------|----------|
-| Inbound   | Pass/Fail | <rule reference> |
-| Outbound  | Pass/Fail | <rule reference> |
+| Direction | IPv4 Status | IPv6 Status | Evidence |
+|-----------|-------------|-------------|----------|
+| Inbound   | Pass/Fail/Not Applicable | Pass/Fail/Not Applicable | <rule reference and IPv6 reachability evidence> |
+| Outbound  | Pass/Fail/Not Applicable | Pass/Fail/Not Applicable | <rule reference and IPv6 reachability evidence> |
 
 ### Shadowed Rules Summary
 | Shadowed Rule | Position | Shadowing Rule | Position | Impact |
 |---------------|----------|----------------|----------|--------|
 
 ### Egress Filtering Status
-| Protocol/Port | Restricted | Authorized Destinations |
-|---------------|-----------|------------------------|
-| DNS (53)      | Yes/No    | <resolver IPs>         |
-| SMTP (25)     | Yes/No    | <mail server IPs>      |
-| HTTPS (443)   | Yes/No    | <proxy or direct>      |
+| Protocol/Port | IPv4 Restricted | IPv6 Restricted | Authorized Destinations |
+|---------------|-----------------|-----------------|------------------------|
+| DNS (53)      | Yes/No/NA       | Yes/No/NA       | <resolver IPs>         |
+| SMTP (25)     | Yes/No/NA       | Yes/No/NA       | <mail server IPs>      |
+| HTTPS (443)   | Yes/No/NA       | Yes/No/NA       | <proxy or direct>      |
+
+### IPv4/IPv6 Parity
+| Service/Rule | IPv4 Exposure | IPv6 Exposure | Reachability Evidence | Status |
+|--------------|---------------|---------------|-----------------------|--------|
+| <service>    | <source/port> | <source/port or NA> | <interface, route, subnet, SG evidence> | Pass/Fail/NA |
+
+### Temporary Rules and Exceptions
+| Rule | Owner | Justification | Change Ticket | Created | Expires | Last Reviewed | Status |
+|------|-------|---------------|---------------|---------|---------|---------------|--------|
+| <rule id> | <team/person> | <business reason> | <ticket> | <date> | <date> | <date> | Active/Expired/Unknown |
 
 ### Prioritized Remediation Plan
 1. **[Critical]** <action item with control reference>
@@ -357,9 +485,13 @@ Produce the final report using the following structure.
 
 3. **Ignoring IPv6 rules.** Many environments have parallel IPv4 and IPv6 rule bases (ip6tables, IPv6 security group rules). If IPv6 is not explicitly disabled at the interface level, an unmanaged IPv6 rule base can bypass all IPv4 firewall controls.
 
-4. **Assuming hit count of zero means the rule is unused.** Hit counters reset on firewall reload or failover. Verify the counter baseline timestamp before recommending rule removal. Cross-reference with SIEM/flow data where available.
+4. **Marking IPv6 as safe without reachability evidence.** A broad `::/0` rule may be acceptable only when routing, subnet assignment, host interface state, proxy controls, and logs prove it is not directly reachable or is tightly inspected.
 
-5. **Conflating network ACLs with security groups in cloud environments.** In AWS, NACLs are stateless and operate at the subnet level; security groups are stateful and operate at the instance level. Both must be audited. A permissive NACL can undermine restrictive security group rules for responses.
+5. **Assuming hit count of zero means the rule is unused.** Hit counters reset on firewall reload or failover. Verify the counter baseline timestamp before recommending rule removal. Cross-reference with SIEM/flow data where available.
+
+6. **Letting temporary rules age silently.** Incident and vendor rules should have an owner, change ticket, expiry, and review trail. Without those fields, temporary access becomes permanent access.
+
+7. **Conflating network ACLs with security groups in cloud environments.** In AWS, NACLs are stateless and operate at the subnet level; security groups are stateful and operate at the instance level. Both must be audited. A permissive NACL can undermine restrictive security group rules for responses.
 
 ---
 
@@ -381,9 +513,13 @@ This skill processes firewall configurations that may contain user-supplied comm
 - NIST SP 800-41 Rev 1, Guidelines on Firewalls and Firewall Policy: https://csrc.nist.gov/publications/detail/sp/800-41/rev-1/final
 - NIST SP 800-41 Rev 1 (PDF): https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-41r1.pdf
 - CIS Benchmarks (platform-specific firewall hardening): https://www.cisecurity.org/cis-benchmarks
+- AWS security group rule reference, including IPv6 CIDR blocks: https://docs.aws.amazon.com/vpc/latest/userguide/security-group-rules.html
+- nftables inet family documentation: https://wiki.nftables.org/wiki-nftables/index.php/Nftables_families
+- Microsoft Azure network security groups and IPv6 overview: https://learn.microsoft.com/azure/virtual-network/network-security-groups-overview
 
 ---
 
 ## Changelog
 
+- **1.1.0** -- Added IPv4/IPv6 parity checks, reachable `::/0` severity guidance, IPv6 not-applicable evidence requirements, and temporary rule exception governance.
 - **1.0.0** -- Initial release. Full coverage of CIS Controls v8 (4.4, 4.5) and NIST SP 800-41 Rev 1 firewall audit methodology.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** firewall-review
**Skill path:** `skills/network/firewall-review/`

### What Was Wrong

The skill mentioned IPv6 as a common pitfall, but the workflow did not give reviewers concrete discovery patterns, evidence tables, severity rules, or output fields for IPv4/IPv6 parity. A reviewer could miss default-deny drift, privileged `::/0` exposure, unrestricted IPv6 egress, or could overstate risk when IPv6 is actually disabled. Temporary/break-fix rules were also described as technical debt but were not governed through owner, ticket, expiry, and last-review evidence.

### What This PR Fixes

- Adds IPv6 discovery patterns for `ip6tables`, nftables, cloud security groups, and IaC IPv6 CIDR fields.
- Requires address-family categorization and independent IPv4/IPv6 default-deny verification.
- Adds reachable `::/0` severity guidance for privileged ingress and unrestricted IPv6 egress.
- Adds explicit `Not Applicable` evidence requirements when IPv6 is disabled or unrouted.
- Adds temporary-rule and exception governance gates for owner, justification, ticket, expiry, last review, and removal/renewal evidence.
- Updates output tables so reports capture IPv4/IPv6 parity and temporary exception status.

### Evidence

**Before (skill misses this / false positive on this):**
```hcl
ingress {
  from_port        = 22
  to_port          = 22
  protocol         = tcp
  ipv6_cidr_blocks = [::/0]
}
```

```yaml
rule_id: TEMP-incident-allow-db
source: 10.40.0.0/16
destination: db-prod-01
port: 5432
action: allow
comment: temporary incident access
expires_at: null
owner: null
change_ticket: null
last_reviewed: unknown
```

**After (now correctly handled):**
```text
- Reviewers must classify address family separately for IPv4, IPv6, dual-stack, or Not Applicable.
- Reachable privileged `::/0` ingress is Critical.
- IPv6 unrestricted egress with restrictive IPv4 egress is High unless IPv6 is proven disabled or unrouted.
- Temporary privileged access with no owner/ticket/expiry is High.
- Reports now include IPv4/IPv6 parity and Temporary Rules and Exceptions tables.
```

### Test Cases Added/Updated
- [ ] Added vulnerable test cases (`tests/vulnerable/`)
- [ ] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass

Validation performed locally:
- `git diff --check`
- Required frontmatter fields verified for `skills/network/firewall-review/SKILL.md`
- Prompt-injection pattern scan passed for the modified skill file

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** GitHub Sponsors; PayPal details can be provided privately after acceptance.

Closes #1260