### PR TITLE
Add API upload parser hardening gates

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -3,15 +3,17 @@ name: api-security
 description: >
   Reviews REST and GraphQL APIs against the OWASP API Security Top 10:2023.
   Auto-invoked when reviewing OpenAPI/Swagger specs, API endpoint code, or
-  GraphQL schemas. Covers BOLA, BFLA, authentication, rate limiting, and
-  SSRF. Produces findings mapped to API1-API10 with remediation guidance.
+  GraphQL schemas. Covers BOLA, BFLA, authentication, rate limiting,
+  multipart file uploads, archive/parser boundaries, storage/download
+  controls, and SSRF. Produces findings mapped to API1-API10 with remediation
+  guidance.
 tags: [appsec, api, rest, graphql]
 role: [appsec-engineer, security-engineer]
 phase: [design, build, review]
 frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -38,6 +40,7 @@ Before analyzing any endpoint, establish a complete inventory of the API surface
 5. **Catalog data objects** -- List the resources/entities exposed by the API and their sensitivity classification (PII, financial, internal, public).
 6. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, or cost-control mechanisms at the gateway or application layer.
 7. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
+8. **Identify file-processing surfaces** -- Multipart upload endpoints, archive imports, image/document converters, malware scanners, object storage buckets, and download handlers.
 
 > **Gate:** Do not proceed until the API style, authentication model, authorization model, and endpoint inventory are documented. Incomplete scope leads to missed findings.
 
@@ -66,6 +69,7 @@ Each finding produced by this review must include the following fields:
 | **Location** | File path and line number(s), or OpenAPI spec path |
 | **Description** | What the vulnerability is and why it matters |
 | **Evidence** | Relevant code snippet or spec excerpt demonstrating the issue |
+| **Parser/Storage Evidence** | For file flows, record gateway, framework parser, scanner/quarantine, storage, archive, and download-header evidence |
 | **Remediation** | Specific fix with code example where possible |
 | **Status** | Open, Mitigated, Accepted Risk, False Positive |
 
@@ -92,7 +96,7 @@ The final review output must be structured as follows:
 **API Style:** [REST / GraphQL / gRPC / Hybrid]
 **Specification:** [OpenAPI spec path, if applicable]
 **Date:** [review date]
-**Reviewer:** AI Agent -- api-security skill v1.0.0
+**Reviewer:** [reviewer name] -- api-security skill v1.1.0
 
 ### Summary
 
@@ -147,6 +151,82 @@ The final review output must be structured as follows:
 | API8:2023 | Security Misconfiguration | CWE-16, CWE-611 | CORS, headers, TLS, error handling, XXE |
 | API9:2023 | Improper Inventory Management | CWE-1059 | Shadow APIs, deprecated versions, missing documentation |
 | API10:2023 | Unsafe Consumption of APIs | CWE-20, CWE-295 | Trusting upstream API data without validation |
+
+---
+
+## File Upload, Multipart, Archive, and Download Boundaries
+
+File upload and file-processing APIs cross several OWASP API risks. Resource exhaustion maps to API4, parser and storage mistakes map to API8, and downstream scanners, converters, and importers can map to API10 when their output is trusted without validation. Review the full lifecycle instead of accepting one gateway body limit or one MIME-type check as sufficient evidence.
+
+### Discovery Patterns
+
+Use allowed read/search tools to inventory these surfaces:
+
+```
+multipart|form-data|multer|busboy|formidable|IFormFile|MultipartFile|request.files|upload.single|upload.array
+originalname|filename|mimetype|Content-Type|content_type|magic|signature|file-type
+ZipFile|extractall|tarfile|unzip|archive|compression|decompress|zip-slip
+quarantine|antivirus|clamav|sandbox|scanner|converter|imagemagick|libreoffice|pdf
+Content-Disposition|nosniff|object storage|bucket policy|public-read|web root
+```
+
+### Required Evidence Table
+
+| Evidence Area | Required Review Evidence | OWASP Mapping |
+|---|---|---|
+| Upload limits | Gateway body limit, framework parser limit, per-file size, file count, and total multipart part count are all bounded and aligned | API4 |
+| Type validation | Extension allowlist is paired with signature/magic-byte validation and safe parser validation; user `Content-Type` is not trusted alone | API8 |
+| Filename and storage | Storage names are server-generated, path separators are stripped, files are outside executable web roots, and object keys are not predictable | API8 |
+| Archive handling | Compressed size, uncompressed size, expansion ratio, entry count, nesting depth, symlink behavior, and canonical extraction paths are bounded | API4/API8 |
+| Scanner/quarantine | Files remain inaccessible until malware scanning, sandboxing, and downstream parser validation have completed successfully | API8/API10 |
+| Parser consistency | Gateway, framework parser, scanner, storage, archive extractor, converter, and business logic process the same accepted file set under the same limits | API4/API10 |
+| Download controls | Downloads use `Content-Disposition: attachment` for untrusted content, `X-Content-Type-Options: nosniff`, non-executable serving, and appropriate cache policy | API8 |
+| Object storage policy | Buckets are private by default, release is explicit, keys are unguessable, and public URLs cannot bypass scan/quarantine state | API8 |
+
+### Review Decision Flow
+
+1. Inventory every endpoint that accepts, stores, extracts, converts, scans, or returns user-controlled files.
+2. Build a lifecycle row for each endpoint: gateway -> framework parser -> type validation -> scanner/quarantine -> storage -> downstream parser/converter -> download path.
+3. Mark the flow `Pass` only when every lifecycle stage has aligned limits and the file cannot be reached before release.
+4. Mark the flow `Not Evaluable` when the implementation, storage policy, scanner behavior, or download behavior is unavailable. List the missing evidence instead of assuming safe or vulnerable behavior.
+5. Raise a finding when one layer accepts a file that another layer does not limit, scan, validate, quarantine, or serve safely.
+
+### API Mapping Rules
+
+- Use **API4:2023** when the primary failure is unbounded body size, multipart part count, file count, archive expansion, parser CPU/memory/time, or downstream converter resource use.
+- Use **API8:2023** when the primary failure is trusting attacker-controlled file labels, writing to executable/web-served storage, exposing public object URLs, missing safe download headers, or releasing before quarantine state is enforced.
+- Use **API10:2023** when scanner, converter, metadata parser, archive importer, or upstream file-processing output is consumed as trusted data without validation.
+- Include secondary mappings when the same endpoint crosses categories, but choose the finding title and severity from the most directly exploitable failure.
+
+### Severity Guidance
+
+| Condition | Severity |
+|---|---|
+| Upload endpoint stores attacker-controlled filenames or active content under a web-served/executable path while trusting `Content-Type`, extension, or original filename | High |
+| Archive extraction lacks canonical path checks, expansion ratio limits, entry/depth limits, symlink controls, or isolated extraction workspace | High |
+| Files are reachable before required scan/quarantine/parser decisions complete | High |
+| Gateway limit exists but framework parser, scanner, archive expansion, converter, or business file-count limits are inconsistent or not evidenced | Medium |
+| Object storage is used but bucket policy, random object keys, safe download headers, and release gating are not evidenced | Medium |
+| Uploads are encrypted, quarantined, never parsed, never extracted, and only moved to a trusted offline workflow, but the report lacks full evidence | Low |
+| Upload endpoint has complete limits, signature validation, quarantine-before-release, safe storage, and safe download headers | Informational or no finding |
+
+### False Positive and Not Evaluable Rules
+
+- Do not report every upload endpoint as vulnerable. First determine whether size, count, type, signature, quarantine, storage, and download controls are evidenced.
+- Mark `Not Evaluable` when only an OpenAPI path is available and the implementation/storage/scanner behavior cannot be inspected. State the missing evidence rather than assuming vulnerability.
+- Treat `Content-Type`, extension, and original filename as attacker-controlled labels. They can support logging or UX, but not the security decision by themselves.
+- Treat polyglot files, signature mismatches, and parser differentials as separate evidence checks. A file can match one parser while triggering another downstream parser differently.
+- For asynchronous malware scanning, quarantine is acceptable only when the file is inaccessible until the clean verdict and downstream parser validation complete.
+- Object storage is not automatically safe. Verify private bucket policy, non-guessable keys, explicit release state, safe content disposition, `nosniff`, and no direct public path around quarantine.
+
+### Remediation Requirements
+
+1. Enforce aligned request, multipart, per-file, file-count, archive expansion, converter, and scanner limits.
+2. Validate with extension allowlists, signature/magic-byte checks, and safe parser validation. Reject mismatches and polyglot formats unless explicitly supported and safely processed.
+3. Generate storage names server-side, normalize metadata only for display, and never write user filenames into web-served or executable paths.
+4. Extract archives only into isolated workspaces after canonical path, symlink, entry count, depth, compressed size, uncompressed size, and expansion-ratio checks.
+5. Keep files quarantined until scan, sandbox, and downstream parser decisions pass; enforce release state in every download and object-storage URL path.
+6. Serve untrusted files with `Content-Disposition: attachment`, `X-Content-Type-Options: nosniff`, disabled execute permissions, and cache controls appropriate to sensitivity.
 
 ---
 

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -267,11 +267,31 @@ query {
 app.use(express.json()); // Default limit may be very large or unconfigured
 ```
 
+```javascript
+// VULNERABLE: Multipart parser has no file count or per-file size limits
+const upload = multer();
+app.post('/api/documents/upload', upload.array('files'), async (req, res) => {
+  return res.json({ accepted: req.files.length });
+});
+```
+
+```python
+# VULNERABLE: Archive expansion has no size, ratio, entry, or depth limits
+@app.post('/api/import')
+def import_archive():
+    archive = zipfile.ZipFile(request.files['archive'])
+    archive.extractall('/srv/imports')
+    return {'entries': len(archive.infolist())}
+```
+
 ### Remediation Guidance
 
 - Implement rate limiting at the API gateway and/or application layer. Use sliding window or token bucket algorithms. Set per-endpoint limits based on expected legitimate usage.
 - Enforce maximum pagination size (e.g., `limit` capped at 100). Default to a reasonable page size (e.g., 20).
 - Set maximum request body sizes (`express.json({ limit: '1mb' })`).
+- For multipart endpoints, enforce aligned gateway body, framework body, multipart part count, file count, per-file size, and total upload size limits.
+- For archive imports, enforce compressed size, uncompressed size, expansion ratio, entry count, nesting depth, symlink behavior, and extraction timeout limits.
+- Apply equivalent bounds to scanners, image/document converters, and downstream parsers so a file accepted by the upload layer cannot exhaust a later processing layer.
 - For GraphQL: enforce query depth limits (e.g., max depth 5), complexity analysis (weighted field costs), and batch query limits.
 - Set execution timeouts for database queries and downstream API calls.
 - Implement cost alerts and circuit breakers for operations that trigger billable third-party APIs.
@@ -281,6 +301,9 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - [ ] Rate limiting is configured for all endpoints, with stricter limits on expensive operations.
 - [ ] Pagination has a maximum page size enforced server-side.
 - [ ] Request body size limits are configured.
+- [ ] Multipart upload endpoints enforce file size, total size, file count, and part count limits across gateway and application parser layers.
+- [ ] Archive processing enforces compressed size, uncompressed size, expansion ratio, entry count, nesting depth, symlink, and timeout limits.
+- [ ] Scanner, converter, and downstream parser limits are aligned with upload acceptance limits.
 - [ ] GraphQL queries have depth limits, complexity limits, and batch restrictions.
 - [ ] Database queries and downstream calls have execution timeouts.
 - [ ] Billable operations have cost controls and alerting.
@@ -423,6 +446,14 @@ def register_webhook():
 **CWE:** CWE-16 (Configuration), CWE-611 (Improper Restriction of XML External Entity Reference), CWE-942 (Permissive Cross-domain Policy with Untrusted Domains)
 **Severity:** High to Medium
 
+### What to Look For
+
+- Upload handlers that make security decisions from `Content-Type`, framework `mimetype`, filename extension, or original filename without signature and parser validation.
+- Files written under web-served or executable paths, or object keys derived from user-controlled path segments.
+- Public object URLs, signed URLs, redirects, or download handlers that bypass scan/quarantine release state.
+- Missing `Content-Disposition: attachment`, `X-Content-Type-Options: nosniff`, private bucket policy, cache controls, or non-executable serving controls for untrusted content.
+- Archive extraction that does not reject absolute paths, parent-directory entries, symlinks, or canonical paths outside the isolated extraction workspace.
+
 ### Vulnerable Patterns
 
 ```python
@@ -450,6 +481,35 @@ DocumentBuilder builder = factory.newDocumentBuilder();
 Document doc = builder.parse(request.getInputStream());
 ```
 
+```javascript
+// VULNERABLE: Trusts client MIME type and original filename for storage
+app.post('/api/upload', upload.single('file'), async (req, res) => {
+  if (req.file.mimetype !== 'image/png') return res.status(400).end();
+  await fs.promises.writeFile(`/var/www/uploads/${req.file.originalname}`, req.file.buffer);
+  res.json({ url: `/uploads/${req.file.originalname}` });
+});
+```
+
+```javascript
+// VULNERABLE: Public object storage serves untrusted files inline
+app.get('/api/files/:key', async (req, res) => {
+  res.json({
+    url: `https://public-bucket.example.com/uploads/${req.params.key}`,
+    contentDisposition: 'inline',
+    xContentTypeOptions: 'missing',
+  });
+});
+```
+
+```javascript
+// VULNERABLE: Download path releases files before scan/quarantine passes
+app.get('/api/files/:id/download', async (req, res) => {
+  const file = await files.findById(req.params.id);
+  if (!file) return res.status(404).end();
+  return res.redirect(file.objectUrl);
+});
+```
+
 ### Remediation Guidance
 
 - Configure CORS with an explicit allowlist of permitted origins. Never use `*` with `credentials: true`.
@@ -460,6 +520,12 @@ Document doc = builder.parse(request.getInputStream());
 - Return generic error messages in production. Log detailed errors server-side with correlation IDs.
 - Disable unnecessary HTTP methods. Return `405 Method Not Allowed` for unsupported methods.
 - Disable XML External Entity processing: set `factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)`.
+- For uploads, generate storage names server-side, strip path separators from display metadata, and store files outside executable web roots.
+- Validate file type with extension allowlists, signature/magic-byte checks, and safe parser validation. Do not trust `Content-Type`, `mimetype`, or original filename alone.
+- Serve untrusted downloads with `Content-Disposition: attachment`, `X-Content-Type-Options: nosniff`, disabled execute permissions, and cache controls appropriate to the data.
+- For object storage, verify private bucket policy, non-guessable keys, explicit scan/quarantine release state, and no public URL path that bypasses download controls.
+- Enforce scan/quarantine release state inside every download, redirect, signed URL, CDN, and object storage path. Returning scan status in metadata is not a control unless access is denied before a clean verdict.
+- For archives, reject absolute paths, parent-directory entries, symlinks, device files, and canonical paths outside the extraction workspace before writing any entry.
 - Enforce TLS 1.2+ with strong cipher suites. Disable TLS 1.0 and 1.1.
 - Automate configuration scanning in CI/CD to detect drift from security baselines.
 
@@ -469,6 +535,11 @@ Document doc = builder.parse(request.getInputStream());
 - [ ] Security headers are present on all API responses.
 - [ ] Error responses in production are generic; no stack traces, SQL queries, or internal paths.
 - [ ] Only required HTTP methods are enabled per endpoint.
+- [ ] Upload handlers do not trust original filenames, filename extensions, or client-supplied content types as security decisions.
+- [ ] Stored files use server-generated names, isolated storage, non-executable permissions, and no direct web-root write path.
+- [ ] Download handlers and object storage responses use safe `Content-Disposition`, `nosniff`, private bucket policy, and scan/quarantine release gates.
+- [ ] Direct object URLs, signed URLs, redirects, CDN paths, and API download paths all enforce the same clean-release state.
+- [ ] Archive extractors reject path traversal, absolute paths, symlinks, and writes outside an isolated canonical extraction workspace.
 - [ ] TLS 1.2+ is enforced with strong cipher suites.
 - [ ] XML parsers disable external entity processing and DTD loading.
 - [ ] Default credentials are changed or removed on all infrastructure components.
@@ -544,6 +615,23 @@ const data = await enrichmentData.json();
 res.send(`<div class="bio">${data.biography}</div>`);  // Stored XSS via third party
 ```
 
+```javascript
+// VULNERABLE: Downstream scanner checks only the first multipart file
+app.post('/api/import', upload.array('files'), async (req, res) => {
+  await scanner.scan(req.files[0].buffer);
+  await Promise.all(req.files.map((file) => storeAndProcess(file)));
+  return res.json({ imported: req.files.length });
+});
+```
+
+```python
+# VULNERABLE: Converter output is trusted after a weak signature check
+def convert_upload(file):
+    if file.content_type == "application/pdf":
+        return libreoffice_convert(file.stream.read())
+    raise ValueError("unsupported")
+```
+
 ### Remediation Guidance
 
 - Treat all data from external and internal APIs as untrusted input. Validate and sanitize before use.
@@ -552,6 +640,9 @@ res.send(`<div class="bio">${data.biography}</div>`);  // Stored XSS via third p
 - Implement timeouts, retry limits with backoff, and circuit breakers on all outbound API calls.
 - Restrict redirects on outbound calls. If following redirects, re-validate the destination URL.
 - Use parameterized queries when inserting data from any source, including trusted internal APIs.
+- Treat malware scanners, archive extractors, image processors, document converters, and metadata parsers as untrusted downstream consumers. Validate their input and output schemas.
+- Ensure every uploaded part that business logic stores or processes is scanned and parser-validated; do not scan only the first multipart part.
+- Sandbox converters and parsers with memory, CPU, wall-clock, output-size, and filesystem limits, and reject parser differentials or signature mismatches.
 
 ### Review Checklist
 
@@ -560,3 +651,5 @@ res.send(`<div class="bio">${data.biography}</div>`);  // Stored XSS via third p
 - [ ] Response schemas from third-party APIs are validated before processing.
 - [ ] Outbound calls have timeouts, retry limits, and circuit breakers.
 - [ ] Redirect following is disabled or restricted on outbound HTTP calls.
+- [ ] Downstream scanners, archive extractors, converters, and parsers validate every accepted file part under explicit resource limits.
+- [ ] Converter/parser output is treated as untrusted until schema, content, and storage decisions are re-validated.

--- a/skills/appsec/api-security/tests/benign/bounded-archive-import.md
+++ b/skills/appsec/api-security/tests/benign/bounded-archive-import.md
@@ -1,0 +1,33 @@
+# Benign: bounded archive import evidence
+
+This fixture represents an archive import endpoint that should not be reported
+as an archive-bomb or zip-slip finding when the listed controls are verified.
+
+```yaml
+endpoint: POST /api/import/archive
+auth: required
+upload_type: zip
+limits:
+  gateway_body_size: 20MB
+  framework_body_size: 20MB
+  compressed_size: 20MB
+  uncompressed_size: 100MB
+  expansion_ratio: 5
+  max_entries: 200
+  max_depth: 4
+  extraction_timeout: 10s
+archive_validation:
+  canonical_path_check: enabled
+  reject_absolute_paths: true
+  reject_parent_directory_entries: true
+  reject_symlinks: true
+  extract_workspace: isolated_temporary_directory
+post_processing:
+  malware_scan_before_release: true
+  parser_validation_before_import: true
+  requester_access_before_clean: false
+```
+
+Expected review outcome: Pass or Informational. Missing evidence for any bound
+should be recorded as `Not Evaluable` or a scoped finding, not generalized to
+all archive uploads.

--- a/skills/appsec/api-security/tests/benign/controlled-upload-evidence.md
+++ b/skills/appsec/api-security/tests/benign/controlled-upload-evidence.md
@@ -1,0 +1,36 @@
+# Benign: controlled upload evidence
+
+This fixture represents a multipart upload endpoint that should not be reported
+as vulnerable when the listed evidence is confirmed.
+
+```yaml
+endpoint: POST /api/documents/upload
+auth: required
+upload_type: multipart/form-data
+limits:
+  gateway_body_size: 10MB
+  framework_body_size: 10MB
+  multipart_part_count: 4
+  max_file_count: 3
+  max_single_file_size: 5MB
+type_validation:
+  extension_allowlist: [pdf, png]
+  content_type_header_trusted: false
+  signature_validation: enabled
+  parser_validation: enabled
+archive_extraction:
+  enabled: false
+scan_and_quarantine:
+  malware_scan: async
+  accessible_before_clean: false
+storage:
+  location: private_object_storage
+  object_key_source: server_generated_uuid
+  original_filename_stored_as_metadata_only: true
+download_headers:
+  content_disposition: attachment
+  x_content_type_options: nosniff
+```
+
+Expected review outcome: Pass or Informational. Do not flag solely because the
+endpoint accepts files.

--- a/skills/appsec/api-security/tests/benign/offline-quarantine-upload.md
+++ b/skills/appsec/api-security/tests/benign/offline-quarantine-upload.md
@@ -1,0 +1,29 @@
+# Benign: offline quarantine upload
+
+This fixture represents an API that accepts a file but does not parse, extract,
+or serve it from the request path.
+
+```yaml
+endpoint: POST /api/legal-hold/evidence
+auth: required
+upload_type: multipart/form-data
+limits:
+  gateway_body_size: 25MB
+  app_body_size: 25MB
+  max_file_count: 1
+processing:
+  inline_parsing: false
+  archive_extraction: false
+  converter_invoked: false
+quarantine:
+  stored_encrypted: true
+  accessible_to_requester: false
+  release_requires_manual_approval: true
+storage:
+  bucket_policy: private
+  object_key_source: server_generated_uuid
+  public_url_available: false
+```
+
+Expected review outcome: Low or Informational if any evidence is missing;
+otherwise no finding.

--- a/skills/appsec/api-security/tests/vulnerable/original-filename-upload.js
+++ b/skills/appsec/api-security/tests/vulnerable/original-filename-upload.js
@@ -1,0 +1,23 @@
+// Vulnerable fixture: trusts MIME type and original filename for storage.
+
+const fs = require("fs/promises");
+const express = require("express");
+const multer = require("multer");
+
+const app = express();
+const upload = multer();
+
+app.post("/api/upload", upload.single("file"), async (req, res) => {
+  if (req.file.mimetype !== "image/png") {
+    return res.status(400).end();
+  }
+
+  const target = `/var/www/uploads/${req.file.originalname}`;
+  await fs.writeFile(target, req.file.buffer);
+  return res.json({ url: `/uploads/${req.file.originalname}` });
+});
+
+module.exports = app;
+
+// Expected review outcome: High if attacker-controlled filenames/content are
+// written under a web-served path while trusting mimetype/originalname.

--- a/skills/appsec/api-security/tests/vulnerable/polyglot-signature-mismatch.md
+++ b/skills/appsec/api-security/tests/vulnerable/polyglot-signature-mismatch.md
@@ -1,0 +1,24 @@
+# Vulnerable: polyglot and signature mismatch accepted
+
+This fixture represents review evidence for an upload path that accepts a file
+when any single label matches instead of requiring consistent validation.
+
+```yaml
+endpoint: POST /api/avatar
+checks:
+  extension: png
+  content_type: image/png
+  first_signature_match: png
+  full_parser_validation: skipped
+  downstream_processor: imagemagick
+  polyglot_detection: absent
+decision:
+  accepted: true
+  stored_under_web_origin: true
+download_headers:
+  content_disposition: inline
+  x_content_type_options: missing
+```
+
+Expected review outcome: Medium or High depending on whether the downstream
+parser can execute active content or expose stored content from the app origin.

--- a/skills/appsec/api-security/tests/vulnerable/public-object-inline-download.js
+++ b/skills/appsec/api-security/tests/vulnerable/public-object-inline-download.js
@@ -1,0 +1,20 @@
+// Vulnerable fixture: public object URL bypasses quarantine and safe headers.
+
+const express = require("express");
+
+const app = express();
+
+app.get("/api/files/:key", async (req, res) => {
+  const objectUrl = `https://public-bucket.example.com/uploads/${req.params.key}`;
+  return res.json({
+    url: objectUrl,
+    headers: {
+      "Content-Disposition": "inline",
+    },
+  });
+});
+
+module.exports = app;
+
+// Expected review outcome: Medium or High when public object access can bypass
+// scan/quarantine state or serve untrusted content inline without nosniff.

--- a/skills/appsec/api-security/tests/vulnerable/scan-before-release-download.js
+++ b/skills/appsec/api-security/tests/vulnerable/scan-before-release-download.js
@@ -1,0 +1,22 @@
+// Vulnerable fixture: download path releases files before scan completion.
+
+const express = require("express");
+
+const app = express();
+
+app.get("/api/files/:id/download", async (req, res) => {
+  const file = await files.findById(req.params.id);
+
+  if (!file) {
+    return res.status(404).end();
+  }
+
+  // The scan status is returned to clients, but it is not enforced before
+  // redirecting to the object URL.
+  return res.redirect(file.objectUrl);
+});
+
+module.exports = app;
+
+// Expected review outcome: High when untrusted files are reachable before a
+// clean scan/quarantine release decision is enforced on every download path.

--- a/skills/appsec/api-security/tests/vulnerable/unbounded-multipart-parser.js
+++ b/skills/appsec/api-security/tests/vulnerable/unbounded-multipart-parser.js
@@ -1,0 +1,18 @@
+// Vulnerable fixture: multipart parser accepts unbounded file arrays.
+
+const express = require("express");
+const multer = require("multer");
+
+const app = express();
+const upload = multer();
+
+app.post("/api/documents/upload", upload.array("files"), async (req, res) => {
+  await Promise.all(req.files.map((file) => processDocument(file.buffer)));
+  return res.json({ processed: req.files.length });
+});
+
+module.exports = app;
+
+// Expected review outcome: Medium or High when gateway limits are not matched
+// by multipart file count, per-file size, total part count, and downstream
+// parser/converter resource limits.

--- a/skills/appsec/api-security/tests/vulnerable/zip-slip-archive-extract.py
+++ b/skills/appsec/api-security/tests/vulnerable/zip-slip-archive-extract.py
@@ -1,0 +1,19 @@
+"""Vulnerable fixture: archive extraction lacks bounds and path checks."""
+
+import zipfile
+
+from flask import Flask, request
+
+
+app = Flask(__name__)
+
+
+@app.post("/api/import")
+def import_zip():
+    archive = zipfile.ZipFile(request.files["archive"])
+    archive.extractall("/srv/imports")
+    return {"imported": len(archive.infolist())}
+
+
+# Expected review outcome: High because extraction has no compression ratio,
+# entry count, nesting depth, canonical path, symlink, or workspace controls.


### PR DESCRIPTION
## Summary
- Upgrades `api-security` to v1.1.0 with multipart upload, archive, parser, storage, quarantine, and download evidence gates.
- Adds API4/API8/API10 mapping rules for upload lifecycle failures, parser-layer consistency, object storage policy, safe download headers, and scan-before-release controls.
- Adds benign and vulnerable fixtures for controlled uploads, bounded archive imports, offline quarantine, original filename storage, zip-slip extraction, public object downloads, scan-before-release bypasses, unbounded multipart parsing, and polyglot/signature mismatch evidence.

## Related issue
Closes #1215

## Validation
- `git diff --cached --check`
- `git diff --check`
- Frontmatter required-field sweep for `skills/` and `roles/`
- Prompt-injection pattern scan on touched files
- Public identity hygiene scan on added diff lines
- Markdown fence-balance check for `skills/appsec/api-security/**/*.md`
- `node --check` for JavaScript fixtures
- `python -m py_compile` for the Python fixture
- Keyword coverage check for multipart, upload, archive, zip-slip, polyglot, quarantine, Content-Disposition, nosniff, object storage, signature, and API8