### PR TITLE
Add gRPC/protobuf evidence gates to API security

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: api-security
 description: >
-  Reviews REST and GraphQL APIs against the OWASP API Security Top 10:2023.
+  Reviews REST, GraphQL, and gRPC/protobuf APIs against the OWASP API
+  Security Top 10:2023.
   Auto-invoked when reviewing OpenAPI/Swagger specs, API endpoint code, or
-  GraphQL schemas. Covers BOLA, BFLA, authentication, rate limiting, and
-  SSRF. Produces findings mapped to API1-API10 with remediation guidance.
-tags: [appsec, api, rest, graphql]
+  GraphQL schemas. Covers BOLA, BFLA, authentication, rate limiting, gRPC
+  reflection, protobuf method authorization, and SSRF. Produces findings
+  mapped to API1-API10 with remediation guidance.
+tags: [appsec, api, rest, graphql, grpc, protobuf]
 role: [appsec-engineer, security-engineer]
 phase: [design, build, review]
 frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -21,7 +23,7 @@ argument-hint: "[target-file-or-directory]"
 
 # API Security Review -- OWASP API Security Top 10:2023
 
-A structured, repeatable process for reviewing REST and GraphQL APIs against the OWASP API Security Top 10:2023. This skill produces findings mapped to API1 through API10 with associated CWE identifiers, severity ratings, and actionable remediation guidance. It applies to OpenAPI/Swagger specifications, API endpoint source code, GraphQL schemas, and API gateway configurations.
+A structured, repeatable process for reviewing REST, GraphQL, and gRPC/protobuf APIs against the OWASP API Security Top 10:2023. This skill produces findings mapped to API1 through API10 with associated CWE identifiers, severity ratings, and actionable remediation guidance. It applies to OpenAPI/Swagger specifications, API endpoint source code, GraphQL schemas, protobuf service definitions, gRPC interceptors, grpc-gateway mappings, and API gateway configurations.
 
 ---
 
@@ -32,12 +34,12 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 Before analyzing any endpoint, establish a complete inventory of the API surface under review.
 
 1. **Identify the API style** -- REST (OpenAPI/Swagger), GraphQL, gRPC, or hybrid. Each style has distinct attack patterns.
-2. **Catalog all endpoints and operations** -- For REST, list every path and HTTP method. For GraphQL, list all queries, mutations, and subscriptions.
-3. **Map authentication mechanisms** -- OAuth 2.0 flows, API keys, JWTs, session cookies, mTLS, or custom tokens. Note which endpoints require authentication and which are public.
-4. **Identify authorization models** -- RBAC, ABAC, ownership-based, or no authorization. Document how object-level and function-level access control decisions are made.
+2. **Catalog all endpoints and operations** -- For REST, list every path and HTTP method. For GraphQL, list all queries, mutations, and subscriptions. For gRPC, list every `.proto` service, RPC method, streaming direction, grpc-gateway annotation, reflection endpoint, and health service exposed by each listener.
+3. **Map authentication mechanisms** -- OAuth 2.0 flows, API keys, JWTs, session cookies, mTLS, gRPC metadata tokens, SPIFFE/SPIRE identities, or custom tokens. Note which endpoints or RPC methods require authentication and which are public.
+4. **Identify authorization models** -- RBAC, ABAC, ownership-based, tenant-boundary, service-to-service, or no authorization. Document how object-level and function-level access control decisions are made per route, resolver, or RPC method.
 5. **Catalog data objects** -- List the resources/entities exposed by the API and their sensitivity classification (PII, financial, internal, public).
 6. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, or cost-control mechanisms at the gateway or application layer.
-7. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
+7. **Identify downstream dependencies** -- Third-party APIs, internal microservices, gRPC upstreams, service meshes, or webhooks that the API consumes.
 
 > **Gate:** Do not proceed until the API style, authentication model, authorization model, and endpoint inventory are documented. Incomplete scope leads to missed findings.
 
@@ -92,7 +94,7 @@ The final review output must be structured as follows:
 **API Style:** [REST / GraphQL / gRPC / Hybrid]
 **Specification:** [OpenAPI spec path, if applicable]
 **Date:** [review date]
-**Reviewer:** AI Agent -- api-security skill v1.0.0
+**Reviewer:** AI Agent -- api-security skill v1.1.0
 
 ### Summary
 
@@ -201,6 +203,53 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 ---
 
+## gRPC/Protobuf-Specific Considerations
+
+gRPC APIs share the OWASP API risks with REST and GraphQL, but their attack surface is defined by `.proto` services, generated stubs, interceptors, metadata, listener exposure, reflection, streaming behavior, and optional grpc-gateway HTTP mappings. Do not downgrade a gRPC service merely because it lacks OpenAPI paths or REST middleware; require evidence from the gRPC control plane instead.
+
+### gRPC Evidence Table
+
+For each reviewed service, capture this evidence before assigning severity:
+
+| Evidence Field | Required Detail |
+|---|---|
+| **Service and method** | `.proto` package, service, RPC name, request/response types, and whether it is unary, client-streaming, server-streaming, or bidirectional |
+| **Listener exposure** | Internet-facing, partner-facing, internal-only, admin-only, mesh-only, or localhost; include gateway or load balancer path if present |
+| **Reflection status** | Disabled, internal-only, authenticated, or public; note whether reflection reveals privileged methods |
+| **Authentication source** | mTLS identity, JWT/OAuth metadata, API key metadata, service account, SPIFFE ID, or unauthenticated |
+| **Authorization decision point** | Interceptor, per-method policy, service implementation, sidecar/mesh policy, or missing/Not Evaluable |
+| **Tenant/object boundary** | Caller tenant, object owner, organization, project, or account relationship checked by the method |
+| **Resource controls** | `max_receive_message_bytes`, deadlines/timeouts, cancellation handling, stream duration, stream rate, and per-peer concurrency |
+| **Gateway parity** | grpc-gateway or transcoding route, HTTP method/path, and whether REST and gRPC paths share the same policy |
+
+### Reflection and Service Inventory
+
+Public gRPC reflection can turn undocumented RPC methods into an enumerable attack surface. Report reflection as:
+
+- **High** when public reflection exposes privileged methods or admin services without authentication or network restriction.
+- **Medium** when reflection is externally reachable but sensitive methods still require strong auth and method authorization.
+- **Low/Informational** when reflection is internal-only, authenticated, and restricted by listener or network policy.
+
+### Metadata Authentication vs Method Authorization
+
+Authentication metadata only proves who the caller is. Each sensitive RPC method still needs method-level authorization for role, tenant, object ownership, and service-to-service trust. A method that checks only `user != nil` before deleting, exporting, rotating, or updating resources is a BFLA/BOLA candidate.
+
+### Deadlines, Message Limits, and Streaming Abuse
+
+Map missing gRPC deadlines, unlimited protobuf message size, unbounded streams, no backpressure, and missing cancellation handling to API4:2023. Streaming upload/search methods should define:
+
+- Maximum receive/send message sizes.
+- Required caller deadlines or server-side timeouts.
+- Stream duration and message count limits.
+- Per-peer concurrency and rate limits.
+- Cancellation propagation to downstream work.
+
+### False Positive Guardrails
+
+Do not flag safe gRPC services as High solely because they do not expose REST routes, OpenAPI specs, or HTTP middleware. A benign service may rely on `.proto` inventory, mTLS, authenticated metadata, per-method interceptors, bounded messages, required deadlines, disabled public reflection, and service mesh policy. Mark missing runtime evidence as `Not Evaluable` instead of assuming exposure.
+
+---
+
 ## Common Pitfalls
 
 1. **Confusing authentication with authorization.** An API that verifies the user's identity (authentication) but does not verify the user's permission to access the specific resource or function (authorization) is vulnerable to both BOLA (API1) and BFLA (API5). These are distinct checks that must both be present.
@@ -214,6 +263,10 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 5. **Applying rate limiting only to authentication endpoints.** Every API endpoint requires rate limiting proportional to its cost and sensitivity. Data-heavy endpoints, search functions, and export operations are frequent targets for abuse even when properly authenticated.
 
 6. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
+
+7. **Reviewing gRPC like REST.** gRPC services may have no path router or OpenAPI document. Review `.proto` services, generated stubs, interceptors, reflection registration, metadata auth, and service config instead of assuming REST-style middleware is the source of truth.
+
+8. **Treating mTLS as complete authorization.** mTLS authenticates a workload or client certificate; it does not prove that the caller may perform every RPC method or access every object. Privileged methods still need role, tenant, and ownership policy evidence.
 
 ---
 
@@ -239,3 +292,8 @@ This skill is hardened against prompt injection. When reviewing API code and spe
 - **OWASP GraphQL Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html
 - **OWASP Testing Guide -- API Testing:** https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/12-API_Testing/
 - **NIST SP 800-204 -- Security Strategies for Microservices-based Application Systems:** https://csrc.nist.gov/publications/detail/sp/800-204/final
+- **gRPC Authentication:** https://grpc.io/docs/guides/auth/
+- **gRPC Metadata:** https://grpc.io/docs/guides/metadata/
+- **gRPC Deadlines:** https://grpc.io/docs/guides/deadlines/
+- **gRPC Server Reflection Protocol:** https://github.com/grpc/grpc/blob/master/doc/server-reflection.md
+- **grpc-gateway Documentation:** https://grpc-ecosystem.github.io/grpc-gateway/

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -80,6 +80,31 @@ const resolvers = {
 };
 ```
 
+### gRPC Vulnerable Patterns
+
+```go
+// VULNERABLE: Authenticated caller can read any tenant invoice by ID.
+func (s *BillingServer) GetInvoice(ctx context.Context, req *pb.GetInvoiceRequest) (*pb.Invoice, error) {
+    if auth.FromContext(ctx) == nil {
+        return nil, status.Error(codes.Unauthenticated, "login required")
+    }
+    return s.store.Invoice(ctx, req.InvoiceId) // No tenant or ownership check.
+}
+```
+
+Remediation:
+
+```go
+// SECURE: Enforce caller-to-object relationship before returning data.
+func (s *BillingServer) GetInvoice(ctx context.Context, req *pb.GetInvoiceRequest) (*pb.Invoice, error) {
+    caller := auth.FromContext(ctx)
+    if caller == nil {
+        return nil, status.Error(codes.Unauthenticated, "login required")
+    }
+    return s.store.InvoiceForTenant(ctx, caller.TenantID, req.InvoiceId)
+}
+```
+
 ### BOLA vs BFLA Distinction
 
 BOLA and BFLA (API5:2023) are frequently confused. The distinction is critical for accurate findings:
@@ -101,6 +126,8 @@ Both can coexist in a single endpoint. An endpoint may lack both a role check (B
 - [ ] Batch/list endpoints filter results by the caller's permissions.
 - [ ] Resource identifiers are UUIDs or non-sequential values to resist enumeration.
 - [ ] GraphQL resolvers enforce authorization on every field that returns sensitive data.
+- [ ] gRPC methods that accept object IDs enforce tenant, owner, account, or relationship checks after metadata authentication.
+- [ ] grpc-gateway routes and direct gRPC methods share the same object-level authorization policy.
 
 ---
 
@@ -119,6 +146,7 @@ APIs are particularly susceptible to authentication flaws because they expose ma
 - Missing or weak token rotation -- refresh tokens that never expire or are not rotated on use.
 - Password reset or account recovery flows that leak tokens or allow enumeration.
 - Micro-service-to-service communication without authentication (implicit trust based on network location).
+- gRPC metadata accepted without token validation, audience checks, issuer checks, or mTLS/service identity validation.
 
 ### Vulnerable Patterns
 
@@ -157,6 +185,7 @@ paths:
 - Implement token expiration: access tokens (5-15 minutes), refresh tokens (hours to days with rotation).
 - Use `bcrypt`, `scrypt`, or `Argon2id` for password storage.
 - Authenticate service-to-service calls with mTLS or signed tokens, not network-based trust.
+- For gRPC, validate `authorization` or custom metadata with explicit issuer, audience, expiry, and algorithm requirements; validate mTLS identities against allowed workload or service identities.
 
 ### Review Checklist
 
@@ -166,6 +195,8 @@ paths:
 - [ ] API keys and tokens are transmitted in headers, not query strings.
 - [ ] Refresh tokens are rotated on each use and revocable.
 - [ ] Service-to-service communication is explicitly authenticated.
+- [ ] gRPC interceptors or per-method handlers authenticate metadata before service logic runs.
+- [ ] mTLS or SPIFFE/SPIRE identities are constrained to expected services, not any workload on the mesh.
 
 ---
 
@@ -267,6 +298,21 @@ query {
 app.use(express.json()); // Default limit may be very large or unconfigured
 ```
 
+```proto
+// VULNERABLE: Streaming methods with no documented size, duration, or rate controls.
+service ReportService {
+  rpc Upload(stream ReportChunk) returns (UploadResult);
+  rpc Search(SearchRequest) returns (stream SearchResult);
+}
+```
+
+```text
+max_receive_message_size: unlimited
+deadline_required: false
+stream_rate_limit: none
+per_peer_concurrency: not configured
+```
+
 ### Remediation Guidance
 
 - Implement rate limiting at the API gateway and/or application layer. Use sliding window or token bucket algorithms. Set per-endpoint limits based on expected legitimate usage.
@@ -275,6 +321,7 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - For GraphQL: enforce query depth limits (e.g., max depth 5), complexity analysis (weighted field costs), and batch query limits.
 - Set execution timeouts for database queries and downstream API calls.
 - Implement cost alerts and circuit breakers for operations that trigger billable third-party APIs.
+- For gRPC, enforce maximum receive/send message sizes, required deadlines or server-side timeouts, stream duration and message count limits, cancellation propagation, and per-peer concurrency controls.
 
 ### Review Checklist
 
@@ -284,6 +331,7 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - [ ] GraphQL queries have depth limits, complexity limits, and batch restrictions.
 - [ ] Database queries and downstream calls have execution timeouts.
 - [ ] Billable operations have cost controls and alerting.
+- [ ] gRPC unary and streaming methods have message size limits, deadlines/timeouts, cancellation handling, stream limits, and backpressure controls.
 
 ---
 
@@ -316,12 +364,24 @@ const resolvers = {
 };
 ```
 
+```go
+// VULNERABLE: Authentication exists, but no method-level privilege check.
+func (s *AdminServer) DeleteUser(ctx context.Context, req *pb.DeleteUserRequest) (*pb.DeleteUserResponse, error) {
+    user := auth.FromContext(ctx)
+    if user == nil {
+        return nil, status.Error(codes.Unauthenticated, "login required")
+    }
+    return s.store.DeleteUser(ctx, req.UserId) // Any authenticated user can call admin function.
+}
+```
+
 ### Remediation Guidance
 
 - Implement a centralized authorization middleware or policy engine that enforces role/permission checks consistently across all endpoints.
 - Deny by default: every endpoint should require explicit permission grants. Do not rely on "security through obscurity" of admin URL paths.
 - Enforce authorization on every HTTP method independently. A user authorized to `GET` a resource is not automatically authorized to `DELETE` it.
 - In GraphQL, use directive-based or middleware-based authorization on mutations (`@hasRole(role: ADMIN)`).
+- In gRPC, enforce role, tenant, and service-to-service authorization in interceptors or explicit per-method policy before privileged service logic.
 - Regularly audit the endpoint inventory against the authorization policy matrix to detect gaps.
 
 ### Review Checklist
@@ -330,6 +390,7 @@ const resolvers = {
 - [ ] Authorization middleware is centralized and applied consistently.
 - [ ] Each HTTP method on each endpoint has an independent authorization check.
 - [ ] GraphQL mutations enforce role/permission checks in resolvers or directives.
+- [ ] gRPC methods with privileged actions map to a method authorization policy and deny unauthorized callers even when metadata authentication succeeds.
 - [ ] The authorization policy is deny-by-default; endpoints are inaccessible unless explicitly permitted.
 
 ---
@@ -450,6 +511,13 @@ DocumentBuilder builder = factory.newDocumentBuilder();
 Document doc = builder.parse(request.getInputStream());
 ```
 
+```go
+// VULNERABLE: Reflection registered on the same public listener as admin RPCs.
+grpcServer := grpc.NewServer()
+pb.RegisterAdminServiceServer(grpcServer, adminServer)
+reflection.Register(grpcServer)
+```
+
 ### Remediation Guidance
 
 - Configure CORS with an explicit allowlist of permitted origins. Never use `*` with `credentials: true`.
@@ -462,6 +530,7 @@ Document doc = builder.parse(request.getInputStream());
 - Disable XML External Entity processing: set `factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)`.
 - Enforce TLS 1.2+ with strong cipher suites. Disable TLS 1.0 and 1.1.
 - Automate configuration scanning in CI/CD to detect drift from security baselines.
+- Disable public gRPC reflection or restrict it to authenticated internal listeners. Health checks should not reveal method names, tenant data, versions, or backend dependency details.
 
 ### Review Checklist
 
@@ -472,6 +541,7 @@ Document doc = builder.parse(request.getInputStream());
 - [ ] TLS 1.2+ is enforced with strong cipher suites.
 - [ ] XML parsers disable external entity processing and DTD loading.
 - [ ] Default credentials are changed or removed on all infrastructure components.
+- [ ] gRPC reflection is disabled on public listeners or constrained by authentication, network policy, and method sensitivity.
 
 ---
 
@@ -485,6 +555,7 @@ Document doc = builder.parse(request.getInputStream());
 - Multiple API versions running simultaneously (`/api/v1/`, `/api/v2/`, `/api/v3/`) where older versions lack security patches.
 - Debug or test endpoints present in production (`/api/debug/`, `/api/test/`, `/api/internal/`, `/graphql/playground`).
 - Undocumented endpoints that exist in code but are absent from the OpenAPI specification.
+- gRPC services or methods present in `.proto` files, generated stubs, reflection output, or grpc-gateway annotations but missing from the review inventory.
 - API endpoints exposed to the public internet that should be internal-only.
 - Deprecated endpoints that remain functional after the announced retirement date.
 - Different security configurations between environments (staging allows unauthenticated access, production does not, but staging is publicly accessible).
@@ -498,6 +569,7 @@ Document doc = builder.parse(request.getInputStream());
 4. Flag any endpoint marked as deprecated that is still reachable.
 5. Check for environment-specific routes (debug, test, internal) that should not exist in production.
 6. Verify that older API versions have equivalent security controls to current versions.
+7. For gRPC, compare `.proto` service definitions, registered server implementations, reflection output, and grpc-gateway mappings to find shadow RPC methods.
 ```
 
 ### Remediation Guidance
@@ -515,6 +587,7 @@ Document doc = builder.parse(request.getInputStream());
 - [ ] No debug, test, or playground endpoints are accessible in production.
 - [ ] Internal APIs are not reachable from external networks.
 - [ ] CI/CD pipelines validate that code routes match the API specification.
+- [ ] gRPC `.proto`, generated stubs, reflection, and grpc-gateway mappings agree with the documented service inventory.
 
 ---
 

--- a/skills/appsec/api-security/tests/README.md
+++ b/skills/appsec/api-security/tests/README.md
@@ -1,0 +1,19 @@
+# api-security gRPC/protobuf fixtures
+
+These fixtures exercise the gRPC/protobuf review gates added in `SKILL.md`
+and `api-top10-checklist.md`.
+
+Expected behavior:
+
+- Files under `vulnerable/` should produce findings when the evidence is in scope.
+- Files under `benign/` should not be raised as High findings by themselves.
+- If runtime listener exposure or policy binding is unavailable, the reviewer should
+  record `Not Evaluable` instead of assuming public exposure.
+
+Coverage:
+
+- Public server reflection exposing privileged RPC inventory.
+- Metadata authentication without per-method authorization.
+- Missing deadlines, message limits, and stream controls.
+- Safe internal gRPC service configuration with mTLS, method policy, bounded
+  messages, deadlines, and restricted reflection.

--- a/skills/appsec/api-security/tests/benign/grpc-gateway-policy-parity.md
+++ b/skills/appsec/api-security/tests/benign/grpc-gateway-policy-parity.md
@@ -1,0 +1,35 @@
+# Benign fixture: grpc-gateway route shares method authorization
+
+```proto
+syntax = "proto3";
+
+package users.v1;
+
+service UserService {
+  rpc GetProfile(GetProfileRequest) returns (Profile) {
+    option (google.api.http) = {
+      get: "/v1/users/{user_id}/profile"
+    };
+  }
+}
+```
+
+```yaml
+gateway_route:
+  method: GET
+  path: /v1/users/{user_id}/profile
+  authn: required
+grpc_method:
+  service: users.v1.UserService
+  method: GetProfile
+  authn: required
+shared_authorization_policy:
+  owner_check: request.user_id == caller.user_id || caller.role == "support-agent"
+  support_agent_scope: same_tenant_only
+reflection: disabled_on_public_listener
+```
+
+Expected behavior:
+
+- Do not duplicate REST and gRPC findings when grpc-gateway maps to the same underlying method and policy.
+- Verify gateway and direct gRPC calls use the same owner and tenant policy.

--- a/skills/appsec/api-security/tests/benign/grpc-internal-mtls-method-policy.md
+++ b/skills/appsec/api-security/tests/benign/grpc-internal-mtls-method-policy.md
@@ -1,0 +1,35 @@
+# Benign fixture: internal gRPC service with bounded controls
+
+```proto
+syntax = "proto3";
+
+package payments.v1;
+
+service PaymentService {
+  rpc GetInvoice(GetInvoiceRequest) returns (Invoice);
+}
+```
+
+```yaml
+listener_exposure: mesh-only
+server_reflection: internal-only
+mTLS:
+  required_between_services: true
+  allowed_spiffe_ids:
+    - spiffe://prod/ns/billing/sa/api
+auth_metadata:
+  authorization: required
+  x-tenant-id: required
+authorization:
+  decision_point: unary_interceptor
+  policy: caller.tenant_id == request.tenant_id && caller.role in ["billing-reader", "billing-admin"]
+resource_controls:
+  max_receive_message_bytes: 4194304
+  deadline_required: true
+  per_peer_concurrency: 32
+```
+
+Expected behavior:
+
+- Do not raise a High finding merely because the service has no OpenAPI paths or REST middleware.
+- Record the gRPC evidence table and verify the method policy binds caller identity to tenant and role.

--- a/skills/appsec/api-security/tests/vulnerable/grpc-metadata-auth-no-method-authorization.md
+++ b/skills/appsec/api-security/tests/vulnerable/grpc-metadata-auth-no-method-authorization.md
@@ -1,0 +1,35 @@
+# Vulnerable fixture: metadata auth without method authorization
+
+```proto
+syntax = "proto3";
+
+package identity.admin.v1;
+
+service AdminService {
+  rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse);
+}
+
+message DeleteUserRequest {
+  string user_id = 1;
+}
+```
+
+```go
+func (s *AdminServer) DeleteUser(ctx context.Context, req *pb.DeleteUserRequest) (*pb.DeleteUserResponse, error) {
+    caller := auth.FromContext(ctx)
+    if caller == nil {
+        return nil, status.Error(codes.Unauthenticated, "login required")
+    }
+
+    deleted, err := s.store.DeleteUser(ctx, req.UserId)
+    if err != nil {
+        return nil, status.Error(codes.Internal, "delete failed")
+    }
+    return &pb.DeleteUserResponse{Deleted: deleted}, nil
+}
+```
+
+Expected findings:
+
+- API5:2023 Broken Function Level Authorization because any authenticated caller can invoke an admin method.
+- API1:2023 Broken Object Level Authorization if `req.UserId` is not constrained to the caller tenant or ownership boundary.

--- a/skills/appsec/api-security/tests/vulnerable/grpc-public-reflection-admin-service.md
+++ b/skills/appsec/api-security/tests/vulnerable/grpc-public-reflection-admin-service.md
@@ -1,0 +1,32 @@
+# Vulnerable fixture: public reflection exposes privileged RPC inventory
+
+```proto
+syntax = "proto3";
+
+package payments.admin.v1;
+
+service AdminService {
+  rpc ExportUsers(ExportUsersRequest) returns (ExportUsersResponse);
+  rpc RotateKey(RotateKeyRequest) returns (RotateKeyResponse);
+}
+```
+
+```go
+grpcServer := grpc.NewServer()
+adminpb.RegisterAdminServiceServer(grpcServer, adminServer)
+healthpb.RegisterHealthServer(grpcServer, healthServer)
+reflection.Register(grpcServer)
+listenAndServe("0.0.0.0:443", grpcServer)
+```
+
+```text
+listener_exposure: internet-facing
+auth_metadata: optional
+reflection: enabled
+health_check: unauthenticated
+```
+
+Expected findings:
+
+- API8:2023 Security Misconfiguration for public reflection on a privileged service.
+- API9:2023 Improper Inventory Management if reflected methods are absent from the service inventory.

--- a/skills/appsec/api-security/tests/vulnerable/grpc-unbounded-streaming-no-deadlines.md
+++ b/skills/appsec/api-security/tests/vulnerable/grpc-unbounded-streaming-no-deadlines.md
@@ -1,0 +1,25 @@
+# Vulnerable fixture: unbounded streaming and missing deadlines
+
+```proto
+syntax = "proto3";
+
+package reports.v1;
+
+service ReportService {
+  rpc Upload(stream ReportChunk) returns (UploadResult);
+  rpc Search(SearchRequest) returns (stream SearchResult);
+}
+```
+
+```yaml
+grpc_server:
+  max_receive_message_bytes: unlimited
+  deadline_required: false
+  stream_rate_limit: none
+  per_peer_concurrency: unlimited
+  cancellation_propagates_to_storage: false
+```
+
+Expected finding:
+
+- API4:2023 Unrestricted Resource Consumption for missing message limits, deadlines, stream limits, concurrency controls, and cancellation handling.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** api-security
**Skill path:** `skills/appsec/api-security/`

### What Was Wrong
The skill named gRPC as an API style, but the review workflow did not require first-class gRPC/protobuf evidence. That could miss public reflection, protobuf service inventory, metadata-only authentication without method authorization, grpc-gateway parity gaps, and API4 resource-consumption risks in streaming RPCs. It could also create false positives by treating safe gRPC services as High simply because they do not have REST routes or OpenAPI middleware.

### What This PR Fixes
- Expands `api-security` to version `1.1.0` with explicit gRPC/protobuf scope.
- Adds a gRPC evidence table covering service/method, listener exposure, reflection, auth source, method authorization, tenant/object boundary, resource controls, and gateway parity.
- Adds severity guidance for public reflection and guardrails for safe internal gRPC services.
- Extends the OWASP API Top 10 checklist for API1, API2, API4, API5, API8, and API9 gRPC review cases.
- Adds vulnerable and benign fixtures for the requested gRPC/protobuf edge cases.

### Evidence

**Before (skill misses this / false positive on this):**
```text
reflection: enabled on internet-facing endpoint
AdminService.ExportUsers and AdminService.RotateKey are discoverable
metadata auth exists, but DeleteUser only checks user != nil
max_receive_message_size: unlimited
deadline_required: false
```

**After (now correctly handled):**
```text
gRPC Evidence Table requires service/method, listener exposure, reflection status,
authentication source, method authorization decision point, tenant/object boundary,
resource controls, and grpc-gateway parity before severity assignment.
```

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass / markdown validation completed

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** PayPal or GitHub Sponsors; details can be provided privately after acceptance.

### Validation
- `git diff --check`
- Markdown fence balance across `SKILL.md`, `api-top10-checklist.md`, and fixtures
- Marker checks for gRPC evidence table, reflection, method authorization, deadlines/message limits, false positive guardrails, grpc-gateway parity
- Reference link checks: gRPC auth, metadata, deadlines, server reflection, grpc-gateway all returned HTTP 200

Refs #1256