### PR TITLE
Add CORS and PNA evidence gates

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -4,14 +4,15 @@ description: >
   Reviews REST and GraphQL APIs against the OWASP API Security Top 10:2023.
   Auto-invoked when reviewing OpenAPI/Swagger specs, API endpoint code, or
   GraphQL schemas. Covers BOLA, BFLA, authentication, rate limiting, and
-  SSRF. Produces findings mapped to API1-API10 with remediation guidance.
+  SSRF, CORS, and Private Network Access configuration. Produces findings mapped
+  to API1-API10 with remediation guidance.
 tags: [appsec, api, rest, graphql]
 role: [appsec-engineer, security-engineer]
 phase: [design, build, review]
 frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -66,6 +67,7 @@ Each finding produced by this review must include the following fields:
 | **Location** | File path and line number(s), or OpenAPI spec path |
 | **Description** | What the vulnerability is and why it matters |
 | **Evidence** | Relevant code snippet or spec excerpt demonstrating the issue |
+| **Configuration Evidence** | CORS, security-header, TLS, gateway, or parser evidence when the finding is API8 |
 | **Remediation** | Specific fix with code example where possible |
 | **Status** | Open, Mitigated, Accepted Risk, False Positive |
 
@@ -92,7 +94,7 @@ The final review output must be structured as follows:
 **API Style:** [REST / GraphQL / gRPC / Hybrid]
 **Specification:** [OpenAPI spec path, if applicable]
 **Date:** [review date]
-**Reviewer:** AI Agent -- api-security skill v1.0.0
+**Reviewer:** [reviewer name] -- api-security skill v1.1.0
 
 ### Summary
 
@@ -111,6 +113,14 @@ The final review output must be structured as follows:
 
 **Total Findings:** [count]
 **Critical:** [count] | **High:** [count] | **Medium:** [count] | **Low:** [count] | **Info:** [count]
+
+### API8 CORS and PNA Evidence
+
+Include this table when API8 findings or false-positive decisions depend on CORS, browser origins, or Private Network Access.
+
+| Endpoint | Credentials Allowed | Origin Decision | `null` / Opaque Origin Policy | `Vary: Origin` | Preflight Method/Header Policy | PNA Decision | Private Resource Impact | Outcome |
+|---|---|---|---|---|---|---|---|---|
+| [path] | [yes/no] | [exact allowlist/reflection/public read-only] | [rejected/justified/not applicable] | [present/missing/not applicable] | [per-endpoint/broad/missing] | [allowed/rejected/not applicable] | [internal admin/resource/public only] | [Pass/Finding/Not Evaluable] |
 
 ### Findings
 
@@ -144,7 +154,7 @@ The final review output must be structured as follows:
 | API5:2023 | Broken Function Level Authorization | CWE-285 | Missing role/permission checks on operations |
 | API6:2023 | Unrestricted Access to Sensitive Business Flows | CWE-799, CWE-837 | Automated abuse of legitimate business logic |
 | API7:2023 | Server Side Request Forgery | CWE-918 | Fetching user-supplied URLs without validation |
-| API8:2023 | Security Misconfiguration | CWE-16, CWE-611 | CORS, headers, TLS, error handling, XXE |
+| API8:2023 | Security Misconfiguration | CWE-16, CWE-611, CWE-942, CWE-346 | CORS/PNA, headers, TLS, error handling, XXE |
 | API9:2023 | Improper Inventory Management | CWE-1059 | Shadow APIs, deprecated versions, missing documentation |
 | API10:2023 | Unsafe Consumption of APIs | CWE-20, CWE-295 | Trusting upstream API data without validation |
 

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -432,6 +432,46 @@ CORS(app, origins="*", supports_credentials=True)  # Allows any origin with cred
 ```
 
 ```javascript
+// VULNERABLE: Reflects any Origin value into a credentialed CORS response
+app.use((req, res, next) => {
+  const origin = req.get("Origin");
+  if (origin) {
+    res.set("Access-Control-Allow-Origin", origin);
+    res.set("Access-Control-Allow-Credentials", "true");
+  }
+  next();
+});
+```
+
+```http
+# VULNERABLE: Credentialed API trusts null/opaque origins
+GET /api/account/export HTTP/1.1
+Host: api.example.test
+Origin: null
+Cookie: session=example
+
+HTTP/1.1 200 OK
+Access-Control-Allow-Origin: null
+Access-Control-Allow-Credentials: true
+Content-Type: application/json
+```
+
+```http
+# VULNERABLE: PNA preflight permits a public origin to reach a private endpoint
+OPTIONS /admin/export HTTP/1.1
+Host: api.example.test
+Origin: https://attacker.example
+Access-Control-Request-Method: POST
+Access-Control-Request-Private-Network: true
+
+HTTP/1.1 204 No Content
+Access-Control-Allow-Origin: https://attacker.example
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Private-Network: true
+Access-Control-Allow-Methods: GET, POST, DELETE
+```
+
+```javascript
 // VULNERABLE: Verbose error messages in production
 app.use((err, req, res, next) => {
   res.status(500).json({
@@ -450,9 +490,37 @@ DocumentBuilder builder = factory.newDocumentBuilder();
 Document doc = builder.parse(request.getInputStream());
 ```
 
+### CORS and Private Network Access Evidence Gates
+
+Review CORS and PNA as browser-enforced access decisions, not as a single header presence check. Exact dynamic allowlists can be safe; arbitrary reflection, credentialed `null` origins, cache-unsafe dynamic responses, and broad PNA grants are findings.
+
+| Evidence gate | Pass evidence | Finding evidence |
+|---|---|---|
+| Origin matching | Exact origin matching by scheme, host, and port against an environment-scoped allowlist | Regex/suffix match allows attacker-controlled subdomains, or any `Origin` is reflected |
+| Credential mode | Credentials are only allowed for trusted origins that need them | `Access-Control-Allow-Credentials: true` with wildcard, reflected, `null`, or opaque origins |
+| `null` and opaque origins | Rejected by default, or documented low-risk public-only use with separate CSRF/session controls | `Origin: null`, `file://`, sandboxed documents, or opaque origins receive credentialed responses |
+| Cache safety | `Vary: Origin` is present whenever CORS output depends on the request origin | Shared caches can reuse one origin's allow decision for another origin |
+| Preflight method/header policy | Allowed methods and headers are restricted per endpoint | Broad method/header grants expose admin, export, or write operations unnecessarily |
+| Private Network Access | `Access-Control-Allow-Private-Network: true` is limited to trusted origins and private-resource endpoints with documented need | Public or attacker-controlled origins can request private-network resources |
+| Public-only false positive guardrail | Endpoint is unauthenticated, read-only, non-sensitive, and does not set credentials | Public API is treated as high severity solely because it allows read-only CORS |
+| Not Evaluable handling | Missing deployed headers, gateway policy, or browser-observed response is recorded as Not Evaluable | Static code assumptions are used to downgrade CORS/PNA risk |
+
+Severity guidance:
+
+- Critical or High: credentialed arbitrary-origin reflection exposes account, payment, admin, token, or regulated data.
+- High: `Origin: null` or opaque origins receive credentialed sensitive responses.
+- High: PNA grants allow untrusted public origins to reach admin or private-network resources.
+- Medium: missing `Vary: Origin`, broad preflight methods/headers, or weak regex allowlists affect authenticated but lower-sensitivity endpoints.
+- Low or Informational: public, unauthenticated, read-only APIs with no credentials and no private-resource path may allow broad CORS when documented.
+
 ### Remediation Guidance
 
 - Configure CORS with an explicit allowlist of permitted origins. Never use `*` with `credentials: true`.
+- Match exact scheme, host, and port. Avoid broad regex or suffix matches such as `.example.com` unless tenant ownership and subdomain takeover risk are separately controlled.
+- Reject `Origin: null`, `file://`, sandboxed document, and opaque origins unless the endpoint is public-only and the exception is documented.
+- Return `Vary: Origin` whenever CORS responses differ by origin.
+- Restrict preflight `Access-Control-Request-Method` and `Access-Control-Request-Headers` per endpoint.
+- For PNA, only return `Access-Control-Allow-Private-Network: true` for trusted origins that are explicitly allowed to reach private-network resources.
 - Set security response headers on all API responses:
   - `Strict-Transport-Security: max-age=31536000; includeSubDomains`
   - `X-Content-Type-Options: nosniff`
@@ -466,6 +534,12 @@ Document doc = builder.parse(request.getInputStream());
 ### Review Checklist
 
 - [ ] CORS is configured with an explicit origin allowlist; wildcard is not used with credentials.
+- [ ] Dynamic CORS logic uses exact-origin matching and does not reflect arbitrary `Origin` values.
+- [ ] `null`, `file://`, sandboxed, and opaque origins are rejected or explicitly justified for public-only endpoints.
+- [ ] CORS responses that vary by origin include `Vary: Origin`.
+- [ ] Preflight methods and headers are restricted per endpoint.
+- [ ] PNA preflights are reviewed; `Access-Control-Allow-Private-Network: true` is limited to trusted origins and documented private-resource endpoints.
+- [ ] Public-only CORS exceptions are documented with no credentials, no sensitive data, and no private-network path.
 - [ ] Security headers are present on all API responses.
 - [ ] Error responses in production are generic; no stack traces, SQL queries, or internal paths.
 - [ ] Only required HTTP methods are enabled per endpoint.

--- a/skills/appsec/api-security/tests/benign/cors-exact-allowlist.js
+++ b/skills/appsec/api-security/tests/benign/cors-exact-allowlist.js
@@ -1,0 +1,16 @@
+const allowedOrigins = new Set([
+  "https://app.example.test",
+  "https://admin.example.test"
+]);
+
+function corsExactAllowlist(req, res, next) {
+  const origin = req.get("Origin");
+  if (allowedOrigins.has(origin)) {
+    res.set("Access-Control-Allow-Origin", origin);
+    res.set("Access-Control-Allow-Credentials", "true");
+    res.set("Vary", "Origin");
+  }
+  next();
+}
+
+module.exports = { corsExactAllowlist };

--- a/skills/appsec/api-security/tests/benign/public-readonly-cors.http
+++ b/skills/appsec/api-security/tests/benign/public-readonly-cors.http
@@ -1,0 +1,14 @@
+GET /api/catalog/items HTTP/1.1
+Host: api.example.test
+Origin: https://docs.example.test
+
+HTTP/1.1 200 OK
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: GET
+Content-Type: application/json
+Cache-Control: public, max-age=300
+
+{"items":[]}
+
+# Benign evidence: public, unauthenticated, read-only endpoint with no cookies,
+# no credentials, no private-resource path, and no sensitive response data.

--- a/skills/appsec/api-security/tests/vulnerable/arbitrary-origin-reflection.js
+++ b/skills/appsec/api-security/tests/vulnerable/arbitrary-origin-reflection.js
@@ -1,0 +1,11 @@
+function arbitraryOriginReflection(req, res, next) {
+  const origin = req.get("Origin");
+  if (origin) {
+    res.set("Access-Control-Allow-Origin", origin);
+    res.set("Access-Control-Allow-Credentials", "true");
+    res.set("Access-Control-Allow-Methods", "GET, POST, DELETE");
+  }
+  next();
+}
+
+module.exports = { arbitraryOriginReflection };

--- a/skills/appsec/api-security/tests/vulnerable/null-origin-credentialed.http
+++ b/skills/appsec/api-security/tests/vulnerable/null-origin-credentialed.http
@@ -1,0 +1,14 @@
+GET /api/account/export HTTP/1.1
+Host: api.example.test
+Origin: null
+Cookie: session=example
+
+HTTP/1.1 200 OK
+Access-Control-Allow-Origin: null
+Access-Control-Allow-Credentials: true
+Content-Type: application/json
+
+{"email":"user@example.test","exportReady":true}
+
+# Finding evidence: credentialed sensitive response is available to a null or
+# opaque origin, such as a sandboxed document or local file context.

--- a/skills/appsec/api-security/tests/vulnerable/pna-private-network-exposure.http
+++ b/skills/appsec/api-security/tests/vulnerable/pna-private-network-exposure.http
@@ -1,0 +1,16 @@
+OPTIONS /admin/export HTTP/1.1
+Host: api.example.test
+Origin: https://attacker.example
+Access-Control-Request-Method: POST
+Access-Control-Request-Headers: authorization,content-type
+Access-Control-Request-Private-Network: true
+
+HTTP/1.1 204 No Content
+Access-Control-Allow-Origin: https://attacker.example
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Methods: GET, POST, DELETE
+Access-Control-Allow-Headers: authorization,content-type,x-admin-action
+Access-Control-Allow-Private-Network: true
+
+# Finding evidence: untrusted public origin is allowed to preflight a private
+# admin endpoint with broad methods, broad headers, credentials, and PNA enabled.


### PR DESCRIPTION
## Summary
- Upgrades `api-security` to v1.1.0 with API8 CORS and Private Network Access evidence output.
- Extends the API8 checklist with exact-origin matching, null and opaque origin handling, `Vary: Origin`, per-endpoint preflight policy, PNA private-resource impact, and public-only false-positive guardrails.
- Adds benign and vulnerable JS/HTTP fixtures for exact allowlists, public read-only CORS, arbitrary origin reflection, credentialed null-origin responses, and PNA private-network exposure.

## Related issue
Closes #1202

## Validation
- `git diff --check`
- `git diff origin/main..HEAD --check`
- Frontmatter required-field check for `api-security/SKILL.md`
- Markdown fence-balance check for `api-security/**/*.md`
- `node --check` for added JS fixtures
- ASCII check for touched files
- Prompt-injection pattern scan on added diff lines
- Public identity hygiene scan on added diff lines
- Marker coverage check for CORS, Private Network Access, PNA, Origin: null, Vary: Origin, Access-Control-Allow-Private-Network, Access-Control-Request-Private-Network, opaque origins, exact origin, preflight, Not Evaluable, CWE-942, and CWE-346
