### PR TITLE
Add IaC variable override evidence gates

### DIFF
--- a/skills/cloud/iac-security/SKILL.md
+++ b/skills/cloud/iac-security/SKILL.md
@@ -55,6 +55,7 @@ The OWASP IaC Security Cheat Sheet categorizes common IaC vulnerabilities. SLSA 
 - Access to IaC source files (Terraform `.tf`/`.tfvars`, CloudFormation `.yaml`/`.json`, Pulumi source, Bicep `.bicep`)
 - Access to module registries or module source references
 - Variable definition files and environment-specific overrides
+- Workspace, CI, or Terraform Cloud/HCP variable inputs that can override source defaults
 - State file references (for understanding current deployment, if available)
 
 ---
@@ -73,6 +74,10 @@ Use Glob to locate all IaC configuration files.
 **/*.tf.json
 **/terraform.tfstate
 **/*.tfstate.backup
+**/*.auto.tfvars
+**/*.tfvars.json
+**/terragrunt.hcl
+**/.terraform.lock.hcl
 **/cloudformation/**/*.yaml
 **/cloudformation/**/*.json
 **/cfn-templates/**/*.yaml
@@ -90,7 +95,54 @@ Classify the IaC stack(s) in use. Record the total file count and frameworks det
 
 ---
 
-### Step 2 through Step 9: Security Domain Evaluation
+### Step 2: Variable Resolution and Environment Override Evidence
+
+**Objective:** Verify that findings are based on the effective input set for the reviewed environment, not only on Terraform defaults or a single source file.
+
+Terraform variable values can come from defaults, environment variables, `terraform.tfvars`, `*.auto.tfvars`, CLI `-var` and `-var-file` arguments, Terraform Cloud/HCP workspace variables, variable sets, Terragrunt inputs, and CI secrets. Later or environment-specific inputs can turn a secure-looking module into a public, unencrypted, or overly permissive deployment.
+
+**What to collect:**
+
+- Reviewed environment/workspace name (`dev`, `staging`, `prod`, Terraform workspace, HCP workspace, Terragrunt stack)
+- Variable files in scope: `terraform.tfvars`, `*.auto.tfvars`, `*.tfvars.json`, environment-specific `-var-file` inputs
+- CI/CD command line or workflow evidence showing `terraform plan/apply` arguments
+- Terraform Cloud/HCP workspace variables and variable sets, if used
+- Terragrunt `inputs`, `include`, and dependency outputs that feed module variables
+- Module defaults for security-sensitive variables such as public access, encryption, logging, CIDR ranges, IAM principals, retention, and deletion protection
+
+**What to look for:**
+
+```
+IAC-VAR-01: Reviewed environment/workspace is not identified
+IAC-VAR-02: Security-sensitive variables have defaults but no environment override evidence
+IAC-VAR-03: `terraform.tfvars`, `*.auto.tfvars`, or CI `-var-file` inputs were not reviewed
+IAC-VAR-04: Environment override weakens a security control (for example public access, encryption, logging, retention, deletion protection, or CIDR scope)
+IAC-VAR-05: Terraform Cloud/HCP workspace variables or variable sets affect the run but are unavailable
+IAC-VAR-06: Terragrunt inputs, dependency outputs, or generated provider/backend blocks are not reviewed
+IAC-VAR-07: Sensitive values are committed in tfvars, auto tfvars, local override files, or CI plan logs
+```
+
+**Decision logic:**
+
+- If the effective value is visible in source, tfvars, Terragrunt, plan JSON, or CI evidence, evaluate the resulting control state.
+- If security posture depends on unavailable workspace variables, variable sets, environment variables, or CLI `-var-file` inputs, mark the relevant finding as `Not Evaluable from Source Only` instead of passing it.
+- If an override explicitly weakens a control for the reviewed environment, report the weakened effective value even when the module default is secure.
+- If only non-production inputs are available, do not claim production readiness unless production input evidence is also provided.
+
+**Output evidence fields:**
+
+| Field | Description |
+|---|---|
+| Environment / Workspace | Reviewed deployment context |
+| Variable Sources Reviewed | Defaults, tfvars, auto tfvars, CLI args, CI, HCP/TFC, Terragrunt |
+| Security-Sensitive Variables | Variables affecting exposure, encryption, IAM, logging, retention, deletion protection |
+| Effective Value Evidence | Source file, tfvars line, plan JSON path, CI command, HCP/TFC export, or Terragrunt input |
+| Missing Inputs | Variable sources not available to the reviewer |
+| Outcome | Pass / Fail / Partial / Not Evaluable from Source Only |
+
+---
+
+### Step 3 through Step 10: Security Domain Evaluation
 
 Evaluate all IaC configurations across eight security domains: Hardcoded Secrets Detection, Public Exposure Analysis, Encryption Gap Analysis, IAM and Access Control Review, Logging and Monitoring Gaps, Network Security Review, Supply Chain Integrity (SLSA Alignment), and Resource Hardening.
 
@@ -101,7 +153,7 @@ For detailed tool-specific rule sets, detection patterns, vulnerable code exampl
 
 ---
 
-### Step 10: Compile Assessment Report
+### Step 11: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
 
@@ -169,6 +221,13 @@ Produce the final report using the structure defined in the Output Format sectio
 - State encryption: <encrypted / unencrypted>
 - State locking: <enabled / disabled>
 - Lock file committed: <yes / no>
+- Input resolution evidence: <complete / partial / not evaluable>
+
+### Variable Resolution and Environment Override Evidence
+
+| Environment | Variable Sources Reviewed | Security-Sensitive Inputs | Missing Inputs | Outcome |
+|---|---|---|---|---|
+| <workspace/env> | <defaults/tfvars/CI/HCP/Terragrunt> | <public_access, encrypted, cidr_blocks, etc.> | <none or list> | <Pass/Fail/Partial/Not Evaluable> |
 
 ### Prioritized Remediation Plan
 
@@ -229,7 +288,8 @@ This skill applies checks equivalent to the following high-impact rules:
 4. **CloudFormation parameters with NoEcho.** Parameters marked `NoEcho: true` are not necessarily secure -- the default value is still in plaintext in the template.
 5. **Confusing `aws_s3_bucket_acl` with `aws_s3_bucket_public_access_block`.** The public access block overrides ACLs. Check both, but the access block is the stronger control.
 6. **Terraform state file secrets.** Even when variables are marked `sensitive`, they may appear in plaintext in the state file. Verify state encryption and access controls.
-7. **Provider-specific encryption defaults.** Some providers encrypt by default (e.g., AWS S3 since January 2023). Know the defaults before flagging missing explicit encryption configuration.
+7. **Assuming module defaults equal production values.** Workspace variables, `*.auto.tfvars`, CI `-var-file` inputs, Terraform Cloud variable sets, or Terragrunt inputs can override secure-looking defaults. Review the effective input chain before passing exposure, encryption, IAM, or logging controls.
+8. **Provider-specific encryption defaults.** Some providers encrypt by default (e.g., AWS S3 since January 2023). Know the defaults before flagging missing explicit encryption configuration.
 
 ---
 
@@ -259,6 +319,10 @@ This skill applies checks equivalent to the following high-impact rules:
 - KICS (Keeping Infrastructure as Code Secure): https://docs.kics.io/
 - cfn-nag Rules: https://github.com/stelligent/cfn_nag
 - Terraform Security Best Practices: https://developer.hashicorp.com/terraform/cloud-docs/recommended-practices
+- Terraform Input Variables and Variable Definitions: https://developer.hashicorp.com/terraform/language/values/variables
+- Terraform Cloud Workspace Variables: https://developer.hashicorp.com/terraform/cloud-docs/variables
+- Terraform CLI Workspaces: https://developer.hashicorp.com/terraform/language/state/workspaces
+- Terragrunt Inputs: https://docs.terragrunt.com/reference/hcl/attributes/
 - AWS Security Best Practices in IAM: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 
 ---

--- a/skills/cloud/iac-security/tool-rules.md
+++ b/skills/cloud/iac-security/tool-rules.md
@@ -403,6 +403,87 @@ resource "aws_security_group_rule" "example" {
 
 Evaluate how IaC modules are sourced and whether the IaC supply chain has integrity controls.
 
+### Variable Resolution and Environment Override Evidence
+
+Terraform source review should account for the full variable input chain for the reviewed environment. A module default or root `variables.tf` value is not enough evidence when CI, workspace variables, Terragrunt inputs, or environment-specific tfvars can override it.
+
+**Files and inputs to locate:**
+
+```
+terraform.tfvars
+terraform.tfvars.json
+*.auto.tfvars
+*.auto.tfvars.json
+*.tfvars
+*.tfvars.json
+terragrunt.hcl
+.github/workflows/*.yml
+.gitlab-ci.yml
+Jenkinsfile
+```
+
+**Search patterns for security-sensitive overrides:**
+
+```
+publicly_accessible\s*=\s*true
+allow_nested_items_to_be_public\s*=\s*true
+cidr_blocks\s*=\s*\["0\.0\.0\.0/0"\]
+source_ranges\s*=\s*\["0\.0\.0\.0/0"\]
+encrypted\s*=\s*false
+storage_encrypted\s*=\s*false
+enable_https_traffic_only\s*=\s*false
+deletion_protection\s*=\s*false
+backup_retention_period\s*=\s*0
+logging_enabled\s*=\s*false
+-var-file
+-var\s+
+TF_VAR_
+inputs\s*=
+```
+
+**Example: secure default weakened by production tfvars**
+
+```hcl
+# variables.tf
+variable "db_public" {
+  type    = bool
+  default = false
+}
+
+# prod.auto.tfvars
+db_public = true
+
+# main.tf
+resource "aws_db_instance" "payments" {
+  publicly_accessible = var.db_public
+}
+```
+
+The source module default is secure, but the reviewed production input makes the RDS instance public. Report the effective production value as a failure and cite both the variable definition and the overriding tfvars source.
+
+**Example: unknown workspace variable**
+
+```hcl
+resource "aws_security_group_rule" "admin" {
+  type        = "ingress"
+  from_port   = 22
+  to_port     = 22
+  protocol    = "tcp"
+  cidr_blocks = var.admin_cidr_blocks
+}
+```
+
+If `admin_cidr_blocks` comes from Terraform Cloud workspace variables, CI `TF_VAR_admin_cidr_blocks`, or a CLI `-var-file` that is unavailable, do not pass the control from source alone. Mark it `Not Evaluable from Source Only` and request the effective input evidence or plan JSON.
+
+**Review guidance:**
+
+- Tie each high-impact finding to an environment/workspace (`dev`, `staging`, `prod`, HCP workspace, or Terragrunt stack).
+- Prefer the effective value after overrides over the module default.
+- Treat missing production input sources as `Not Evaluable from Source Only`, not as a pass.
+- Flag committed secrets in tfvars and auto tfvars even when the variable is marked `sensitive`.
+- Review CI jobs for `terraform plan/apply` arguments such as `-var`, `-var-file`, `TF_VAR_*`, and environment-specific wrapper scripts.
+- For Terragrunt, review `inputs`, `include`, `dependency`, and generated backend/provider blocks because they can change module behavior without modifying the Terraform module itself.
+
 ### Module Source Pinning
 
 ```hcl


### PR DESCRIPTION
Closes #1296.

Addresses the variable-resolution evidence gap in the related review issue.

## Summary

- Adds a `Variable Resolution and Environment Override Evidence` step to `iac-security`.
- Requires reviewers to record workspace/environment, variable sources, security-sensitive variables, effective value evidence, missing inputs, and outcome.
- Adds `IAC-VAR-*` finding IDs for missing workspace context, missing tfvars/CI/HCP/Terragrunt inputs, weakening overrides, and committed sensitive variable files.
- Extends the output template and SLSA section with input-resolution evidence.
- Adds tool-rule guidance and grep patterns for `TF_VAR_*`, `-var-file`, `*.auto.tfvars`, Terragrunt `inputs`, and security-sensitive override values.

## Validation

- Markdown fence balance checked for `SKILL.md` and `tool-rules.md`.
- Required marker checks passed for `Variable Resolution and Environment Override Evidence`, `IAC-VAR-01`, `IAC-VAR-07`, `Not Evaluable from Source Only`, `TF_VAR_`, `Terragrunt`, `terraform.tfvars`, and `*.auto.tfvars`.
- Reference URL checks returned HTTP 200 for Terraform variable docs, Terraform Cloud variables, Terraform workspaces, and Terragrunt attributes.

## Bounty

Improver bounty requested if accepted. Payment details can be provided privately after maintainer acceptance.
