### PR TITLE
Add IaC variable resolution evidence gates

### DIFF
--- a/skills/cloud/iac-security/SKILL.md
+++ b/skills/cloud/iac-security/SKILL.md
@@ -13,7 +13,7 @@ phase: [build, review]
 frameworks: [OWASP-IaC-Security, SLSA-v1.0, CIS-Benchmarks]
 difficulty: intermediate
 time_estimate: "45-90min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -55,6 +55,7 @@ The OWASP IaC Security Cheat Sheet categorizes common IaC vulnerabilities. SLSA 
 - Access to IaC source files (Terraform `.tf`/`.tfvars`, CloudFormation `.yaml`/`.json`, Pulumi source, Bicep `.bicep`)
 - Access to module registries or module source references
 - Variable definition files and environment-specific overrides
+- Access to CI apply commands, Terraform Cloud/HCP workspace variables, Terragrunt inputs, or plan JSON when they can override source defaults
 - State file references (for understanding current deployment, if available)
 
 ---
@@ -73,6 +74,11 @@ Use Glob to locate all IaC configuration files.
 **/*.tf.json
 **/terraform.tfstate
 **/*.tfstate.backup
+**/*.auto.tfvars
+**/*.tfvars.json
+**/terragrunt.hcl
+**/.github/workflows/*.yml
+**/.github/workflows/*.yaml
 **/cloudformation/**/*.yaml
 **/cloudformation/**/*.json
 **/cfn-templates/**/*.yaml
@@ -90,7 +96,40 @@ Classify the IaC stack(s) in use. Record the total file count and frameworks det
 
 ---
 
-### Step 2 through Step 9: Security Domain Evaluation
+### Step 2: Effective Input Chain and Workspace Override Evidence
+
+Resolve security-sensitive variables for the reviewed environment before passing or failing exposure, encryption, IAM, logging, retention, backup, or deletion-protection controls. A secure module default is not enough when a production `*.auto.tfvars`, CI `-var-file`, `TF_VAR_*`, Terraform Cloud/HCP workspace variable, variable set, Terragrunt `inputs`, or generated wrapper can change the effective value.
+
+**Evidence to collect:**
+
+| Evidence item | What to record | Outcome if missing |
+|---|---|---|
+| Reviewed environment | Terraform workspace, HCP/TFC workspace, Terragrunt stack, account/subscription/project, and environment name | `Partial` when non-production only |
+| Variable source chain | Defaults, `terraform.tfvars`, `*.auto.tfvars`, `*.tfvars.json`, CLI `-var`, CLI `-var-file`, `TF_VAR_*`, CI wrapper, HCP/TFC variable set, Terragrunt `inputs` | `Not Evaluable from Source Only` when the effective input is external and unavailable |
+| Security-sensitive inputs | Variables controlling public access, CIDRs, encryption, logging, retention, deletion protection, IAM principals, provider/account, and region | `Fail` if an override weakens the reviewed environment |
+| Effective value evidence | File/line, plan JSON path, CI command, workspace export, or reviewer-attested screenshot reference | `Partial` when only a default or module source is available |
+| Secret handling | Whether sensitive tfvars, plan logs, or state files contain plaintext secrets despite `sensitive = true` | `Fail` for committed or exposed secret material |
+
+**Status rules:**
+
+- `Pass`: effective value evidence is available for the reviewed environment and the resulting control is secure.
+- `Fail`: an override weakens a security control, exposes secrets, or changes the deployment target in a risky way.
+- `Partial`: some inputs are present, but the environment or source chain is incomplete.
+- `Not Evaluable from Source Only`: posture depends on unavailable HCP/TFC variables, CI `TF_VAR_*`, CLI arguments, Terragrunt dependency outputs, or plan/state evidence.
+
+**Finding IDs:**
+
+- `IAC-VAR-01`: Reviewed environment or workspace is not identified.
+- `IAC-VAR-02`: Security-sensitive variable has only a default value and no effective input evidence.
+- `IAC-VAR-03`: `terraform.tfvars`, `*.auto.tfvars`, CLI `-var-file`, or CI wrapper inputs are missing from review scope.
+- `IAC-VAR-04`: Effective override weakens exposure, encryption, logging, backup, retention, deletion protection, or IAM posture.
+- `IAC-VAR-05`: Terraform Cloud/HCP workspace variables or variable sets affect posture but are unavailable.
+- `IAC-VAR-06`: Terragrunt `inputs`, dependency outputs, or generated provider/backend blocks are unavailable.
+- `IAC-VAR-07`: Sensitive values appear in committed tfvars, plan logs, state, or CI output.
+
+---
+
+### Step 3 through Step 10: Security Domain Evaluation
 
 Evaluate all IaC configurations across eight security domains: Hardcoded Secrets Detection, Public Exposure Analysis, Encryption Gap Analysis, IAM and Access Control Review, Logging and Monitoring Gaps, Network Security Review, Supply Chain Integrity (SLSA Alignment), and Resource Hardening.
 
@@ -101,7 +140,7 @@ For detailed tool-specific rule sets, detection patterns, vulnerable code exampl
 
 ---
 
-### Step 10: Compile Assessment Report
+### Step 11: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
 
@@ -169,6 +208,13 @@ Produce the final report using the structure defined in the Output Format sectio
 - State encryption: <encrypted / unencrypted>
 - State locking: <enabled / disabled>
 - Lock file committed: <yes / no>
+- Effective input chain: <complete / partial / not evaluable from source only>
+
+### Effective Input Chain Evidence
+
+| Environment / workspace | Variable sources reviewed | Security-sensitive inputs | Effective value evidence | Missing inputs | Outcome |
+|---|---|---|---|---|---|
+| <env> | <defaults/tfvars/auto tfvars/CI/HCP/TFC/Terragrunt/plan> | <public_access, cidrs, encryption, IAM, logging> | <file:line, plan path, CI command, workspace export> | <none or list> | <Pass/Fail/Partial/Not Evaluable from Source Only> |
 
 ### Prioritized Remediation Plan
 
@@ -229,7 +275,8 @@ This skill applies checks equivalent to the following high-impact rules:
 4. **CloudFormation parameters with NoEcho.** Parameters marked `NoEcho: true` are not necessarily secure -- the default value is still in plaintext in the template.
 5. **Confusing `aws_s3_bucket_acl` with `aws_s3_bucket_public_access_block`.** The public access block overrides ACLs. Check both, but the access block is the stronger control.
 6. **Terraform state file secrets.** Even when variables are marked `sensitive`, they may appear in plaintext in the state file. Verify state encryption and access controls.
-7. **Provider-specific encryption defaults.** Some providers encrypt by default (e.g., AWS S3 since January 2023). Know the defaults before flagging missing explicit encryption configuration.
+7. **Assuming defaults are deployed values.** `*.auto.tfvars`, CI `-var-file`, `TF_VAR_*`, HCP/TFC variables, and Terragrunt inputs can override secure-looking module defaults. Review the effective input chain before passing a control.
+8. **Provider-specific encryption defaults.** Some providers encrypt by default (e.g., AWS S3 since January 2023). Know the defaults before flagging missing explicit encryption configuration.
 
 ---
 
@@ -259,6 +306,10 @@ This skill applies checks equivalent to the following high-impact rules:
 - KICS (Keeping Infrastructure as Code Secure): https://docs.kics.io/
 - cfn-nag Rules: https://github.com/stelligent/cfn_nag
 - Terraform Security Best Practices: https://developer.hashicorp.com/terraform/cloud-docs/recommended-practices
+- Terraform Input Variables: https://developer.hashicorp.com/terraform/language/values/variables
+- Terraform Cloud Workspace Variables: https://developer.hashicorp.com/terraform/cloud-docs/variables
+- Terraform Workspaces: https://developer.hashicorp.com/terraform/language/state/workspaces
+- Terragrunt HCL Attributes: https://docs.terragrunt.com/reference/hcl/attributes/
 - AWS Security Best Practices in IAM: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 
 ---

--- a/skills/cloud/iac-security/tests/benign/complete-effective-input-chain.json
+++ b/skills/cloud/iac-security/tests/benign/complete-effective-input-chain.json
@@ -1,0 +1,26 @@
+{
+  "environment": "prod",
+  "terraform_workspace": "payments-prod",
+  "variable_sources_reviewed": [
+    "variables.tf",
+    "prod.auto.tfvars",
+    ".github/workflows/deploy.yml",
+    "terraform-plan-prod.json"
+  ],
+  "security_sensitive_inputs": {
+    "allowed_cidrs": {
+      "effective_value": ["10.20.0.0/16"],
+      "evidence": "terraform-plan-prod.json:resource_changes[aws_security_group_rule.admin].change.after.cidr_blocks"
+    },
+    "db_public": {
+      "effective_value": false,
+      "evidence": "prod.auto.tfvars:3"
+    },
+    "storage_encrypted": {
+      "effective_value": true,
+      "evidence": "terraform-plan-prod.json:resource_changes[aws_db_instance.payments].change.after.storage_encrypted"
+    }
+  },
+  "missing_inputs": [],
+  "outcome": "Pass"
+}

--- a/skills/cloud/iac-security/tests/benign/tfc-workspace-export-attested.json
+++ b/skills/cloud/iac-security/tests/benign/tfc-workspace-export-attested.json
@@ -1,0 +1,17 @@
+{
+  "environment": "prod",
+  "workspace": "hcp-payments-prod",
+  "source_review": ["variables.tf", "main.tf", "terraform.lock.hcl"],
+  "workspace_variable_evidence": {
+    "source": "Terraform Cloud workspace variable export",
+    "reviewed_by": "security-engineering",
+    "reviewed_at": "2026-06-06",
+    "variables": {
+      "admin_cidr_blocks": ["10.30.0.0/16"],
+      "enable_public_bucket": false,
+      "backup_retention_period": 35
+    }
+  },
+  "missing_inputs": [],
+  "outcome": "Pass"
+}

--- a/skills/cloud/iac-security/tests/vulnerable/github-actions-missing-prod-var-file.yaml
+++ b/skills/cloud/iac-security/tests/vulnerable/github-actions-missing-prod-var-file.yaml
@@ -1,0 +1,13 @@
+name: terraform-prod
+on:
+  workflow_dispatch:
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Terraform plan
+        run: terraform plan -var-file=env/prod.tfvars -out=tfplan
+
+# Risk: source review has variables.tf and main.tf, but env/prod.tfvars is not
+# available. Security-sensitive values are Not Evaluable from Source Only.

--- a/skills/cloud/iac-security/tests/vulnerable/prod-public-cidr.auto.tfvars
+++ b/skills/cloud/iac-security/tests/vulnerable/prod-public-cidr.auto.tfvars
@@ -1,0 +1,4 @@
+allowed_cidrs = ["0.0.0.0/0"]
+db_public = true
+storage_encrypted = false
+backup_retention_period = 0

--- a/skills/cloud/iac-security/tests/vulnerable/secure-defaults-overridden.tf
+++ b/skills/cloud/iac-security/tests/vulnerable/secure-defaults-overridden.tf
@@ -1,0 +1,21 @@
+variable "allowed_cidrs" {
+  type    = list(string)
+  default = ["10.0.0.0/8"]
+}
+
+variable "db_public" {
+  type    = bool
+  default = false
+}
+
+resource "aws_security_group_rule" "admin" {
+  type        = "ingress"
+  from_port   = 22
+  to_port     = 22
+  protocol    = "tcp"
+  cidr_blocks = var.allowed_cidrs
+}
+
+resource "aws_db_instance" "payments" {
+  publicly_accessible = var.db_public
+}

--- a/skills/cloud/iac-security/tests/vulnerable/sensitive-values-committed.tfvars
+++ b/skills/cloud/iac-security/tests/vulnerable/sensitive-values-committed.tfvars
@@ -1,0 +1,3 @@
+db_password = "example-only-password"
+api_token = "example-only-token"
+private_key = "example-only-private-key"

--- a/skills/cloud/iac-security/tests/vulnerable/terragrunt-public-bucket-inputs.hcl
+++ b/skills/cloud/iac-security/tests/vulnerable/terragrunt-public-bucket-inputs.hcl
@@ -1,0 +1,10 @@
+terraform {
+  source = "../modules/storage"
+}
+
+inputs = {
+  enable_public_bucket   = true
+  logging_enabled        = false
+  deletion_protection    = false
+  backup_retention_days  = 0
+}

--- a/skills/cloud/iac-security/tests/vulnerable/tfc-workspace-variable-not-evaluable.json
+++ b/skills/cloud/iac-security/tests/vulnerable/tfc-workspace-variable-not-evaluable.json
@@ -1,0 +1,12 @@
+{
+  "environment": "prod",
+  "workspace": "hcp-shared-admin-prod",
+  "source_review": ["variables.tf", "network.tf"],
+  "security_sensitive_expression": "cidr_blocks = var.admin_cidr_blocks",
+  "external_inputs": [
+    "Terraform Cloud workspace variable admin_cidr_blocks",
+    "organization variable set shared-network-admin"
+  ],
+  "available_to_reviewer": false,
+  "required_outcome": "Not Evaluable from Source Only"
+}

--- a/skills/cloud/iac-security/tool-rules.md
+++ b/skills/cloud/iac-security/tool-rules.md
@@ -81,6 +81,76 @@ variable "db_password" {
 
 ---
 
+## Terraform Variable and Workspace Override Evidence
+
+Review Terraform controls against the effective input chain for the target environment. Source defaults, module variables, and example tfvars can be misleading when production inputs are supplied by auto tfvars, CLI flags, CI jobs, Terraform Cloud/HCP workspace variables, variable sets, or Terragrunt.
+
+### Input Sources to Locate
+
+```
+terraform.tfvars
+terraform.tfvars.json
+*.auto.tfvars
+*.auto.tfvars.json
+*.tfvars
+*.tfvars.json
+terragrunt.hcl
+.github/workflows/*.yml
+.github/workflows/*.yaml
+.gitlab-ci.yml
+Jenkinsfile
+```
+
+### CLI and Environment Input Patterns
+
+```
+-var-file
+-var\s+
+TF_VAR_
+terraform\s+(plan|apply)
+terraform\s+workspace\s+select
+tfc_workspace|terraform_cloud|workspace_variables|variable_set
+inputs\s*=
+dependency\s+"
+generate\s+"
+```
+
+### Security-Sensitive Override Patterns
+
+```
+publicly_accessible\s*=\s*true
+allow_nested_items_to_be_public\s*=\s*true
+cidr_blocks\s*=\s*\["0\.0\.0\.0/0"\]
+source_ranges\s*=\s*\["0\.0\.0\.0/0"\]
+authorized_networks.*0\.0\.0\.0/0
+encrypted\s*=\s*false
+storage_encrypted\s*=\s*false
+enable_https_traffic_only\s*=\s*false
+deletion_protection\s*=\s*false
+backup_retention_period\s*=\s*0
+logging_enabled\s*=\s*false
+skip_final_snapshot\s*=\s*true
+```
+
+### Review Outcomes
+
+| Outcome | Evidence standard |
+|---|---|
+| Pass | Effective value for the reviewed environment is known and secure |
+| Fail | An override weakens exposure, encryption, logging, backup, retention, deletion protection, IAM, or secret handling |
+| Partial | Some input sources are present, but the workspace or deployment context is incomplete |
+| Not Evaluable from Source Only | Effective values depend on unavailable HCP/TFC variables, CI environment, CLI args, Terragrunt dependency outputs, plan JSON, or state |
+
+### Example Finding Patterns
+
+- `IAC-VAR-03`: CI uses `terraform plan -var-file=prod.tfvars`, but `prod.tfvars` is unavailable to the reviewer.
+- `IAC-VAR-04`: `prod.auto.tfvars` sets `allowed_cidrs = ["0.0.0.0/0"]` while `variables.tf` defaults to private ranges.
+- `IAC-VAR-05`: `admin_cidr_blocks` is populated from Terraform Cloud workspace variables with no export, plan JSON, or reviewer evidence.
+- `IAC-VAR-06`: Terragrunt `inputs` enable a public bucket or disable retention outside the Terraform module source.
+- `IAC-VAR-07`: `terraform.tfvars` commits a secret value even though the variable is marked `sensitive`.
+
+---
+
 ## Public Exposure Analysis
 
 Identify resources that are unintentionally exposed to the public internet.


### PR DESCRIPTION
## Summary
- Upgrades `iac-security` to v1.1.0 with effective input-chain evidence for Terraform defaults, tfvars, auto tfvars, CLI inputs, CI wrappers, Terraform Cloud/HCP variables, Terragrunt inputs, plan/state evidence, and source-only gaps.
- Extends `tool-rules.md` with input-source discovery, CLI/environment patterns, security-sensitive override patterns, review outcomes, and `IAC-VAR-*` finding examples.
- Adds benign and vulnerable fixtures for complete prod input evidence, HCP/TFC variable exports, missing prod var-files, secure defaults weakened by auto tfvars, committed sensitive tfvars, Terragrunt overrides, and unavailable workspace variables.

This expands coverage with fixture-backed evidence for effective environment values and `Not Evaluable from Source Only` decisions.

## Related issue
Closes #1296

## Validation
- `git diff --check`
- `git diff origin/main..HEAD --check`
- Frontmatter required-field check for `iac-security/SKILL.md`
- Markdown fence-balance check for `iac-security/**/*.md`
- JSON parse check for added fixtures
- Prompt-injection pattern scan on added diff lines
- Public identity hygiene scan on added diff lines
- Keyword coverage check for Effective Input Chain, IAC-VAR-01, IAC-VAR-07, Not Evaluable from Source Only, TF_VAR_, -var-file, *.auto.tfvars, terraform.tfvars, Terragrunt, inputs, workspace variables, prod.auto.tfvars, 0.0.0.0/0, sensitive, Pass, Fail, and Partial