### PR TITLE
Improve GCP BigQuery fine-grained access gates

### DIFF
--- a/skills/cloud/gcp-review/SKILL.md
+++ b/skills/cloud/gcp-review/SKILL.md
@@ -54,6 +54,7 @@ The CIS Google Cloud Platform Foundation Benchmark v2.0.0 is a consensus-driven 
 - IAM policy bindings and org policy definitions
 - VPC and firewall rule definitions
 - Cloud Audit Logs configuration
+- BigQuery dataset access blocks, IAM policies, table schemas, row access policies, policy tags, authorized views or authorized datasets, when BigQuery is in scope
 
 ---
 
@@ -100,8 +101,8 @@ Produce the final report using the structure defined in the Output Format sectio
 | Severity | Definition | Examples |
 |----------|-----------|----------|
 | **Critical** | Immediate risk of data breach or unauthorized access | Public GCS buckets, firewall rules allowing 0.0.0.0/0 on SSH/RDP, Cloud SQL with public IP and no SSL, user-managed SA keys with admin roles |
-| **High** | Significant security gap that materially weakens posture | Default service accounts with broad scopes, missing Cloud Audit Logs, no VPC flow logs, instances with public IPs |
-| **Medium** | Control gap that should be addressed in normal cycle | Missing log metric filters, DNSSEC not enabled, Shielded VM not enabled, uniform bucket access not set |
+| **High** | Significant security gap that materially weakens posture | Default service accounts with broad scopes, missing Cloud Audit Logs, no VPC flow logs, instances with public IPs, unbounded BigQuery authorized views exposing sensitive source tables |
+| **Medium** | Control gap that should be addressed in normal cycle | Missing log metric filters, DNSSEC not enabled, Shielded VM not enabled, uniform bucket access not set, BigQuery row or column access policy evidence missing for sensitive tables |
 | **Low** | Hardening recommendation or defense-in-depth measure | OS Login not enabled, serial port access not explicitly disabled, BigQuery tables without CMEK |
 | **Informational** | Best practice observation, no direct security impact | Default network still exists (non-production), naming conventions, documentation gaps |
 
@@ -177,7 +178,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | 4 | Virtual Machines | Default service accounts, access scopes, project SSH key blocking, OS Login, serial port, IP forwarding, CMEK disks, Shielded VM, public IPs, Confidential Computing |
 | 5 | Storage | Public bucket access, uniform bucket-level access |
 | 6 | Cloud SQL | MySQL/PostgreSQL/SQL Server database flags, SSL enforcement, authorized networks, public IP, automated backups |
-| 7 | BigQuery | Public dataset access, CMEK encryption for tables and datasets |
+| 7 | BigQuery | Public dataset access, CMEK encryption for tables and datasets, fine-grained data access evidence for authorized views, row access policies, policy tags, and IAM Conditions |
 
 ### CIS Profile Levels
 
@@ -193,7 +194,8 @@ Produce the final report using the structure defined in the Output Format sectio
 3. **VPC flow logs must be per-subnet.** CIS 3.8 requires flow logs on every subnet, not just the VPC. Each `google_compute_subnetwork` must have a `log_config` block.
 4. **Cloud SQL authorized_networks vs. private IP.** CIS 6.5 flags `0.0.0.0/0` in authorized networks, but CIS 6.6 goes further and recommends disabling public IP entirely in favor of private networking.
 5. **BigQuery dataset-level vs. table-level CMEK.** CIS 7.2 checks table-level encryption, while CIS 7.3 checks the dataset default. Both should be evaluated independently.
-6. **Default compute service account identification.** The default SA follows the pattern `PROJECT_NUMBER-compute@developer.gserviceaccount.com`. Grep for this pattern, not just the string "default."
+6. **BigQuery non-public is not enough for sensitive data.** A dataset can pass the public-access check while still exposing source data through authorized views, authorized datasets, broad row-access grantees, missing column policy tags, or IAM Conditions that were not retrieved with `accessPolicyVersion=3`.
+7. **Default compute service account identification.** The default SA follows the pattern `PROJECT_NUMBER-compute@developer.gserviceaccount.com`. Grep for this pattern, not just the string "default."
 
 ---
 
@@ -219,6 +221,10 @@ Produce the final report using the structure defined in the Output Format sectio
 - Google Cloud Audit Logs: https://cloud.google.com/logging/docs/audit
 - Google Cloud VPC Documentation: https://cloud.google.com/vpc/docs
 - Google Cloud SQL Security: https://cloud.google.com/sql/docs/mysql/configure-ssl-instance
+- Google Cloud BigQuery authorized views: https://cloud.google.com/bigquery/docs/authorized-views
+- Google Cloud BigQuery row-level security: https://cloud.google.com/bigquery/docs/managing-row-level-security
+- Google Cloud BigQuery column-level access control: https://cloud.google.com/bigquery/docs/column-level-security
+- Google Cloud BigQuery IAM Conditions: https://cloud.google.com/bigquery/docs/conditions
 - Terraform Google Provider Documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs
 
 ---

--- a/skills/cloud/gcp-review/benchmark-checklist.md
+++ b/skills/cloud/gcp-review/benchmark-checklist.md
@@ -773,3 +773,120 @@ resource "google_bigquery_dataset" {
 ### CIS 7.3 -- Ensure that a Default Customer-Managed Encryption Key (CMEK) Is Specified for All BigQuery Datasets
 
 Verify `default_encryption_configuration` is set on all datasets.
+
+### BigQuery fine-grained data access evidence gates
+
+These checks supplement CIS 7.1-7.3 when BigQuery datasets contain sensitive,
+regulated, multi-tenant, or customer data. Do not mark a dataset as fully
+acceptable only because it is not public and uses CMEK; also record whether
+the effective data-sharing controls are known and bounded.
+
+#### Authorized views, authorized datasets, and routines
+
+Review dataset `access` blocks and `google_bigquery_dataset_access` resources.
+Authorized views and authorized datasets are valid ways to share filtered data,
+but they should be tied to approved view datasets, expected source datasets,
+and least-privilege principals.
+
+```hcl
+# REVIEW: Authorized view grant. Verify the view query, destination dataset,
+# principal access to the view dataset, source dataset location, and change owner.
+resource "google_bigquery_dataset_access" "sales_view" {
+  dataset_id = google_bigquery_dataset.source.dataset_id
+  view {
+    project_id = google_bigquery_table.sales_view.project
+    dataset_id = google_bigquery_table.sales_view.dataset_id
+    table_id   = google_bigquery_table.sales_view.table_id
+  }
+}
+
+# REVIEW: Authorized dataset. Verify that every view in the authorized dataset
+# is governed; otherwise future views can inherit access to the source data.
+resource "google_bigquery_dataset_access" "analytics_views" {
+  dataset_id = google_bigquery_dataset.source.dataset_id
+  dataset {
+    dataset {
+      project_id = google_bigquery_dataset.views.project
+      dataset_id = google_bigquery_dataset.views.dataset_id
+    }
+    target_types = ["VIEWS"]
+  }
+}
+```
+
+Flag as High when an authorized dataset grants a broad view dataset access to
+sensitive source tables without view inventory, owner approval, region evidence,
+and monitoring for new views.
+
+#### Row access policies
+
+For tables that require row-level separation, look for explicit row access
+policies and verify both the filter predicate and grantee list. The
+`roles/bigquery.filteredDataViewer` role is system-managed and should be granted
+through row access policies, not directly through IAM bindings.
+
+```hcl
+resource "google_bigquery_row_access_policy" "tenant_filter" {
+  dataset_id       = google_bigquery_dataset.app.dataset_id
+  table_id         = google_bigquery_table.orders.table_id
+  policy_id        = "tenant_filter"
+  filter_predicate = "tenant_id = SESSION_USER()"
+  grantees         = ["group:tenant-analysts@example.com"]
+}
+
+# BAD: Direct filteredDataViewer IAM grant bypasses the expected policy-managed path.
+resource "google_bigquery_table_iam_member" "direct_filtered_viewer" {
+  role   = "roles/bigquery.filteredDataViewer"
+  member = "group:tenant-analysts@example.com"
+}
+```
+
+Flag as High when a table is documented as tenant- or region-scoped but no row
+access policy, authorized-view filter, or separate-table evidence is present.
+Flag as Medium when a policy exists but the filter predicate or grantee evidence
+is not available for review.
+
+#### Column policy tags and data policies
+
+For sensitive columns, inspect table schemas for `policyTags` and verify that
+the corresponding Data Catalog / BigQuery Data Policy access is enforced and
+granted only to approved readers.
+
+```json
+{
+  "name": "customer_ssn",
+  "type": "STRING",
+  "policyTags": {
+    "names": [
+      "projects/p/locations/us/taxonomies/t/policyTags/pii"
+    ]
+  }
+}
+```
+
+Flag as High when production PII, secrets, payment, or regulated columns have
+no policy tag, masking policy, row-level control, authorized-view projection, or
+separate-table design. Flag as Medium when tags exist but enforcement or
+Fine-Grained Reader / Masked Reader grants cannot be evaluated.
+
+#### IAM Conditions and tag-based access
+
+When reviewing conditional BigQuery access, confirm the evidence was retrieved
+with access policy version 3 so conditions are visible. Conditions should use
+positive `resource.type`, `resource.name`, and `resource.service` checks instead
+of broad negative expressions.
+
+```json
+{
+  "role": "roles/bigquery.dataViewer",
+  "userByEmail": "analyst@example.com",
+  "condition": {
+    "title": "Only table_1",
+    "expression": "resource.type == 'bigquery.googleapis.com/Table' && resource.name == 'projects/p/datasets/d/tables/table_1'"
+  }
+}
+```
+
+Flag as Not Evaluable when dataset IAM was exported without condition details or
+when Terraform resources split dataset `access` and IAM bindings in a way that
+makes the effective access graph unclear.

--- a/skills/cloud/gcp-review/tests/bigquery-fine-grained-access-edge-cases.md
+++ b/skills/cloud/gcp-review/tests/bigquery-fine-grained-access-edge-cases.md
@@ -1,0 +1,96 @@
+# BigQuery Fine-Grained Access Edge Cases
+
+Use these cases to verify that `gcp-review` does not stop at CIS 7.1 public
+access and CIS 7.2/7.3 CMEK checks when BigQuery contains sensitive data.
+
+## False Positive Guard: Controlled Authorized View
+
+```hcl
+resource "google_bigquery_dataset_access" "authorized_sales_view" {
+  dataset_id = google_bigquery_dataset.source.dataset_id
+  view {
+    project_id = "analytics-prod"
+    dataset_id = "approved_views"
+    table_id   = "regional_sales_view"
+  }
+}
+```
+
+Expected outcome: do not automatically fail the dataset only because an
+authorized view exists. Record the view dataset, source dataset, location,
+view-owner approval, viewer principals, and query projection/filter evidence.
+Flag only if the authorized view or authorized dataset is broad, unmanaged, or
+not tied to approved sensitive-data handling.
+
+## Missed Variant: Authorized Dataset Grants Future Views
+
+```hcl
+resource "google_bigquery_dataset_access" "all_views_dataset" {
+  dataset_id = google_bigquery_dataset.customer_source.dataset_id
+  dataset {
+    dataset {
+      project_id = "analytics-prod"
+      dataset_id = "team_views"
+    }
+    target_types = ["VIEWS"]
+  }
+}
+```
+
+Expected outcome: High when the authorized dataset can add future views against
+sensitive source tables without inventory, approval, monitoring, or ownership
+evidence.
+
+## Missed Variant: Tenant Table Without Row Policy Evidence
+
+```hcl
+resource "google_bigquery_table" "orders" {
+  dataset_id = google_bigquery_dataset.app.dataset_id
+  table_id   = "orders"
+  schema     = file("orders-schema.json")
+}
+```
+
+Expected outcome: High or Not Evaluable when documentation says the table is
+tenant-scoped but there is no row access policy, authorized-view filter,
+separate-table design, or other row-separation evidence.
+
+## Missed Variant: Direct Filtered Data Viewer Grant
+
+```hcl
+resource "google_bigquery_table_iam_member" "direct_filtered_viewer" {
+  dataset_id = google_bigquery_dataset.app.dataset_id
+  table_id   = google_bigquery_table.orders.table_id
+  role       = "roles/bigquery.filteredDataViewer"
+  member     = "group:analysts@example.com"
+}
+```
+
+Expected outcome: fail the direct grant. `roles/bigquery.filteredDataViewer`
+should be granted through a row access policy rather than directly through IAM.
+
+## Missed Variant: Sensitive Column Without Policy Tag Evidence
+
+```json
+[
+  {"name": "customer_id", "type": "STRING"},
+  {"name": "customer_ssn", "type": "STRING"},
+  {"name": "card_last4", "type": "STRING"}
+]
+```
+
+Expected outcome: High when production PII, payment, secret, or regulated
+columns lack policy tags, masking policy, authorized-view projection,
+row-level control, or separate-table evidence.
+
+## Missed Variant: Conditional Access Hidden By Export Mode
+
+```text
+Evidence command: bq show --format=prettyjson project:dataset
+Observed binding: withcond_1234567890
+Missing evidence: accessPolicyVersion=3 dataset export
+```
+
+Expected outcome: Not Evaluable until the dataset access policy is retrieved
+with condition details visible. Do not count conditional access as a pass when
+the condition expression is hidden.


### PR DESCRIPTION
## Summary

- Implements #1314.
- Adds BigQuery fine-grained data access evidence gates to `gcp-review`.
- Updates the skill summary/prerequisites/severity examples/pitfalls/references so sensitive BigQuery datasets are not treated as acceptable solely because they are non-public and CMEK-backed.
- Adds edge-case fixtures for authorized datasets, missing row policy evidence, direct `filteredDataViewer` grants, missing policy tags, and hidden IAM Conditions.

## Validation

- Checked Markdown fence balance for the edited skill, checklist, and new fixture.
- Verified official Google Cloud reference URLs return HTTP 200.
- Scanned the changed public files for private payment/contact strings.

## Bounty

- I have read and agree to the CONTRIBUTING.md bounty terms.
- Preferred payment method can be provided privately after maintainer acceptance.
