### PR TITLE
Improve Azure Storage key and SAS evidence gates

### DIFF
--- a/skills/cloud/azure-review/SKILL.md
+++ b/skills/cloud/azure-review/SKILL.md
@@ -54,6 +54,7 @@ The CIS Microsoft Azure Foundations Benchmark v2.1.0 is a consensus-driven secur
 - Entra ID (Azure AD) configuration files or policy documents
 - NSG and firewall rule definitions
 - Key Vault access policies and RBAC assignments
+- Storage account Shared Key, SAS expiration policy, diagnostic logging, Azure Policy, and data-plane authorization evidence when Storage Accounts are in scope
 
 ---
 
@@ -102,7 +103,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | Severity | Definition | Examples |
 |----------|-----------|----------|
 | **Critical** | Immediate risk of data breach or unauthorized access | NSGs open to 0.0.0.0/0 on RDP/SSH, SQL databases publicly accessible, Defender for Cloud disabled |
-| **High** | Significant security gap that materially weakens posture | Missing MFA enforcement, storage accounts with public access, Key Vault without purge protection |
+| **High** | Significant security gap that materially weakens posture | Missing MFA enforcement, storage accounts with public access, Shared Key/SAS left enabled for sensitive storage without compensating controls, Key Vault without purge protection |
 | **Medium** | Control gap that should be addressed in normal cycle | Missing activity log alerts, soft delete not enabled, TLS below 1.2 |
 | **Low** | Hardening recommendation or defense-in-depth measure | HTTP/2 not enabled, FTP not fully disabled, missing CMK on non-sensitive storage |
 | **Informational** | Best practice observation, no direct security impact | Naming conventions, tag policies, documentation gaps |
@@ -177,7 +178,7 @@ Produce the final report using the structure defined in the Output Format sectio
 |---------|--------|-----------------|
 | 1 | Identity and Access Management | Entra ID security defaults, MFA enforcement, Conditional Access policies, guest user management, PIM configuration |
 | 2 | Microsoft Defender for Cloud | Defender plan enablement (Servers, App Service, SQL, Storage, Containers, Key Vault, DNS, ARM), security contacts, auto-provisioning |
-| 3 | Storage Accounts | HTTPS enforcement, infrastructure encryption, public access, network rules, soft delete, CMK encryption, TLS version |
+| 3 | Storage Accounts | HTTPS enforcement, infrastructure encryption, public access, network rules, soft delete, CMK encryption, TLS version, Shared Key/SAS authorization controls |
 | 4 | Database Services | SQL auditing, firewall rules, threat detection, SSL enforcement, TDE, Entra ID admin, Cosmos DB public access |
 | 5 | Logging and Monitoring | Diagnostic settings, activity log alerts (policy, NSG, SQL firewall, public IP), Key Vault logging, Network Watcher |
 | 6 | Networking | NSG rules (RDP, SSH, UDP, HTTP), flow log retention, traffic analytics |
@@ -197,9 +198,10 @@ Produce the final report using the structure defined in the Output Format sectio
 1. **Confusing Entra ID Security Defaults with Conditional Access.** CIS 1.1.1 accepts either, but if Conditional Access is used, Security Defaults must be disabled. Do not flag this as a failure if equivalent CA policies exist.
 2. **Missing Defender for Cloud plan coverage.** Each resource type (Servers, SQL, Storage, etc.) requires its own Defender plan enablement. A single `azurerm_security_center_subscription_pricing` resource only covers one type.
 3. **Overlooking `allow_nested_items_to_be_public` on storage accounts.** CIS 3.7 checks the account-level setting, not individual container access levels. The account setting must be `false` to prevent any container from being public.
-4. **NSG rules using service tags.** A rule with `source_address_prefix = "Internet"` is equivalent to `0.0.0.0/0`. Both must be flagged for CIS 6.1 and 6.2.
-5. **Key Vault purge protection is irreversible.** CIS 8.5 requires `purge_protection_enabled = true`. Note this cannot be disabled once enabled -- flag this for awareness during remediation.
-6. **App Service TLS version on both Linux and Windows.** Check `azurerm_linux_web_app` and `azurerm_windows_web_app` resources separately.
+4. **Treating network-deny as proof that storage data-plane auth is safe.** A storage account can deny public network access and still allow account-key or SAS access from trusted paths. Review `allowSharedKeyAccess`, `shared_access_key_enabled`, SAS expiration policy, `listkeys` permissions, and SAS diagnostic evidence separately.
+5. **NSG rules using service tags.** A rule with `source_address_prefix = "Internet"` is equivalent to `0.0.0.0/0`. Both must be flagged for CIS 6.1 and 6.2.
+6. **Key Vault purge protection is irreversible.** CIS 8.5 requires `purge_protection_enabled = true`. Note this cannot be disabled once enabled -- flag this for awareness during remediation.
+7. **App Service TLS version on both Linux and Windows.** Check `azurerm_linux_web_app` and `azurerm_windows_web_app` resources separately.
 
 ---
 
@@ -223,6 +225,10 @@ Produce the final report using the structure defined in the Output Format sectio
 - Microsoft Defender for Cloud Documentation: https://learn.microsoft.com/en-us/azure/defender-for-cloud/
 - Microsoft Entra ID Security: https://learn.microsoft.com/en-us/entra/identity/
 - Azure Storage Security: https://learn.microsoft.com/en-us/azure/storage/common/storage-security-guide
+- Azure Storage Shared Key authorization prevention: https://learn.microsoft.com/en-us/azure/storage/common/shared-key-authorization-prevent
+- Azure Storage SAS expiration policy: https://learn.microsoft.com/en-us/azure/storage/common/sas-expiration-policy
+- Azure Storage stored access policy: https://learn.microsoft.com/en-us/rest/api/storageservices/define-stored-access-policy
+- Azure Storage data access authorization: https://learn.microsoft.com/en-us/azure/storage/common/authorize-data-access
 - Azure Key Vault Best Practices: https://learn.microsoft.com/en-us/azure/key-vault/general/best-practices
 - Azure App Service Security: https://learn.microsoft.com/en-us/azure/app-service/overview-security
 - Terraform AzureRM Provider Documentation: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs

--- a/skills/cloud/azure-review/benchmark-checklist.md
+++ b/skills/cloud/azure-review/benchmark-checklist.md
@@ -290,6 +290,108 @@ resource "azurerm_storage_account" {
 }
 ```
 
+### Storage Shared Key and SAS authorization evidence gates
+
+These checks supplement the CIS Storage controls when storage accounts contain
+sensitive, regulated, backup, diagnostic, or customer data. Do not treat
+`default_action = "Deny"`, private endpoints, HTTPS-only, and disabled blob
+public access as proof that the data-plane authorization path is least
+privilege.
+
+#### Shared Key authorization
+
+Record whether Shared Key authorization is explicitly disallowed. Microsoft
+recommends Microsoft Entra authorization over Shared Key where supported, and
+disallowing Shared Key is required before Microsoft Entra Conditional Access can
+protect Storage data access.
+
+```hcl
+# GOOD: Account-key authorization disabled for supported workloads.
+resource "azurerm_storage_account" "secure" {
+  shared_access_key_enabled = false
+}
+
+# REVIEW: If Shared Key remains enabled, require workload justification,
+# affected services, `listkeys` role assignments, key rotation evidence, and
+# SAS controls.
+resource "azurerm_storage_account" "legacy_files" {
+  shared_access_key_enabled = true
+}
+```
+
+For ARM/Bicep evidence, review `properties.allowSharedKeyAccess`. For live
+evidence, `az storage account show --query "allowSharedKeyAccess"` should return
+`false` for accounts where Shared Key is not required.
+
+Flag as High when sensitive Storage Accounts allow Shared Key without a
+documented workload exception, migration plan to Microsoft Entra/user-delegation
+authorization, key rotation evidence, and monitoring for key/SAS usage.
+
+#### SAS expiration policy and enforcement
+
+If SAS is required, record the SAS type, maximum validity interval, expiration
+action, diagnostic logs, and whether out-of-policy SAS usage is blocked or only
+logged.
+
+```hcl
+resource "azurerm_storage_account" "with_sas_policy" {
+  shared_access_key_enabled = true
+
+  sas_policy {
+    expiration_period = "01.00:00:00"
+    expiration_action = "Block"
+  }
+}
+```
+
+For ARM/Bicep evidence, inspect:
+
+```bicep
+properties: {
+  sasPolicy: {
+    sasExpirationPeriod: '01.00:00:00'
+    expirationAction: 'Block'
+  }
+}
+```
+
+Flag as High when account SAS or service SAS is used for sensitive data with no
+SAS expiration policy. Flag as Medium when policy action is `Log` only for a
+production sensitive account or when diagnostic logs do not capture
+`SasExpiryStatus` evidence.
+
+#### Stored access policies and revocation path
+
+For service SAS, verify whether a stored access policy is used so expiry and
+permissions can be changed server-side after issuance. If ad hoc SAS tokens are
+used, reviewers should document the token lifetime and the emergency revocation
+path, usually account-key rotation.
+
+```text
+SAS inventory:
+  type: service SAS
+  stored access policy: container-read-24h
+  expiry: 24h
+  permissions: read only
+  revocation path: delete/rename stored access policy
+```
+
+Flag as High when long-lived ad hoc SAS tokens grant write/delete/list access
+and the only revocation path is account-key rotation. Flag as Not Evaluable when
+review evidence contains generated SAS URLs or variables but omits SAS type,
+expiry, permissions, IP/protocol restrictions, and revocation method.
+
+#### RBAC access to account keys
+
+Identify principals with `Microsoft.Storage/storageAccounts/listkeys/action`,
+`Owner`, `Contributor`, `Storage Account Contributor`, or custom roles that can
+retrieve account keys. These principals can create Shared Key authorization and
+account/service SAS paths even if they are not data readers through Azure RBAC.
+
+Flag as High when broad human or workload identities can list storage account
+keys for sensitive accounts without approval, just-in-time access, rotation, and
+monitoring.
+
 ---
 
 ## Section 4 -- Database Services

--- a/skills/cloud/azure-review/tests/storage-shared-key-sas-edge-cases.md
+++ b/skills/cloud/azure-review/tests/storage-shared-key-sas-edge-cases.md
@@ -1,0 +1,103 @@
+# Azure Storage Shared Key and SAS Edge Cases
+
+Use these cases to verify that `azure-review` evaluates the effective Storage
+data-plane authorization path, not only network exposure, public blob access,
+TLS, and encryption settings.
+
+## False Positive Guard: Legacy Azure Files Exception
+
+```hcl
+resource "azurerm_storage_account" "files" {
+  name                      = "legacyfilesprod"
+  shared_access_key_enabled = true
+  network_rules {
+    default_action = "Deny"
+  }
+}
+```
+
+Expected outcome: do not automatically fail every enabled Shared Key account.
+Record the workload exception, service type, RBAC/listkeys owners, key rotation
+evidence, SAS policy, diagnostic logging, and migration plan. Fail only when the
+exception is missing, stale, overly broad, or unmonitored.
+
+## Missed Variant: Network Deny But Shared Key Allowed
+
+```hcl
+resource "azurerm_storage_account" "sensitive" {
+  allow_nested_items_to_be_public = false
+  enable_https_traffic_only       = true
+  min_tls_version                 = "TLS1_2"
+  shared_access_key_enabled       = true
+  network_rules {
+    default_action = "Deny"
+  }
+}
+```
+
+Expected outcome: High for sensitive data unless there is a documented Shared
+Key exception, key rotation evidence, SAS controls, and monitored key/SAS usage.
+The network deny control is not sufficient proof of least-privilege data-plane
+authorization.
+
+## Missed Variant: SAS Required But No Expiration Policy
+
+```hcl
+resource "azurerm_storage_account" "exports" {
+  shared_access_key_enabled = true
+}
+
+data "azurerm_storage_account_sas" "exports" {
+  connection_string = azurerm_storage_account.exports.primary_connection_string
+  https_only        = true
+}
+```
+
+Expected outcome: High or Not Evaluable for production sensitive data when SAS
+is generated but no `sas_policy`, SAS type, expiry, permissions, IP/protocol
+restrictions, diagnostics, or revocation method is available.
+
+## Missed Variant: Log-Only SAS Expiration Policy
+
+```hcl
+resource "azurerm_storage_account" "reports" {
+  shared_access_key_enabled = true
+  sas_policy {
+    expiration_period = "07.00:00:00"
+    expiration_action = "Log"
+  }
+}
+```
+
+Expected outcome: Medium for sensitive production data unless log-only is a
+documented transition state with Azure Monitor evidence and a target date for
+`Block` enforcement.
+
+## Missed Variant: Broad ListKeys Permission
+
+```json
+{
+  "role": "Contributor",
+  "scope": "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sensitive",
+  "principal": "group:platform-operators"
+}
+```
+
+Expected outcome: High when broad human or workload identities can perform
+`Microsoft.Storage/storageAccounts/listkeys/action` for sensitive accounts
+without just-in-time approval, monitoring, and key rotation evidence.
+
+## Missed Variant: Long-Lived Ad Hoc Service SAS
+
+```text
+SAS type: service SAS
+permissions: read, write, delete, list
+expiry: 365 days
+stored access policy: none
+revocation path: rotate account key
+```
+
+Expected outcome: High because the SAS is long-lived, high-privilege, and not
+bound to a stored access policy. Recommend a short-lived SAS, stored access
+policy for service SAS where supported, or user delegation SAS / Entra
+authorization where possible.


### PR DESCRIPTION
## Summary

- Implements #1319.
- Adds Azure Storage Shared Key/SAS evidence gates to `azure-review`.
- Updates the skill prerequisites, severity examples, section map, pitfalls, and references so sensitive Storage Accounts are not treated as acceptable solely because public access, network, TLS, and encryption controls pass.
- Adds edge-case fixtures for Shared Key exceptions, network-deny-with-key-access, missing SAS policy, log-only SAS policy, broad `listkeys`, and long-lived ad hoc SAS.

## Validation

- Checked Markdown fence balance for the edited skill, checklist, and new fixture.
- Verified official Microsoft Learn reference URLs return HTTP 200.
- Scanned the changed public files for private payment/contact strings.

## Bounty

- I have read and agree to the CONTRIBUTING.md bounty terms.
- Preferred payment method can be provided privately after maintainer acceptance.
