### PR TITLE
docs: add IAM analyzer evidence gates

### DIFF
--- a/skills/identity/iam-review/SKILL.md
+++ b/skills/identity/iam-review/SKILL.md
@@ -176,17 +176,46 @@ IAM-PRIV-07: Cross-account access without external ID or condition keys
 IAM-PRIV-08: Resource-based policies granting public or overly broad access
 ```
 
+#### Entitlement Evidence and Analyzer Corroboration
+
+Use cloud-native analyzers as evidence sources, but do not treat their output as
+the final authorization decision. Analyzer findings must be reconciled against
+business ownership, workload behavior, exception approvals, and recent activity
+windows before recommending removal or privilege reduction.
+
+```
+IAM-PRIV-09: External access analyzer findings are not triaged to an owner
+IAM-PRIV-10: Unused-permission recommendations are accepted without workload evidence
+IAM-PRIV-11: Access exceptions do not include approver, expiry date, and compensating control
+IAM-PRIV-12: Cross-account / cross-tenant grants lack external ID, audience, or condition constraints
+IAM-PRIV-13: Permission reduction plan has no rollback owner or break-glass path
+IAM-PRIV-14: Findings are based on stale telemetry outside the review window
+```
+
+**Evidence requirements:**
+
+| Evidence Source | Required Checks | Failure Mode |
+|---|---|---|
+| Access analyzer findings | Finding ID, affected principal/resource, external principal, last analyzed timestamp, owner disposition | External access remains unowned or unreviewed |
+| Unused access recommendations | Observation period, last-used timestamp, business owner sign-off, planned removal date | Legitimate rare-use permissions are removed without validation |
+| Policy simulation / dry run | Representative action set, target resources, denied actions reviewed by owner | Remediation breaks production workloads |
+| Exception register | Approver, expiry, compensating control, review cadence | Permanent exceptions become undocumented standing access |
+| Recent audit logs | Human/API activity within review window, service account call patterns | Stale telemetry misclassifies active access as unused |
+
 **Platform-specific checks:**
 
 | Platform | Check | What to look for |
 |---|---|---|
-| **AWS** | IAM Access Analyzer, IAM policy simulator | External access findings, unused access, policy validation |
+| **AWS** | IAM Access Analyzer, IAM policy simulator | External access findings, unused access, policy validation, last analyzed timestamp |
 | **AWS** | SCPs (Service Control Policies) | Missing guardrails at organization level |
 | **AWS** | `aws iam get-account-authorization-details` | Full policy enumeration, inline vs. managed policies |
+| **AWS** | CloudTrail, IAM last accessed details | Recent activity window before permission removal |
 | **Azure / Entra ID** | PIM (Privileged Identity Management) role assignments | Permanent vs. eligible assignments, activation requirements |
 | **Azure / Entra ID** | Azure RBAC, custom role definitions | Overly broad custom roles, wildcard actions |
+| **Azure / Entra ID** | Access reviews, sign-in logs, workload identity federation | Owner decisions, guest/service principal activity, federated credential conditions |
 | **GCP** | IAM Recommender, Policy Analyzer | Excess permissions, recommended removals |
 | **GCP** | Organization-level IAM bindings | Primitive roles (Owner, Editor) at org/folder level |
+| **GCP** | Audit logs, service account insights, workload identity pools | Activity window, impersonation graph, audience/provider restrictions |
 
 **Severity Classification:**
 
@@ -194,6 +223,8 @@ IAM-PRIV-08: Resource-based policies granting public or overly broad access
 |---|---|---|
 | Wildcard admin (`*:*`) on production | **Critical** | Full environment compromise potential |
 | Standing admin without JIT | **High** | Persistent lateral movement target |
+| External access analyzer finding with no owner or expiry | **High** | Unbounded third-party access path |
+| Unused-permission cleanup without simulation or rollback | **Medium** | High chance of production outage or compensating shadow access |
 | Unused permissions > 90 days | **Medium** | Attack surface reduction opportunity |
 | Direct policy attachment | **Low** | Governance improvement, not direct risk |
 
@@ -380,6 +411,9 @@ For each finding, produce a row with:
 | **Framework Ref** | NIST SP 800-63B section, NIST SP 800-207 tenet, or CIS Control ID |
 | **Affected Scope** | Accounts, roles, policies, or platforms impacted |
 | **Evidence** | Specific configuration, policy, or data supporting the finding |
+| **Evidence Freshness** | Timestamp or observation window for analyzer output, last-used data, and logs |
+| **Owner / Exception** | Business owner, exception approval, expiry date, or "none" |
+| **Rollback Path** | Named rollback or break-glass path for privilege reduction findings |
 | **Remediation** | Prioritized fix with implementation guidance |
 | **Effort** | Low (< 1 day) / Medium (1-5 days) / High (> 5 days) |
 
@@ -446,6 +480,15 @@ For each finding, produce a row with:
 | `cloud/azure-review.md` | Azure/Entra ID-specific security configuration |
 | `cloud/gcp-review.md` | GCP-specific IAM and organization policy review |
 | `compliance/soc2-gap.md` | Mapping IAM findings to SOC 2 Trust Services Criteria (CC6.1-CC6.3) |
+
+## References
+
+- AWS IAM Access Analyzer: https://docs.aws.amazon.com/IAM/latest/UserGuide/what-is-access-analyzer.html
+- AWS last accessed information: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html
+- Microsoft workload identity federation: https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation
+- Microsoft Entra access reviews: https://learn.microsoft.com/en-us/entra/id-governance/access-reviews-overview
+- Google Cloud role recommendations: https://docs.cloud.google.com/policy-intelligence/docs/role-recommendations-overview
+- Google Cloud Policy Analyzer: https://cloud.google.com/policy-intelligence/docs/analyze-iam-policies
 
 ---
 

--- a/skills/identity/iam-review/tests/access-analyzer-evidence-edge-cases.md
+++ b/skills/identity/iam-review/tests/access-analyzer-evidence-edge-cases.md
@@ -1,0 +1,73 @@
+# IAM Analyzer Evidence Edge Cases
+
+These fixtures validate that the IAM review does not blindly trust analyzer
+recommendations or stale telemetry when producing least-privilege findings.
+
+## Edge Case 1: External Access Finding Without Ownership
+
+Input evidence:
+
+```json
+{
+  "source": "AWS IAM Access Analyzer",
+  "findingId": "abc123",
+  "resource": "arn:aws:s3:::finance-prod-ledger",
+  "principal": "arn:aws:iam::999999999999:role/vendor-export",
+  "condition": {},
+  "lastAnalyzedAt": "2026-06-05T10:00:00Z",
+  "ownerDisposition": null
+}
+```
+
+Expected output:
+
+- Finding ID: `IAM-PRIV-09`
+- Severity: High
+- Evidence freshness includes `lastAnalyzedAt`
+- Owner / Exception is `none`
+- Remediation requires owner triage, condition constraints, and expiry
+
+## Edge Case 2: Unused Permission Recommendation With Stale Telemetry
+
+Input evidence:
+
+```json
+{
+  "source": "GCP IAM Recommender",
+  "principal": "serviceAccount:quarterly-report@project.iam.gserviceaccount.com",
+  "recommendation": "remove bigquery.jobs.create",
+  "observationPeriodDays": 30,
+  "workloadPattern": "quarterly financial close",
+  "lastAuditLogWindowEnds": "2026-03-31T23:59:59Z"
+}
+```
+
+Expected output:
+
+- Finding ID: `IAM-PRIV-10` or `IAM-PRIV-14`
+- Do not recommend immediate removal
+- Require business-owner validation and a longer observation window
+- Rollback Path names the owner responsible for restoring access
+
+## Edge Case 3: Cross-Tenant Grant Missing Audience Constraint
+
+Input evidence:
+
+```json
+{
+  "source": "Entra workload identity federation",
+  "appId": "11111111-2222-3333-4444-555555555555",
+  "issuer": "https://token.actions.githubusercontent.com",
+  "subject": "repo:example/payments:*",
+  "audiences": ["api://AzureADTokenExchange"],
+  "expiry": null,
+  "approver": null
+}
+```
+
+Expected output:
+
+- Finding ID: `IAM-PRIV-11` or `IAM-PRIV-12`
+- Severity: High when the grant reaches production resources
+- Owner / Exception includes missing approver and expiry
+- Remediation tightens subject/audience constraints and adds an exception expiry


### PR DESCRIPTION
## Summary

Adds entitlement evidence and analyzer-corroboration guidance to `iam-review` so least-privilege findings are based on owner-validated, fresh evidence instead of blindly trusting analyzer recommendations.

## Changes

- Added `IAM-PRIV-09` through `IAM-PRIV-14` for analyzer ownership, stale telemetry, exception expiry, cross-tenant constraints, and rollback paths.
- Added an evidence requirements table for external access findings, unused access recommendations, policy simulation, exception registers, and recent audit logs.
- Expanded AWS, Azure / Entra ID, and GCP platform checks with analyzer freshness, sign-in/audit logs, workload identity federation, and service-account insights.
- Added output fields for evidence freshness, owner/exception, and rollback path.
- Added official references for AWS IAM Access Analyzer, AWS last accessed information, Microsoft workload identity federation, Entra access reviews, Google Cloud role recommendations, and Policy Analyzer.
- Added edge-case fixtures for unowned external access, stale recommender telemetry, and cross-tenant federation grants.

## Validation

- `git diff --check`
- Added-line prompt-injection marker scan
- Reference URL reachability check:
  - AWS IAM Access Analyzer: 200
  - AWS last accessed information: 200
  - Microsoft workload identity federation: 200
  - Microsoft Entra access reviews: 200
  - Google Cloud role recommendations: 200
  - Google Cloud Policy Analyzer: 200

## Related issue

Created from review issue: #1333
