### PR TITLE
Improve AWS GuardDuty coverage evidence gates

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -6,14 +6,15 @@ description: >
   IAM policies, S3 configurations, CloudTrail settings, VPC security groups, or
   RDS encryption. Walks through all five benchmark sections, evaluates each
   recommendation, and produces a prioritized findings report with remediation
-  guidance mapped to specific CIS control IDs.
+  guidance mapped to specific CIS control IDs, with supplemental GuardDuty
+  protection-plan coverage evidence.
 tags: [cloud, aws, cis-benchmark]
 role: [cloud-security-engineer, security-engineer]
 phase: [assess, operate]
 frameworks: [CIS-AWS-v3.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -55,6 +56,7 @@ The CIS Amazon Web Services Foundations Benchmark v3.0.0 is a consensus-driven s
 - S3 bucket policies and ACL configurations
 - VPC, security group, and NACL definitions
 - CloudTrail and CloudWatch configuration files
+- GuardDuty detector, delegated administrator, organization auto-enable, protection plan, finding export, and EventBridge/S3 destination evidence when threat detection is in scope
 
 ---
 
@@ -99,6 +101,62 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
+### Step 6a: GuardDuty Protection Plan Coverage
+
+Review GuardDuty as supplemental AWS threat-detection posture evidence. This
+does not replace CIS Security Hub, CloudTrail, or CloudWatch alarm checks. It
+prevents overclaiming detection coverage when GuardDuty is enabled only in a
+single account/Region or when important protection plans are disabled.
+
+**What to collect:**
+
+- GuardDuty detector status per in-scope account and Region.
+- Delegated administrator and organization configuration, including auto-enable status for new and existing member accounts.
+- Enabled protection plans and feature status for S3 Protection, EKS Audit Logs, Runtime Monitoring, Malware Protection for EC2, RDS Protection, Lambda Protection, and Malware Protection for S3 or AWS Backup when relevant.
+- Runtime Monitoring security-agent management status for EKS, ECS/Fargate, and EC2 workloads where applicable.
+- Finding delivery path, including EventBridge rules, optional S3 export destination, KMS key, and export frequency.
+- Suppressed/archived GuardDuty findings and filters, with owner, reason, expiration/review date, and compensating evidence.
+- Account and Region coverage denominator, including suspended, newly created, standalone, and management/delegated admin accounts.
+
+**Detection patterns:**
+
+```
+aws_guardduty_detector
+aws_guardduty_detector_feature
+aws_guardduty_organization_admin_account
+aws_guardduty_organization_configuration
+aws_guardduty_organization_configuration_feature
+aws_guardduty_malware_protection_plan
+aws_guardduty_publishing_destination
+AWS::GuardDuty::Detector
+S3_DATA_EVENTS
+EKS_AUDIT_LOGS
+RUNTIME_MONITORING
+EBS_MALWARE_PROTECTION
+RDS_LOGIN_EVENTS
+LAMBDA_NETWORK_LOGS
+```
+
+**Finding calibration:**
+
+| Condition | Severity |
+|---|---|
+| GuardDuty is disabled for a production or internet-facing account and no equivalent threat detection is evidenced | High |
+| GuardDuty is enabled but organization auto-enable is disabled or does not cover existing and new member accounts | Medium |
+| Workload-relevant protection plans are disabled (for example S3 Protection for sensitive S3 data or Runtime Monitoring for EKS/ECS/EC2 workloads) without a documented exception | Medium |
+| GuardDuty findings are not routed to an operational alerting or ticketing path, or S3 export/KMS evidence is missing where historical retention is required | Medium |
+| Suppression filters archive high/critical finding types without owner, reason, expiry, and review evidence | High |
+| GuardDuty is enabled, protection plans match workload inventory, findings route to EventBridge/SOC, and S3 export is encrypted where required | Informational |
+
+**Important limitations:**
+
+- GuardDuty findings are detection signals, not proof that the underlying exposure or vulnerability has been remediated.
+- Security Hub enabled does not prove GuardDuty detector, protection-plan, or finding-export coverage.
+- Runtime Monitoring requires security-agent coverage; enabling the feature without agent status evidence may still leave workload gaps.
+- Malware Protection for S3 can be used independently of foundational GuardDuty, so record whether the organization is using the independent plan or the broader GuardDuty service.
+
+---
+
 ### Step 7: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
@@ -110,7 +168,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | Severity | Definition | Examples |
 |----------|-----------|----------|
 | **Critical** | Immediate risk of data breach or account compromise | Public S3 buckets with sensitive data, `*:*` admin policies on users, security groups open to 0.0.0.0/0 on admin ports |
-| **High** | Significant security gap that materially weakens posture | Missing CloudTrail, no MFA enforcement, unencrypted RDS, IMDSv1 enabled |
+| **High** | Significant security gap that materially weakens posture | Missing CloudTrail, no MFA enforcement, unencrypted RDS, IMDSv1 enabled, GuardDuty disabled for production accounts with no equivalent detection |
 | **Medium** | Control gap that should be addressed in normal cycle | Missing log metric filters, password policy below requirements, no VPC flow logs |
 | **Low** | Hardening recommendation or defense-in-depth measure | Missing Macie classification, no hardware MFA on root (when virtual MFA exists), missing access analyzer in non-primary regions |
 | **Informational** | Best practice observation, no direct security impact | Naming conventions, tag hygiene, documentation gaps |
@@ -146,6 +204,18 @@ Produce the final report using the structure defined in the Output Format sectio
 | 4 | Monitoring | X/16 | Y | Z | nn% |
 | 5 | Networking | X/6 | Y | Z | nn% |
 
+### GuardDuty Coverage Evidence
+
+| Field | Value |
+|---|---|
+| Detector status by account/Region | <coverage denominator or Not Evaluable> |
+| Delegated admin account | <account ID or Not Evaluable> |
+| Organization auto-enable | <ALL / NEW / NONE / Not Evaluable> |
+| Protection plans enabled | <S3 / EKS / Runtime / EC2 malware / S3 malware / RDS / Lambda / Backup> |
+| Workload coverage gaps | <S3 buckets / EKS clusters / ECS tasks / EC2 instances / RDS databases / Lambda functions> |
+| Finding delivery | <EventBridge / S3 export / Detective / ticketing / Not Evaluable> |
+| Suppression filters reviewed | <Yes / No / Not Evaluable> |
+
 ### Detailed Findings
 
 #### [CIS X.Y] <Recommendation Title>
@@ -154,6 +224,7 @@ Produce the final report using the structure defined in the Output Format sectio
 - **CIS Profile:** Level 1 / Level 2
 - **File:** <path to relevant config>
 - **Line(s):** <line numbers if applicable>
+- **Evidence Scope:** <account / OU / organization / Region / Not Evaluable>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration or code snippet>
 - **Remediation:** <specific fix with code example>
@@ -182,7 +253,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | 1 | Identity and Access Management | 22 | Root account security, MFA, password policy, access keys, IAM policies, Access Analyzer, identity federation |
 | 2 | Storage | 10 | S3 bucket security (public access, encryption, TLS), EBS encryption, RDS encryption and access, EFS encryption |
 | 3 | Logging | 11 | CloudTrail (multi-region, validation, encryption), AWS Config, S3 access logging, VPC flow logs, object-level logging |
-| 4 | Monitoring | 16 | CloudWatch metric filters and alarms for 15 critical event types, Security Hub enablement |
+| 4 | Monitoring | 16 | CloudWatch metric filters and alarms for 15 critical event types, Security Hub enablement, GuardDuty detection coverage |
 | 5 | Networking | 6 | NACL restrictions, security group hardening, default SG lockdown, VPC peering routes, IMDSv2 enforcement |
 
 ### CIS Profile Levels
@@ -200,6 +271,7 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
 5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
 6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
+7. **Treating Security Hub as proof of GuardDuty coverage.** Security Hub can aggregate findings, but it does not prove GuardDuty detectors, organization auto-enable, protection plans, Runtime Monitoring agents, or finding export are configured.
 
 ---
 
@@ -224,6 +296,10 @@ Produce the final report using the structure defined in the Output Format sectio
 - AWS IAM Best Practices: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 - AWS CloudTrail Documentation: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/
 - AWS Security Hub: https://docs.aws.amazon.com/securityhub/latest/userguide/
+- Amazon GuardDuty: https://docs.aws.amazon.com/guardduty/latest/ug/what-is-guardduty.html
+- Amazon GuardDuty protection plans: https://docs.aws.amazon.com/guardduty/latest/ug/protection-plans-overview.html
+- Amazon GuardDuty finding export: https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_exportfindings.html
+- Amazon GuardDuty Runtime Monitoring: https://docs.aws.amazon.com/guardduty/latest/ug/runtime-monitoring.html
 - AWS VPC Security: https://docs.aws.amazon.com/vpc/latest/userguide/security.html
 - Terraform AWS Provider Documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 
@@ -231,4 +307,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Added GuardDuty detector, protection-plan, organization auto-enable, finding-export, Runtime Monitoring, and suppression-filter coverage evidence.
 - **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 (62 recommendations).

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -405,6 +405,96 @@ aws_securityhub_account
 aws_securityhub_standards_subscription
 ```
 
+### Supplemental -- GuardDuty detector and protection-plan coverage
+
+Security Hub enabled is not sufficient evidence that GuardDuty is enabled,
+organization-wide, and routed to an operational response path. When production
+or internet-facing AWS accounts are in scope, review GuardDuty coverage as a
+supplemental monitoring control.
+
+#### Detector and organization coverage
+
+```hcl
+resource "aws_guardduty_detector" "detector" {
+  enable = true
+}
+
+resource "aws_guardduty_organization_admin_account" "delegated" {
+  admin_account_id = var.security_account_id
+}
+
+resource "aws_guardduty_organization_configuration" "org" {
+  detector_id                      = aws_guardduty_detector.detector.id
+  auto_enable_organization_members = "ALL"
+}
+```
+
+Review account and Region denominators. Flag as Medium when auto-enable is
+`NONE` or only covers new accounts while existing member accounts remain outside
+GuardDuty.
+
+#### Protection-plan feature coverage
+
+```hcl
+resource "aws_guardduty_organization_configuration_feature" "s3" {
+  detector_id = aws_guardduty_detector.detector.id
+  name        = "S3_DATA_EVENTS"
+  auto_enable = "ALL"
+}
+
+resource "aws_guardduty_organization_configuration_feature" "runtime" {
+  detector_id = aws_guardduty_detector.detector.id
+  name        = "RUNTIME_MONITORING"
+  auto_enable = "ALL"
+
+  additional_configuration {
+    name        = "EKS_ADDON_MANAGEMENT"
+    auto_enable = "ALL"
+  }
+
+  additional_configuration {
+    name        = "ECS_FARGATE_AGENT_MANAGEMENT"
+    auto_enable = "ALL"
+  }
+
+  additional_configuration {
+    name        = "EC2_AGENT_MANAGEMENT"
+    auto_enable = "ALL"
+  }
+}
+```
+
+Check feature names such as `S3_DATA_EVENTS`, `EKS_AUDIT_LOGS`,
+`RUNTIME_MONITORING`, `EBS_MALWARE_PROTECTION`, `RDS_LOGIN_EVENTS`, and
+`LAMBDA_NETWORK_LOGS`. For sensitive S3 upload workflows, also review
+`aws_guardduty_malware_protection_plan` or equivalent Malware Protection for S3
+configuration.
+
+Flag as Medium when workload-relevant protection plans are disabled without a
+documented exception. Flag as Not Evaluable when the workload inventory is
+missing, because the reviewer cannot determine whether disabled protection
+plans are justified.
+
+#### Finding delivery, retention, and suppression filters
+
+```hcl
+resource "aws_guardduty_publishing_destination" "findings" {
+  detector_id     = aws_guardduty_detector.detector.id
+  destination_arn = aws_s3_bucket.guardduty_findings.arn
+  kms_key_arn     = aws_kms_key.guardduty_findings.arn
+}
+```
+
+Verify GuardDuty findings are routed through EventBridge or an equivalent SOC
+workflow, and that optional S3 exports are encrypted with KMS when historical
+retention is required. Review `aws_guardduty_filter` resources for suppression
+logic that archives findings.
+
+Flag as High when high/critical finding types are suppressed without owner,
+reason, expiry, and review evidence. Flag as Medium when findings are generated
+but not routed to alerting/ticketing or encrypted historical export where the
+organization requires retention beyond GuardDuty's active finding window.
+
 ---
 
 ## Section 5 -- Networking

--- a/skills/cloud/aws-review/tests/guardduty-coverage-edge-cases.md
+++ b/skills/cloud/aws-review/tests/guardduty-coverage-edge-cases.md
@@ -1,0 +1,102 @@
+# GuardDuty Coverage Edge Cases
+
+Use these cases to verify that `aws-review` distinguishes basic CIS monitoring
+evidence from effective GuardDuty detector, protection-plan, and finding-delivery
+coverage.
+
+## False Positive Guard: Security Hub And GuardDuty Both Covered
+
+```hcl
+resource "aws_securityhub_account" "hub" {}
+
+resource "aws_guardduty_detector" "detector" {
+  enable = true
+}
+```
+
+Expected outcome: do not fail solely because GuardDuty appears as a supplemental
+control rather than a CIS 4.16 Security Hub resource. Record Security Hub and
+GuardDuty independently.
+
+## Missed Variant: Security Hub Enabled But No GuardDuty Detector
+
+```hcl
+resource "aws_securityhub_account" "hub" {}
+```
+
+Expected outcome: Medium or Not Evaluable when production AWS accounts require
+threat detection but no GuardDuty detector, delegated admin, or equivalent
+detection evidence is available.
+
+## Missed Variant: Organization Auto-Enable Does Not Cover Existing Accounts
+
+```hcl
+resource "aws_guardduty_organization_configuration" "org" {
+  detector_id                      = aws_guardduty_detector.detector.id
+  auto_enable_organization_members = "NEW"
+}
+```
+
+Expected outcome: Medium unless existing member accounts are separately
+inventoried and enabled. The review should record both new-account and
+existing-account coverage.
+
+## Missed Variant: S3 Protection Disabled For Sensitive Buckets
+
+```hcl
+resource "aws_s3_bucket" "customer_uploads" {
+  bucket = "customer-uploads-prod"
+}
+
+resource "aws_guardduty_organization_configuration_feature" "lambda" {
+  detector_id = aws_guardduty_detector.detector.id
+  name        = "LAMBDA_NETWORK_LOGS"
+  auto_enable = "ALL"
+}
+```
+
+Expected outcome: Medium or Not Evaluable when sensitive S3 data/upload
+workflows exist but `S3_DATA_EVENTS` or Malware Protection for S3 evidence is
+missing.
+
+## Missed Variant: Runtime Monitoring Enabled Without Agent Evidence
+
+```hcl
+resource "aws_guardduty_organization_configuration_feature" "runtime" {
+  detector_id = aws_guardduty_detector.detector.id
+  name        = "RUNTIME_MONITORING"
+  auto_enable = "ALL"
+}
+```
+
+Expected outcome: Not Evaluable until EKS/ECS/EC2 agent management or runtime
+coverage status is evidenced for the in-scope workloads.
+
+## Missed Variant: Findings Generated But Not Routed
+
+```hcl
+resource "aws_guardduty_detector" "detector" {
+  enable = true
+}
+```
+
+Expected outcome: Medium when there is no EventBridge/SOC/ticketing route and
+no encrypted S3 export where historical retention is required.
+
+## Missed Variant: Suppression Filter Without Review Evidence
+
+```hcl
+resource "aws_guardduty_filter" "archive_crypto" {
+  detector_id = aws_guardduty_detector.detector.id
+  action      = "ARCHIVE"
+  finding_criteria {
+    criterion {
+      field  = "type"
+      equals = ["CryptoCurrency:EC2/BitcoinTool.B!DNS"]
+    }
+  }
+}
+```
+
+Expected outcome: High when suppression archives high/critical finding types
+without owner, reason, expiry, compensating evidence, and periodic review.


### PR DESCRIPTION
## Summary

- Implements #1337.
- Adds GuardDuty detector, delegated administrator, organization auto-enable,
  protection-plan, finding-delivery, Runtime Monitoring, and suppression-filter
  evidence gates to `aws-review`.
- Updates the skill prerequisites, severity examples, output format, section
  map, pitfalls, and references so Security Hub is not treated as proof of
  GuardDuty coverage.
- Adds edge-case fixtures for Security Hub-only evidence, organization
  auto-enable gaps, missing S3 protection, Runtime Monitoring without agent
  evidence, unrouted findings, and suppression filters without review evidence.

## Validation

- Checked Markdown fence balance for the edited skill, checklist, and new fixture.
- Verified official AWS reference URLs return HTTP 200.
- Scanned the changed public files for private payment/contact strings.

## Bounty

- I have read and agree to the CONTRIBUTING.md bounty terms.
- Preferred payment method can be provided privately after maintainer acceptance.
