### PR TITLE
docs: add firewall rule lifecycle gates

### DIFF
--- a/skills/network/firewall-review/SKILL.md
+++ b/skills/network/firewall-review/SKILL.md
@@ -252,6 +252,48 @@ Egress filtering prevents compromised internal hosts from establishing unrestric
 
 **Finding classification:** Unrestricted outbound egress (allow all) is **High**. Missing DNS egress restriction is **Medium**.
 
+#### 2.8 Rule Lifecycle and Change Evidence (CIS Controls 4.1, 4.4; NIST SP 800-41 Section 4.3)
+
+Firewall review should verify not only the packet-matching logic, but also
+whether each risky or temporary rule has an owner, business justification,
+approval trail, expiry, validation evidence, and rollback path. Temporary
+incident or project rules are especially likely to become permanent exposure.
+
+**Lifecycle findings:**
+
+```
+FW-LIFE-01: Rule lacks owner, business justification, ticket, or approver
+FW-LIFE-02: Temporary rule has no expiry date or expired without removal
+FW-LIFE-03: Risk acceptance is missing for broad, internet-facing, or privileged-management access
+FW-LIFE-04: Rule removal recommendation lacks dependency validation or rollback plan
+FW-LIFE-05: Emergency rule was added outside change control and not reviewed after stabilization
+FW-LIFE-06: Rule description references a decommissioned system, project, or incident
+FW-LIFE-07: Rule logging was not validated after deployment or change
+FW-LIFE-08: Cloud security group or NACL drift is detected outside infrastructure-as-code
+```
+
+**Evidence requirements:**
+
+| Evidence | Required Detail | Failure Mode |
+|---|---|---|
+| Change ticket | Requester, approver, business purpose, implementation date, affected zones | Rule cannot be tied to authorized change |
+| Rule owner | Team/person accountable for review, expiry, and rollback | Orphaned rule persists indefinitely |
+| Expiry / review date | Temporary access expiration or next review cadence | Temporary permit becomes permanent |
+| Risk acceptance | Risk owner, compensating control, approved duration, affected assets | Broad exposure remains unaccepted |
+| Dependency validation | Hit counters with baseline time, flow logs, asset owner confirmation | Legitimate traffic is broken by cleanup |
+| Rollback plan | Previous rule set, restore command/procedure, validation tests | Cleanup cannot be reversed safely |
+| Drift evidence | IaC source, deployed rule hash/export, last reconciliation | Console changes bypass review |
+
+**Decision guidance:**
+
+| Situation | Audit action |
+|---|---|
+| Temporary rule is expired but still active | High if internet-facing or privileged; Medium otherwise |
+| Any/any rule has risk acceptance but no expiry | Keep severity high; risk acceptance does not eliminate exposure |
+| Zero hit count but counter reset recently | Do not mark unused; require longer observation or flow-log evidence |
+| Emergency rule lacks post-incident review | Record `FW-LIFE-05` and require retroactive approval or removal |
+| IaC denies a flow but deployed cloud rule permits it | Treat as drift; review change path and reconcile source of truth |
+
 ---
 
 ### Step 3: Compile Assessment Report
@@ -317,6 +359,11 @@ Produce the final report using the following structure.
 | SMTP (25)     | Yes/No    | <mail server IPs>      |
 | HTTPS (443)   | Yes/No    | <proxy or direct>      |
 
+### Rule Lifecycle Review
+| Rule | Owner | Ticket | Expiry/Review Date | Risk Acceptance | Last Hit / Evidence Window | Rollback Path |
+|------|-------|--------|--------------------|-----------------|----------------------------|---------------|
+| <rule id> | <owner or missing> | <ticket> | <date or missing> | <approved/missing> | <timestamp/window> | <procedure/ref> |
+
 ### Prioritized Remediation Plan
 1. **[Critical]** <action item with control reference>
 2. **[High]** <action item with control reference>
@@ -334,6 +381,7 @@ Produce the final report using the following structure.
 | 4.4 | Implement and Manage a Firewall on Servers | Inbound/outbound restriction, default deny, rule hygiene, logging |
 | 4.5 | Implement and Manage a Firewall on End-User Devices | Host-based firewall policy enforcement, default deny on endpoints |
 | 4.1 | Establish and Maintain a Secure Configuration Process | Applies to firewall configuration management and change control |
+| 4.2 | Establish and Maintain a Secure Configuration Process for Network Infrastructure | Applies to firewall and security group source-of-truth management |
 | 8.5 | Collect Detailed Audit Logs | Firewall logging requirements for denied and permitted traffic |
 
 ### NIST SP 800-41 Rev 1
@@ -360,6 +408,12 @@ Produce the final report using the following structure.
 4. **Assuming hit count of zero means the rule is unused.** Hit counters reset on firewall reload or failover. Verify the counter baseline timestamp before recommending rule removal. Cross-reference with SIEM/flow data where available.
 
 5. **Conflating network ACLs with security groups in cloud environments.** In AWS, NACLs are stateless and operate at the subnet level; security groups are stateful and operate at the instance level. Both must be audited. A permissive NACL can undermine restrictive security group rules for responses.
+
+6. **Removing rules from hit count alone.** A zero-hit rule may still support quarterly jobs, disaster recovery, or failover paths. Confirm counter reset time, flow logs, asset owner context, and rollback procedure before recommending removal.
+
+7. **Accepting risk without expiry.** A risk acceptance can justify a temporary exception, but it should not turn broad firewall exposure into a permanent control state. Require owner, compensating controls, approved duration, and a next-review date.
+
+8. **Reviewing IaC but not deployed state.** Cloud console edits, emergency CLI changes, and provider defaults can drift from Terraform, CloudFormation, or ARM. Compare source-of-truth configuration with deployed exports before declaring pass.
 
 ---
 

--- a/skills/network/firewall-review/tests/rule-lifecycle-edge-cases.md
+++ b/skills/network/firewall-review/tests/rule-lifecycle-edge-cases.md
@@ -1,0 +1,73 @@
+# Firewall Rule Lifecycle Edge Cases
+
+These fixtures validate that firewall-review checks the governance lifecycle of
+rules, not only packet-matching logic.
+
+## Edge Case 1: Expired Emergency Rule Still Active
+
+Input evidence:
+
+```yaml
+rule_id: fw-443-admin-temp
+source: 0.0.0.0/0
+destination: admin-jumpbox
+port: 443
+action: allow
+description: "temporary incident access IR-2026-041"
+ticket: IR-2026-041
+owner: platform-security
+expiry: "2026-05-30"
+current_date: "2026-06-06"
+logging_enabled: true
+```
+
+Expected output:
+
+- Finding ID: `FW-LIFE-02`
+- Severity: High because the rule is internet-facing and expired
+- Remediation requires removal or renewed risk acceptance with owner and expiry
+
+## Edge Case 2: Zero Hit Count With Recent Counter Reset
+
+Input evidence:
+
+```yaml
+rule_id: fw-dr-replication
+source: dr-subnet
+destination: prod-db
+port: 5432
+action: allow
+hit_count: 0
+counter_reset_at: "2026-06-05T22:00:00Z"
+review_started_at: "2026-06-06T09:00:00Z"
+business_context: quarterly_dr_test
+rollback_plan: missing
+```
+
+Expected output:
+
+- Do not classify as unused based on hit count alone
+- Finding ID: `FW-LIFE-04` if removal is recommended without dependency validation
+- Require flow logs, owner confirmation, and rollback plan
+
+## Edge Case 3: IaC Drift From Cloud Console Rule
+
+Input evidence:
+
+```yaml
+iac_rule:
+  rule_id: sg-web-egress
+  egress: deny_all_except_proxy
+deployed_rule:
+  rule_id: sg-web-egress-console-override
+  egress: allow_all
+  source_of_change: console
+  ticket: null
+  approver: null
+```
+
+Expected output:
+
+- Finding ID: `FW-LIFE-08`
+- Severity: High because deployed egress is allow-all and not in source control
+- Remediation reconciles deployed state back to IaC and reviews change path


### PR DESCRIPTION
## Summary

Adds firewall rule lifecycle and change-evidence gates to `firewall-review` so cleanup and acceptance decisions are backed by owner, expiry, risk, dependency, rollback, and drift evidence.

## Changes

- Added `FW-LIFE-01` through `FW-LIFE-08` for owner/ticket gaps, expired temporary rules, risk acceptance gaps, unsafe removal, emergency-rule review, decommissioned references, logging validation, and cloud/IaC drift.
- Added evidence requirements for change tickets, rule owners, expiry/review dates, risk acceptance, dependency validation, rollback plans, and drift evidence.
- Added decision guidance for expired temporary rules, broad accepted risk, recent counter resets, emergency rules, and cloud drift.
- Extended the output template with a Rule Lifecycle Review table.
- Expanded CIS mapping to include network infrastructure secure configuration process.
- Added pitfalls for hit-count-only removal, risk acceptance without expiry, and IaC-only review.
- Added edge-case fixtures for expired emergency access, zero-hit rules with recent counter reset, and cloud console drift.

## Validation

- `git diff --check`
- Added-line non-ASCII scan
- Added-line prompt-injection marker scan
- Markdown code fence balance check for touched files

## Related issue

Created from review issue: #1343
