### PR TITLE
Add AWS third-party role trust evidence gates

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-AWS-v3.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -97,6 +97,19 @@ Evaluate all AWS configurations against CIS AWS v3.0.0 Sections 1 through 5, cov
 
 For detailed CIS benchmark checklist items with specific Terraform patterns, grep patterns, and configuration examples for all five sections, see [benchmark-checklist.md](benchmark-checklist.md) in this skill directory.
 
+During Section 1 IAM review, add an AWS-specific third-party role trust pass for every `sts:AssumeRole` trust policy that names an external AWS account, OIDC provider, SAML provider, SaaS vendor, scanner, support provider, MSP, SIEM, CSPM, backup tool, CI/CD platform, or incident-response partner. Do not score a role as low risk only because the attached permissions are read-only. Require evidence for:
+
+- trusted principal scope: exact role ARN or provider claims, not broad account root unless justified
+- confused-deputy protection: unique `sts:ExternalId` for third-party AWS principals, or service-specific `aws:SourceArn` and `aws:SourceAccount` constraints for AWS services
+- OIDC/SAML restrictions: issuer, audience, subject, thumbprint or certificate lifecycle, and claim pinning
+- ExternalId owner, creation date, last rotation date, and rotation trigger
+- role session duration and whether vendor automation needs the configured maximum
+- role last-used timestamp, CloudTrail `AssumeRole` evidence, and post-offboarding activity check
+- sensitive read-only exposure: S3, CloudTrail, Security Hub, IAM metadata, Secrets Manager metadata, KMS aliases, backup catalogs, or account inventory
+- integration owner, contract or ticket reference, data handled, and offboarding status
+
+If any required evidence is unavailable, mark the trust path as `Not Evaluable` with a reason code such as `not_evaluable_missing_external_id_owner`, `not_evaluable_missing_external_id_rotation`, `not_evaluable_missing_role_last_used`, `not_evaluable_missing_vendor_offboarding`, or `not_evaluable_missing_source_constraints`.
+
 ---
 
 ### Step 7: Compile Assessment Report
@@ -158,6 +171,12 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Evidence:** <specific configuration or code snippet>
 - **Remediation:** <specific fix with code example>
 
+### Third-Party AWS Trust Evidence
+
+| Role | Trusted Principal | Trust Type | ExternalId / Source Constraint | Owner | Last Rotated | Last Used | Session Duration | Sensitive Read Scope | Offboarding Status | Evidence Status |
+|------|-------------------|------------|--------------------------------|-------|--------------|-----------|------------------|----------------------|--------------------|-----------------|
+| <role> | <account/provider/service> | AWS account / AWS service / OIDC / SAML | <evidence or gap code> | <owner> | <date/status> | <date/status> | <duration> | <scope> | <active/offboarded/not evaluable> | <pass/fail/not evaluable> |
+
 ### Prioritized Remediation Plan
 
 1. **[Critical]** CIS X.Y -- <action item>
@@ -200,6 +219,9 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
 5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
 6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
+7. **Over-crediting read-only vendor roles.** `SecurityAudit`, `ReadOnlyAccess`, or service-specific read permissions can still expose sensitive inventory, logs, identities, bucket names, trail configuration, and security findings. Review the trust path and data exposure, not only admin privileges.
+8. **Treating vendor UI disablement as AWS offboarding.** Disabling an integration in a SaaS console does not prove the AWS role trust was removed, ExternalId rotated, sessions expired, or post-offboarding `AssumeRole` activity stopped.
+9. **Using account-root trust without lifecycle evidence.** Trusting `arn:aws:iam::<vendor-account>:root` is not automatically unsafe, but it requires stronger evidence: unique ExternalId, owner, rotation trigger, last-used review, and vendor-side principal governance.
 
 ---
 
@@ -222,6 +244,9 @@ Produce the final report using the structure defined in the Output Format sectio
 - CIS Amazon Web Services Foundations Benchmark v3.0.0: https://www.cisecurity.org/benchmark/amazon_web_services
 - AWS Security Best Practices: https://docs.aws.amazon.com/security/
 - AWS IAM Best Practices: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
+- AWS IAM confused deputy prevention and ExternalId guidance: https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html
+- AWS IAM cross-account role access: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_common-scenarios_third-party.html
+- AWS STS AssumeRole API: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
 - AWS CloudTrail Documentation: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/
 - AWS Security Hub: https://docs.aws.amazon.com/securityhub/latest/userguide/
 - AWS VPC Security: https://docs.aws.amazon.com/vpc/latest/userguide/security.html
@@ -231,4 +256,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.1.0** -- Added third-party AWS role trust evidence gates for ExternalId/source constraints, role last-used, session duration, sensitive read-only exposure, and vendor offboarding.
 - **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 (62 recommendations).

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -160,6 +160,95 @@ aws_organizations_organization
 
 Look for policies restricting CloudShell access.
 
+### AWS-Specific IAM Gate -- Third-party AssumeRole trust and ExternalId lifecycle
+
+This gate complements CIS Section 1. Use it for vendor, MSP, scanner, SIEM, CSPM,
+backup, CI/CD, support, and incident-response integrations that assume roles in
+the reviewed AWS account.
+
+**Trust policies to inspect:**
+
+```json
+{
+  "Effect": "Allow",
+  "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+  "Action": "sts:AssumeRole"
+}
+```
+
+Flag third-party AWS principals as `Fail` or `Not Evaluable` when the policy lacks
+customer-unique confused-deputy protection:
+
+```json
+{
+  "Condition": {
+    "StringEquals": {
+      "sts:ExternalId": "<customer-unique-external-id>"
+    }
+  }
+}
+```
+
+For AWS service principals, check for service-specific source constraints instead
+of ExternalId:
+
+```json
+{
+  "Condition": {
+    "StringEquals": {"aws:SourceAccount": "<account-id>"},
+    "ArnLike": {"aws:SourceArn": "arn:aws:<service>:<region>:<account-id>:<resource>"}
+  }
+}
+```
+
+For OIDC or SAML federation, require issuer/provider, audience, subject, and
+certificate/thumbprint or claim lifecycle evidence:
+
+```
+aws_iam_openid_connect_provider
+aws_iam_saml_provider
+token.actions.githubusercontent.com:aud
+token.actions.githubusercontent.com:sub
+sts:AssumeRoleWithWebIdentity
+sts:AssumeRoleWithSAML
+```
+
+**Grep patterns:**
+
+```
+sts:AssumeRole
+sts:ExternalId
+aws:SourceArn
+aws:SourceAccount
+AssumeRolePolicyDocument
+aws_iam_role
+aws_iam_role_policy
+aws_iam_policy_document
+arn:aws:iam::[0-9]{12}:root
+ReadOnlyAccess
+SecurityAudit
+MaxSessionDuration
+```
+
+**Evidence to record:**
+
+- role name and trusted principal
+- whether the principal is an entire account root, exact role ARN, service principal, OIDC provider, or SAML provider
+- ExternalId value source without exposing secret-like values; record owner, age, last rotation date, and rotation trigger
+- `aws:SourceArn` and `aws:SourceAccount` for service integrations
+- OIDC/SAML issuer, audience, subject, and claim/certificate lifecycle evidence
+- `MaxSessionDuration` and whether vendor automation justifies it
+- AWS role last-used timestamp and CloudTrail `AssumeRole` review
+- sensitive read-only exposure such as S3, CloudTrail, Security Hub, IAM metadata, Secrets Manager metadata, KMS aliases, backup catalogs, or account inventory
+- vendor owner, contract/ticket reference, data handled, integration status, and offboarding evidence
+
+**Finding guidance:**
+
+- **High:** third-party AWS account root can assume the role without ExternalId, or role remains assumable after vendor offboarding.
+- **Medium:** ExternalId exists but owner, rotation, last-used, or sensitive read exposure cannot be verified.
+- **Low:** source constraints or ExternalId are present, but session duration or documentation needs hardening.
+- **Not Evaluable:** trust path exists but evidence for owner, ExternalId rotation, role last-used, or offboarding status is missing.
+
 ---
 
 ## Section 2 -- Storage


### PR DESCRIPTION
## Summary
- Adds an AWS-specific third-party AssumeRole trust evidence pass to `aws-review` for vendor/MSP/scanner/SIEM/CSPM/support integrations.
- Requires ExternalId or service-specific source constraints, OIDC/SAML claim evidence, role last-used review, session duration review, sensitive read-only exposure scope, owner/contract linkage, and offboarding status.
- Adds a structured output table plus concrete checklist patterns for trust policies, `sts:ExternalId`, `aws:SourceArn`, `aws:SourceAccount`, `MaxSessionDuration`, OIDC/SAML providers, and broad account-root trust.

## Validation
- `git diff --check` clean (CRLF warning only)
- Markdown fence counts balanced for `SKILL.md` and `benchmark-checklist.md`
- Content markers present for ExternalId, source constraints, role last-used, not-evaluable reason codes, and third-party trust evidence table
- AWS reference URLs return HTTP 200:
  - confused deputy / ExternalId guidance
  - third-party cross-account role access
  - STS AssumeRole API

Closes #1330

Requested tier: Improver Moderate ($100) if accepted.
Preferred payment method: crypto or GitHub Sponsors/PayPal details can be provided privately after maintainer acceptance.