### PR TITLE
docs: add RBAC migration validation gates

### DIFF
--- a/skills/identity/rbac-design/SKILL.md
+++ b/skills/identity/rbac-design/SKILL.md
@@ -336,6 +336,53 @@ RBAC-MINE-06: Mining does not account for SoD constraints (mined roles may creat
 
 ---
 
+### Step 7: Migration Simulation and Regression Evidence
+
+**Objective:** Validate that a redesigned RBAC/ABAC model preserves required
+business access, removes excess access, enforces constraints, and can be rolled
+back safely before production cutover.
+
+Role redesigns fail when they are treated as documentation exercises instead of
+authorization migrations. Require simulation evidence against current
+assignments, historical access requests, and SoD constraints before approving a
+new model.
+
+**Migration validation checklist:**
+
+```
+RBAC-MIG-01: No before/after access diff for users, roles, permissions, and resources
+RBAC-MIG-02: Simulation does not replay representative historical access requests
+RBAC-MIG-03: SoD and cardinality constraints are not regression-tested after role changes
+RBAC-MIG-04: Break-glass, service account, and machine identity access are not included
+RBAC-MIG-05: ABAC attribute changes are not tested for missing, stale, or conflicting values
+RBAC-MIG-06: Migration plan lacks pilot cohort, rollback path, and owner sign-off
+RBAC-MIG-07: Removed permissions are not mapped to business owner approval or compensating access
+RBAC-MIG-08: Policy evaluation logs are unavailable for post-cutover verification
+```
+
+**Evidence requirements:**
+
+| Evidence | Required Detail | Failure Mode |
+|---|---|---|
+| Before/after access diff | User, role, permission, resource, grant source, added/removed/unchanged | Hidden privilege gain or business access loss |
+| Historical replay | Sample window, request count, permit/deny deltas, false deny review | New model breaks known workflows |
+| Constraint regression | SSoD/DSoD pairs, cardinality limits, prerequisite roles, violations | Conflicting roles survive redesign |
+| Exception inventory | Break-glass, service accounts, machine identities, temporary access | Special identities bypass model |
+| Attribute test set | Missing/stale/conflicting subject, resource, action, environment attributes | ABAC policies fail open or deny valid access |
+| Cutover plan | Pilot cohort, approval owner, rollback trigger, monitoring window | Migration cannot be reversed safely |
+
+**Decision guidance:**
+
+| Situation | Design action |
+|---|---|
+| New model adds access without explicit owner approval | Treat as High until approved or removed |
+| Historical replay shows false denies for critical workflows | Do not cut over; revise roles or ABAC conditions |
+| SoD violations remain but are exception-based | Require owner, expiry, compensating control, and review cadence |
+| ABAC attribute source is non-authoritative | Reduce confidence and add PIP assurance work |
+| Policy logs cannot explain permit/deny decisions | Add auditability requirement before production adoption |
+
+---
+
 ## Findings Classification
 
 | Severity | Definition | Examples |
@@ -359,6 +406,7 @@ RBAC-MINE-06: Mining does not account for SoD constraints (mined roles may creat
 | **Framework Ref** | NIST RBAC model level or NIST SP 800-162 section |
 | **Current State** | What exists today |
 | **Recommended State** | Target design |
+| **Migration Evidence** | Before/after diff, replay results, SoD regression, rollback readiness |
 | **Remediation** | Steps to implement the design change |
 | **Effort** | Low / Medium / High |
 
@@ -388,6 +436,7 @@ RBAC-MINE-06: Mining does not account for SoD constraints (mined roles may creat
 - Permission Boundaries (Step 4): [count]
 - ABAC Policies (Step 5): [count]
 - Role Mining (Step 6): [count]
+- Migration Validation (Step 7): [count]
 
 ### Detailed Findings
 [Findings table]
@@ -397,6 +446,11 @@ RBAC-MINE-06: Mining does not account for SoD constraints (mined roles may creat
 
 ### Remediation Roadmap
 [Phased implementation plan]
+
+### Migration Validation Plan
+| Phase | Scope | Evidence | Exit Criteria | Rollback |
+|-------|-------|----------|---------------|----------|
+| Pilot | <users/apps> | <diff/replay/logs> | <success criteria> | <rollback trigger/procedure> |
 ```
 
 ---
@@ -436,6 +490,8 @@ RBAC-MINE-06: Mining does not account for SoD constraints (mined roles may creat
 5. **Ignoring permission boundaries** — roles define what you get; boundaries define maximum what you can get. Without boundaries, misconfigured roles grant unlimited access.
 6. **Role mining without business validation** — clustering users by access patterns may replicate existing privilege creep rather than correct it.
 7. **Choosing RBAC vs. ABAC as binary** — most environments need both. RBAC for structural, ABAC for contextual. Hybrid is the norm.
+8. **Skipping migration simulation** - a clean target model can still break production or silently add privilege. Replay historical access, test SoD constraints, include service accounts, and retain rollback evidence before cutover.
+9. **Testing ABAC only with happy-path attributes** - missing, stale, or conflicting attributes are common. Test failure modes and ensure the policy engine denies safely with auditable decision logs.
 
 ---
 

--- a/skills/identity/rbac-design/tests/migration-validation-edge-cases.md
+++ b/skills/identity/rbac-design/tests/migration-validation-edge-cases.md
@@ -1,0 +1,72 @@
+# RBAC Migration Validation Edge Cases
+
+These fixtures validate that RBAC/ABAC redesigns include migration simulation,
+constraint regression, and rollback evidence before production cutover.
+
+## Edge Case 1: New Model Adds Privilege
+
+Input evidence:
+
+```yaml
+user: finance-analyst-17
+before:
+  roles: [finance-reader]
+  permissions: [invoice.read, budget.read]
+after:
+  roles: [finance-analyst]
+  permissions: [invoice.read, budget.read, payment.approve]
+owner_approval: null
+historical_replay: not_run
+```
+
+Expected output:
+
+- Finding ID: `RBAC-MIG-01` and `RBAC-MIG-07`
+- Severity: High because the migration adds payment approval without owner approval
+- Remediation requires explicit owner approval or permission removal before cutover
+
+## Edge Case 2: SoD Regression After Role Merge
+
+Input evidence:
+
+```yaml
+role_merge:
+  from: [payment-initiator, payment-approver]
+  to: finance-operator
+constraints:
+  ssod_pairs:
+    - [payment-initiator, payment-approver]
+regression_test:
+  status: failed
+  violation_count: 12
+```
+
+Expected output:
+
+- Finding ID: `RBAC-MIG-03`
+- Severity: Critical or High depending on production financial impact
+- Do not approve role merge until SoD constraints are enforced or model is redesigned
+
+## Edge Case 3: ABAC Missing Attribute Fails Open
+
+Input evidence:
+
+```yaml
+policy: tenant_data_read
+condition: subject.tenant_id == resource.tenant_id
+test_case:
+  subject:
+    user: contractor-22
+    tenant_id: null
+  resource:
+    tenant_id: acme
+  observed_decision: permit
+  expected_decision: deny
+decision_log: missing
+```
+
+Expected output:
+
+- Finding ID: `RBAC-MIG-05` and `RBAC-MIG-08`
+- Severity: High because missing attribute fails open
+- Remediation requires fail-closed behavior and auditable policy evaluation logs


### PR DESCRIPTION
## Summary

Adds RBAC/ABAC migration simulation and regression evidence gates to `rbac-design` so authorization redesigns are validated before production cutover.

## Changes

- Added `RBAC-MIG-01` through `RBAC-MIG-08` for access diffs, historical replay, SoD regression, special identities, ABAC attribute tests, pilot/rollback planning, owner approval, and policy evaluation logs.
- Added evidence requirements for before/after diffs, historical replay, constraint regression, exception inventory, attribute test sets, and cutover plans.
- Added decision guidance for unapproved privilege additions, false denies, exception-based SoD violations, non-authoritative attributes, and missing decision logs.
- Extended findings and summary output with migration evidence and validation-plan sections.
- Added pitfalls for skipping migration simulation and testing ABAC only on happy-path attributes.
- Added edge-case fixtures for privilege-adding migration, SoD regression after role merge, and missing-attribute fail-open behavior.

## Validation

- `git diff --check`
- Added-line non-ASCII scan
- Added-line prompt-injection marker scan
- Markdown code fence balance check for touched files

## Related issue

Created from review issue: #1351
