### PR TITLE
docs: add GCP VPC-SC perimeter gates

### DIFF
--- a/skills/cloud/gcp-review/SKILL.md
+++ b/skills/cloud/gcp-review/SKILL.md
@@ -88,6 +88,49 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
+### Supplemental: VPC Service Controls and Data Exfiltration Perimeters
+
+CIS GCP controls cover many project-level hardening checks, but regulated or
+sensitive GCP environments also need evidence that managed services cannot be
+used as cross-project data exfiltration paths. Review VPC Service Controls
+(VPC-SC), Access Context Manager, and perimeter ingress/egress policies when
+GCS, BigQuery, Cloud Storage transfer, Pub/Sub, Dataflow, Vertex AI, or other
+managed services process sensitive data.
+
+```
+GCP-VPCSC-01: Sensitive projects are not assigned to a service perimeter
+GCP-VPCSC-02: Perimeter omits restricted services used by in-scope data stores
+GCP-VPCSC-03: Ingress/egress policies allow broad project, principal, or service access
+GCP-VPCSC-04: Access levels rely only on IP ranges without device, identity, or workforce context
+GCP-VPCSC-05: Dry-run mode violations are not reviewed before enforcing or modifying perimeters
+GCP-VPCSC-06: Bridge perimeter connects environments with different data classification or trust level
+GCP-VPCSC-07: Perimeter changes lack owner, business justification, rollback, and audit-log evidence
+GCP-VPCSC-08: Cross-project service account or workload identity path bypasses perimeter intent
+```
+
+**Evidence requirements:**
+
+| Evidence | Required Detail | Failure Mode |
+|---|---|---|
+| Perimeter inventory | Perimeter name, mode, protected projects, restricted services, data classification | Sensitive services remain outside perimeter |
+| Access levels | Identity, device, IP, region, workforce, and exception criteria | Access rules are broader than intended |
+| Ingress/egress policies | Source, destination, principal, service, method, project, justification | Cross-project exfiltration path remains open |
+| Dry-run analysis | Violation logs, false-positive disposition, owner approval, enforcement date | Enforcement breaks workloads or misses bypasses |
+| Audit logs | `VpcServiceControlAuditMetadata`, denied/allowed events, change author | No proof of perimeter effectiveness |
+| Change record | Owner, ticket, rollback, affected services, review date | Perimeter exception becomes unmanaged |
+
+**Decision guidance:**
+
+| Situation | Assessment action |
+|---|---|
+| BigQuery/GCS sensitive data exists with no service perimeter | High; Critical if public or cross-org principals also exist |
+| Egress policy permits `*` project or all principals | High; require scoped destination and principal justification |
+| Bridge perimeter connects prod and dev projects | High unless data classification and access controls match |
+| Dry-run violations are ignored for more than one review cycle | Medium; High for regulated data paths |
+| Perimeter only covers network IP but not workload identity | Medium or High depending on service account privilege |
+
+---
+
 ### Step 9: Compile Assessment Report
 
 
@@ -179,6 +222,14 @@ Produce the final report using the structure defined in the Output Format sectio
 | 6 | Cloud SQL | MySQL/PostgreSQL/SQL Server database flags, SSL enforcement, authorized networks, public IP, automated backups |
 | 7 | BigQuery | Public dataset access, CMEK encryption for tables and datasets |
 
+### Supplemental GCP Controls
+
+| Area | Key Focus |
+|------|-----------|
+| VPC Service Controls | Service perimeters, bridge perimeters, restricted services, ingress/egress rules |
+| Access Context Manager | Access levels, identity/device/IP conditions, dry-run policy validation |
+| Data exfiltration paths | Cross-project service accounts, workload identity, BigQuery/GCS/Pub/Sub/Dataflow paths |
+
 ### CIS Profile Levels
 
 - **Level 1** -- Practical security settings that can be implemented with minimal impact on business functionality.
@@ -194,6 +245,10 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Cloud SQL authorized_networks vs. private IP.** CIS 6.5 flags `0.0.0.0/0` in authorized networks, but CIS 6.6 goes further and recommends disabling public IP entirely in favor of private networking.
 5. **BigQuery dataset-level vs. table-level CMEK.** CIS 7.2 checks table-level encryption, while CIS 7.3 checks the dataset default. Both should be evaluated independently.
 6. **Default compute service account identification.** The default SA follows the pattern `PROJECT_NUMBER-compute@developer.gserviceaccount.com`. Grep for this pattern, not just the string "default."
+
+7. **Treating VPC firewall rules as sufficient for managed services.** GCS, BigQuery, Pub/Sub, Dataflow, and similar services are not fully governed by VM-centric firewall rules. Use VPC Service Controls and scoped ingress/egress policies for sensitive managed-service data paths.
+
+8. **Skipping VPC-SC dry-run evidence.** Enforcing a perimeter without reviewing dry-run violations can break legitimate workloads; ignoring dry-run logs can also leave cross-project exfiltration paths unresolved. Require owner disposition for violations before enforcement.
 
 ---
 
@@ -218,6 +273,8 @@ Produce the final report using the structure defined in the Output Format sectio
 - Google Cloud IAM Documentation: https://cloud.google.com/iam/docs
 - Google Cloud Audit Logs: https://cloud.google.com/logging/docs/audit
 - Google Cloud VPC Documentation: https://cloud.google.com/vpc/docs
+- Google Cloud VPC Service Controls: https://cloud.google.com/vpc-service-controls/docs
+- Google Cloud Access Context Manager: https://cloud.google.com/access-context-manager/docs
 - Google Cloud SQL Security: https://cloud.google.com/sql/docs/mysql/configure-ssl-instance
 - Terraform Google Provider Documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs
 

--- a/skills/cloud/gcp-review/tests/vpcsc-perimeter-edge-cases.md
+++ b/skills/cloud/gcp-review/tests/vpcsc-perimeter-edge-cases.md
@@ -1,0 +1,68 @@
+# GCP VPC Service Controls Edge Cases
+
+These fixtures validate that `gcp-review` captures managed-service data
+exfiltration risks that are not visible from firewall rules alone.
+
+## Edge Case 1: Sensitive BigQuery Project Outside Perimeter
+
+Input evidence:
+
+```yaml
+project: analytics-prod
+data_classification: restricted
+services:
+  - bigquery.googleapis.com
+  - storage.googleapis.com
+vpc_service_controls:
+  perimeter: null
+public_access:
+  bigquery_dataset_all_users: false
+```
+
+Expected output:
+
+- Finding ID: `GCP-VPCSC-01`
+- Severity: High because restricted data is processed by managed services outside a perimeter
+- Remediation requires perimeter assignment and restricted service inventory
+
+## Edge Case 2: Broad Egress Policy to Any Project
+
+Input evidence:
+
+```yaml
+perimeter: prod-data-perimeter
+egress_policy:
+  principals: ["*"]
+  resources: ["projects/*"]
+  services:
+    - bigquery.googleapis.com
+  justification: "temporary analytics migration"
+  owner: null
+  expiry: null
+```
+
+Expected output:
+
+- Finding ID: `GCP-VPCSC-03` and `GCP-VPCSC-07`
+- Severity: High
+- Require scoped principals, destination projects, owner, expiry, and rollback plan
+
+## Edge Case 3: Dry-Run Violations Ignored
+
+Input evidence:
+
+```yaml
+perimeter: pii-services-dry-run
+mode: dry_run
+dry_run_violations:
+  count: 132
+  oldest: "2026-04-01T00:00:00Z"
+  reviewed: false
+enforcement_date: null
+```
+
+Expected output:
+
+- Finding ID: `GCP-VPCSC-05`
+- Do not mark perimeter readiness as pass
+- Require owner disposition for dry-run violations before enforcement


### PR DESCRIPTION
## Summary

Adds GCP VPC Service Controls and data exfiltration perimeter evidence gates to `gcp-review`.

## Changes

- Added `GCP-VPCSC-01` through `GCP-VPCSC-08` for perimeter coverage, restricted services, broad ingress/egress, weak access levels, dry-run review, bridge perimeters, change evidence, and cross-project identity bypasses.
- Added evidence requirements for perimeter inventory, access levels, ingress/egress policies, dry-run analysis, VPC-SC audit logs, and change records.
- Added decision guidance for sensitive BigQuery/GCS outside perimeters, broad egress, prod/dev bridge perimeters, ignored dry-run violations, and workload identity gaps.
- Added supplemental GCP control mapping and pitfalls for managed-service paths and dry-run evidence.
- Added official references for VPC Service Controls and Access Context Manager.
- Added edge-case fixtures for sensitive BigQuery outside a perimeter, broad egress to any project, and ignored dry-run violations.

## Validation

- `git diff --check`
- Added-line non-ASCII scan
- Added-line prompt-injection marker scan
- Markdown code fence balance check for touched files
- Reference URL checks returned HTTP 200:
  - Google Cloud VPC Service Controls
  - Google Cloud Access Context Manager

## Related issue

Created from review issue: #1356
