### PR TITLE
docs: add CVE applicability evidence gates

### DIFF
--- a/skills/vuln-management/cve-triage/SKILL.md
+++ b/skills/vuln-management/cve-triage/SKILL.md
@@ -82,6 +82,40 @@ CVE Context Summary:
 - Known Aliases:       [Common names, e.g., "Log4Shell", "Heartbleed"]
 ```
 
+### Step 1A: Confirm CVE Record Status and Product Applicability
+
+Before assigning CVSS-derived urgency or an SLA, verify that the CVE record is usable for the product and package actually present in the environment.
+
+**Framework mapping:** CVE List record lifecycle, NVD vulnerability status, vendor advisory/VEX applicability
+
+1. Check the CVE record status from NVD and the CVE List when available.
+2. If the record is `Rejected`/`REJECTED`, do not assign an SLA to that CVE ID. Treat it as invalid unless a replacement CVE is named in the rejection reason.
+3. If the record is `Disputed`, `Modified`, `Deferred`, or `Undergoing Analysis`, require authoritative evidence before escalation: vendor advisory, CNA statement, affected-version table, VEX/CSAF status, or distro security tracker entry.
+4. Compare scanner CPE/package mapping with the installed product, edition, module, architecture, and package epoch/release. Do not rely on upstream semantic version comparison when a distro package may contain a backported fix.
+5. Classify vendor status as one of: `affected`, `fixed`, `not_affected`, `under_investigation`, `unknown`, or `conflicting`.
+6. For `not_affected` or `fixed`, require proof that names the same product branch/package and the installed version or fixed build. For `under_investigation`, `unknown`, or `conflicting`, mark applicability as `Not Evaluable` rather than safe.
+7. Record whether the vulnerable component or code path is present and enabled. Optional modules, compile-time flags, container base-image inheritance, and product editions must be verified before escalation.
+
+**Decision impact:**
+- `Rejected` CVE record: close or suppress the scanner finding with replacement-CVE tracking if applicable; no remediation SLA for the rejected ID.
+- Vendor `not_affected`/VEX `not_affected` with matching product evidence: de-escalate to Defer or close as not applicable.
+- Vendor `fixed` or distro backport proof matching the installed build: close as fixed or assign a verification task, not an emergency patch SLA.
+- `Disputed`, `under_investigation`, incomplete NVD enrichment, or weak CPE match: hold SLA at Scheduled/Not Evaluable until applicability is confirmed, unless KEV or vendor exploitation evidence proves real exposure.
+- Conflicting sources: prefer the vendor/CNA statement for product applicability, keep the scanner result open as `Needs Evidence`, and require human review before risk acceptance.
+
+```
+CVE Status and Applicability:
+- CVE Record Status:   [Published | Modified | Rejected | Disputed | Reserved | Deferred | Unknown]
+- NVD API Status:      [Analyzed | Modified | Rejected | Deferred | Awaiting Analysis | Unknown]
+- Vendor Status:       [affected | fixed | not_affected | under_investigation | unknown | conflicting]
+- Product Match:       [Exact | Family-only CPE | Edition mismatch | Package mismatch | Unknown]
+- Version Evidence:    [Vendor advisory | Distro tracker | VEX/CSAF | Scanner only | None]
+- Backport/Epoch Check:[Not applicable | Matched fixed distro release | Missing | Conflicting]
+- Code Path Present:   [Yes | No | Optional/disabled | Unknown]
+- Applicability:       [Applicable | Not Applicable | Fixed | Not Evaluable]
+- Rationale:           [1-2 sentences explaining the evidence and confidence]
+```
+
 ### Step 2: CVSS 4.0 Assessment
 
 Walk through the CVSS 4.0 metric groups to compute or validate the Base score. CVSS 4.0 replaces the CVSS 3.1 "Temporal" group with "Threat" metrics and adds a Supplemental metric group.
@@ -329,6 +363,18 @@ recommended SLA tier. Lead with the most critical fact.]
 | Affected Component | [Component] |
 | Patch Available | [Yes/No/Workaround] |
 
+### CVE Status and Applicability
+| Field | Value |
+|---|---|
+| CVE Record Status | [Published/Modified/Rejected/Disputed/Reserved/Deferred/Unknown] |
+| NVD API Status | [Analyzed/Modified/Rejected/Deferred/Awaiting Analysis/Unknown] |
+| Vendor Status | [affected/fixed/not_affected/under_investigation/unknown/conflicting] |
+| Product Match | [Exact/Family-only CPE/Edition mismatch/Package mismatch/Unknown] |
+| Version Evidence | [Vendor advisory/Distro tracker/VEX or CSAF/Scanner only/None] |
+| Backport/Epoch Check | [Not applicable/Matched fixed distro release/Missing/Conflicting] |
+| Code Path Present | [Yes/No/Optional or disabled/Unknown] |
+| **Applicability** | **[Applicable/Not Applicable/Fixed/Not Evaluable]** |
+
 ### CVSS 4.0 Assessment
 | Metric Group | Score | Severity |
 |---|---|---|
@@ -367,6 +413,7 @@ recommended SLA tier. Lead with the most critical fact.]
 - **Recommended Action:** [Specific action -- patch to version X, apply workaround Y, disable feature Z]
 - **Escalation Factors:** [List any factors that elevated the SLA tier]
 - **De-escalation Factors:** [List any compensating controls or mitigating factors]
+- **Applicability Decision:** [Applicable / Not Applicable / Fixed / Not Evaluable, with required evidence]
 - **Assumptions Made:** [List any assumptions due to missing context]
 
 ### Risk Acceptance (If Deferring)
@@ -426,6 +473,9 @@ When triaging multiple CVEs (e.g., from a scan report), produce a summary table 
 - CVSS v4.0 Calculator: https://www.first.org/cvss/calculator/4.0
 - SSVC 2.1 (CERT/CC): https://github.com/CERTCC/SSVC
 - SSVC Decision Tree Documentation: https://certcc.github.io/SSVC/
+- NVD Vulnerability Status: https://nvd.nist.gov/vuln/vulnerability-status
+- NVD Vulnerability API: https://nvd.nist.gov/developers/vulnerabilities
+- CVE Record Dispute Policy: https://www.cve.org/Resources/General/Policies/CVE-Record-Dispute-Policy.pdf
 - CISA KEV Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog
 - CISA BOD 22-01: https://www.cisa.gov/binding-operational-directive-22-01
 - EPSS (FIRST.org): https://www.first.org/epss/

--- a/skills/vuln-management/cve-triage/tests/disputed-applicability-edge-cases.md
+++ b/skills/vuln-management/cve-triage/tests/disputed-applicability-edge-cases.md
@@ -1,0 +1,115 @@
+# CVE Status and Applicability Edge Cases
+
+These fixtures exercise false-positive reductions for CVE records that should not be converted directly into emergency remediation SLAs from scanner output alone.
+
+## Case 1: Rejected CVE ID
+
+Scanner input:
+
+```yaml
+scanner_finding:
+  cve: CVE-2025-99999
+  package: example-lib
+  detected_version: 1.2.3
+  scanner_severity: critical
+nvd:
+  vulnStatus: Rejected
+  rejection_reason: Duplicate of CVE-2025-11111
+asset:
+  exposure: internet-facing
+  business_criticality: essential
+```
+
+Expected triage:
+
+- `CVE Record Status` is `Rejected`.
+- `Applicability` is `Not Evaluable` for the rejected ID unless the replacement CVE is triaged separately.
+- No Immediate or Out-of-Cycle SLA is assigned to `CVE-2025-99999`.
+- Recommended action is to suppress/close the rejected ID and open a separate triage item for `CVE-2025-11111`.
+
+## Case 2: Vendor Not Affected Beats Scanner CPE Family Match
+
+Scanner input:
+
+```yaml
+scanner_finding:
+  cve: CVE-2026-12345
+  product: acme-server-enterprise
+  detected_cpe: cpe:2.3:a:acme:acme-server:*:*:*:*:*:*:*:*
+  detected_version: 4.8.1
+  scanner_severity: high
+vendor_advisory:
+  product: acme-server-enterprise
+  branch: 4.8
+  status: not_affected
+  reason: vulnerable parser is only built in community edition
+asset:
+  installed_edition: enterprise
+  optional_module_enabled: false
+```
+
+Expected triage:
+
+- `Product Match` records the scanner match as `Family-only CPE`.
+- `Vendor Status` is `not_affected`.
+- `Code Path Present` is `No` or `Optional/disabled`.
+- `Applicability` is `Not Applicable`.
+- SLA is Defer or closed as not applicable, with the advisory URL/evidence retained.
+
+## Case 3: Distro Backport Fix With Older Upstream Version
+
+Scanner input:
+
+```yaml
+scanner_finding:
+  cve: CVE-2026-23456
+  package: openssl
+  detected_version: 3.0.8-1ubuntu1.12
+  scanner_fixed_version: 3.0.12
+  scanner_severity: critical
+vendor_advisory:
+  distro: ubuntu
+  package: openssl
+  fixed_release: 3.0.8-1ubuntu1.12
+  status: fixed
+  evidence: distro_security_tracker
+asset:
+  package_epoch_release: 3.0.8-1ubuntu1.12
+```
+
+Expected triage:
+
+- `Version Evidence` is `Distro tracker`.
+- `Backport/Epoch Check` is `Matched fixed distro release`.
+- `Vendor Status` is `fixed`.
+- `Applicability` is `Fixed`.
+- Recommended action is verification or scanner suppression, not an emergency upgrade based only on the upstream version.
+
+## Case 4: Disputed CVE With Conflicting Sources
+
+Scanner input:
+
+```yaml
+scanner_finding:
+  cve: CVE-2026-34567
+  product: widget-runtime
+  detected_version: 2.1.0
+  scanner_severity: critical
+nvd:
+  vulnStatus: Modified
+  tags:
+    - disputed
+vendor_advisory:
+  status: under_investigation
+threat_intel:
+  cisa_kev: false
+  public_poc: false
+```
+
+Expected triage:
+
+- `CVE Record Status` is `Disputed` or `Modified` with disputed tag noted.
+- `Vendor Status` is `under_investigation`.
+- `Applicability` is `Not Evaluable`.
+- SLA does not escalate to Immediate solely from the scanner severity.
+- Output requires human review and additional vendor/CNA evidence before risk acceptance or suppression.


### PR DESCRIPTION
## Summary
- Adds a CVE record status and product applicability gate before CVSS/EPSS/SSVC SLA assignment.
- Documents handling for rejected, disputed, modified, deferred, vendor not affected, fixed/backported, weak CPE match, and unknown/conflicting applicability cases.
- Adds edge-case fixtures covering rejected IDs, vendor not affected, distro backports, and disputed records.

## Created from review issue
Fixes #1328

## What was wrong
Scanner severity and CPE matches could be converted into emergency remediation SLAs before confirming whether the CVE record is usable, disputed/rejected, or applicable to the installed product/package. This can over-prioritize false positives such as rejected IDs, vendor not affected advisories, fixed distro backports, or optional code paths that are not present.

## What changed
- Added Step 1A to require CVE status, NVD API status, vendor/VEX applicability, product match, version evidence, backport/epoch checks, and code-path presence.
- Added decision impacts for rejected, disputed, fixed, not affected, under investigation, weak CPE, and conflicting-source cases.
- Added an output table so final reports preserve the applicability decision and supporting evidence.
- Added tests in `skills/vuln-management/cve-triage/tests/disputed-applicability-edge-cases.md`.

## Validation
- `git diff --check`
- Added-line non-ASCII scan
- Added-line prompt-injection marker scan
- Markdown code-fence balance check
- Reference URL checks for CVE dispute policy and NVD pages
