### PR TITLE
docs: add DNS resolver privacy evidence gates

### DIFF
--- a/skills/network/dns-security/SKILL.md
+++ b/skills/network/dns-security/SKILL.md
@@ -292,6 +292,18 @@ abcdef0123456789.dnscat.example.com TXT
 - **DGA detection:** Domain Generation Algorithms produce random-appearing domain names. Detection relies on entropy analysis and machine learning classifiers integrated into protective DNS services.
 - **Typosquatting monitoring:** Monitor for DNS queries to domains that are typographic variations of the organization's primary domains.
 
+### Step 6A: Resolver Privacy and Log Minimization
+
+DNSSEC, encrypted transport, and RPZ filtering do not automatically minimize resolver privacy exposure. For each recursive resolver or protective DNS service, collect evidence for:
+
+- **QNAME minimization:** Recursive resolvers should minimize the full query name sent to each delegation level where supported. Record whether QNAME minimization is enabled, disabled, or not supported.
+- **EDNS Client Subnet (ECS):** Record whether ECS is disabled, anonymized/coarsened, or forwarded with client-specific prefixes. Document any CDN/performance exception.
+- **Query log minimization:** Record whether logs contain full client IPs, user IDs, full QNAMEs, ECS values, and response data; document aggregation, pseudonymization, encryption, access controls, and retention.
+- **Privacy exception evidence:** If detailed logs or ECS are required for security operations, record purpose, owner, retention period, access controls, and review date.
+- **Resolver privacy statement:** For external or managed DNS privacy services, record the provider policy or resolver privacy statement and whether it covers retention, sharing, and operational access.
+
+**Finding classification:** QNAME minimization disabled without compatibility justification is **Medium**. Forwarding full or overly specific ECS for enterprise clients without documented exception is **Medium**. Long-lived detailed DNS logs without minimization, access controls, or retention justification are **High** for user-identifiable data and **Medium** otherwise. Missing privacy evidence for a managed resolver is **Low** unless sensitive populations are in scope.
+
 ---
 
 ## Findings Classification
@@ -300,7 +312,7 @@ abcdef0123456789.dnscat.example.com TXT
 |----------|-----------|
 | **Critical** | Broken DNSSEC chain of trust (missing DS record in parent); authoritative zones serving invalid signatures. |
 | **High** | DNSSEC validation disabled on resolvers; no DNS filtering/RPZ; unsigned public authoritative zones; DNS bypass paths around protective DNS; no DNS query logging; weak signing algorithms. |
-| **Medium** | Plaintext DNS forwarding over untrusted networks; stale RPZ feeds; undocumented NTAs; no NRD blocking; no exfiltration detection; DoH bypass not controlled. |
+| **Medium** | Plaintext DNS forwarding over untrusted networks; stale RPZ feeds; undocumented NTAs; no NRD blocking; no exfiltration detection; DoH bypass not controlled; QNAME minimization disabled without justification; ECS forwarding without documented exception. |
 | **Low** | Missing documentation of DNS architecture; resolver software not at latest version; cosmetic configuration issues. |
 
 ---
@@ -343,6 +355,11 @@ abcdef0123456789.dnscat.example.com TXT
 - Entropy-based detection: <Deployed / Not deployed>
 - Volumetric thresholds: <Configured / Not configured>
 - SIEM integration: <Yes / No>
+
+### Resolver Privacy Posture
+| Resolver | QNAME Minimization | ECS Forwarding | Log Detail | Retention | Access Controls | Exception Owner | Status |
+|----------|--------------------|----------------|------------|-----------|-----------------|-----------------|--------|
+| resolver1 | Enabled/Disabled/Unknown | Disabled/Coarsened/Full/Unknown | Aggregated/Full | 7d/30d/365d | Yes/No | <owner or N/A> | Pass/Fail/Not Evaluable |
 
 ### Prioritized Remediation Plan
 1. **[Critical]** <action item with control reference>
@@ -405,6 +422,9 @@ This skill processes DNS configuration files that may contain user-supplied zone
 - RFC 4033 -- DNS Security Introduction and Requirements: https://datatracker.ietf.org/doc/html/rfc4033
 - RFC 7858 -- DNS over TLS: https://datatracker.ietf.org/doc/html/rfc7858
 - RFC 8484 -- DNS over HTTPS: https://datatracker.ietf.org/doc/html/rfc8484
+- RFC 9156 -- DNS Query Name Minimisation to Improve Privacy: https://www.rfc-editor.org/rfc/rfc9156
+- RFC 7871 -- Client Subnet in DNS Queries: https://www.rfc-editor.org/rfc/rfc7871
+- RFC 8932 -- Recommendations for DNS Privacy Service Operators: https://www.rfc-editor.org/rfc/rfc8932
 - RFC 7719 -- DNS Terminology: https://datatracker.ietf.org/doc/html/rfc7719
 - ISC Response Policy Zones (RPZ): https://www.isc.org/rpz/
 - CISA Protective DNS: https://www.cisa.gov/protective-dns

--- a/skills/network/dns-security/tests/resolver-privacy-edge-cases.md
+++ b/skills/network/dns-security/tests/resolver-privacy-edge-cases.md
@@ -1,0 +1,83 @@
+# Resolver Privacy Edge Cases
+
+These fixtures verify that DNSSEC, encrypted transport, RPZ, and query logging do not hide resolver privacy gaps.
+
+## Case 1: Secure Resolver With QNAME Minimization Disabled
+
+```yaml
+resolver: corp-recursive-1
+dnssec_validation: enabled
+upstream_transport: DoT
+rpz_filtering: enabled
+qname_minimization: disabled
+compatibility_exception: null
+```
+
+Expected review:
+
+- DNSSEC and encrypted transport can pass.
+- Resolver Privacy Posture records `QNAME Minimization` as `Disabled`.
+- Finding is Medium unless compatibility evidence explains the exception.
+
+## Case 2: EDNS Client Subnet Forwarded With Full Client Prefix
+
+```yaml
+resolver: protective-dns
+ecs:
+  mode: forwarded
+  ipv4_prefix_length: 32
+  ipv6_prefix_length: 128
+  exception_owner: null
+  cdn_performance_justification: null
+```
+
+Expected review:
+
+- `ECS Forwarding` is `Full`.
+- Finding is Medium because client-specific prefixes are forwarded without a documented exception.
+- Remediation recommends disabling ECS or coarsening prefixes with owner/review evidence.
+
+## Case 3: Detailed Query Logs Retained for One Year
+
+```yaml
+resolver: dns-analytics
+query_logs:
+  fields:
+    - client_ip
+    - authenticated_user
+    - full_qname
+    - response_code
+    - ecs_prefix
+  retention_days: 365
+  encrypted_at_rest: false
+  access_review: missing
+```
+
+Expected review:
+
+- `Log Detail` is `Full`.
+- Finding is High because user-identifiable DNS logs are retained long-term without encryption, access review, or minimization evidence.
+- Report records retention and access-control gaps separately from exfiltration detection readiness.
+
+## Case 4: Bounded Security Logging With Privacy Evidence
+
+```yaml
+resolver: soc-dns
+qname_minimization: enabled
+ecs:
+  mode: disabled
+query_logs:
+  fields:
+    - client_subnet_coarse
+    - qname_hash
+    - response_code
+  retention_days: 14
+  encrypted_at_rest: true
+  access_review: quarterly
+  purpose: threat_hunting
+```
+
+Expected review:
+
+- Resolver Privacy Posture is Pass.
+- Security logging can remain enabled because retention, access controls, and minimization evidence are documented.


### PR DESCRIPTION
## Summary
- Adds resolver privacy and log minimization evidence gates to `dns-security`.
- Covers QNAME minimization, EDNS Client Subnet forwarding, detailed DNS log retention, privacy exceptions, and managed resolver privacy statements.
- Adds edge-case fixtures showing how DNSSEC/DoT/RPZ can pass while resolver privacy still fails.

## Created from review issue
Created from review issue: #1369

## What was wrong
The skill could treat a recursive resolver as strong because DNSSEC, encrypted transport, RPZ filtering, and query logging were enabled. That misses privacy leaks from full QNAME forwarding, ECS client subnet forwarding, and long-lived detailed DNS logs.

## What changed
- Added Step 6A: Resolver Privacy and Log Minimization.
- Added severity guidance for disabled QNAME minimization, ECS forwarding, and detailed log retention.
- Added a Resolver Privacy Posture output table.
- Added RFC 9156, RFC 7871, and RFC 8932 references.
- Added `tests/resolver-privacy-edge-cases.md`.

## Validation
- `git diff --check`
- Added-line non-ASCII scan
- Added-line prompt-injection marker scan
- Markdown code-fence balance check
- RFC reference URL checks returned HTTP 200
