### PR TITLE
docs: add pipeline attestation verification gates

### DIFF
--- a/skills/devsecops/pipeline-security/SKILL.md
+++ b/skills/devsecops/pipeline-security/SKILL.md
@@ -392,6 +392,9 @@ docker.sock
 - No SBOM (Software Bill of Materials) generation in the build pipeline.
 - Downloaded dependencies or tools without checksum verification.
 - Missing provenance attestation (SLSA provenance, in-toto, Sigstore).
+- Provenance or signatures generated during build but never verified before deployment.
+- Verification commands that omit identity constraints such as OIDC issuer, certificate identity, repository, workflow ref, builder ID, or SLSA predicate type.
+- Deployment policies that verify mutable tags instead of the immutable digest that was attested.
 
 **Grep patterns:**
 
@@ -412,9 +415,36 @@ sbom
 # Look for digest pinning in container references
 image: nginx@sha256:abcdef...  # GOOD
 image: nginx:latest            # BAD
+
+# Look for deployment-time attestation verification
+cosign verify --certificate-identity --certificate-oidc-issuer
+cosign verify-attestation --type slsaprovenance
+gh attestation verify --owner
+ClusterImagePolicy
+verifyImages
+cosigned
+kyverno
+gatekeeper
+connaisseur
 ```
 
-**Finding format:** Report whether artifacts are signed, whether provenance is generated, whether SBOMs are produced, and whether container images use digest pinning.
+##### Attestation Verification and Deployment Enforcement
+
+Treat artifact signing and provenance generation as incomplete unless the release path verifies and enforces that evidence before production deployment.
+
+**Required evidence:**
+
+- The deployed artifact is referenced by immutable digest, not only by a mutable tag.
+- Signature verification binds the artifact digest to a trusted identity, including OIDC issuer and certificate identity or equivalent private PKI subject.
+- Provenance verification checks the attestation subject digest, source repository, workflow ref or commit, builder identity, and SLSA provenance predicate type.
+- The verification runs in the release gate, deploy pipeline, or admission policy before production workloads are admitted.
+- Production policies fail closed when verification fails. Warn-only mode is acceptable for development only and must be clearly scoped.
+- Exceptions include an owner, reason, affected environment, and expiration date.
+- Multi-arch images verify the deployed manifest digest and account for per-platform attestations where the platform-specific image can differ from the manifest list.
+
+**False positive to avoid:** Do not mark CICD-SEC-9 as pass solely because the build creates an attestation with `actions/attest-build-provenance` or signs an image with `cosign sign`. If deployment later uses `repo/app:latest`, or if `cosign verify` runs without issuer and identity constraints, the control is at best Partial and may be Fail for production releases.
+
+**Finding format:** Report whether artifacts are signed, whether provenance is generated, whether SBOMs are produced, whether container images use digest pinning, whether deployment verifies signatures and attestations, which identity constraints are enforced, and where the enforcement point runs.
 
 ---
 
@@ -490,6 +520,12 @@ Produce the final report using the following structure:
 - **Description:** <what was found>
 - **Remediation:** <specific fix>
 
+### Attestation Verification
+
+| Artifact | Deployed By Digest | Signature Verified | Provenance Verified | Identity Constraints | Enforcement Point | Mode | Status |
+|----------|--------------------|--------------------|---------------------|----------------------|-------------------|------|--------|
+| <image/artifact> | Yes/No/Unknown | Yes/No/Unknown | Yes/No/Unknown | <issuer, identity, repo, ref, builder> | <deploy gate/admission/release job> | Enforce/Warn/None | Pass/Partial/Fail |
+
 ### Prioritized Remediation Plan
 
 1. **[Critical]** <CICD-SEC-X> -- <action item>
@@ -551,6 +587,8 @@ This skill processes user-supplied content including CI/CD configuration files, 
 - OWASP Top 10 CI/CD Security Risks: https://owasp.org/www-project-top-10-ci-cd-security-risks/
 - GitHub Actions Security Hardening: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
 - Sigstore / Cosign: https://docs.sigstore.dev/
+- Cosign Signature Verification: https://docs.sigstore.dev/cosign/verifying/verify/
+- GitHub Artifact Attestations: https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
 - SLSA GitHub Generator: https://github.com/slsa-framework/slsa-github-generator
 
 ---

--- a/skills/devsecops/pipeline-security/tests/attestation-verification-edge-cases.md
+++ b/skills/devsecops/pipeline-security/tests/attestation-verification-edge-cases.md
@@ -1,0 +1,84 @@
+# Attestation Verification Edge Cases
+
+These fixtures validate CICD-SEC-9 review behavior for pipelines that generate signatures or provenance but may not enforce that evidence during release.
+
+## Case 1: Build Attests Digest, Deploy Uses Mutable Tag
+
+```yaml
+build:
+  steps:
+    - uses: actions/attest-build-provenance@v2
+      with:
+        subject-name: registry.example.com/api
+        subject-digest: sha256:abc123
+    - run: cosign sign registry.example.com/api@sha256:abc123
+
+deploy:
+  steps:
+    - run: kubectl set image deploy/api api=registry.example.com/api:latest
+```
+
+**Expected result:** Fail for production CICD-SEC-9.
+
+**Reason:** The attested subject digest is not the artifact reference used by deployment. A mutable tag can resolve to a different image after the attestation is produced.
+
+## Case 2: Signature Verification Without Identity Constraints
+
+```yaml
+release:
+  steps:
+    - run: cosign verify registry.example.com/api@sha256:abc123
+    - run: kubectl set image deploy/api api=registry.example.com/api@sha256:abc123
+```
+
+**Expected result:** Partial, or Fail when identity trust is required for production.
+
+**Reason:** The command verifies that a signature exists, but does not constrain the OIDC issuer, certificate identity, source repository, workflow ref, or builder identity.
+
+## Case 3: Production Admission Policy Enforces Provenance
+
+```yaml
+apiVersion: policy.sigstore.dev/v1beta1
+kind: ClusterImagePolicy
+metadata:
+  name: require-api-provenance
+spec:
+  images:
+    - glob: registry.example.com/api@sha256:*
+  authorities:
+    - keyless:
+        identities:
+          - issuer: https://token.actions.githubusercontent.com
+            subject: https://github.com/example/api/.github/workflows/release.yml@refs/heads/main
+      attestations:
+        - name: slsa-provenance
+          predicateType: https://slsa.dev/provenance/v1
+```
+
+**Expected result:** Pass for the attestation verification portion of CICD-SEC-9 when paired with digest-based deployment.
+
+**Reason:** The production admission policy verifies provenance and constrains the trusted identity before admitting the workload.
+
+## Case 4: Multi-Arch Manifest Without Platform Attestation Clarity
+
+```yaml
+build:
+  steps:
+    - run: docker buildx build --platform linux/amd64,linux/arm64 --push -t registry.example.com/api:1.2.3 .
+    - run: cosign attest --predicate provenance.json registry.example.com/api@sha256:manifest
+
+deploy:
+  steps:
+    - run: kubectl set image deploy/api api=registry.example.com/api@sha256:manifest
+```
+
+**Expected result:** Partial / Not Evaluable until the review confirms how per-platform image digests are covered.
+
+**Reason:** Multi-arch manifests can point to platform-specific images. The reviewer must confirm whether the attestation covers the deployed manifest, the per-platform images, or both.
+
+## Review Assertions
+
+- Do not credit build-time attestation as deployment enforcement.
+- Require digest binding between the attested subject and deployed artifact.
+- Require issuer and identity constraints for keyless signature or attestation verification.
+- Distinguish enforce mode from warn-only mode and record exception owner/expiry.


### PR DESCRIPTION
Created from review issue: #1372

## Summary

- Add deployment-time attestation verification checks to CICD-SEC-9.
- Require digest binding, issuer/certificate identity constraints, source and builder provenance checks, and production enforcement evidence.
- Add an attestation verification output table and edge-case fixtures for mutable tags, unconstrained verification, admission enforcement, and multi-arch images.

## Validation

- `git diff --check`
- Markdown fence/non-ASCII sanity check
- Reference URL checks for SLSA, Sigstore cosign verification, and GitHub artifact attestations
