### PR TITLE
docs: add LLM08 retrieval authorization gates

### DIFF
--- a/skills/ai-security/llm-top-10/SKILL.md
+++ b/skills/ai-security/llm-top-10/SKILL.md
@@ -313,6 +313,19 @@ Review the application against each of the ten OWASP LLM risk categories below. 
 - Do not store raw source text in vector metadata unless access controls are equivalent to the source document's classification.
 - Monitor vector store access patterns for anomalous query volumes or bulk extraction attempts.
 
+**Retrieval authorization evidence gates:**
+
+- **Pre-query authorization:** Verify the authenticated tenant, user, group, role, and document permission scope are converted into query filters before vector, keyword, or hybrid search runs.
+- **Post-retrieval validation:** Verify every returned chunk is checked against the current document or chunk ACL before reranking, aggregation, prompt assembly, or response streaming.
+- **Cache scoping:** Retrieval caches must be keyed by tenant, user or permission scope, source collection, query, model/embedding version, and permission version. Shared caches keyed only by query text or embedding hash are unsafe.
+- **Reranker and hybrid search metadata:** Rerankers, BM25 results, graph expansion, and chunk stitching must preserve source document ID, tenant ID, ACL metadata, classification, and permission version.
+- **Chunk-level permissions:** Review whether redacted or section-specific documents require chunk ACLs instead of only document-level ACLs.
+- **Permission change invalidation:** Group membership changes, document sharing changes, source deletion, and classification changes must invalidate affected indexes, caches, and prompt-context stores.
+- **Public content exception:** Public/shared documents require explicit classification and immutable source metadata. Do not infer public access because a collection is shared.
+- **Prompt assembly boundary:** The final context passed to the model should include only chunks that passed authorization after all retrieval, reranking, cache, and aggregation steps.
+
+**False positive to avoid:** Do not mark LLM08 as pass because the initial vector query includes `tenant_id` or because the vector database has collection-level ACLs. Confirm the full path from query construction through cache, reranker, aggregation, and prompt assembly preserves and enforces the requesting user's current permissions.
+
 **CWE Mapping:** CWE-284 (Improper Access Control), CWE-311 (Missing Encryption of Sensitive Data)
 
 ---
@@ -434,6 +447,12 @@ Structure the findings report as follows:
 | ID | OWASP Category | Severity | Priority | Status |
 |----|---------------|----------|----------|--------|
 | FINDING-001 | LLM0X:2025 | High | P1 | Open |
+
+## RAG Retrieval Authorization
+
+| Pipeline | Pre-query Filter | Post-retrieval ACL Check | Cache Scope | Reranker Preserves ACL Metadata | Permission Invalidation | Residual Risk |
+|----------|------------------|--------------------------|-------------|----------------------------------|-------------------------|---------------|
+| [pipeline name] | [tenant/user/group/doc/chunk] | [Yes/No] | [tenant/user/permission/version] | [Yes/No] | [events handled] | [Low/Medium/High] |
 
 ## Recommendations
 

--- a/skills/ai-security/llm-top-10/tests/retrieval-authorization-edge-cases.md
+++ b/skills/ai-security/llm-top-10/tests/retrieval-authorization-edge-cases.md
@@ -1,0 +1,112 @@
+# Retrieval Authorization Edge Cases
+
+These fixtures validate LLM08 review behavior for RAG retrieval authorization across vector search, cache, reranking, and prompt assembly.
+
+## Case 1: Tenant Filter Without Post-Retrieval ACL Check
+
+```yaml
+retrieval:
+  pre_query_filter:
+    tenant_id: request.tenant_id
+  post_retrieval_acl_check: false
+  prompt_assembly:
+    include_all_returned_chunks: true
+```
+
+**Expected result:** High severity finding.
+
+**Reason:** The initial query is scoped, but stale metadata, shared documents, or misindexed chunks can still enter the prompt without validation against the user's current ACL.
+
+## Case 2: Shared Retrieval Cache Keyed Only by Query
+
+```yaml
+cache:
+  enabled: true
+  key_fields:
+    - normalized_query
+    - embedding_model
+  missing_key_fields:
+    - tenant_id
+    - user_id
+    - permission_version
+    - collection_id
+```
+
+**Expected result:** High severity finding.
+
+**Reason:** One user's authorized retrieval result can be reused for another user or tenant with the same query.
+
+## Case 3: Reranker Drops Authorization Metadata
+
+```yaml
+pipeline:
+  vector_results:
+    metadata:
+      - document_id
+      - tenant_id
+      - acl_version
+  reranker:
+    input_fields:
+      - text
+      - score
+    output_fields:
+      - text
+      - rerank_score
+  final_context:
+    uses_reranker_output_only: true
+```
+
+**Expected result:** High severity finding.
+
+**Reason:** The reranker output cannot be rechecked against source document ACLs before prompt assembly.
+
+## Case 4: Complete Retrieval Authorization Chain
+
+```yaml
+rag_authorization:
+  pre_query_filter:
+    tenant_id: request.tenant_id
+    user_id: request.user_id
+    groups: request.groups
+    permission_version: request.permission_version
+  vector_query:
+    collection: tenant_scoped
+    include_metadata:
+      - document_id
+      - chunk_id
+      - tenant_id
+      - acl_hash
+      - classification
+      - permission_version
+  cache:
+    key_fields:
+      - tenant_id
+      - user_id
+      - groups_hash
+      - permission_version
+      - query_hash
+      - embedding_model
+      - collection_id
+  reranker:
+    preserves_metadata: true
+  post_retrieval_acl_check:
+    before_rerank: true
+    after_rerank: true
+    before_prompt_assembly: true
+  invalidation_events:
+    - group_membership_changed
+    - document_acl_changed
+    - document_deleted
+    - classification_changed
+```
+
+**Expected result:** Pass for retrieval authorization if implementation evidence confirms each enforcement point.
+
+**Reason:** Authorization is enforced before query construction, after retrieval, after reranking, and before prompt assembly, with cache keys and invalidation tied to permission state.
+
+## Review Assertions
+
+- Do not credit tenant filters without post-retrieval ACL validation.
+- Confirm retrieval cache keys include permission scope and permission version.
+- Confirm rerankers and hybrid search preserve source ACL metadata.
+- Confirm permission changes invalidate indexes, caches, and assembled prompt contexts.


### PR DESCRIPTION
Created from review issue: #1384

## Summary

- Add LLM08 retrieval authorization evidence gates for RAG pipelines.
- Require pre-query filters, post-retrieval ACL checks, cache scoping, reranker metadata preservation, permission-change invalidation, public-content classification, and prompt assembly boundaries.
- Add output fields and edge-case fixtures for tenant-filter-only retrieval, shared cache leakage, reranker ACL metadata loss, and complete authorization chains.

## Validation

- `git diff --check`
- Markdown fence/non-ASCII sanity check
- Reference URL checks for OWASP LLM08, OWASP LLM Top 10, and NIST AI RMF
