### PR TITLE
docs: add PCI scope change evidence gates

### DIFF
--- a/skills/compliance/pci-dss-review/SKILL.md
+++ b/skills/compliance/pci-dss-review/SKILL.md
@@ -138,6 +138,43 @@ PCI DSS v4.0 requires scope confirmation at least every 12 months and upon signi
 - All in-scope system components are identified
 - Segmentation controls are validated
 
+#### 1.5 Significant Change Scope Impact Analysis (Req 12.5.3)
+
+For each significant change, verify that PCI scope impact was assessed before production release or through a documented emergency-change follow-up.
+
+**Significant-change triggers to look for:**
+
+- New or changed payment channel, payment page, API, mobile flow, serverless function, queue, storage bucket, or batch process that can store, process, transmit, or redirect CHD/SAD.
+- Network, firewall, routing, VPN, Kubernetes, security group, IAM, or DNS changes that affect CDE segmentation or connected-to systems.
+- New security-impacting services for the CDE, including identity providers, logging/SIEM, endpoint security, vulnerability scanning, secrets management, backup, monitoring, and admin access paths.
+- TPSP additions or responsibility changes, including payment processors, fraud providers, analytics tags, payment page scripts, hosting providers, and managed security providers.
+- Cloud architecture changes that alter shared responsibility, inherited controls, region/account/project boundaries, or data residency.
+
+**Evidence required:**
+
+| Evidence Item | What to Verify |
+|---|---|
+| Change record | Change ID, owner, date, risk classification, and whether PCI impact was considered |
+| Data flow update | CHD/SAD flow diagram updated or explicitly confirmed unchanged |
+| Scope inventory update | CDE, connected-to, and security-impacting system list updated |
+| Segmentation validation | Firewall/route/security group/Kubernetes policy impact reviewed; penetration-test or validation evidence refreshed when segmentation changed |
+| TPSP matrix update | Provider inventory, written responsibility acknowledgments, AoC/ROC status, and responsibility matrix updated when providers or duties changed |
+| Control evidence refresh | Requirements affected by the change mapped to updated evidence, including Req 1, 6, 10, 11, and 12 where applicable |
+| Approval and residual risk | PCI owner, security owner, and business owner sign-off with residual scope risk documented |
+
+**What constitutes a finding:**
+
+| Condition | Severity |
+|---|---|
+| Significant change deployed with no PCI scope impact analysis | High |
+| New CHD/SAD flow not reflected in scope diagrams or system inventory | High |
+| Segmentation-affecting change lacks revalidation evidence | High |
+| TPSP or payment page responsibility changed without updating provider inventory and responsibility matrix | High |
+| Emergency change lacks retrospective scope impact review | Medium |
+| Scope reduction claim lacks updated evidence after architecture change | Medium |
+
+**False positive to avoid:** Do not credit annual scope confirmation as proof that mid-cycle significant changes were assessed. Req 12.5.3 requires change-specific evidence that the change was evaluated for PCI DSS scope impact.
+
 ---
 
 ### Step 2: Requirement-by-Requirement Assessment
@@ -424,6 +461,12 @@ Note: Not all requirements support the Customized Approach. Requirements with "T
 - **Scope reduction methods**: [tokenization, P2PE, segmentation, outsourcing]
 - **Connected-to systems**: [list]
 - **Third-party service providers in scope**: [list]
+
+## Significant Change Scope Impact
+
+| Change ID | Trigger | CHD/SAD Flow Impact | Scope Inventory Updated | Segmentation Revalidated | TPSP Matrix Updated | Evidence Refreshed | Owner / Approval | Status |
+|-----------|---------|---------------------|--------------------------|--------------------------|---------------------|--------------------|------------------|--------|
+| [change] | [payment/network/TPSP/cloud/etc.] | [Yes/No/Unknown] | [Yes/No] | [Yes/No/N/A] | [Yes/No/N/A] | [requirements/evidence] | [owner/date] | [Pass/Partial/Fail] |
 
 ## Requirement Assessment Summary
 

--- a/skills/compliance/pci-dss-review/tests/scope-change-edge-cases.md
+++ b/skills/compliance/pci-dss-review/tests/scope-change-edge-cases.md
@@ -1,0 +1,108 @@
+# PCI Scope Change Edge Cases
+
+These fixtures validate PCI DSS v4.0 review behavior for significant-change scope impact analysis under Req 12.5.3.
+
+## Case 1: New Serverless Payment Flow After Annual Review
+
+```yaml
+annual_scope_review:
+  completed: "2026-01-15"
+change:
+  id: CHG-101
+  deployed: "2026-04-10"
+  component: payment-webhook-lambda
+  handles:
+    - payment_token
+    - transaction_metadata
+  pci_scope_impact_review: missing
+  cde_diagram_updated: false
+```
+
+**Expected result:** High severity finding.
+
+**Reason:** A new payment flow was deployed after annual scope confirmation without change-specific PCI scope impact evidence.
+
+## Case 2: Segmentation Change Without Revalidation
+
+```yaml
+change:
+  id: CHG-202
+  type: firewall_rule_update
+  affects:
+    - cde_to_corp_network
+    - admin_vpn_to_cde
+  segmentation_validation:
+    updated_pen_test: false
+    route_review: partial
+    security_owner_approval: true
+```
+
+**Expected result:** High severity finding.
+
+**Reason:** Segmentation-affecting changes require refreshed validation evidence; approval alone does not prove segmentation remains effective.
+
+## Case 3: TPSP Responsibility Changed
+
+```yaml
+provider_change:
+  id: CHG-303
+  provider: fraud-analytics-saas
+  new_data_access:
+    - transaction_id
+    - masked_pan
+  tpsp_inventory_updated: false
+  responsibility_matrix_updated: false
+  aoc_reviewed: false
+```
+
+**Expected result:** High severity finding.
+
+**Reason:** Provider responsibility and data access changed, but the TPSP inventory, responsibility matrix, and compliance evidence were not refreshed.
+
+## Case 4: Complete Scope Impact Evidence
+
+```yaml
+scope_change_impact:
+  change_id: CHG-404
+  trigger: new_payment_api
+  owner: pci-program-manager
+  reviewed_before_release: true
+  data_flow_update:
+    chd_sad_flow_changed: true
+    diagram_version: cde-flow-v18
+  scope_inventory:
+    cde_components_added:
+      - payment-api
+    connected_to_systems_added:
+      - auth-service
+      - siem-forwarder
+  segmentation:
+    affected: true
+    validation_evidence: seg-test-2026-06-01
+  tpsp:
+    affected: true
+    responsibility_matrix_version: tpsp-raci-v9
+    aoc_status_reviewed: true
+  evidence_refresh:
+    requirements:
+      - "1"
+      - "6"
+      - "10"
+      - "11"
+      - "12"
+  approvals:
+    security_owner: approved
+    business_owner: approved
+    pci_owner: approved
+```
+
+**Expected result:** Pass for Req 12.5.3 evidence if implementation evidence matches the record.
+
+**Reason:** The change is explicitly tied to scope, data-flow, segmentation, TPSP, evidence refresh, and owner approval artifacts.
+
+## Review Assertions
+
+- Do not accept annual scope confirmation as proof of mid-cycle change review.
+- Confirm payment, network, cloud, TPSP, and security-impacting changes trigger PCI scope impact analysis.
+- Confirm segmentation changes refresh validation evidence.
+- Confirm scope reduction claims are updated after architecture changes.


### PR DESCRIPTION
Created from review issue: #1392

## Summary

- Add PCI DSS v4.0 Req 12.5.3 significant-change scope impact evidence gates.
- Require change records, CHD/SAD flow updates, CDE and connected-to system inventory refresh, segmentation revalidation, TPSP responsibility updates, evidence refresh, and owner approvals.
- Add a Significant Change Scope Impact report table and edge-case fixtures for serverless payment flows, segmentation changes, TPSP changes, and complete scope impact records.

## Validation

- `git diff --check`
- Markdown fence/non-ASCII sanity check
- Reference URL checks for PCI SSC document library and PCI DSS v4.0 summary of changes
