### PR TITLE
docs: add patch deferral revalidation gates

### DIFF
--- a/skills/vuln-management/patch-prioritization/SKILL.md
+++ b/skills/vuln-management/patch-prioritization/SKILL.md
@@ -256,6 +256,49 @@ Risk Exception Request:
 - Status:                 [Pending | Approved | Denied | Expired]
 ```
 
+### Step 7: Deferred Vulnerability Revalidation
+
+Risk exceptions and deferred patch decisions are temporary. Revalidate them whenever threat intelligence, patch availability, exploitability, asset exposure, or compensating control status changes. Do not wait for the scheduled review date if a trigger invalidates the original assumptions.
+
+#### Revalidation Triggers
+
+| Trigger | Required Action | Why It Matters |
+|---|---|---|
+| Vendor patch or hotfix becomes available | Replace "patch unavailable" justification with a remediation deadline and patch window | The original exception basis no longer applies |
+| CVE is added to CISA KEV | Re-run SSVC, escalate SLA tier, and apply KEV-driven deadlines | Confirmed exploitation changes urgency |
+| EPSS surges or crosses tier threshold | Re-run EPSS trend analysis and update SLA tier if needed | Exploitation likelihood changed materially |
+| Public exploit or reliable PoC appears | Re-run SSVC exploitation and automatability decisions | Attack feasibility may have changed |
+| Active exploitation observed internally or by trusted intelligence | Escalate to P0/P1 and require incident-response coordination | The risk is no longer theoretical |
+| Asset exposure changes | Re-score internet-facing, newly critical, or newly reachable assets | Previous risk acceptance may depend on obsolete exposure assumptions |
+| Compensating control changes or fails validation | Re-test the control and remove SLA extension if ineffective | Extensions depend on verified control effectiveness |
+| Exception reaches 50% of approved duration | Confirm patch status, controls, residual risk, and owner accountability | Prevent silent aging toward expiration |
+
+#### Revalidation Record
+
+```
+Deferred Vulnerability Revalidation:
+- CVE ID:                 [CVE-YYYY-NNNNN]
+- Exception ID:           [EXC-YYYY-NNNN or N/A]
+- Last Revalidated:       [YYYY-MM-DD]
+- Trigger Checked:        [Patch Available | KEV | EPSS | Public Exploit | Asset Exposure | Control Validation | Duration Aging]
+- Trigger Source:         [Vendor advisory / CISA KEV / EPSS API / threat intel / CMDB / control test]
+- Previous Assumption:    [Why deferral or exception was allowed]
+- Current Finding:        [What changed or "No material change"]
+- Required Action:        [Maintain exception | Escalate tier | Schedule patch | Expire exception | Re-test control]
+- New SLA Deadline:       [YYYY-MM-DD or N/A]
+- Owner:                  [Name/team]
+- Next Revalidation Date: [YYYY-MM-DD]
+```
+
+#### Revalidation Rules
+
+1. **Patch available:** If the exception reason is "patch unavailable" and a vendor patch is released, set a new remediation deadline based on current SSVC, EPSS, KEV, and asset exposure. The old exception must not remain open unchanged.
+2. **KEV or active exploitation:** Any KEV listing or credible active exploitation signal overrides routine review cadence. Reclassify immediately and notify the vulnerability owner and security leadership for P0/P1 decisions.
+3. **EPSS threshold change:** If EPSS crosses a threshold used in the SLA matrix or is classified as Surging, update the SLA tier or document why SSVC evidence supports keeping the current tier.
+4. **Exposure drift:** If an asset moves from internal to internet-facing, becomes business-critical, or is newly reachable from untrusted networks, re-run asset criticality and exposure modifiers.
+5. **Control dependency:** If an exception depends on a WAF, IPS, segmentation rule, EDR detection, or disabled feature, re-test that control whenever exploit details, traffic path, or affected asset scope changes.
+6. **Expiration enforcement:** Expired exceptions become SLA breaches unless a new exception is approved by the required authority before expiration.
+
 ---
 
 ## Findings Classification
@@ -326,6 +369,13 @@ findings requiring immediate action.]
 | Exception ID | CVE ID(s) | Original SLA | New Deadline | Approver | Status |
 |---|---|---|---|---|---|
 | [EXC-ID] | [CVE-IDs] | [tier] | [date] | [name] | [Approved/Pending] |
+
+### Deferred Vulnerability Revalidation
+[List deferred vulnerabilities and exceptions that were revalidated or require revalidation]
+
+| CVE ID | Exception ID | Last Revalidated | Trigger Checked | Current Finding | Required Action | Next Revalidation |
+|---|---|---|---|---|---|---|
+| [CVE-ID] | [EXC-ID/N/A] | [date] | [Patch/KEV/EPSS/Exploit/Exposure/Control] | [Finding] | [Maintain/Escalate/Schedule/Expire/Re-test] | [date] |
 
 ### Recommendations
 1. [Highest-priority actionable recommendation]

--- a/skills/vuln-management/patch-prioritization/tests/deferred-revalidation-edge-cases.md
+++ b/skills/vuln-management/patch-prioritization/tests/deferred-revalidation-edge-cases.md
@@ -1,0 +1,121 @@
+# Deferred Vulnerability Revalidation Edge Cases
+
+Use these cases to validate that `patch-prioritization` revalidates deferred vulnerabilities and risk exceptions when the original assumptions change.
+
+## Case 1: Vendor patch released after "patch unavailable" exception
+
+**Input**
+
+```yaml
+exception:
+  id: EXC-2026-0042
+  cve: CVE-2026-12345
+  status: approved
+  reason: vendor patch unavailable
+  original_sla: P2
+  review_date: 2026-09-01
+current_state:
+  vendor_patch: released
+  vendor_advisory_date: 2026-06-15
+  epss: 0.18
+  cisa_kev: false
+  asset_exposure: internal
+```
+
+**Expected result**
+
+The exception must be revalidated immediately. "Patch unavailable" is no longer a valid basis, and the report must set a new remediation deadline and patch window instead of leaving the exception unchanged until September.
+
+## Case 2: KEV listing and EPSS surge during approved exception
+
+**Input**
+
+```yaml
+exception:
+  id: EXC-2026-0051
+  cve: CVE-2026-23456
+  status: approved
+  original_sla: P3
+  compensating_control: waf_rule
+  review_date: 2026-08-30
+current_state:
+  cisa_kev: true
+  epss_current: 0.73
+  epss_30_day_prior: 0.08
+  public_exploit: reliable_poc
+  asset_exposure: internet_facing
+```
+
+**Expected result**
+
+Escalate immediately. KEV listing, EPSS surge, reliable public exploit, and internet exposure invalidate routine review cadence and require SSVC/SLA re-evaluation with P0/P1 leadership visibility.
+
+## Case 3: Asset exposure drift invalidates risk acceptance
+
+**Input**
+
+```yaml
+exception:
+  id: EXC-2026-0060
+  cve: CVE-2026-34567
+  status: approved
+  reason: asset internal only
+  original_sla: P3
+current_state:
+  asset_exposure_previous: internal
+  asset_exposure_current: internet_facing
+  business_criticality_current: critical
+  cmdb_change_date: 2026-06-20
+  compensating_control_validation: stale
+```
+
+**Expected result**
+
+Re-score the vulnerability using the current exposure and criticality. The previous risk acceptance must not remain valid because it depended on obsolete asset assumptions.
+
+## Case 4: Compensating control fails after exploit details change
+
+**Input**
+
+```yaml
+exception:
+  id: EXC-2026-0077
+  cve: CVE-2026-45678
+  status: approved
+  original_sla: P2
+  compensating_control: waf_virtual_patch
+current_state:
+  new_exploit_path: bypasses_original_waf_signature
+  control_retest: failed
+  affected_assets_covered: 12_of_20
+  residual_risk: undocumented
+```
+
+**Expected result**
+
+Remove the SLA extension or mark it invalid. The report must require updated control testing, residual risk documentation, and a new remediation deadline for uncovered or bypassable assets.
+
+## Case 5: No material change with documented revalidation
+
+**Input**
+
+```yaml
+exception:
+  id: EXC-2026-0088
+  cve: CVE-2026-56789
+  status: approved
+  original_sla: P3
+  review_date: 2026-07-30
+current_state:
+  vendor_patch: unavailable
+  cisa_kev: false
+  epss_current: 0.012
+  epss_30_day_prior: 0.011
+  public_exploit: none
+  asset_exposure: internal
+  compensating_control_validation: passed
+```
+
+**Expected result**
+
+Maintain the exception only if the report records the last revalidation date, trigger checks, current finding, owner, and next revalidation date.


### PR DESCRIPTION
Created from review issue: #1401

## Summary

- Add deferred vulnerability revalidation gates to `patch-prioritization`
- Require early re-triage when vendor patches, CISA KEV status, EPSS trends, public exploits, asset exposure, or compensating control validation change
- Add edge-case fixtures for patch availability, KEV/EPSS escalation, exposure drift, failed compensating controls, and documented no-change revalidation

## Validation

- `git diff --check`
- Markdown fence balance and ASCII check for touched files
- Reference URL checks for SSVC, EPSS, CISA KEV, and CISA BOD 22-01
