### PR TITLE
docs: add SOC 2 evidence sampling gates

### DIFF
--- a/skills/compliance/soc2-gap/SKILL.md
+++ b/skills/compliance/soc2-gap/SKILL.md
@@ -297,6 +297,55 @@ For detailed Trust Services Criteria evaluation questions, evidence requirements
 
 ---
 
+### Step 5: Evidence Quality and Audit Period Coverage
+
+SOC 2 Type II readiness requires evidence that supports operating effectiveness across the observation period, not only control design at a single point in time. For each criterion and control, record whether the evidence covers the in-scope system boundary, the review period, and a sufficient sample population.
+
+#### 5.1 Evidence Quality Gates
+
+| Gate | Requirement | Readiness Impact |
+|---|---|---|
+| Audit Period Coverage | Evidence start/end dates align to the planned Type II review period | Downgrade if evidence is point-in-time or outside the period |
+| Population Definition | Full population is identified for sampled controls | Downgrade if sample cannot be tied to the complete population |
+| Sample Sufficiency | Sample size and selection method are documented | Downgrade if sample count or selection logic is missing |
+| System Boundary Mapping | Evidence maps to in-scope systems, people, processes, data, and third parties | Downgrade if evidence covers only a subset of the system description |
+| Evidence Freshness | Evidence date, collection date, owner, source system, and retention location are recorded | Downgrade stale or ownerless evidence |
+| Exception Handling | Exceptions are documented with remediation status and retest evidence | Downgrade unresolved or untracked exceptions |
+
+#### 5.2 Evidence Record Template
+
+```
+SOC 2 Evidence Record:
+- Criteria ID:             [CC/A/C/PI/P criterion]
+- Control Name:            [Control title]
+- Artifact Name:           [Evidence artifact]
+- Evidence Type:           [Policy | Configuration | Report | Ticket sample | Log export | Meeting minutes | Screenshot]
+- Supports:                [Design | Operating Effectiveness | Both]
+- Audit Period Covered:    [YYYY-MM-DD to YYYY-MM-DD]
+- Evidence Date:           [YYYY-MM-DD]
+- Collection Date:         [YYYY-MM-DD]
+- Source System:           [GRC/IAM/SIEM/CI-CD/HRIS/Vendor portal/etc.]
+- Evidence Owner:          [Name/team]
+- Retention Location:      [Repository/GRC folder/path]
+- System Boundary Covered: [Systems/processes/people/data/vendors]
+- Population:              [Full population description or N/A]
+- Sample Size:             [N of total population or N/A]
+- Sample Method:           [Full population | Random | Judgmental | Exception-based | N/A]
+- Exceptions Found:        [None / count and summary]
+- Exception Remediation:   [Ticket IDs, retest evidence, or N/A]
+- Freshness Status:        [Current | Stale | Outside period | Partial period]
+```
+
+#### 5.3 Scoring Impact
+
+- Score no higher than 2 when evidence exists but does not identify the audit period, population, or system boundary.
+- Score no higher than 2 when a Type II control has only point-in-time design evidence and no operating evidence.
+- Score no higher than 3 when evidence covers only part of the observation period or a subset of in-scope systems without documented justification.
+- Score no higher than 3 when exceptions exist but remediation and retest evidence are incomplete.
+- Reserve score 4 for controls with complete period coverage, traceable samples, resolved exceptions, and owner/source/retention metadata.
+
+---
+
 ### Step 6: Remediation Roadmap
 
 Prioritize remediation by audit readiness impact. Items that would result in examination exceptions or qualifications take highest priority.
@@ -365,7 +414,7 @@ When performing a SOC 2 gap analysis, produce the following deliverables:
 2. **Gap Assessment Matrix**: Completed scoring template from Step 4 with all in-scope criteria scored and annotated.
 3. **Category Summary**: Average maturity score per category with narrative assessment.
 4. **Critical Findings**: List of all criteria scored 0 or 1, with specific gap descriptions and remediation recommendations.
-5. **Evidence Checklist**: Customized evidence requirements based on in-scope criteria, marking items as Exists / Partial / Missing.
+5. **Evidence Checklist**: Customized evidence requirements based on in-scope criteria, marking items as Exists / Partial / Missing and recording period coverage, sample sufficiency, owner, source, and boundary mapping.
 6. **90-Day Remediation Roadmap**: Prioritized action items with owners, deadlines, and dependencies.
 7. **Overall Readiness Assessment**: Go/no-go recommendation for engaging a SOC 2 auditor.
 

--- a/skills/compliance/soc2-gap/tests/evidence-period-sampling-edge-cases.md
+++ b/skills/compliance/soc2-gap/tests/evidence-period-sampling-edge-cases.md
@@ -1,0 +1,104 @@
+# SOC 2 Evidence Period and Sampling Edge Cases
+
+Use these cases to validate that `soc2-gap` does not treat any existing artifact as audit-ready Type II evidence without period coverage, sample sufficiency, and boundary mapping.
+
+## Case 1: Access review evidence outside the audit period
+
+**Input**
+
+```yaml
+criterion: CC6.1
+control: quarterly access review
+planned_audit_period:
+  start: 2026-01-01
+  end: 2026-06-30
+evidence:
+  artifact: access-review.xlsx
+  evidence_date: 2025-01-15
+  audit_period_covered: missing
+  population: missing
+  sample_size: missing
+  system_boundary: production only
+  owner: missing
+```
+
+**Expected result**
+
+Do not score above 2. The artifact exists, but it is stale, outside the audit period, ownerless, and does not define population or sample coverage.
+
+## Case 2: Change management sample covers only one month
+
+**Input**
+
+```yaml
+criterion: CC8.1
+control: production change approval
+planned_audit_period:
+  start: 2026-01-01
+  end: 2026-06-30
+evidence:
+  artifact: pr-review-sample.csv
+  supports: operating_effectiveness
+  audit_period_covered: 2026-06-01 to 2026-06-30
+  population: all production changes
+  sample_size: 5 of 214
+  sample_method: judgmental
+  exceptions_found: 0
+  system_boundary: api service only
+```
+
+**Expected result**
+
+Cap at 3 unless the report documents why a one-month, five-item, single-service sample is sufficient for the planned Type II period and system boundary.
+
+## Case 3: Vulnerability management evidence has unresolved exceptions
+
+**Input**
+
+```yaml
+criterion: CC7.1
+control: scheduled vulnerability scanning
+evidence:
+  artifact: scan-results-and-remediation.csv
+  audit_period_covered: 2026-01-01 to 2026-06-30
+  population: all internet-facing assets
+  sample_size: full population
+  exceptions_found: 12 critical findings past SLA
+  exception_remediation: missing
+  retest_evidence: missing
+```
+
+**Expected result**
+
+Cap at 3 or lower. Full-period evidence is present, but unresolved exceptions without remediation and retest evidence prevent a managed readiness score.
+
+## Case 4: Complete Type II evidence record
+
+**Input**
+
+```yaml
+criterion: CC6.5
+control: timely access deprovisioning
+planned_audit_period:
+  start: 2026-01-01
+  end: 2026-06-30
+evidence:
+  artifact: offboarding-sample-and-iam-log-export.zip
+  supports: operating_effectiveness
+  audit_period_covered: 2026-01-01 to 2026-06-30
+  evidence_date: 2026-06-30
+  collection_date: 2026-07-02
+  source_system: HRIS and IAM
+  evidence_owner: security-compliance
+  retention_location: grc://soc2/2026/cc6.5
+  system_boundary: all in-scope workforce identities and production IAM
+  population: 48 terminated users during audit period
+  sample_size: 15 of 48
+  sample_method: random
+  exceptions_found: 1
+  exception_remediation: ticket IAM-991 retested pass
+```
+
+**Expected result**
+
+Eligible for score 4 if the control is otherwise implemented and the exception remediation evidence is complete. The record covers the period, population, sample method, owner, source, retention location, system boundary, and retest result.

--- a/skills/compliance/soc2-gap/tsc-criteria.md
+++ b/skills/compliance/soc2-gap/tsc-criteria.md
@@ -446,6 +446,16 @@ Score each criterion using the following maturity scale:
 | 3 | **Defined** | Controls are implemented and documented. Procedures are standardized. Evidence exists but may not cover the full audit period. |
 | 4 | **Managed** | Controls are fully implemented, documented, monitored, and operating effectively. Evidence covers the full audit period. Ready for SOC 2 Type II examination. |
 
+### Evidence Quality Scoring Constraints
+
+Apply these caps after the initial maturity score:
+
+- Cap at 2 if evidence exists but lacks audit period coverage, population, sample size, or system boundary mapping.
+- Cap at 2 if a Type II control has only design evidence and no operating effectiveness evidence.
+- Cap at 3 if evidence covers only part of the observation period or a partial population without documented auditor-ready justification.
+- Cap at 3 if exceptions were found but remediation and retest evidence are missing.
+- Score 4 only when evidence is current, owner-assigned, retained in a traceable location, mapped to the in-scope system boundary, and supports the full observation period.
+
 ### Scoring Template
 
 Complete the following matrix for all in-scope criteria:
@@ -568,3 +578,23 @@ After scoring, calculate:
 | P1.6 | Third-party data sharing agreements; breach notification procedures |
 | P1.7 | Data quality procedures; data subject update mechanisms |
 | P1.8 | Privacy compliance monitoring; complaint handling process; privacy impact assessments |
+
+### Evidence Quality Checklist
+
+For every artifact in the evidence reference table, record the following fields before marking it audit-ready:
+
+| Field | Required For | Auditor-Ready Expectation |
+|---|---|---|
+| Criteria ID | All evidence | Maps to a valid in-scope TSC criterion |
+| Control Owner | All evidence | Named team or individual accountable for evidence quality |
+| Source System | All evidence | GRC tool, IAM system, SIEM, CI/CD, HRIS, vendor portal, ticketing system, or policy repository |
+| Audit Period Covered | Type II operating evidence | Start and end dates align to the planned review period |
+| Evidence Date | All evidence | Artifact date is inside or relevant to the review period |
+| Collection Date | All evidence | Date the evidence was captured for the readiness binder |
+| System Boundary | All evidence | Maps to in-scope systems, people, procedures, data, and third parties |
+| Population | Sampled controls | Full population is identified before sampling |
+| Sample Size | Sampled controls | Sample count is documented and defensible |
+| Sample Method | Sampled controls | Full population, random, judgmental, or exception-based selection is stated |
+| Exceptions | Sampled controls | Exceptions are counted and summarized |
+| Remediation Evidence | Exceptions found | Ticket, owner, completion evidence, and retest result are linked |
+| Retention Location | All evidence | Stored in a stable evidence binder or GRC location |


### PR DESCRIPTION
Created from review issue: #1403

## Summary

- Add SOC 2 Type II evidence quality gates for audit-period coverage, sample sufficiency, system boundary mapping, evidence freshness, and exception handling
- Add scoring caps so stale, point-in-time, partial-period, or ownerless evidence cannot produce inflated readiness scores
- Add edge-case fixtures for stale access review evidence, partial-period change samples, unresolved vulnerability exceptions, and complete Type II evidence records

## Validation

- `git diff --check`
- Markdown fence balance and ASCII check for touched files
- Reference URL checks for AICPA Trust Services Criteria PDF, AICPA SOC suite, AICPA SOC 2 overview, and NIST Cybersecurity Framework
