### PR TITLE
docs: add ISO 27001 SoA traceability gates

### DIFF
--- a/skills/compliance/iso27001-gap/SKILL.md
+++ b/skills/compliance/iso27001-gap/SKILL.md
@@ -316,10 +316,51 @@ Use the following maturity scoring:
 Build or review the SoA. For each of the 93 Annex A controls, document:
 
 ```
-| Control ID | Control Title | Applicable? | Justification (if excluded) | Implementation Status | Maturity Score | Gap Description |
+| Control ID | Control Title | Applicable? | Driver | Linked Risk/Requirement | Treatment Option | Owner | Evidence Location | Residual Risk Acceptance | Implementation Status | Maturity Score | Gap Description |
 ```
 
 Exclusions are permitted only where the control is genuinely not applicable to the ISMS scope. A control cannot be excluded solely because it is difficult to implement.
+
+#### 5.1 SoA Traceability Gates
+
+Every SoA record must be traceable to the risk treatment process in Clause 6.1.3. A complete SoA is not merely a list of Annex A controls; it is the audit trail showing why each control is included or excluded and how the decision supports the ISMS.
+
+| Gate | Requirement | Certification Risk |
+|---|---|---|
+| Inclusion Driver | Included controls identify risk, legal, statutory, regulatory, contractual, or business drivers | Weak driver evidence makes control selection look arbitrary |
+| Linked Risk or Requirement | Each included control links to risk register ID, obligation ID, or business requirement | Missing linkage weakens Clause 6.1.3 risk treatment evidence |
+| Exclusion Justification | Excluded controls explain why the control is outside scope and why exclusion does not affect ISMS conformity | Generic exclusions are likely audit findings |
+| Treatment Option | Mitigate, accept, avoid, or transfer decision is recorded | Missing treatment option breaks risk treatment traceability |
+| Control Owner | Accountable owner is named for implementation and evidence maintenance | Ownerless controls are difficult to maintain and audit |
+| Evidence Location | Evidence repository, policy, configuration export, ticket, or GRC link is recorded | Implementation status cannot be verified |
+| Residual Risk Acceptance | Residual risk is accepted by the risk owner when applicable | Unaccepted residual risk can become a nonconformity |
+
+#### 5.2 SoA Record Template
+
+```
+Statement of Applicability Record:
+- Control ID:                 [A.5.x/A.6.x/A.7.x/A.8.x]
+- Control Title:              [ISO 27001:2022 Annex A title]
+- Applicable:                 [Yes/No]
+- Decision Driver:            [Risk | Legal | Regulatory | Contractual | Business | Scope exclusion]
+- Linked Risk/Requirement ID: [Risk ID / obligation ID / contract clause / N/A]
+- Applicability Rationale:    [Why included or why genuinely excluded]
+- Risk Treatment Option:      [Mitigate | Accept | Avoid | Transfer | N/A if excluded]
+- Treatment Plan Link:        [Plan/ticket/GRC record or N/A]
+- Control Owner:              [Name/team]
+- Evidence Location:          [Evidence binder/GRC path/repository/config export]
+- Implementation Status:      [Not Implemented | Partial | Implemented | Measured]
+- Residual Risk:              [Description or N/A]
+- Residual Risk Acceptance:   [Risk owner/date or N/A]
+- Last Reviewed:              [YYYY-MM-DD]
+```
+
+#### 5.3 SoA Traceability Findings
+
+- Classify as a **major nonconformity** when SoA decisions are not traceable to the risk treatment process across many controls or entire Annex A themes.
+- Classify as a **major nonconformity** when Annex A controls are blanket-included or blanket-excluded without risk, scope, or requirement rationale.
+- Classify as a **minor nonconformity** when isolated controls have weak owner, evidence, or residual risk acceptance fields but the overall SoA process is traceable.
+- Treat "not applicable", "not relevant", or "too difficult" as insufficient exclusion justification unless supported by scope and risk rationale.
 
 ---
 
@@ -409,6 +450,11 @@ Classify each finding using the following severity levels:
 - Controls applicable: [count] / 93
 - Controls excluded: [count] — [list with justification]
 - Average maturity of applicable controls: [score] / 5.0
+
+### SoA Traceability Summary
+| Control | Driver | Linked Risk/Requirement | Treatment Option | Owner | Evidence | Residual Risk Acceptance | Traceability Status |
+|---------|--------|-------------------------|------------------|-------|----------|--------------------------|---------------------|
+| A.5.1 | [Risk/Legal/Contractual/etc.] | [ID] | [Mitigate/Accept/Avoid/Transfer] | [Owner] | [Location] | [Owner/date/N/A] | [Complete/Partial/Missing] |
 
 ## Risk Assessment Findings
 [Summary of risk methodology review, gaps in risk register, treatment plan status]

--- a/skills/compliance/iso27001-gap/tests/soa-risk-traceability-edge-cases.md
+++ b/skills/compliance/iso27001-gap/tests/soa-risk-traceability-edge-cases.md
@@ -1,0 +1,98 @@
+# SoA Risk Traceability Edge Cases
+
+Use these cases to validate that `iso27001-gap` treats the Statement of Applicability as a risk-driven artifact, not a checklist of Annex A controls.
+
+## Case 1: Blanket inclusion without risk linkage
+
+**Input**
+
+```yaml
+soa:
+  scope: enterprise
+  controls_applicable: 93
+  controls_excluded: 0
+  rationale: all controls are included for certification
+sample_record:
+  control: A.8.11
+  title: Data masking
+  applicable: true
+  linked_risk: missing
+  legal_or_contractual_driver: missing
+  treatment_option: missing
+  owner: missing
+  evidence_location: missing
+```
+
+**Expected result**
+
+Classify as a major nonconformity if this pattern is systemic. Including all controls does not satisfy Clause 6.1.3 unless control selection traces to risks, obligations, treatment decisions, owners, and evidence.
+
+## Case 2: Generic exclusion for a cloud control
+
+**Input**
+
+```yaml
+soa_record:
+  control: A.5.23
+  title: Information security for use of cloud services
+  applicable: false
+  exclusion_justification: not relevant
+  scope:
+    systems: customer SaaS platform
+    hosting: AWS
+  linked_risk: missing
+  evidence_location: missing
+```
+
+**Expected result**
+
+Reject the exclusion. The organization uses cloud services, so a generic "not relevant" justification is not auditor-defensible and should be classified as at least a minor nonconformity, or major if repeated.
+
+## Case 3: Residual risk accepted by wrong owner
+
+**Input**
+
+```yaml
+soa_record:
+  control: A.8.16
+  title: Monitoring activities
+  applicable: true
+  driver: risk
+  linked_risk: RISK-044
+  treatment_option: accept
+  residual_risk: limited monitoring in legacy environment
+  residual_risk_acceptance:
+    approver: security analyst
+    date: 2026-06-01
+  risk_owner: business system owner
+```
+
+**Expected result**
+
+Mark traceability as partial or failing. Residual risk should be accepted by the accountable risk owner, not only by the control implementer or analyst.
+
+## Case 4: Complete traceable SoA record
+
+**Input**
+
+```yaml
+soa_record:
+  control: A.5.7
+  title: Threat intelligence
+  applicable: true
+  decision_driver: risk
+  linked_risk_requirement_id: RISK-017
+  applicability_rationale: ransomware and supply chain threats affect in-scope SaaS operations
+  risk_treatment_option: mitigate
+  treatment_plan_link: GRC-PLAN-017
+  control_owner: security-operations
+  evidence_location: grc://iso27001/soa/a.5.7
+  implementation_status: measured
+  residual_risk: medium after mitigations
+  residual_risk_acceptance: CISO 2026-06-30
+  last_reviewed: 2026-06-30
+```
+
+**Expected result**
+
+Pass the SoA traceability gate. The record ties applicability to a risk driver, treatment plan, owner, evidence, residual risk, and review date.


### PR DESCRIPTION
Created from review issue: #1412

## Summary

- Add SoA risk traceability gates to `iso27001-gap`
- Require Annex A applicability decisions to link to risk or requirement drivers, treatment options, control owners, evidence locations, and residual risk acceptance
- Add edge-case fixtures for blanket inclusion, generic cloud-control exclusion, wrong residual-risk approver, and complete traceable SoA records

## Validation

- `git diff --check`
- Markdown fence balance and ASCII check for the new test fixture
- Reference URL checks for ISO/IEC 27001, ISO/IEC 27002, and ISO/IEC 27005 overview pages
