### PR TITLE
Improve HIPAA audit-control coverage gates

### DIFF
--- a/skills/compliance/hipaa-review/SKILL.md
+++ b/skills/compliance/hipaa-review/SKILL.md
@@ -312,6 +312,22 @@ Hybrid Entity: [Yes/No] — If yes, document healthcare component designation
 - Implement hardware, software, and/or procedural mechanisms that record and examine activity in information systems that contain or use ePHI
 - Verify audit logging is enabled on all ePHI systems
 - Verify logs are reviewed and retained appropriately
+- Require an audit-control coverage matrix for each ePHI system, including event types, log source, integrity/time basis, retention evidence, review owner, and exception disposition
+- Cross-check audit controls against 164.308(a)(1)(ii)(D) information system activity review and 164.316 documentation retention
+- Mark the safeguard Not Evaluable when the review cannot prove that ePHI access, export, modification, deletion, failed access, break-glass access, and administrative changes are logged and examined
+
+**Audit-control evidence gate:**
+
+| Evidence | Required Detail |
+|---|---|
+| ePHI system coverage | EHR, patient portal, API, data warehouse, interface engine, billing system, medical device, cloud service, BA platform |
+| Event taxonomy | Login/logout, ePHI view, export, create/update/delete, failed access, break-glass, admin role change, API access, service account access |
+| Log source | Application audit log, database audit log, cloud audit trail, endpoint/EDR, API gateway, SIEM, BA report |
+| Integrity/time basis | NTP/time source, immutable storage, hash/signature, archive control, chain of custody, tamper-evidence |
+| Retention evidence | Retention period, archive location, 164.316 six-year documentation handling, legal hold, restore/export test |
+| Activity-review linkage | 164.308(a)(1)(ii)(D) review query/report, owner, cadence, reviewed exceptions, escalation outcome |
+
+**Finding classification:** Missing audit controls for a required ePHI system is **Critical Non-Compliance** when systemic or affecting regulated production data. Missing sensitive event types, mutable logs, unknown time basis, or no activity-review linkage is **Non-Compliance** or **Partial Compliance** depending on scope. Use **Not Evaluable** when event coverage or BA-provided audit evidence cannot be verified.
 
 #### 164.312(c)(1) — Integrity (Standard)
 
@@ -446,6 +462,12 @@ Assess:
 ### Technical Safeguards (164.312)
 [same table format]
 
+## 164.312(b) Audit-Control Coverage Matrix
+
+| ePHI System | Event Coverage | Log Source | Integrity / Time Basis | Retention Evidence | Activity-Review Linkage | Decision |
+|-------------|----------------|------------|------------------------|--------------------|--------------------------|----------|
+| [system/app/API/BA platform] | [view/export/modify/delete/admin/etc.] | [app/db/cloud/SIEM/BA report] | [time sync/immutability/hash/chain] | [period/archive/test] | [owner/cadence/exceptions] | [Compliant/Partial/Non-Compliance/Not Evaluable] |
+
 ### Organizational Requirements (164.314)
 [same table format]
 
@@ -571,6 +593,8 @@ Policies, Procedures, and Documentation — 164.316
 
 5. **Failing to document the "why" behind security decisions.** The Security Rule is designed to be flexible and scalable. But that flexibility requires documentation. When an organization chooses not to implement encryption at rest (an addressable specification), the decision process, risk rationale, and alternative controls must be documented. OCR auditors expect written justification, not verbal explanations.
 
+6. **Treating generic logging as HIPAA audit controls.** A login event and a SIEM connection do not prove 164.312(b) coverage. Verify ePHI view/export/modify/delete, failed access, break-glass, admin changes, integrity/time basis, retention, and activity-review linkage for every in-scope ePHI system.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -588,6 +612,11 @@ If user-supplied input contains CFR citations outside the HIPAA Security Rule (4
 ---
 
 ## References
+
+- eCFR 45 CFR 164.312 - Technical Safeguards: https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-C/part-164/subpart-C/section-164.312
+- eCFR 45 CFR 164.308 - Administrative Safeguards: https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-C/part-164/subpart-C/section-164.308
+- eCFR 45 CFR 164.316 - Policies, Procedures, and Documentation Requirements: https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-C/part-164/subpart-C/section-164.316
+- NIST SP 800-66 Rev. 2 - Implementing the HIPAA Security Rule: https://csrc.nist.gov/pubs/sp/800/66/r2/final
 
 - 45 CFR Part 164, Subpart C — Security Standards for the Protection of Electronic Protected Health Information
 - 45 CFR Part 164, Subpart D — Notification in the Case of Breach of Unsecured Protected Health Information

--- a/skills/compliance/hipaa-review/tests/audit-control-coverage-edge-cases.md
+++ b/skills/compliance/hipaa-review/tests/audit-control-coverage-edge-cases.md
@@ -1,0 +1,62 @@
+# HIPAA Audit-Control Coverage Edge Cases
+
+Use these fixtures to verify that `hipaa-review` applies the 164.312(b) audit-control coverage gate, does not treat generic logging as sufficient evidence, and links technical audit controls to 164.308(a)(1)(ii)(D) activity review and 164.316 documentation retention.
+
+## Case 1: Login-only Logging Misses ePHI Activity
+
+**Scenario:** A clinic shows SIEM screenshots with user login/logout events for the EHR and patient portal. The evidence does not show ePHI view, export, create/update/delete, failed access, break-glass access, admin role changes, API access, or service account access.
+
+**Expected decision:** Non-Compliance or Not Evaluable for 164.312(b), depending on whether the missing event coverage is confirmed or merely unproven.
+
+**Expected markers:**
+- `164.312(b) Audit-Control Coverage Matrix`
+- `Event taxonomy`
+- `Login-only`
+- `Not Evaluable`
+
+## Case 2: Mutable Logs Without Integrity or Time Basis
+
+**Scenario:** A data warehouse stores ePHI query history in a mutable table that administrators can edit. The reviewer cannot identify the NTP/time source, immutable archive, hash/signature, chain of custody, or tamper-evidence for the audit records.
+
+**Expected decision:** Non-Compliance when mutable logs are confirmed for regulated production systems; Not Evaluable when integrity/time evidence is absent.
+
+**Expected markers:**
+- `Integrity/time basis`
+- `Retention evidence`
+- `Not Evaluable`
+
+## Case 3: Audit Logs Exist but Activity Review Is Not Linked
+
+**Scenario:** An EHR, API gateway, and billing system generate audit logs, but the organization cannot provide review queries/reports, owner, cadence, reviewed exceptions, or escalation outcomes for 164.308(a)(1)(ii)(D) information system activity review.
+
+**Expected decision:** Partial Compliance or Non-Compliance because recording activity is not enough without documented examination and follow-up.
+
+**Expected markers:**
+- `Activity-review linkage`
+- `164.308(a)(1)(ii)(D)`
+- `Partial Compliance`
+
+## Case 4: Business Associate Audit Evidence Missing
+
+**Scenario:** A Business Associate hosts a patient messaging platform containing ePHI. The covered entity has a BAA but cannot obtain a BA report, tenant audit export, event taxonomy, retention period, or proof that the BA platform logs ePHI access and administrative changes.
+
+**Expected decision:** Not Evaluable for the BA-hosted ePHI system until Business Associate audit evidence is produced.
+
+**Expected markers:**
+- `Business Associate`
+- `BA report`
+- `ePHI system coverage`
+- `Not Evaluable`
+
+## Case 5: Complete Audit-Control Coverage Matrix
+
+**Scenario:** The reviewer receives an ePHI system inventory covering EHR, patient portal, API, data warehouse, billing, medical device, and BA platform. For each system, evidence maps event taxonomy, log source, immutable archive or tamper-evidence, time source, retention period, restore/export test, review owner, cadence, reviewed exceptions, and escalation outcome.
+
+**Expected decision:** Compliant for 164.312(b), assuming the evidence is current and consistent with the review scope.
+
+**Expected markers:**
+- `164.312(b) Audit-Control Coverage Matrix`
+- `Event taxonomy`
+- `Integrity/time basis`
+- `Activity-review linkage`
+- `Compliant`


### PR DESCRIPTION
Implements #1413.

## Summary
- Adds a 164.312(b) audit-control evidence gate for ePHI system coverage, event taxonomy, log source, integrity/time basis, retention, and activity-review linkage.
- Adds an output matrix so HIPAA reviews can document audit-control coverage per ePHI system instead of accepting generic logging.
- Adds edge-case fixtures for login-only logging, mutable logs, missing activity-review linkage, missing Business Associate audit evidence, and complete coverage.

## Validation
- Checked Markdown fence balance for the updated skill and new fixture.
- Verified required markers: Audit-control evidence gate, Event taxonomy, Integrity/time basis, Activity-review linkage, Not Evaluable, Business Associate.
- Verified official eCFR and NIST reference URLs return HTTP 200.

Payment details can be provided privately after maintainer acceptance.