### PR TITLE
Improve pipeline OIDC trust policy gates

### DIFF
--- a/skills/devsecops/pipeline-security/SKILL.md
+++ b/skills/devsecops/pipeline-security/SKILL.md
@@ -209,6 +209,30 @@ permissions:
 
 **Finding format:** Report the effective permission model, whether least-privilege is enforced, and whether identity controls (CODEOWNERS, required reviewers) are in place.
 
+**OIDC Federation Trust Policy Evidence Gate:**
+
+When a pipeline uses OIDC or workload identity federation, do not treat "no long-lived secret" as a pass by itself. Validate the cloud-side trust policy or federated credential configuration that decides which workflow tokens can assume the role, identity, or service account.
+
+| Evidence Item | What to Verify | Risk if Missing |
+|---------------|----------------|-----------------|
+| Token issuer | The trusted issuer is the expected CI provider (for example, `https://token.actions.githubusercontent.com`) | Tokens from an unintended issuer may be trusted |
+| Workflow token permission | The workflow requests `id-token: write` only in jobs that need federation | Broad token minting increases blast radius |
+| Audience (`aud`) | The expected audience is enforced by the cloud provider or login action | Tokens meant for another relying party may be accepted |
+| Subject (`sub`) | The subject is restricted to the intended org, repository, branch/tag/ref, environment, or reusable workflow | Wildcards such as `repo:org/repo:*` can expose production credentials to unintended workflows |
+| Repository/ref/environment claims | Provider-specific conditions restrict repository, immutable repository ID where available, ref, environment, and workflow identity | Renames, forks, broad refs, or missing environment claims can bypass intended pipeline boundaries |
+| Reusable workflow claim | `job_workflow_ref` or equivalent claim is restricted when privileged deployments are delegated to reusable workflows | Any caller may reach a privileged reusable workflow path |
+| Provider configuration evidence | AWS trust policy, Azure federated identity credential, GCP Workload Identity Federation attribute condition, or equivalent config is available | The reviewer cannot prove that federation is scoped to the intended workload |
+| Decision | Pass, Fail, Partial, or Not Evaluable from Config | Keeps OIDC findings from passing on workflow YAML alone |
+
+**Provider-specific checks:**
+
+- **AWS:** Require `token.actions.githubusercontent.com:aud` and `token.actions.githubusercontent.com:sub` or stronger claim conditions in the role trust policy. Treat `repo:ORG/REPO:*` as high risk for production roles unless additional `ref`, `environment`, `repository_id`, or `job_workflow_ref` conditions narrow access.
+- **Azure / Microsoft Entra:** Verify the federated identity credential `issuer`, `subject`, and `audience` exactly match the expected GitHub token values. A workflow using `azure/login` does not prove the Entra trust object is scoped correctly.
+- **Google Cloud:** Require Workload Identity Federation attribute conditions that restrict GitHub tokens to the trusted organization, and preferably the repository, ref, environment, or workflow. A shared GitHub issuer without attribute conditions is not sufficient.
+- **Reusable workflows:** If deployment credentials are minted inside a reusable workflow, require evidence that the calling workflow identity is constrained with `job_workflow_ref` or equivalent provider-supported claims.
+
+If the cloud-side trust policy is not available, mark the relevant CICD-SEC-2 or CICD-SEC-6 finding as `Not Evaluable from Config` and list the missing provider evidence.
+
 ---
 
 #### CICD-SEC-3: Dependency Chain Abuse
@@ -328,6 +352,8 @@ runs-on: self-hosted  # Shared runners are a risk
 ```
 
 **Finding format:** Report credential types in use (long-lived vs. short-lived), whether OIDC/workload identity is used where available, and any secrets exposed in logs or command arguments.
+
+For OIDC/workload identity findings, include the OIDC Federation Trust Policy Evidence Gate result. Short-lived tokens reduce credential hygiene risk only when the trust policy also scopes which workflow identities can mint credentials.
 
 ---
 
@@ -480,6 +506,12 @@ Produce the final report using the following structure:
 | CICD-SEC-2 | Inadequate IAM | ... | ... | ... |
 | ... | ... | ... | ... | ... |
 
+### OIDC Federation Trust Matrix
+
+| Provider / Role | Workflow / Job | Issuer | Audience | Subject / Claim Restrictions | Provider Trust Evidence | Decision |
+|-----------------|----------------|--------|----------|------------------------------|-------------------------|----------|
+| <AWS/Azure/GCP/etc.> | <workflow/job> | <issuer> | <audience> | <repo/ref/environment/job_workflow_ref/etc.> | <trust policy / federated credential / attribute condition> | <Pass/Fail/Partial/Not Evaluable from Config> |
+
 ### Detailed Findings
 
 #### [CICD-SEC-X] <Risk Name>
@@ -550,6 +582,11 @@ This skill processes user-supplied content including CI/CD configuration files, 
 - SLSA Build Track: https://slsa.dev/spec/v1.0/levels#build-track
 - OWASP Top 10 CI/CD Security Risks: https://owasp.org/www-project-top-10-ci-cd-security-risks/
 - GitHub Actions Security Hardening: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
+- GitHub Actions OpenID Connect Reference: https://docs.github.com/en/actions/reference/security/oidc
+- GitHub Actions OIDC in AWS: https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws
+- AWS IAM OIDC Condition Keys: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_iam-condition-keys.html
+- Google Cloud Workload Identity Federation for Deployment Pipelines: https://docs.cloud.google.com/iam/docs/workload-identity-federation-with-deployment-pipelines
+- Microsoft Entra Workload Identity Federation: https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation
 - Sigstore / Cosign: https://docs.sigstore.dev/
 - SLSA GitHub Generator: https://github.com/slsa-framework/slsa-github-generator
 

--- a/skills/devsecops/pipeline-security/tests/oidc-trust-policy-edge-cases.md
+++ b/skills/devsecops/pipeline-security/tests/oidc-trust-policy-edge-cases.md
@@ -1,0 +1,92 @@
+# OIDC Trust Policy Edge Cases
+
+Use these fixtures to verify that `pipeline-security` evaluates workload identity federation by checking both workflow YAML and cloud-side trust policy evidence.
+
+## Case 1: AWS role trusts every ref in the repository
+
+**Input evidence:**
+
+- Workflow uses `permissions: id-token: write` and `aws-actions/configure-aws-credentials`.
+- AWS role trust policy includes:
+  - `token.actions.githubusercontent.com:aud = sts.amazonaws.com`
+  - `token.actions.githubusercontent.com:sub = repo:acme/payments-api:*`
+- The role can deploy production infrastructure.
+
+**Expected behavior:**
+
+- Do not pass the finding because OIDC is present.
+- Flag the wildcard subject as broad access for a production role.
+- Recommend narrowing to the intended branch, environment, immutable repository identity where supported, or reusable workflow claim.
+
+## Case 2: AWS trust policy omits audience
+
+**Input evidence:**
+
+- Workflow requests an OIDC token with `id-token: write`.
+- AWS role trust policy restricts `token.actions.githubusercontent.com:sub` to `repo:acme/payments-api:ref:refs/heads/main`.
+- No `token.actions.githubusercontent.com:aud` condition is present.
+
+**Expected behavior:**
+
+- Mark OIDC trust policy evidence as `Partial` or `Fail`.
+- Require an audience condition such as `sts.amazonaws.com`.
+- Report the gap under CICD-SEC-2 and CICD-SEC-6 if the role is used for deployment credentials.
+
+## Case 3: Azure federated credential subject mismatch
+
+**Input evidence:**
+
+- Workflow uses `azure/login` with OIDC.
+- Microsoft Entra federated identity credential has:
+  - issuer `https://token.actions.githubusercontent.com`
+  - audience `api://AzureADTokenExchange`
+  - subject `repo:acme/payments-api:environment:prod`
+- The GitHub job does not set `environment: prod`; it only runs on `refs/heads/main`.
+
+**Expected behavior:**
+
+- Mark the configuration as failing or not currently functional because issuer, subject, and audience must match the external token.
+- Do not claim production federation is protected by the environment condition unless the workflow actually emits that environment claim.
+
+## Case 4: GCP Workload Identity Federation lacks organization condition
+
+**Input evidence:**
+
+- Workflow uses `google-github-actions/auth`.
+- Workload Identity Pool provider trusts issuer `https://token.actions.githubusercontent.com`.
+- Attribute mapping includes repository and ref claims.
+- Attribute condition is empty or only checks `assertion.repository == 'payments-api'`.
+
+**Expected behavior:**
+
+- Flag the provider as insufficiently constrained because GitHub uses a shared issuer.
+- Require an attribute condition that restricts `assertion.repository_owner` to the trusted organization, and preferably repository/ref/environment/workflow as needed.
+
+## Case 5: Reusable workflow mints production credentials for any caller
+
+**Input evidence:**
+
+- `deploy.yml` is a reusable workflow that assumes a production role.
+- Caller workflows from multiple repos can invoke it.
+- The cloud trust policy only checks `repo:acme/deploy-workflows:*` and does not restrict `job_workflow_ref`, caller repository, or environment.
+
+**Expected behavior:**
+
+- Flag missing reusable workflow claim restrictions.
+- Require evidence that only approved caller workflows and refs can mint production credentials.
+- Mark as high severity if production deployment credentials are reachable.
+
+## Case 6: Complete least-privilege OIDC configuration
+
+**Input evidence:**
+
+- Workflow grants `id-token: write` only to the deployment job.
+- Job uses a protected `production` environment.
+- Cloud trust policy enforces issuer, audience, repository or immutable repository ID, `ref=refs/heads/main`, environment `production`, and `job_workflow_ref` for the approved reusable workflow.
+- Provider trust policy is available in code or exported configuration.
+
+**Expected behavior:**
+
+- Mark OIDC trust policy evidence as `Pass`.
+- Report that short-lived credentials are used and scoped to the intended workflow identity.
+- Still evaluate downstream role permissions separately for least privilege.


### PR DESCRIPTION
Implements #1424.

## Summary
- Adds an OIDC federation trust-policy evidence gate to `pipeline-security` so reviewers validate issuer, `id-token: write`, audience, subject, repository/ref/environment claims, reusable workflow claims, and provider trust evidence.
- Adds an OIDC Federation Trust Matrix to the assessment output.
- Adds edge-case fixtures for broad AWS subjects, missing AWS audience checks, Azure subject/audience mismatch, GCP Workload Identity Federation without organization attribute conditions, unrestricted reusable workflows, and a complete least-privilege OIDC setup.

## Validation
- Verified Markdown fence balance for the updated skill and new fixture.
- Verified required markers for issuer, workflow token permission, audience, subject, reusable workflow claims, provider trust evidence, Not Evaluable from Config, and Workload Identity Federation.
- Verified new reference URLs with live HTTP 200 checks.
- Verified no private payment details are present in the workspace.

Payment details can be provided privately after maintainer acceptance.