### PR TITLE
Improve IAM external trust session gates

### DIFF
--- a/skills/identity/iam-review/SKILL.md
+++ b/skills/identity/iam-review/SKILL.md
@@ -199,6 +199,59 @@ IAM-PRIV-08: Resource-based policies granting public or overly broad access
 
 ---
 
+### Step 3.5: External Trust and Session Constraint Evidence
+
+**Objective:** Verify the trust boundary and session attributes before passing external, cross-account, service-principal, or federated access as least privilege.
+
+Do not mark external or federated access as **Pass** based only on identity-based permissions. Review the trust policy, resource policy, federation provider configuration, and session controls that decide who can obtain the permission-bearing session. If that evidence is unavailable, mark the trust boundary **Not Evaluable** and explain which artifact is missing.
+
+#### Review Checklist
+
+```
+IAM-TRUST-01: External AWS principal without sts:ExternalId or equivalent confused-deputy control
+IAM-TRUST-02: Broad trusted principal without aws:PrincipalOrgID, aws:SourceAccount, aws:SourceArn, or scoped provider constraint
+IAM-TRUST-03: Federated trust missing issuer, audience, subject, or claim-mapping restrictions
+IAM-TRUST-04: Role permits sts:TagSession without aws:RequestTag, aws:TagKeys, or sts:TransitiveTagKeys limits
+IAM-TRUST-05: Tag-based authorization accepts caller-supplied session tags as privileged attributes
+IAM-TRUST-06: sts:SourceIdentity or role session name not required for shared/admin roles
+IAM-TRUST-07: MFA, session duration, or session age controls absent for privileged assume-role paths
+IAM-TRUST-08: Review passes without Access Analyzer/provider finding evidence for external access
+IAM-TRUST-09: Only identity policy was reviewed; trust boundary marked Pass instead of Not Evaluable
+```
+
+**Evidence Matrix:**
+
+| Evidence Item | What to Verify | Risk if Missing |
+|---|---|---|
+| Trusted principal inventory | Principal type, account/org boundary, service principal, SAML/OIDC provider, delegated admin, and service-linked role exclusions | Review may treat a broad or unintended principal as a bounded identity |
+| Trust policy / resource policy | `Principal`, `Action`, and `Condition` statements for every external or federated assume path | Permission policy can look narrow while the role remains assumable by the wrong actor |
+| Confused-deputy controls | `sts:ExternalId`, `aws:SourceArn`, `aws:SourceAccount`, `aws:SourceOrgID`, or provider-specific equivalent | A third party or service principal can be tricked into using the role for another tenant/account |
+| Principal scope | `aws:PrincipalOrgID`, account allowlists, provider tenant/client IDs, or explicit subject constraints | Broad account/org/provider trust may outgrow the intended integration |
+| Federation claims | Issuer, audience, subject, group/role claim mapping, and provider thumbprint/certificate lifecycle | Token from the wrong workflow, tenant, branch, or application can assume the role |
+| Session identity | `sts:SourceIdentity`, `sts:RoleSessionName`, identity-provider attribute mapping, and CloudTrail visibility | Incident response cannot determine who or what used the assumed role |
+| Session tags | `sts:TagSession`, `aws:RequestTag`, `aws:TagKeys`, `aws:PrincipalTag`, and `sts:TransitiveTagKeys` constraints | Callers can self-assert tags that drive ABAC or persist privileged attributes through role chaining |
+| Session context | MFA requirement, session duration, session age, source network/device context, and JIT activation evidence | Privileged sessions can be long-lived, unverified, or detached from the approved access event |
+| Analyzer evidence | IAM Access Analyzer external/internal findings, cloud-provider policy analyzer output, or documented compensating review | Hidden external access paths may remain outside the assessment scope |
+
+**Platform-specific checks:**
+
+| Platform | Check | What to look for |
+|---|---|---|
+| **AWS** | Role trust policies, resource policies, IAM Access Analyzer findings | Missing `sts:ExternalId`, broad `Principal`, absent `aws:SourceAccount` / `aws:SourceArn` / `aws:PrincipalOrgID`, unconstrained session tags |
+| **AWS** | CloudTrail `AssumeRole*` events | `sourceIdentity`, session tags, role session name, MFA context, unexpected caller account, excessive session duration |
+| **Azure / Entra ID** | App registrations, federated identity credentials, workload identity federation | Issuer/audience/subject drift, broad repo/branch/environment claims, long-lived client secrets used as fallback |
+| **GCP** | Workload Identity Federation pools/providers, IAM Conditions, Policy Analyzer | Provider attribute mapping, audience/subject restrictions, principalSet breadth, missing time or resource conditions |
+
+**Decision Rules:**
+
+- Treat external principals without a unique external ID or equivalent confused-deputy protection as **High** or **Critical**, depending on reachable privileges.
+- Treat `sts:TagSession` as **High** when tag-based authorization uses caller-controlled tags without `aws:RequestTag`, `aws:TagKeys`, or transitive-tag limits.
+- Treat missing `sts:SourceIdentity`, role session name, or equivalent audit identity as at least **Medium** for shared roles and **High** for administrative roles.
+- Mark the trust boundary **Not Evaluable** when the role trust policy, provider trust config, resource policy, or analyzer evidence is absent from the review package.
+- Separate service-linked roles and managed service principals from customer-managed trust relationships; document the service-specific condition keys that are supported.
+
+---
+
 ### Step 4: Service Account Hygiene
 
 **Objective:** Assess service account security posture and credential management.
@@ -414,6 +467,12 @@ For each finding, produce a row with:
 ### Detailed Findings
 [Findings table — see above]
 
+### External Trust and Session Constraint Matrix
+
+| Role / Trust | Principal | Conditions Reviewed | Session Controls | Analyzer Evidence | Decision |
+|---|---|---|---|---|---|
+| [role/resource] | [account/service/federated provider] | [ExternalId, SourceArn, SourceAccount, PrincipalOrgID, issuer/aud/sub, etc.] | [SourceIdentity, session tags, MFA, duration, JIT] | [finding ID or Not Provided] | Pass / Fail / Partial / Not Evaluable |
+
 ### Remediation Roadmap
 [Prioritized actions: immediate (0-7 days), short-term (30 days), medium-term (90 days)]
 
@@ -431,6 +490,15 @@ For each finding, produce a row with:
 | **P1 — Urgent** | 8-30 days | No JIT for admin access, service account keys > 1 year old, no stale account process |
 | **P2 — Important** | 31-90 days | No phishing-resistant MFA, incomplete identity inventory, no access review cadence |
 | **P3 — Planned** | 91-180 days | Zero trust maturity gaps, device trust integration, continuous access evaluation |
+
+---
+
+## References
+
+- AWS IAM: The confused deputy problem - `sts:ExternalId`, `aws:SourceArn`, `aws:SourceAccount`, and `aws:SourceOrgID` - https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html
+- AWS IAM: Monitor and control actions taken with assumed roles - `sts:SourceIdentity` and CloudTrail visibility - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_control-access_monitor.html
+- AWS IAM: Pass session tags in AWS STS - `sts:TagSession`, `aws:RequestTag`, `aws:TagKeys`, and transitive tags - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html
+- AWS IAM: IAM Access Analyzer findings - external, internal, and unused access findings - https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-findings.html
 
 ---
 

--- a/skills/identity/iam-review/tests/external-trust-session-edge-cases.md
+++ b/skills/identity/iam-review/tests/external-trust-session-edge-cases.md
@@ -1,0 +1,118 @@
+# IAM Review External Trust and Session Edge Cases
+
+These fixtures validate that the IAM review skill evaluates trust boundaries and session attributes before passing external, cross-account, service-principal, or federated access as least privilege.
+
+## Expected Review Behavior
+
+- Do not pass a role based on identity-based permissions alone when the trust policy, resource policy, provider trust configuration, or analyzer evidence is missing.
+- Mark the trust boundary `Not Evaluable` when required trust/session evidence is not available.
+- Record trust/session outcomes in the External Trust and Session Constraint Matrix.
+- Escalate caller-controlled session tags when ABAC or privilege decisions depend on those tags.
+
+## Case 1: External Principal Without Confused-Deputy Control
+
+**Input evidence:**
+
+- AWS role trust policy allows `sts:AssumeRole` from `arn:aws:iam::222222222222:root`.
+- Permission policy is limited to `s3:GetObject` on one bucket prefix.
+- No `sts:ExternalId`, `aws:PrincipalOrgID`, `aws:SourceAccount`, `aws:SourceArn`, or equivalent provider constraint is present.
+- IAM Access Analyzer shows the role is externally accessible.
+
+**Expected result:**
+
+- Finding: `IAM-TRUST-01`.
+- Severity: High, or Critical if the target data is regulated or privileged.
+- Decision: Fail.
+- Rationale: Least-privilege permissions do not compensate for a broad external assume-role path.
+
+## Case 2: Self-Asserted Session Tags Drive Authorization
+
+**Input evidence:**
+
+- Trust policy permits both `sts:AssumeRole` and `sts:TagSession`.
+- Downstream policy allows elevated actions when `aws:PrincipalTag/Admin = true`.
+- The trust policy does not restrict `aws:RequestTag/Admin`, `aws:TagKeys`, or `sts:TransitiveTagKeys`.
+
+**Expected result:**
+
+- Finding: `IAM-TRUST-04` and `IAM-TRUST-05`.
+- Severity: High.
+- Decision: Fail.
+- Rationale: A caller can self-assert tags that the authorization policy treats as privileged attributes.
+
+## Case 3: Shared Admin Role Missing Source Identity
+
+**Input evidence:**
+
+- Multiple administrators and automation identities can assume the same administrative role.
+- CloudTrail contains `AssumeRole` events with inconsistent role session names.
+- Trust policy does not require `sts:SourceIdentity` or a constrained `sts:RoleSessionName`.
+- Session duration is set to 12 hours.
+
+**Expected result:**
+
+- Finding: `IAM-TRUST-06` and `IAM-TRUST-07`.
+- Severity: High.
+- Decision: Partial or Fail depending on compensating JIT/MFA evidence.
+- Rationale: Reviewers cannot reliably attribute privileged actions to an initiating human or workload.
+
+## Case 4: Federated Role Missing Issuer, Audience, or Subject Constraints
+
+**Input evidence:**
+
+- OIDC/SAML federation is used for deployment access.
+- Permission policy is narrowly scoped to deployment resources.
+- Provider trust allows broad issuer or tenant-level access without precise audience, subject, group, branch, environment, or application constraints.
+- No provider-side evidence is supplied showing the intended claim mapping.
+
+**Expected result:**
+
+- Finding: `IAM-TRUST-03`.
+- Severity: High for deployment or production roles.
+- Decision: Fail, or Not Evaluable if provider evidence is absent.
+- Rationale: A narrow permission policy is insufficient when an unintended federated principal can obtain the session.
+
+## Case 5: Service Principal Without Source Conditions
+
+**Input evidence:**
+
+- Resource policy trusts an AWS service principal.
+- Policy does not constrain requests with supported `aws:SourceArn`, `aws:SourceAccount`, `aws:SourceOrgID`, or `aws:SourceOrgPaths` keys.
+- Review package does not identify whether the integration supports service-specific confused-deputy controls.
+
+**Expected result:**
+
+- Finding: `IAM-TRUST-02`.
+- Severity: Medium to High depending on resource sensitivity.
+- Decision: Partial or Fail.
+- Rationale: The service principal may be usable outside the intended account, resource, or organization path.
+
+## Case 6: Permission Policy Only
+
+**Input evidence:**
+
+- Reviewer receives only an identity-based permission policy for a cross-account role.
+- The trust policy, provider configuration, resource policies, and analyzer findings are unavailable.
+
+**Expected result:**
+
+- Finding: `IAM-TRUST-09`.
+- Severity: Medium.
+- Decision: Not Evaluable.
+- Rationale: The review cannot determine who can obtain the role session.
+
+## Case 7: Complete Bounded Trust and Session Evidence
+
+**Input evidence:**
+
+- External account trust is scoped to a specific principal.
+- Trust policy requires a unique `sts:ExternalId` supplied by the third party.
+- Session tagging is either disabled or constrained with `aws:RequestTag`, `aws:TagKeys`, and `sts:TransitiveTagKeys`.
+- `sts:SourceIdentity` or equivalent provider identity is required and visible in logs.
+- Privileged paths require MFA/JIT, bounded session duration, and current Access Analyzer evidence.
+
+**Expected result:**
+
+- No `IAM-TRUST-*` finding for the trust path.
+- Decision: Pass.
+- Rationale: Trust, session, and analyzer evidence support the least-privilege decision.


### PR DESCRIPTION
Implements #1426.

## Summary

- Adds an external trust and session-constraint evidence gate to `identity/iam-review`.
- Requires reviewers to evaluate trust policies, resource policies, federation claims, session identity, session tags, MFA/session duration, and analyzer evidence before passing external or federated access as least privilege.
- Adds a dedicated External Trust and Session Constraint Matrix plus edge-case fixtures for confused-deputy controls, self-asserted session tags, source identity, federation claim drift, service principals, permission-policy-only reviews, and a complete passing case.

## Validation

- Verified no open duplicate PRs/issues for the same iam-review external trust/session evidence gap.
- Confirmed markdown fence balance for the updated skill and fixture.
- Confirmed all AWS IAM reference URLs return HTTP 200.
- Confirmed private payment details are not present in the repository content.

## References

- https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html
- https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_control-access_monitor.html
- https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html
- https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-findings.html

Payment details can be provided privately after maintainer acceptance.