### PR TITLE
Improve prompt injection hidden content gates

### DIFF
--- a/skills/ai-security/prompt-injection/SKILL.md
+++ b/skills/ai-security/prompt-injection/SKILL.md
@@ -100,6 +100,44 @@ For each external content source identified in Step 1, determine whether an adve
 
 ---
 
+## Step 3.5: Verify Hidden Content Extraction and Sanitization
+
+For each external-content pipeline from Step 3, prove which fields are extracted, how they are labeled, and which hidden or non-visible fields are removed, retained, or downgraded before they reach the LLM context. A delimiter such as `<retrieved_content>` is not sufficient evidence if the loader still imports hidden instructions as ordinary body text.
+
+**Review checklist:**
+
+```
+PI-HIDDEN-01: HTML comments, CSS-hidden text, zero-size text, or offscreen text are extracted without provenance
+PI-HIDDEN-02: Image alt text, ARIA labels, captions, or title attributes are treated as instruction-equivalent content
+PI-HIDDEN-03: Markdown image URLs, link targets, reference definitions, or frontmatter carry hidden instructions or exfiltration endpoints
+PI-HIDDEN-04: PDF annotations, embedded files, OCR layers, form fields, or document metadata are inserted as visible body text
+PI-HIDDEN-05: Email headers, quoted replies, signatures, attachment metadata, or forwarded content are not separated from the active message
+PI-HIDDEN-06: Tool/API response fields such as debug messages, descriptions, labels, or error strings are passed through as trusted instructions
+PI-HIDDEN-07: Sanitization relies only on a prompt instruction telling the model to ignore hidden text
+PI-HIDDEN-08: Loader output has no field-level provenance, visibility class, source URL/file, extraction method, or sanitization decision
+PI-HIDDEN-09: Review marks hidden-content handling as safe without deterministic extraction tests or representative fixtures
+```
+
+**Evidence matrix:**
+
+| Source Type | Hidden / Metadata Fields to Verify | Required Evidence |
+|---|---|---|
+| HTML / web pages | Comments, hidden CSS, offscreen text, script/template content, alt/title/ARIA attributes, metadata | Sanitizer configuration, parser output sample, field labels, removed/retained field list |
+| Markdown | Image/link targets, reference definitions, frontmatter, fenced code examples, embedded HTML | Rendered-vs-raw comparison, URL handling policy, code-block preservation as quoted data |
+| PDF / office documents | Annotations, OCR text, form fields, hidden layers, embedded files, document properties | Loader extraction trace, metadata policy, annotation handling, visible-text baseline |
+| Email / messaging | Headers, quoted replies, signatures, forwarded messages, attachments, display names | Parsed message tree, active-message boundary, attachment metadata handling |
+| Tool / API responses | Error messages, descriptions, labels, comments, debug fields, nested metadata | Response schema allowlist, untrusted-field labeling, dropped-field evidence |
+
+**Decision rules:**
+
+- Mark hidden-content handling **Not Evaluable** when the review cannot inspect loader output, parser configuration, or representative extraction fixtures.
+- Treat hidden instructions that reach the LLM as visible body text as **High** when the application has tool access, sensitive data access, or autonomous actions.
+- Treat markdown image/link target passthrough as **High** when rendered output can create external requests or user-click exfiltration paths.
+- Treat preserved accessibility content such as alt text as acceptable only when it is labeled as metadata, bounded in length, and never promoted above the user's or system's instruction hierarchy.
+- Treat prompt-only mitigations as insufficient. The evidence must come from deterministic parsing, sanitization, labeling, or downstream policy enforcement.
+
+---
+
 ## Step 4: Test Categories
 
 Assess the application against the following documented vulnerability categories. For each category, determine whether the application's architecture makes it susceptible and whether existing defenses mitigate the risk.
@@ -234,6 +272,11 @@ Each finding should be assigned a severity based on potential impact:
 ### Interaction Surface Map
 [Table from Step 1]
 
+### Hidden Content Extraction Matrix
+| Source | Loader / Parser | Extracted Fields | Hidden / Metadata Handling | Sanitization Evidence | Residual Risk |
+|--------|-----------------|------------------|----------------------------|-----------------------|---------------|
+| [URL/file/API/email] | [component] | [visible body, links, alt text, comments, metadata, OCR, etc.] | [removed / retained as metadata / quoted data / Not Evaluable] | [fixture, parser trace, config, test output] | [Critical / High / Medium / Low] |
+
 ### Findings
 
 #### Finding [N]: [Title]
@@ -275,7 +318,14 @@ Each finding should be assigned a severity based on potential impact:
 
 5. **Failing to treat retrieved content as untrusted.** RAG pipelines often insert retrieved document chunks directly into the prompt with no distinction from system instructions. The LLM cannot inherently distinguish "this is data to reason about" from "this is an instruction to follow." Retrieved content should be explicitly demarcated and, where possible, processed through a model or layer that enforces instruction hierarchy.
 
+6. **Assuming visible-page review equals loader review.** Web pages, documents, emails, markdown, and tool responses often contain hidden or metadata fields that a human reviewer will not see but a loader may still extract. Review the actual parser output, not only the rendered page or document.
+
 ---
+
+## Hidden Content Reference URLs
+
+- OWASP LLM01:2025 Prompt Injection - https://genai.owasp.org/llmrisk/llm01-prompt-injection/
+- Indirect prompt injection paper - https://arxiv.org/abs/2302.12173
 
 ## References
 

--- a/skills/ai-security/prompt-injection/tests/hidden-content-sanitization-edge-cases.md
+++ b/skills/ai-security/prompt-injection/tests/hidden-content-sanitization-edge-cases.md
@@ -1,0 +1,116 @@
+# Prompt Injection Hidden Content Sanitization Edge Cases
+
+These fixtures validate that the prompt-injection skill reviews actual loader output, field provenance, and sanitization evidence before treating external content as safe context.
+
+## Expected Review Behavior
+
+- Do not pass a RAG, browsing, document, email, or API-response pipeline based only on delimiters or prompt instructions.
+- Require field-level provenance for visible body text, hidden text, metadata, links, annotations, OCR layers, quoted replies, and tool/API response fields.
+- Mark hidden-content handling `Not Evaluable` when parser output, sanitizer configuration, or representative extraction fixtures are unavailable.
+- Record the result in the Hidden Content Extraction Matrix.
+
+## Case 1: Hidden HTML Text Reaches the Prompt
+
+**Input evidence:**
+
+- A web loader extracts text from rendered HTML and raw DOM nodes.
+- The page contains HTML comments, `display:none` content, zero-size text, offscreen text, and `title` attributes.
+- Loader output merges these fields into one plain `content` string.
+- The prompt wraps the result in `<retrieved_content>` delimiters.
+
+**Expected result:**
+
+- Finding: `PI-HIDDEN-01` and `PI-HIDDEN-08`.
+- Severity: High if the application has tools, sensitive data access, or autonomous actions.
+- Decision: Fail.
+- Rationale: Hidden instructions are promoted into ordinary retrieved content, and delimiters do not remove the injection source.
+
+## Case 2: Markdown Links and Images as Exfiltration Channels
+
+**Input evidence:**
+
+- Retrieved markdown includes image URLs and reference-style link targets with attacker-controlled query strings.
+- The renderer allows markdown images and external links in final model output.
+- The review only inspected rendered link text, not raw targets.
+
+**Expected result:**
+
+- Finding: `PI-HIDDEN-03`.
+- Severity: High when sensitive context can be encoded into URLs or user-click links.
+- Decision: Fail.
+- Rationale: Raw markdown targets are hidden from visible text review and can carry instructions or exfiltration endpoints.
+
+## Case 3: PDF Metadata and OCR Layer Bypass
+
+**Input evidence:**
+
+- A PDF loader extracts visible text, document properties, annotations, form fields, and OCR text.
+- The PDF contains a hidden OCR layer with instructions that do not appear in the visible text baseline.
+- Loader output does not label the source field for each extracted chunk.
+
+**Expected result:**
+
+- Finding: `PI-HIDDEN-04` and `PI-HIDDEN-08`.
+- Severity: High for RAG or summarization flows that can invoke tools or disclose sensitive context.
+- Decision: Fail.
+- Rationale: Non-visible document fields can become model-readable instructions without provenance.
+
+## Case 4: Email Quoted Reply Boundary Missing
+
+**Input evidence:**
+
+- The assistant summarizes support emails and can draft replies.
+- Parser output combines the active message, quoted history, forwarded content, headers, signatures, and attachment metadata.
+- There is no boundary marker or policy that downgrades quoted/forwarded content.
+
+**Expected result:**
+
+- Finding: `PI-HIDDEN-05`.
+- Severity: Medium to High depending on reply-sending authority and data access.
+- Decision: Fail.
+- Rationale: An attacker can hide instructions in quoted or forwarded content that the assistant treats as current instructions.
+
+## Case 5: Tool API Metadata Treated as Trusted Text
+
+**Input evidence:**
+
+- A third-party API response is summarized by the LLM.
+- The response schema includes `description`, `debug_message`, `label`, and `error` fields.
+- The application inserts all fields into context without a response-field allowlist.
+
+**Expected result:**
+
+- Finding: `PI-HIDDEN-06`.
+- Severity: High if API output can influence tool calls or security decisions.
+- Decision: Fail.
+- Rationale: Tool/API metadata can carry untrusted instructions unless the response schema is allowlisted and labeled.
+
+## Case 6: Prompt-Only Sanitization Claim
+
+**Input evidence:**
+
+- Pipeline configuration says `sanitize: true`.
+- The only demonstrated mitigation is a system prompt telling the model to ignore hidden instructions.
+- No parser trace, removed-field list, sanitizer config, or test fixture is available.
+
+**Expected result:**
+
+- Finding: `PI-HIDDEN-07` and `PI-HIDDEN-09`.
+- Severity: Medium, or High when external content reaches tool-enabled agents.
+- Decision: Not Evaluable.
+- Rationale: Prompt instructions are not deterministic sanitization evidence.
+
+## Case 7: Accessibility Metadata Preserved Safely
+
+**Input evidence:**
+
+- Image alt text and ARIA labels are preserved for accessibility summarization.
+- Loader labels them as metadata, enforces length bounds, strips URLs/instructions, and never ranks them above visible body text.
+- Fixtures show visible body, metadata, removed fields, and final prompt assembly separately.
+
+**Expected result:**
+
+- No `PI-HIDDEN-*` finding for the accessibility metadata path.
+- Severity: Informational if residual risk is documented.
+- Decision: Pass.
+- Rationale: Metadata is preserved with provenance and bounded influence rather than promoted to instruction-equivalent content.


### PR DESCRIPTION
Implements #1390.

## Summary

- Adds a hidden-content extraction and sanitization evidence gate to `prompt-injection`.
- Requires loader-level provenance for HTML comments/hidden text, markdown link/image targets, PDF/document metadata, OCR layers, email quoted content, and tool/API response fields before external content is trusted as LLM context.
- Adds a Hidden Content Extraction Matrix and edge-case fixtures covering hidden HTML, markdown exfiltration channels, PDF OCR/metadata, email quoted replies, API metadata, prompt-only sanitization claims, and safe accessibility metadata handling.

## Validation

- Verified no open duplicate PRs for this hidden-content sanitization gap before implementation.
- Confirmed markdown fence balance for the updated skill and fixture.
- Confirmed required content markers for `PI-HIDDEN-*`, Hidden Content Extraction Matrix, `Not Evaluable`, and source-specific hidden fields.
- Confirmed referenced URLs return HTTP 200.
- Confirmed private payment details are not present in repository content.

## References

- https://genai.owasp.org/llmrisk/llm01-prompt-injection/
- https://arxiv.org/abs/2302.12173

Payment details can be provided privately after maintainer acceptance.