### PR TITLE
Improve PCI significant-change scope gates

### DIFF
--- a/skills/compliance/pci-dss-review/SKILL.md
+++ b/skills/compliance/pci-dss-review/SKILL.md
@@ -138,6 +138,42 @@ PCI DSS v4.0 requires scope confirmation at least every 12 months and upon signi
 - All in-scope system components are identified
 - Segmentation controls are validated
 
+#### 1.5 Significant-Change Scope Impact Analysis (Req 12.5.2 / 12.5.3)
+
+For every material business, technology, infrastructure, payment-flow, segmentation, or third-party service provider change since the last scope confirmation, verify that PCI scope was re-evaluated before relying on annual scope documentation.
+
+**Trigger checklist:**
+
+```
+PCI-SCOPE-CHANGE-01: New hardware, software, network, cloud, serverless, or payment component added to the CDE without scope impact review
+PCI-SCOPE-CHANGE-02: Account-data flow or storage changed without updated data-flow diagram and CHD/SAD handling decision
+PCI-SCOPE-CHANGE-03: CDE boundary, segmentation path, firewall/routing, VPN, Kubernetes network policy, or security group changed without revalidation
+PCI-SCOPE-CHANGE-04: Supporting infrastructure changed (directory services, time, logging, monitoring, vulnerability scanning, EDR, DNS, CI/CD) without connected-to/security-impacting assessment
+PCI-SCOPE-CHANGE-05: TPSP, payment processor, payment page script provider, fraud/analytics provider, or shared-responsibility matrix changed without scope refresh
+PCI-SCOPE-CHANGE-06: Emergency change closed without retrospective scope impact analysis, owner, date, and compensating monitoring
+PCI-SCOPE-CHANGE-07: Change marked "scope reducing" without evidence that diagrams, inventories, responsibilities, and validation evidence were refreshed
+PCI-SCOPE-CHANGE-08: Annual scope review used as evidence even though a significant change occurred after the review date
+```
+
+**Evidence required:**
+
+| Evidence Item | What to Verify |
+|---|---|
+| Change trigger | Change ID, date, owner, affected service, and why it may affect CDE, connected-to, or security-impacting systems |
+| Scope impact analysis | Explicit determination for CHD/SAD flows, CDE boundaries, connected-to systems, security-impacting systems, and applicability of controls |
+| Refreshed artifacts | Data-flow diagrams, network diagrams, system inventory, component inventory, SAQ/ROC scope notes, and responsibility matrix |
+| Validation linkage | Segmentation test, internal/external scan, penetration-test update, control retest, or documented rationale for no retest |
+| TPSP/shared responsibility | Updated TPSP inventory, AOC/compliance status, written acknowledgement, responsibility matrix, and service description |
+| Governance | Approval, executive communication when required, retrospective review for emergency changes, and residual assessor risk |
+
+**Decision rules:**
+
+- Mark Req 12.5.2 **Not in Place** when the entity cannot show scope confirmation after a significant in-scope environment change.
+- Mark Req 12.5.3 **Not in Place** for service providers when significant organizational changes lack documented scope/applicability impact review and executive communication.
+- Treat segmentation-impacting changes as incomplete until the relevant segmentation validation or assessor-accepted retest evidence is linked.
+- Treat TPSP/payment-provider changes as incomplete until the inventory and responsibility matrix show who owns each affected PCI DSS requirement.
+- Treat cloud/serverless changes as in scope until the entity proves whether the component stores, processes, transmits, connects to, or can affect CHD/SAD.
+
 ---
 
 ### Step 2: Requirement-by-Requirement Assessment
@@ -425,6 +461,11 @@ Note: Not all requirements support the Customized Approach. Requirements with "T
 - **Connected-to systems**: [list]
 - **Third-party service providers in scope**: [list]
 
+## Significant-Change Scope Impact Matrix
+| Change ID | Trigger Type | Affected CHD/SAD Flow or CDE Boundary | Refreshed Evidence | Validation / Retest Link | Owner / Date | Decision |
+|-----------|--------------|----------------------------------------|--------------------|--------------------------|--------------|----------|
+| [change] | [cloud/serverless, segmentation, TPSP, infrastructure, payment flow, emergency, etc.] | [data flow, system, network, vendor, responsibility] | [diagrams, inventory, scope doc, responsibility matrix] | [scan, segmentation test, penetration test, control retest, Not Provided] | [owner/date] | In Place / Not in Place / Not Tested |
+
 ## Requirement Assessment Summary
 
 | Req | Title | Sub-Reqs Assessed | In Place | Not in Place | CCW | N/A |
@@ -520,6 +561,8 @@ Maintain an Information Security Policy:                Requirement 12
 
 5. **Failing to manage third-party service provider (TPSP) compliance.** Requirement 12.8 and 12.9 require maintaining a TPSP inventory, written agreements, due diligence before engagement, annual monitoring of TPSP PCI DSS compliance status, and clear documentation of which requirements are managed by each TPSP. The shared responsibility model must be explicitly documented.
 
+6. **Treating annual scope review as enough after mid-cycle changes.** A current annual scope package does not prove Req 12.5.2/12.5.3 if cloud/serverless, segmentation, payment-flow, supporting-infrastructure, or TPSP changes happened afterward without a documented scope impact analysis.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -545,3 +588,5 @@ If user-supplied input contains PCI DSS requirement IDs outside the valid v4.0 n
 - PCI DSS Prioritized Approach for PCI DSS v4.0
 - PCI SSC Information Supplements: Scoping and Segmentation, Penetration Testing, Tokenization, Cloud Computing
 - PCI SSC Glossary of Terms, Abbreviations, and Acronyms
+- PCI SSC FAQ: What is meant by "significant change" in PCI DSS? https://www.pcisecuritystandards.org/faqs/1317/
+- PCI SSC Document Library: PCI DSS v4.0.1 https://www.pcisecuritystandards.org/document_library/

--- a/skills/compliance/pci-dss-review/tests/significant-change-scope-edge-cases.md
+++ b/skills/compliance/pci-dss-review/tests/significant-change-scope-edge-cases.md
@@ -1,0 +1,117 @@
+# PCI DSS Significant-Change Scope Impact Edge Cases
+
+These fixtures validate that the PCI DSS review skill does not rely on annual scope confirmation when a significant change may have changed CDE boundaries, account-data flows, segmentation, supporting infrastructure, or TPSP responsibilities.
+
+## Expected Review Behavior
+
+- Require a documented scope impact analysis after significant changes, not only annual scope documentation.
+- Link each change to refreshed scope artifacts and validation evidence.
+- Record results in the Significant-Change Scope Impact Matrix.
+- Mark Req 12.5.2, 12.5.2.1, or 12.5.3 Not in Place when required change-driven scope evidence is absent.
+
+## Case 1: New Serverless Payment Flow After Annual Review
+
+**Input evidence:**
+
+- Annual scope review was completed in Q1.
+- A new payment Lambda/function, API gateway route, queue, and storage bucket were deployed in Q2.
+- The function receives tokenized checkout events but logs request bodies during errors.
+- Scope diagrams and component inventory still show the Q1 environment.
+
+**Expected result:**
+
+- Finding: `PCI-SCOPE-CHANGE-01`, `PCI-SCOPE-CHANGE-02`, and `PCI-SCOPE-CHANGE-08`.
+- Requirement impact: Req 12.5.2 Not in Place.
+- Decision: Not in Place.
+- Rationale: Annual scope evidence predates a payment-flow/cloud change and does not prove whether the new components store, process, transmit, connect to, or can affect CHD/SAD.
+
+## Case 2: Segmentation Path Changed Without Revalidation
+
+**Input evidence:**
+
+- A firewall rule, route table, Kubernetes network policy, or security group was changed to support a new service.
+- The change affects traffic between a non-CDE segment and a CDE subnet.
+- No segmentation test, penetration-test update, or assessor-approved retest rationale is linked to the change.
+
+**Expected result:**
+
+- Finding: `PCI-SCOPE-CHANGE-03`.
+- Requirement impact: Req 12.5.2 plus related segmentation validation evidence under Req 11.4.5/11.4.6.
+- Decision: Not in Place or Not Tested.
+- Rationale: Segmentation cannot be assumed after a boundary-affecting change.
+
+## Case 3: TPSP Responsibility Change Without Matrix Refresh
+
+**Input evidence:**
+
+- A new payment processor, fraud service, analytics vendor, hosted payment page provider, or payment script provider was added.
+- TPSP inventory lists the vendor, but the PCI responsibility matrix and AOC/compliance status were not updated.
+- Scope notes still reference the previous provider responsibilities.
+
+**Expected result:**
+
+- Finding: `PCI-SCOPE-CHANGE-05`.
+- Requirement impact: Req 12.5.2 and Req 12.8/12.9 evidence gaps.
+- Decision: Not in Place.
+- Rationale: Outsourcing can reduce or move scope only when responsibilities and compliance status are refreshed.
+
+## Case 4: Supporting Infrastructure Change
+
+**Input evidence:**
+
+- Directory service, time server, logging platform, SIEM, EDR, vulnerability scanner, DNS, or CI/CD system supporting the CDE changed.
+- The system does not store CHD, so the change was closed as "out of scope."
+- No connected-to/security-impacting assessment was performed.
+
+**Expected result:**
+
+- Finding: `PCI-SCOPE-CHANGE-04`.
+- Requirement impact: Req 12.5.2 Not in Place if the supporting system can affect CDE security.
+- Decision: Not in Place.
+- Rationale: Security-impacting systems may be in scope even when they do not store account data.
+
+## Case 5: Emergency Change Closed Without Retrospective Scope Review
+
+**Input evidence:**
+
+- Emergency VPN, firewall, routing, or payment-processing change was made during an incident.
+- CAB record closes the emergency change as successful.
+- No retrospective PCI scope impact analysis, owner/date, monitoring evidence, or remediation task is attached.
+
+**Expected result:**
+
+- Finding: `PCI-SCOPE-CHANGE-06`.
+- Requirement impact: Req 12.5.2, and Req 12.5.3 for service providers when organizational/scope impact applies.
+- Decision: Not in Place.
+- Rationale: Emergency handling does not remove the need for documented scope impact review after the change.
+
+## Case 6: Scope-Reducing Change Without Evidence
+
+**Input evidence:**
+
+- A payment page is moved to a hosted provider or tokenization/P2PE is introduced.
+- The entity claims reduced PCI scope.
+- Diagrams, inventories, TPSP responsibility matrix, and validation evidence were not refreshed.
+
+**Expected result:**
+
+- Finding: `PCI-SCOPE-CHANGE-07`.
+- Requirement impact: Req 12.5.2 Not in Place.
+- Decision: Not in Place.
+- Rationale: A scope-reducing claim still needs documented evidence and updated artifacts.
+
+## Case 7: Complete Significant-Change Review
+
+**Input evidence:**
+
+- Change record identifies trigger, owner, date, affected CDE/payment flow, and affected controls.
+- Scope impact analysis updates data-flow diagrams, network diagrams, component inventory, connected-to systems, and TPSP responsibilities.
+- Segmentation/scans/control retests are linked or documented as not applicable with rationale.
+- Service provider review includes executive communication where required.
+
+**Expected result:**
+
+- No `PCI-SCOPE-CHANGE-*` finding for this change.
+- Requirement impact: Req 12.5.2/12.5.3 evidence supports In Place.
+- Decision: In Place.
+- Rationale: The review proves that the significant change refreshed PCI scope and applicability evidence.


### PR DESCRIPTION
Implements #1392.

## Summary

- Adds a PCI DSS significant-change scope impact evidence gate to `pci-dss-review`.
- Requires trigger evidence for cloud/serverless, account-data flow, segmentation, supporting infrastructure, emergency, scope-reducing, and TPSP/shared-responsibility changes before annual scope documentation is credited.
- Adds a Significant-Change Scope Impact Matrix and edge-case fixtures for mid-cycle changes that should refresh diagrams, inventories, responsibility matrices, and validation/retest evidence.

## Validation

- Verified no open duplicate PRs for this PCI significant-change scope-impact gap before implementation.
- Confirmed markdown fence balance for the updated skill and fixture.
- Confirmed required content markers for `PCI-SCOPE-CHANGE-*`, Req 12.5.2/12.5.3, TPSP, serverless, segmentation, and Significant-Change Scope Impact Matrix.
- Confirmed official PCI SSC URLs return HTTP 200.
- Confirmed private payment details are not present in repository content.

## References

- https://www.pcisecuritystandards.org/faqs/1317/
- https://www.pcisecuritystandards.org/document_library/

Payment details can be provided privately after maintainer acceptance.