### PR TITLE
Add SOC2 subservice CUEC evidence gates

### DIFF
--- a/skills/compliance/soc2-gap/SKILL.md
+++ b/skills/compliance/soc2-gap/SKILL.md
@@ -12,7 +12,7 @@ phase: [assess, operate]
 frameworks: [AICPA-TSC, NIST-CSF-2.0]
 difficulty: intermediate
 time_estimate: "60-120min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -111,6 +111,39 @@ System Description Boundary:
 - Procedures: ___
 - Data: ___
 ```
+
+#### 1.4 Subservice Organization and CUEC Scope Gate
+
+Vendor SOC 2 report collection is not enough to prove SOC 2 readiness. For each critical provider, determine whether the provider is a vendor, carved-out subservice organization, or included subservice organization, then map the relied-upon controls and complementary controls back to internal owners and evidence.
+
+```
+SOC2-SUBSERVICE-01: Critical provider supports in-scope system objectives but is not classified as vendor, carved-out subservice organization, or included subservice organization
+SOC2-SUBSERVICE-02: Subservice reporting method is missing, unsupported by the system description, or inconsistent with auditor expectations
+SOC2-SUBSERVICE-03: Vendor SOC 2 report is collected but report period does not cover the audit period and bridge-letter/current assurance evidence is missing
+SOC2-SUBSERVICE-04: CUECs or complementary subservice organization controls are not extracted from the vendor report
+SOC2-SUBSERVICE-05: CUEC/CSOC is not mapped to an internal control owner, frequency, evidence artifact, and operating-effectiveness status
+SOC2-SUBSERVICE-06: Vendor report exceptions, opinion type, relevant TSC criteria, or carved-out nested subservice providers are not evaluated
+SOC2-SUBSERVICE-07: NDA-limited or unavailable SOC reports are accepted without documented alternative assurance, reviewer, review date, exceptions, and residual risk
+```
+
+**Subservice Organization Scope Matrix:**
+
+| Provider | System Dependency | Data / Function Touched | Role | Reporting Method | Report Period / Bridge | CUECs / CSOCs Extracted | Internal Control Mapping | Decision |
+|---|---|---|---|---|---|---|---|---|
+| [AWS/Okta/Stripe/etc.] | [hosting/IAM/payment/etc.] | [data/function] | Vendor / Carved-out / Included | [SOC report method] | [period and bridge evidence] | [Yes/No] | [owner/control/evidence] | Pass / Gap / Not Evaluable |
+
+**CUEC/CSOC Mapping Worksheet:**
+
+| Provider | Complementary Control | Internal Owner | Internal Control ID | Frequency | Evidence Artifact | Audit Period Coverage | Status |
+|---|---|---|---|---|---|---|---|
+| [provider] | [CUEC/CSOC text] | [owner] | [control] | [frequency] | [evidence] | [covered/gap/bridge] | Implemented / Partial / Missing |
+
+**Decision rules:**
+
+- Mark CC9.2 and system-description readiness **Provisional** when critical providers have SOC 2 reports but no carve-out/inclusive method, CUEC/CSOC extraction, or control mapping.
+- Mark **High** when a critical cloud, identity, payment, support, monitoring, or data-processing provider supports in-scope objectives and the organization cannot identify who operates the relied-upon controls.
+- Mark **Medium** when report period coverage, bridge-letter evidence, opinion/exceptions review, or nested subservice review is incomplete.
+- Mark **Not Evaluable** when the vendor report is unavailable due to NDA or access limits and no qualified alternative assurance package is documented.
 
 ---
 
@@ -339,6 +372,7 @@ Prioritize remediation by audit readiness impact. Items that would result in exa
 - [ ] Complete business impact analysis (CC9.1)
 - [ ] Establish annual policy review cycle with documented approvals (CC5.3)
 - [ ] Conduct fraud risk assessment (CC3.3)
+- [ ] Map critical subservice organizations, CUECs, CSOCs, report periods, bridge letters, and internal control owners (CC9.2)
 - [ ] Compile evidence binder for all in-scope criteria
 - [ ] Perform self-assessment using the scoring matrix from Step 4
 - [ ] Engage SOC 2 auditor for readiness assessment (if score >= 3.0)
@@ -366,8 +400,9 @@ When performing a SOC 2 gap analysis, produce the following deliverables:
 3. **Category Summary**: Average maturity score per category with narrative assessment.
 4. **Critical Findings**: List of all criteria scored 0 or 1, with specific gap descriptions and remediation recommendations.
 5. **Evidence Checklist**: Customized evidence requirements based on in-scope criteria, marking items as Exists / Partial / Missing.
-6. **90-Day Remediation Roadmap**: Prioritized action items with owners, deadlines, and dependencies.
-7. **Overall Readiness Assessment**: Go/no-go recommendation for engaging a SOC 2 auditor.
+6. **Subservice Organization and CUEC Matrix**: Provider role, reporting method, report period, bridge evidence, CUECs/CSOCs, internal control mapping, and readiness decision for critical providers.
+7. **90-Day Remediation Roadmap**: Prioritized action items with owners, deadlines, and dependencies.
+8. **Overall Readiness Assessment**: Go/no-go recommendation for engaging a SOC 2 auditor.
 
 ## Prompt Injection Safety Notice
 
@@ -393,3 +428,10 @@ This skill processes user-supplied content including compliance documentation, p
 - The gap analysis is based on information available in the codebase and documentation. It cannot assess controls that exist only in human processes without documentation.
 - Scoring is subjective and should be validated by the organization's security leadership and, ideally, a qualified auditor.
 - This analysis uses the 2017 AICPA Trust Services Criteria (with 2022 updates). Verify with your auditor that these criteria are current for your engagement.
+
+---
+
+## Changelog
+
+- **1.0.1** -- Add subservice organization, CUEC/CSOC, report-period, bridge-letter, and complementary-control mapping evidence gates.
+- **1.0.0** -- Initial release. SOC 2 Type II readiness gap analysis across Common Criteria and selected additional criteria.

--- a/skills/compliance/soc2-gap/tests/subservice-cuec-evidence.md
+++ b/skills/compliance/soc2-gap/tests/subservice-cuec-evidence.md
@@ -1,0 +1,144 @@
+# SOC 2 Subservice Organization and CUEC Evidence Fixtures
+
+These fixtures calibrate CC9.2 and system-description readiness for subservice organization and complementary-control evidence.
+
+```yaml
+case: vendor_reports_collected_without_subservice_mapping
+audit_period: 2026-01-01_to_2026-12-31
+vendors:
+  - name: AWS
+    supports_system_objectives:
+      - infrastructure_availability
+      - physical_security
+      - environmental_controls
+    soc2_report_collected: true
+    reporting_method: not_documented
+    report_period: 2025-01-01_to_2025-12-31
+    bridge_letter: missing
+    cuecs_extracted: false
+    internal_control_mapping: []
+expected_decision: Provisional
+expected_findings:
+  - check: SOC2-SUBSERVICE-01
+    severity: High
+    reason: Critical provider role is not classified as vendor, carved-out, or included subservice organization.
+  - check: SOC2-SUBSERVICE-03
+    severity: Medium
+    reason: Vendor report period does not cover the audit period and bridge evidence is missing.
+  - check: SOC2-SUBSERVICE-04
+    severity: High
+    reason: Complementary controls were not extracted from the vendor report.
+```
+
+```yaml
+case: cuecs_extracted_but_unmapped
+provider: cloud_provider
+reporting_method: carved_out
+cuecs_from_report:
+  - Customer configures logical access to cloud consoles.
+  - Customer enables logging for in-scope workloads.
+  - Customer reviews privileged users periodically.
+mapped_internal_controls: []
+expected_decision: Gap
+expected_findings:
+  - check: SOC2-SUBSERVICE-05
+    severity: High
+    reason: CUECs are not mapped to owners, control IDs, frequencies, and evidence artifacts.
+```
+
+```yaml
+case: bridge_letter_closes_period_gap
+audit_period: 2026-01-01_to_2026-12-31
+provider: payment_processor
+reporting_method: carved_out
+report_period: 2025-10-01_to_2026-09-30
+bridge_letter:
+  covers_period: 2026-10-01_to_2026-12-31
+  reviewed_by: compliance_owner
+  review_date: "2026-12-15"
+cuecs_extracted: true
+internal_control_mapping:
+  - cuec: Customer reviews dashboard users quarterly.
+    owner: finance_ops
+    control_id: CC6.1-QAR
+    frequency: quarterly
+    evidence: access_review_q4
+expected_decision: Pass
+expected_findings: []
+```
+
+```yaml
+case: nda_limited_vendor_report_without_alternative_assurance
+provider: support_platform
+report_access: nda_required_not_obtained
+security_summary: received
+reviewer: missing
+review_date: missing
+exceptions_reviewed: false
+alternative_assurance:
+  questionnaire: missing
+  iso_certificate: missing
+  pen_test_summary: missing
+  contract_controls: partial
+expected_decision: Not Evaluable
+expected_findings:
+  - check: SOC2-SUBSERVICE-07
+    severity: Medium
+    reason: SOC report is unavailable and no qualified alternative assurance package is documented.
+```
+
+```yaml
+case: nested_subservice_not_evaluated
+provider: identity_provider
+reporting_method: carved_out
+soc2_report_collected: true
+nested_subservice_providers:
+  - cloud_hosting_provider
+report_carves_out_nested_subservices: true
+nested_subservice_review: missing
+cuecs_extracted: true
+internal_control_mapping:
+  - cuec: Customer maintains MFA and SSO configuration.
+    owner: identity_team
+    control_id: CC6.1-MFA
+    frequency: continuous
+    evidence: conditional_access_policy
+expected_decision: Partial
+expected_findings:
+  - check: SOC2-SUBSERVICE-06
+    severity: Medium
+    reason: Nested subservice providers carved out of the vendor report were not evaluated for residual risk.
+```
+
+```yaml
+case: complete_subservice_and_cuec_mapping
+audit_period: 2026-01-01_to_2026-12-31
+provider: aws
+role: carved_out_subservice_organization
+system_dependency: hosting_and_infrastructure_availability
+data_touched:
+  - encrypted_customer_data
+reporting_method: carved_out
+report_period: 2026-01-01_to_2026-09-30
+bridge_letter:
+  covers_period: 2026-10-01_to_2026-12-31
+  reviewed_by: compliance_owner
+  review_date: "2026-12-20"
+report_opinion: unqualified
+exceptions: none_relevant
+nested_subservice_review: completed
+cuecs_extracted: true
+internal_control_mapping:
+  - cuec: Customer configures logical access to cloud consoles.
+    owner: cloud_security
+    control_id: CC6.1-IAM
+    frequency: continuous
+    evidence: iam_policy_and_access_review
+  - cuec: Customer enables logging for in-scope workloads.
+    owner: security_operations
+    control_id: CC7.2-LOG
+    frequency: continuous
+    evidence: cloudtrail_and_siem_exports
+expected_decision: Pass
+expected_findings: []
+```

--- a/skills/compliance/soc2-gap/tsc-criteria.md
+++ b/skills/compliance/soc2-gap/tsc-criteria.md
@@ -327,17 +327,27 @@ This file contains the detailed Trust Services Criteria evaluation questions, ev
   - Is there a vendor management program?
   - Are vendors assessed for security risk before onboarding?
   - Are vendor SOC 2 reports or equivalent assurance reports collected and reviewed?
+  - Are critical providers classified as vendors, carved-out subservice organizations, or included subservice organizations?
+  - Are CUECs and complementary subservice organization controls extracted from vendor SOC 2 reports and mapped to internal control owners?
+  - Do vendor report periods cover the SOC 2 observation period, or is bridge-letter/current assurance evidence available?
 - Evidence to look for:
   - Vendor management policy
   - Vendor risk assessment questionnaires (completed)
   - Vendor SOC 2 report review records
   - Vendor inventory with risk classifications
   - Contract provisions for security requirements (data processing agreements, BAAs)
+  - Subservice organization scope matrix with provider role, system dependency, data/function touched, reporting method, and control reliance
+  - CUEC/CSOC mapping worksheet with internal control owner, frequency, evidence artifact, and operating-effectiveness status
+  - Vendor report opinion, exceptions, period coverage, bridge letters, nested subservice method, relevant TSC criteria, and review sign-off
 - Common gaps:
   - No formal vendor management program
   - Vendor SOC 2 reports are not collected or reviewed
   - No vendor risk assessment performed prior to onboarding
   - Contracts lack security and data protection provisions
+  - Critical provider SOC 2 reports are collected but carve-out/inclusive method is not documented
+  - CUECs/CSOCs are not mapped to internal controls and owners
+  - Vendor report period does not overlap the audit period and no bridge letter exists
+  - Nested subservice providers, report exceptions, or qualified opinions are not evaluated
 
 ---
 
@@ -553,7 +563,7 @@ After scoring, calculate:
 | CC7.5 | DR plan; BC plan; backup configs; backup restoration test records |
 | CC8.1 | Change management policy; CI/CD pipeline configs with approval gates; PR review records; CAB minutes; segregation of duties evidence |
 | CC9.1 | Risk treatment plans; business impact analysis; risk acceptance sign-off records |
-| CC9.2 | Vendor management policy; vendor risk assessments; vendor SOC 2 review records; vendor inventory; DPAs/BAAs |
+| CC9.2 | Vendor management policy; vendor risk assessments; vendor SOC 2 review records; vendor inventory; DPAs/BAAs; subservice organization scope matrix; carve-out/inclusive method; CUEC/CSOC extraction worksheet; internal owner/control/evidence mapping; report period and bridge-letter evidence; report opinion/exceptions/nested subservice review |
 | A1.1 | Capacity monitoring dashboards; auto-scaling configs; capacity planning documentation |
 | A1.2 | Backup policy with RPO/RTO; backup monitoring records; restoration test results; redundancy configs |
 | A1.3 | DR test plan; DR test execution records; DR test findings and remediation |


### PR DESCRIPTION
## Summary
- add a SOC 2 subservice organization and CUEC/CSOC scope gate to `soc2-gap`
- require critical providers to be classified as vendor, carved-out subservice organization, or included subservice organization before system-description readiness is marked complete
- add `SOC2-SUBSERVICE-01` through `SOC2-SUBSERVICE-07` checks for reporting method, report-period/bridge-letter coverage, CUEC/CSOC extraction, internal control mapping, report exceptions, nested subservice providers, and NDA-limited reports
- update CC9.2 criteria evidence so vendor SOC 2 collection does not score as ready without complementary-control mapping
- add six YAML fixtures covering unmapped vendor reports, extracted-but-unmapped CUECs, bridge-letter coverage, NDA-limited reports, nested subservice gaps, and a complete passing package

## Validation
- `git diff --check`
- parsed all 6 YAML fixture blocks with Ruby `YAML.safe_load`
- verified Markdown fence balance across touched Markdown files
- marker scan confirmed `SOC2-SUBSERVICE-*`, CUEC/CSOC worksheet, bridge-letter evidence, and version `1.0.1`
- privacy scan found no local user/path/email strings in changed files

Closes #1124

Bounty target: Improver Moderate if accepted.

## Bounty Info

- [x] I have read and agree to the CONTRIBUTING.md bounty terms.
- Preferred payment method can be coordinated privately after maintainer acceptance.

/claim #1124
