### PR TITLE
Add patch deferral revalidation gates

### DIFF
--- a/skills/vuln-management/patch-prioritization/SKILL.md
+++ b/skills/vuln-management/patch-prioritization/SKILL.md
@@ -265,23 +265,26 @@ Approved exceptions and deferred patch decisions are not static. Revalidate them
 | Trigger | Why It Matters | Required Action |
 |---|---|---|
 | **Vendor patch or workaround released** | "Patch unavailable" is no longer a valid justification | Set a new remediation deadline and update patch window scheduling |
-| **CISA KEV listing added** | Confirmed exploitation changes SSVC and compliance urgency | Re-run SSVC, apply KEV override, and escalate to P0/P1 as applicable |
+| **CISA KEV listing or BOD deadline added** | Confirmed exploitation and mandatory due dates change SSVC and compliance urgency | Re-run SSVC, apply KEV/BOD override, record required due date, and escalate to P0/P1 as applicable |
 | **EPSS surge or percentile jump** | Exploitation likelihood changed before review date | Re-run EPSS trend analysis and escalate tier when thresholds are met |
 | **Public exploit/PoC published** | Attack feasibility and automatability may have changed | Re-run SSVC exploitation/automatable decisions and retest controls |
 | **Active exploitation observed** | Risk is no longer theoretical | Break exception, start incident/vulnerability emergency workflow |
 | **Asset becomes internet-facing or business-critical** | Prior exposure or mission-prevalence assumptions are stale | Re-score asset context and shorten SLA/exception duration |
 | **Compensating control changed or failed test** | Residual risk assumption is invalid | Retest control, remove SLA extension if ineffective |
+| **Threat-intel or scanner feed is stale/unavailable** | Missing current evidence can hide KEV, EPSS, exploit, or patch changes | Mark revalidation Not Evaluable, fail open to human review, and refresh evidence before continuing the exception |
 | **Exception owner, system owner, or service scope changes** | Approval accountability may no longer be valid | Re-approve exception with current owner and updated scope |
 
 #### Revalidation Requirements
 
 For every deferred vulnerability or active exception, record:
 
-- **Last revalidation date** and evidence source checked.
+- **Last revalidation date**, evidence source checked, feed timestamp, and source freshness status.
 - **Next scheduled revalidation date** based on exception severity.
-- **Triggers checked**: vendor advisory, CISA KEV, EPSS, public exploit, active exploitation, asset exposure, business criticality, and compensating control status.
-- **Resulting action**: maintain exception, shorten deadline, escalate SLA tier, schedule patch, retest compensating control, or revoke risk acceptance.
+- **Triggers checked**: vendor advisory, CISA KEV, BOD deadline, EPSS, public exploit, active exploitation, asset exposure, business criticality, scanner evidence, and compensating control status.
+- **Resulting action**: maintain exception, shorten deadline, escalate SLA tier, schedule patch, retest compensating control, revoke risk acceptance, or route Not Evaluable records to human review.
 - **Patch-available deadline** when a vendor fix becomes available after exception approval.
+- **Mandatory due date** when CISA KEV or BOD evidence imposes a stricter deadline than the original exception.
+- **Control retest evidence** with test date, method, exploit path covered, asset coverage, and pass/fail result.
 - **Human approver** for any decision to keep accepting risk after a trigger fires.
 
 #### Revalidation Cadence
@@ -293,9 +296,9 @@ For every deferred vulnerability or active exception, record:
 | **P3** | Monthly | Within 5 business days of trigger |
 | **P4/P5** | At scheduled review date, max quarterly | At next backlog review unless KEV/active exploitation appears |
 
-Do not count exceptions with missed revalidation, stale evidence, or untested compensating controls as "healthy" patch posture.
+Do not count exceptions with missed revalidation, stale evidence, unavailable source feeds, or untested compensating controls as "healthy" patch posture.
 
-**Test fixture:** Use `tests/deferred-revalidation-gates.md` to validate patch-available, KEV/EPSS surge, exposure drift, failed compensating control, and no-material-change revalidation paths.
+**Test fixture:** Use `tests/deferred-revalidation-gates.md` to validate patch-available, KEV/BOD/EPSS surge, exposure drift, failed compensating control, stale-source Not Evaluable, and no-material-change revalidation paths.
 
 ---
 
@@ -313,6 +316,7 @@ Classify the overall patch posture into one of the following states:
 **Exception health modifiers:**
 
 - Downgrade to **Elevated Risk** when any active exception has stale revalidation evidence, a missed review date, or an untested compensating control.
+- Downgrade to **Elevated Risk** when KEV, EPSS, vendor advisory, scanner, or asset-inventory evidence is stale or unavailable for active exceptions.
 - Downgrade to **Critical Backlog** when a deferred vulnerability becomes KEV-listed, actively exploited, or patch-available without an updated deadline and owner-approved action.
 
 ---
@@ -374,9 +378,9 @@ findings requiring immediate action.]
 | [EXC-ID] | [CVE-IDs] | [tier] | [date] | [name] | [Approved/Pending] | [date] | [date] |
 
 ### Deferred Vulnerability Revalidation
-| CVE ID | Exception ID | Triggers Checked | Trigger Fired? | Current Evidence | Resulting Action | Human Approver |
-|---|---|---|---|---|---|---|
-| [CVE-ID] | [EXC-ID] | [Vendor patch, KEV, EPSS, exploit, exposure, control status] | [Yes/No] | [Evidence source/date] | [Maintain/Escalate/Schedule patch/Revoke exception/Retest control] | [Name/title] |
+| CVE ID | Exception ID | Triggers Checked | Trigger Fired? | Evidence Freshness | Mandatory Due Date | Control Retest | Resulting Action | Human Approver |
+|---|---|---|---|---|---|---|---|---|
+| [CVE-ID] | [EXC-ID] | [Vendor patch, KEV/BOD, EPSS, exploit, exposure, scanner, control status] | [Yes/No/Not Evaluable] | [source/timestamp/freshness] | [date or N/A] | [Pass/Fail/Not Tested] | [Maintain/Escalate/Schedule patch/Revoke exception/Retest control/Human review] | [Name/title] |
 
 ### Recommendations
 1. [Highest-priority actionable recommendation]

--- a/skills/vuln-management/patch-prioritization/SKILL.md
+++ b/skills/vuln-management/patch-prioritization/SKILL.md
@@ -13,7 +13,7 @@ phase: [operate]
 frameworks: [SSVC-2.1, EPSS-v3, CISA-KEV]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -256,6 +256,47 @@ Risk Exception Request:
 - Status:                 [Pending | Approved | Denied | Expired]
 ```
 
+### Step 7: Deferred Vulnerability Revalidation
+
+Approved exceptions and deferred patch decisions are not static. Revalidate them whenever exploitability, patch availability, asset exposure, or business impact changes, even if the scheduled review date has not arrived.
+
+#### Revalidation Trigger Matrix
+
+| Trigger | Why It Matters | Required Action |
+|---|---|---|
+| **Vendor patch or workaround released** | "Patch unavailable" is no longer a valid justification | Set a new remediation deadline and update patch window scheduling |
+| **CISA KEV listing added** | Confirmed exploitation changes SSVC and compliance urgency | Re-run SSVC, apply KEV override, and escalate to P0/P1 as applicable |
+| **EPSS surge or percentile jump** | Exploitation likelihood changed before review date | Re-run EPSS trend analysis and escalate tier when thresholds are met |
+| **Public exploit/PoC published** | Attack feasibility and automatability may have changed | Re-run SSVC exploitation/automatable decisions and retest controls |
+| **Active exploitation observed** | Risk is no longer theoretical | Break exception, start incident/vulnerability emergency workflow |
+| **Asset becomes internet-facing or business-critical** | Prior exposure or mission-prevalence assumptions are stale | Re-score asset context and shorten SLA/exception duration |
+| **Compensating control changed or failed test** | Residual risk assumption is invalid | Retest control, remove SLA extension if ineffective |
+| **Exception owner, system owner, or service scope changes** | Approval accountability may no longer be valid | Re-approve exception with current owner and updated scope |
+
+#### Revalidation Requirements
+
+For every deferred vulnerability or active exception, record:
+
+- **Last revalidation date** and evidence source checked.
+- **Next scheduled revalidation date** based on exception severity.
+- **Triggers checked**: vendor advisory, CISA KEV, EPSS, public exploit, active exploitation, asset exposure, business criticality, and compensating control status.
+- **Resulting action**: maintain exception, shorten deadline, escalate SLA tier, schedule patch, retest compensating control, or revoke risk acceptance.
+- **Patch-available deadline** when a vendor fix becomes available after exception approval.
+- **Human approver** for any decision to keep accepting risk after a trigger fires.
+
+#### Revalidation Cadence
+
+| Original SLA Tier | Minimum Revalidation Cadence | Event-Driven Revalidation |
+|---|---|---|
+| **P0/P1** | Daily to weekly while deferred | Immediate on any trigger |
+| **P2** | Weekly to biweekly | Within 1 business day of KEV, exploit, EPSS surge, or exposure change |
+| **P3** | Monthly | Within 5 business days of trigger |
+| **P4/P5** | At scheduled review date, max quarterly | At next backlog review unless KEV/active exploitation appears |
+
+Do not count exceptions with missed revalidation, stale evidence, or untested compensating controls as "healthy" patch posture.
+
+**Test fixture:** Use `tests/deferred-revalidation-gates.md` to validate patch-available, KEV/EPSS surge, exposure drift, failed compensating control, and no-material-change revalidation paths.
+
 ---
 
 ## Findings Classification
@@ -269,6 +310,11 @@ Classify the overall patch posture into one of the following states:
 | **On Track** | Remediation is proceeding within SLA for all tiers | No findings past SLA; all P0/P1 addressed or in active remediation |
 | **Healthy** | Minimal outstanding findings; strong patch posture | No P0-P2 findings open; P3/P4 within SLA; exception rate < 5% |
 
+**Exception health modifiers:**
+
+- Downgrade to **Elevated Risk** when any active exception has stale revalidation evidence, a missed review date, or an untested compensating control.
+- Downgrade to **Critical Backlog** when a deferred vulnerability becomes KEV-listed, actively exploited, or patch-available without an updated deadline and owner-approved action.
+
 ---
 
 ## Output Format
@@ -278,7 +324,7 @@ Produce a structured report with these exact sections:
 ```markdown
 ## Patch Prioritization Report
 **Date:** [YYYY-MM-DD]
-**Skill:** patch-prioritization v1.0.0
+**Skill:** patch-prioritization v1.0.1
 **Frameworks:** SSVC 2.1, EPSS v3, CISA KEV
 **Reviewer:** AI-assisted (human review required for P0/P1 actions and risk acceptances)
 
@@ -323,9 +369,14 @@ findings requiring immediate action.]
 ### Risk Exceptions
 [List all active risk acceptance/exception records]
 
-| Exception ID | CVE ID(s) | Original SLA | New Deadline | Approver | Status |
-|---|---|---|---|---|---|
-| [EXC-ID] | [CVE-IDs] | [tier] | [date] | [name] | [Approved/Pending] |
+| Exception ID | CVE ID(s) | Original SLA | New Deadline | Approver | Status | Last Revalidated | Next Revalidation |
+|---|---|---|---|---|---|---|---|
+| [EXC-ID] | [CVE-IDs] | [tier] | [date] | [name] | [Approved/Pending] | [date] | [date] |
+
+### Deferred Vulnerability Revalidation
+| CVE ID | Exception ID | Triggers Checked | Trigger Fired? | Current Evidence | Resulting Action | Human Approver |
+|---|---|---|---|---|---|---|
+| [CVE-ID] | [EXC-ID] | [Vendor patch, KEV, EPSS, exploit, exposure, control status] | [Yes/No] | [Evidence source/date] | [Maintain/Escalate/Schedule patch/Revoke exception/Retest control] | [Name/title] |
 
 ### Recommendations
 1. [Highest-priority actionable recommendation]
@@ -370,9 +421,13 @@ Known Exploited Vulnerabilities catalog maintained by CISA. Contains CVEs with c
 
 3. **Allowing risk exceptions to auto-renew without review.** Risk acceptances that roll over indefinitely create a shadow backlog of unpatched vulnerabilities. Every exception must have a hard expiration date and mandatory re-evaluation. Track exception aging as a KPI and report to leadership quarterly.
 
-4. **Ignoring EPSS trend direction.** A CVE with a low absolute EPSS score but a rapidly rising trend (e.g., from 0.02 to 0.15 in two weeks) signals that exploit development is progressing. Treating EPSS as a static snapshot rather than a time series misses emerging threats. Always evaluate 7/30/90-day trends.
+4. **Waiting for the scheduled review date after risk changes.** A valid exception can become invalid the same day a vendor patch ships, the CVE enters CISA KEV, exploit code becomes public, EPSS surges, or the asset becomes internet-facing. Event-driven triggers must reopen the decision before the calendar review date.
 
-5. **Scheduling patches without rollback plans.** Patch deployment failures without rollback procedures cause unplanned outages that erode trust in the patching program. Every patch window must include a validated rollback procedure, tested in a non-production environment where possible.
+5. **Ignoring EPSS trend direction.** A CVE with a low absolute EPSS score but a rapidly rising trend (e.g., from 0.02 to 0.15 in two weeks) signals that exploit development is progressing. Treating EPSS as a static snapshot rather than a time series misses emerging threats. Always evaluate 7/30/90-day trends.
+
+6. **Not retesting compensating controls after trigger changes.** A WAF rule, segmentation boundary, or EDR detection that worked before exploit conditions changed may no longer reduce risk. Retest controls after public exploit release, KEV listing, exposure change, or control/configuration drift.
+
+7. **Scheduling patches without rollback plans.** Patch deployment failures without rollback procedures cause unplanned outages that erode trust in the patching program. Every patch window must include a validated rollback procedure, tested in a non-production environment where possible.
 
 ---
 

--- a/skills/vuln-management/patch-prioritization/tests/deferred-revalidation-gates.md
+++ b/skills/vuln-management/patch-prioritization/tests/deferred-revalidation-gates.md
@@ -1,0 +1,119 @@
+# Deferred Vulnerability Revalidation Gates
+
+Use these cases to validate that `patch-prioritization` does not treat active risk exceptions as valid after the assumptions behind the exception change.
+
+## Case 1: Patch-unavailable exception after vendor fix
+
+**Input**
+
+```yaml
+exception:
+  id: EXC-2026-101
+  cve: CVE-2026-12345
+  status: approved
+  reason: vendor patch unavailable
+  original_sla: P2
+  review_date: 2026-09-01
+current_state:
+  vendor_patch: released
+  vendor_advisory_date: 2026-06-15
+  cisa_kev: false
+  epss_current: 0.18
+  asset_exposure: internal
+```
+
+**Expected result**
+
+The exception is no longer valid as-is. The report must set a patch-available deadline, schedule a patch window, and record a human-approved action if risk is still accepted.
+
+## Case 2: KEV listing plus EPSS surge
+
+**Input**
+
+```yaml
+exception:
+  id: EXC-2026-102
+  cve: CVE-2026-23456
+  status: approved
+  original_sla: P3
+  compensating_control: waf_rule
+current_state:
+  cisa_kev: true
+  epss_current: 0.73
+  epss_30_day_prior: 0.08
+  public_exploit: reliable_poc
+  asset_exposure: internet_facing
+```
+
+**Expected result**
+
+The vulnerability must be re-triaged immediately. KEV, EPSS surge, reliable PoC, and internet exposure require SSVC/SLA re-evaluation and P0/P1 owner visibility rather than waiting for the review date.
+
+## Case 3: Exposure drift invalidates acceptance
+
+**Input**
+
+```yaml
+exception:
+  id: EXC-2026-103
+  cve: CVE-2026-34567
+  status: approved
+  reason: asset internal only
+  original_sla: P3
+current_state:
+  asset_exposure_previous: internal
+  asset_exposure_current: internet_facing
+  business_criticality_current: critical
+  cmdb_change_date: 2026-06-20
+```
+
+**Expected result**
+
+The prior acceptance assumptions are stale. Re-score asset exposure and business criticality, shorten the deadline if needed, and record the resulting action in the Deferred Vulnerability Revalidation table.
+
+## Case 4: Compensating control no longer works
+
+**Input**
+
+```yaml
+exception:
+  id: EXC-2026-104
+  cve: CVE-2026-45678
+  status: approved
+  original_sla: P2
+  compensating_control: waf_virtual_patch
+current_state:
+  new_exploit_path: bypasses_original_waf_signature
+  control_retest: failed
+  affected_assets_covered: 12_of_20
+  residual_risk: undocumented
+```
+
+**Expected result**
+
+Remove the SLA extension or mark it invalid until the control is updated and retested. The report must not classify posture as healthy while the exception depends on a failed or stale control.
+
+## Case 5: No material trigger, but evidence required
+
+**Input**
+
+```yaml
+exception:
+  id: EXC-2026-105
+  cve: CVE-2026-56789
+  status: approved
+  original_sla: P4
+  review_date: 2026-07-30
+current_state:
+  vendor_patch: unavailable
+  cisa_kev: false
+  epss_current: 0.012
+  epss_30_day_prior: 0.011
+  public_exploit: none
+  asset_exposure: internal
+  compensating_control_validation: passed
+```
+
+**Expected result**
+
+Maintaining the exception is acceptable only if the report records last revalidation date, triggers checked, current evidence source, resulting action, human approver when required, and next revalidation date.

--- a/skills/vuln-management/patch-prioritization/tests/deferred-revalidation-gates.md
+++ b/skills/vuln-management/patch-prioritization/tests/deferred-revalidation-gates.md
@@ -13,10 +13,10 @@ exception:
   status: approved
   reason: vendor patch unavailable
   original_sla: P2
-  review_date: 2026-09-01
+  review_date: "2026-09-01"
 current_state:
   vendor_patch: released
-  vendor_advisory_date: 2026-06-15
+  vendor_advisory_date: "2026-06-15"
   cisa_kev: false
   epss_current: 0.18
   asset_exposure: internal
@@ -39,6 +39,7 @@ exception:
   compensating_control: waf_rule
 current_state:
   cisa_kev: true
+  bod_due_date: "2026-07-01"
   epss_current: 0.73
   epss_30_day_prior: 0.08
   public_exploit: reliable_poc
@@ -64,7 +65,7 @@ current_state:
   asset_exposure_previous: internal
   asset_exposure_current: internet_facing
   business_criticality_current: critical
-  cmdb_change_date: 2026-06-20
+  cmdb_change_date: "2026-06-20"
 ```
 
 **Expected result**
@@ -103,10 +104,11 @@ exception:
   cve: CVE-2026-56789
   status: approved
   original_sla: P4
-  review_date: 2026-07-30
+  review_date: "2026-07-30"
 current_state:
   vendor_patch: unavailable
   cisa_kev: false
+  bod_due_date: null
   epss_current: 0.012
   epss_30_day_prior: 0.011
   public_exploit: none
@@ -117,3 +119,57 @@ current_state:
 **Expected result**
 
 Maintaining the exception is acceptable only if the report records last revalidation date, triggers checked, current evidence source, resulting action, human approver when required, and next revalidation date.
+
+## Case 6: Source feed unavailable
+
+**Input**
+
+```yaml
+exception:
+  id: EXC-2026-106
+  cve: CVE-2026-67890
+  status: approved
+  original_sla: P2
+  review_date: "2026-08-15"
+current_state:
+  vendor_advisory_feed:
+    status: unavailable
+    last_successful_check: "2026-05-01"
+  cisa_kev_feed:
+    status: timeout
+    last_successful_check: "2026-05-01"
+  epss_feed:
+    status: stale
+    last_successful_check: "2026-05-01"
+  scanner_run:
+    status: failed_authentication
+    last_successful_check: "2026-04-29"
+```
+
+**Expected result**
+
+The exception must be marked Not Evaluable rather than maintained as healthy. The report should route the record to human review, refresh source evidence, and avoid extending the deferral until KEV, EPSS, vendor advisory, and scanner evidence are current.
+
+## Case 7: KEV with mandatory due date
+
+**Input**
+
+```yaml
+exception:
+  id: EXC-2026-107
+  cve: CVE-2026-78901
+  status: approved
+  original_sla: P3
+  new_deadline: "2026-09-30"
+current_state:
+  cisa_kev: true
+  bod_due_date: "2026-07-10"
+  public_exploit: weaponized
+  active_exploitation: observed
+  asset_exposure: internet_facing
+  compensating_control_validation: not_tested_after_kev
+```
+
+**Expected result**
+
+The exception cannot keep the later September deadline. The report must record the mandatory due date, re-run SSVC, escalate the SLA, retest controls against the current exploit path, and revoke or shorten the exception unless a current human approval accepts the updated risk.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `patch-prioritization`
**Skill path:** `skills/vuln-management/patch-prioritization/`

### What Was Wrong
Fixes #1401.

The skill documented compensating controls, risk exceptions, expiration dates, and review dates, but did not require event-driven revalidation while a vulnerability remained deferred or under exception. That can make a previously valid exception look safe after the vendor releases a patch, the CVE enters CISA KEV, EPSS surges, exploit code becomes public, asset exposure changes, or compensating controls fail.

### What This PR Fixes
- Adds a deferred vulnerability revalidation step for active exceptions and deferred patch decisions.
- Adds trigger coverage for vendor patch/workaround release, KEV/BOD deadline, EPSS surge, public exploit, active exploitation, exposure drift, scanner/source-feed freshness, compensating-control failure, and ownership/scope changes.
- Defines revalidation requirements: last/next revalidation date, triggers checked, evidence source and feed timestamp, resulting action, patch-available deadline, mandatory due date, control retest evidence, and human approver.
- Adds cadence expectations by original SLA tier.
- Adds exception-health modifiers so stale exceptions or untested controls downgrade patch posture.
- Extends the report with risk-exception revalidation fields and a dedicated Deferred Vulnerability Revalidation table.
- Adds fixture cases for patch availability, KEV/BOD/EPSS escalation, exposure drift, failed compensating controls, no-material-change revalidation, stale/unavailable source feeds, and mandatory due-date handling.

### Evidence
**Before (false positive patch posture):**
```yaml
exception:
  cve: CVE-2026-12345
  status: approved
  reason: vendor patch unavailable
  review_date: "2026-09-01"
  compensating_control: waf_rule
current_state:
  vendor_patch: released
  cisa_kev: listed
  epss_30_day_change: +0.42
  asset_exposure: internet_facing
```

The old skill could leave this exception valid until the scheduled review date.

**After (now correctly handled):**
The skill requires immediate revalidation when patch availability, KEV/BOD, EPSS, exploitability, exposure, scanner/source freshness, or compensating-control evidence changes. The report must record triggers checked, evidence freshness, mandatory due dates, control retest state, resulting action, new deadline when applicable, and human approval for continued risk acceptance.

### Test Cases Added/Updated
- [x] Added edge-case fixtures: `skills/vuln-management/patch-prioritization/tests/deferred-revalidation-gates.md`
- [x] Existing content sanity checks pass

Validation performed:
- Ruby `YAML.safe_load` parsed all 7 YAML fixtures
- `git diff --check`
- Added-line ASCII scan
- Privacy scan for local paths/personal-name fragments

### Bounty Tier
- [ ] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** To be provided privately if awarded

## Bounty Info

- [x] I have read and agree to the CONTRIBUTING.md bounty terms.
- Preferred payment method can be coordinated privately after maintainer acceptance.

/claim #1401
