### PR TITLE
Add pipeline OIDC trust claim gates

### DIFF
--- a/skills/devsecops/pipeline-security/SKILL.md
+++ b/skills/devsecops/pipeline-security/SKILL.md
@@ -12,7 +12,7 @@ phase: [build, deploy]
 frameworks: [SLSA-v1.0, OWASP-CICD-Top-10]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -49,6 +49,7 @@ The assessment produces a formal report containing a SLSA build level determinat
 - Access to CI/CD configuration files (e.g., `.github/workflows/*.yml`, `.gitlab-ci.yml`, `Jenkinsfile`, `cloudbuild.yaml`).
 - Access to repository settings context (branch protection rules, environment configurations).
 - Read access to dependency manifests and lock files for supply-chain analysis.
+- Read access to cloud-side OIDC/workload identity trust policies or federated credential definitions when pipelines request cloud credentials.
 
 ---
 
@@ -189,6 +190,7 @@ environment:
 - Shared service accounts across environments.
 - Missing `CODEOWNERS` file or broad ownership patterns.
 - Workflows that do not pin the `GITHUB_TOKEN` to minimum required permissions.
+- OIDC or workload identity federation configured without verifying cloud-side issuer, audience, subject, repository/ref/environment, and reusable-workflow claim restrictions.
 
 **Specific patterns in GitHub Actions:**
 
@@ -208,6 +210,30 @@ permissions:
 ```
 
 **Finding format:** Report the effective permission model, whether least-privilege is enforced, and whether identity controls (CODEOWNERS, required reviewers) are in place.
+
+**OIDC trust-policy evidence gate (CICD-SEC-2 / CICD-SEC-6):**
+
+When a workflow uses OIDC or workload identity federation, do not treat `id-token: write` or the absence of static secrets as sufficient evidence. Review the CI token request and the cloud-side trust policy together.
+
+| Evidence Field | Required Detail |
+|----------------|-----------------|
+| Token Issuer | Expected issuer, such as `https://token.actions.githubusercontent.com`, and provider/account where it is registered |
+| Workflow Permission | Whether `id-token: write` is scoped to only jobs that need cloud credentials |
+| Audience | Expected `aud` value and whether the trust policy checks it |
+| Subject Pattern | Exact allowed `sub` value or bounded pattern; flag broad values such as `repo:org/repo:*` |
+| Repository / Organization | Repository, immutable repository ID where available, owner, and organization conditions that prevent tokens from sibling, renamed, or untrusted repos |
+| Ref / Environment | Branch, tag, protected environment, or deployment environment restrictions for production credentials |
+| Reusable Workflow Claims | `job_workflow_ref` or equivalent restriction when reusable workflows can mint credentials |
+| Provider Policy | AWS role trust policy, Azure federated credential, Google Workload Identity Federation provider/attribute condition, or other cloud trust configuration |
+| Fork / Pull Request Reachability | Whether untrusted forks, pull requests, tags, or reusable workflows can satisfy the claims |
+| Decision | `Pass`, `Fail`, `Partial`, or `Not Evaluable` with the reason and credential blast radius |
+
+**Provider-specific checks:**
+
+- **AWS IAM:** Require `token.actions.githubusercontent.com:aud` and bounded `token.actions.githubusercontent.com:sub` conditions, plus immutable repository ID conditions where supported by the provider/action path. Flag wildcard subjects such as `repo:org/repo:*` for production roles unless a separate environment or branch condition prevents unintended access.
+- **Microsoft Entra / Azure:** Verify issuer, subject, and audience in each federated identity credential exactly match the external token. Treat mismatched or overly broad subjects as failing evidence even if the workflow uses OIDC.
+- **Google Cloud Workload Identity Federation:** Because GitHub uses a shared issuer, require attribute mapping and attribute conditions that restrict organization, repository, ref/environment, and workflow context before granting production service account access.
+- **Reusable workflows:** If `workflow_call` or shared deployment workflows can request OIDC tokens, require `job_workflow_ref` or an equivalent provider-side claim restriction so arbitrary caller workflows cannot mint production credentials.
 
 ---
 
@@ -328,6 +354,8 @@ runs-on: self-hosted  # Shared runners are a risk
 ```
 
 **Finding format:** Report credential types in use (long-lived vs. short-lived), whether OIDC/workload identity is used where available, and any secrets exposed in logs or command arguments.
+
+For OIDC findings, include both workflow-side evidence and cloud-side trust-policy evidence. If the cloud trust policy is unavailable, mark the OIDC control `Not Evaluable` rather than passing it from workflow YAML alone.
 
 ---
 
@@ -490,6 +518,12 @@ Produce the final report using the following structure:
 - **Description:** <what was found>
 - **Remediation:** <specific fix>
 
+### OIDC / Workload Identity Trust Evidence
+
+| Workflow / Job | Cloud Provider | Issuer | Audience | Subject / Claims | Repository / Owner Binding | Ref / Environment Restrictions | Reusable Workflow Restriction | Fork / PR Reachability | Decision |
+|----------------|----------------|--------|----------|------------------|----------------------------|-------------------------------|------------------------------|------------------------|----------|
+| <file:job> | <AWS/Azure/GCP/Other> | <issuer> | <aud claim and policy check> | <sub/repo/ref/environment claims> | <repository, owner, immutable ID if available> | <branch/tag/environment policy> | <job_workflow_ref or N/A> | <reachable/not reachable/not evaluable> | <Pass/Fail/Partial/Not Evaluable> |
+
 ### Prioritized Remediation Plan
 
 1. **[Critical]** <CICD-SEC-X> -- <action item>
@@ -529,6 +563,7 @@ The final deliverable is a structured assessment report as shown in Step 4 above
 - If no CI/CD configuration files are found, report this as the primary finding and recommend establishing a pipeline configuration.
 - If configurations use a platform not covered by this skill (e.g., a niche CI system), document what was found and note which controls could not be fully evaluated.
 - If file access is denied, record the file path and note the control as "Not Evaluable -- Access Denied."
+- If a workflow uses OIDC but the cloud provider trust policy is unavailable, report "Not Evaluable -- Missing Cloud Trust Policy" for the OIDC trust evidence rather than assuming short-lived credentials are safe.
 
 ---
 
@@ -550,6 +585,11 @@ This skill processes user-supplied content including CI/CD configuration files, 
 - SLSA Build Track: https://slsa.dev/spec/v1.0/levels#build-track
 - OWASP Top 10 CI/CD Security Risks: https://owasp.org/www-project-top-10-ci-cd-security-risks/
 - GitHub Actions Security Hardening: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
+- GitHub OpenID Connect Security Hardening: https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect
+- GitHub OIDC with AWS: https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws
+- AWS IAM OIDC condition keys for GitHub: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_iam-condition-keys.html
+- Microsoft Entra workload identity federation: https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation
+- Google Cloud Workload Identity Federation deployment pipelines: https://cloud.google.com/iam/docs/workload-identity-federation-with-deployment-pipelines
 - Sigstore / Cosign: https://docs.sigstore.dev/
 - SLSA GitHub Generator: https://github.com/slsa-framework/slsa-github-generator
 
@@ -558,3 +598,4 @@ This skill processes user-supplied content including CI/CD configuration files, 
 ## Changelog
 
 - **1.0.0** -- Initial release. Full coverage of SLSA v1.0 build track and OWASP Top 10 CI/CD Security Risks (CICD-SEC-1 through CICD-SEC-10).
+- **1.0.1** -- Adds OIDC/workload identity trust-policy claim evidence gates for CI cloud credential federation.

--- a/skills/devsecops/pipeline-security/tests/oidc-trust-policy-edge-cases.md
+++ b/skills/devsecops/pipeline-security/tests/oidc-trust-policy-edge-cases.md
@@ -1,0 +1,145 @@
+# OIDC Trust-Policy Claim Edge Cases
+
+These fixtures calibrate the `pipeline-security` OIDC/workload identity trust-policy gate. The expected behavior is to evaluate workflow-side token issuance and cloud-side trust conditions together before treating short-lived credentials as safe.
+
+## Vulnerable: AWS Role Trusts Any Ref in the Repository
+
+```yaml
+case: aws-broad-repo-subject
+workflow:
+  permissions:
+    id-token: write
+    contents: read
+  job: deploy
+  ref: refs/pull/44/merge
+cloud_trust_policy:
+  provider: aws
+  issuer: https://token.actions.githubusercontent.com
+  conditions:
+    StringEquals:
+      token.actions.githubusercontent.com:aud: sts.amazonaws.com
+    StringLike:
+      token.actions.githubusercontent.com:sub: repo:acme/payments:*
+expected_result:
+  decision: Fail
+  reason: Production role accepts every branch, tag, pull request, and environment from the repository.
+  required_evidence: Narrow sub to a protected branch/environment, such as repo:acme/payments:environment:production, and document fork/PR reachability.
+```
+
+## Vulnerable: AWS Trust Policy Missing Audience Check
+
+```yaml
+case: aws-missing-audience
+workflow:
+  permissions:
+    id-token: write
+  requested_audience: sts.amazonaws.com
+cloud_trust_policy:
+  provider: aws
+  issuer: https://token.actions.githubusercontent.com
+  conditions:
+    StringEquals:
+      token.actions.githubusercontent.com:sub: repo:acme/payments:ref:refs/heads/main
+expected_result:
+  decision: Fail
+  reason: Trust policy constrains subject but does not verify the intended audience.
+  required_evidence: Add and verify token.actions.githubusercontent.com:aud equals sts.amazonaws.com.
+```
+
+## Vulnerable: Azure Federated Credential Mismatched Subject and Audience
+
+```yaml
+case: azure-subject-audience-mismatch
+workflow:
+  permissions:
+    id-token: write
+  requested_audience: api://AzureADTokenExchange
+  expected_subject: repo:acme/payments:environment:production
+cloud_trust_policy:
+  provider: azure
+  issuer: https://token.actions.githubusercontent.com
+  federated_credential:
+    subject: repo:acme/payments:ref:refs/heads/main
+    audiences:
+      - api://WrongAudience
+expected_result:
+  decision: Fail
+  reason: Microsoft Entra federated credential subject and audience do not match the external token expected by the workflow.
+  required_evidence: Align issuer, subject, and audience exactly, then bind production credentials to the protected environment or intended ref.
+```
+
+## Vulnerable: Google WIF Provider Without Organization Attribute Conditions
+
+```yaml
+case: gcp-wif-missing-organization-condition
+workflow:
+  permissions:
+    id-token: write
+  repository: acme/payments
+cloud_trust_policy:
+  provider: gcp
+  issuer: https://token.actions.githubusercontent.com
+  attribute_mapping:
+    google.subject: assertion.sub
+    attribute.repository: assertion.repository
+    attribute.ref: assertion.ref
+  attribute_condition: attribute.repository == "acme/payments"
+expected_result:
+  decision: Partial
+  reason: Repository is constrained, but shared GitHub issuer risk is not reduced with organization/owner and deployment ref/environment conditions.
+  required_evidence: Add organization/owner, repository, ref/environment, and workflow-context conditions before production service account impersonation.
+```
+
+## Vulnerable: Reusable Workflow Without job_workflow_ref Restriction
+
+```yaml
+case: reusable-workflow-no-job-workflow-ref
+workflow:
+  caller: acme/app/.github/workflows/release.yml@refs/heads/main
+  reusable_workflow: acme/deploy/.github/workflows/prod.yml@refs/tags/v1
+  permissions:
+    id-token: write
+cloud_trust_policy:
+  provider: aws
+  conditions:
+    StringEquals:
+      token.actions.githubusercontent.com:aud: sts.amazonaws.com
+    StringLike:
+      token.actions.githubusercontent.com:sub: repo:acme/*:*
+  job_workflow_ref_condition: missing
+expected_result:
+  decision: Fail
+  reason: Any matching caller repository can use the reusable workflow path to mint cloud credentials because job_workflow_ref is not constrained.
+  required_evidence: Restrict job_workflow_ref or equivalent provider-side claim to the approved reusable workflow and immutable ref.
+```
+
+## Benign: Complete Least-Privilege OIDC Configuration
+
+```yaml
+case: complete-least-privilege-oidc
+workflow:
+  file: .github/workflows/deploy.yml
+  job: deploy-production
+  permissions:
+    contents: read
+    id-token: write
+  environment: production
+  ref: refs/heads/main
+cloud_trust_policy:
+  provider: aws
+  issuer: https://token.actions.githubusercontent.com
+  conditions:
+    StringEquals:
+      token.actions.githubusercontent.com:aud: sts.amazonaws.com
+      token.actions.githubusercontent.com:sub: repo:acme/payments:environment:production
+    StringLike:
+      token.actions.githubusercontent.com:job_workflow_ref: acme/payments/.github/workflows/deploy.yml@refs/heads/main
+controls:
+  branch_protection: required_reviews_and_status_checks
+  environment_protection: required_reviewers
+  fork_pull_request_access: blocked_from_environment
+expected_result:
+  decision: Pass
+  reason: Token issuance, audience, subject, workflow ref, branch, environment, and fork/PR reachability are all bounded for production credentials.
+  required_evidence: Record issuer, aud, sub, job_workflow_ref, protected environment, branch protection, and cloud role policy in the OIDC evidence table.
+```


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified

**Skill name:** `pipeline-security`
**Skill path:** `skills/devsecops/pipeline-security/`

### What Was Wrong

The skill recommends OIDC/workload identity federation over long-lived credentials, but it did not require reviewers to validate the cloud-side trust policy that decides which workflow identities can exchange OIDC tokens for cloud credentials. A workflow can look safer because it uses `id-token: write` while production credentials are still reachable through broad `sub`, missing `aud`, weak repository/ref/environment conditions, or unrestricted reusable workflow claims.

Fixes #1424.

### What This PR Fixes

- Adds an OIDC trust-policy evidence gate under CICD-SEC-2 / CICD-SEC-6.
- Requires token issuer, `id-token: write` scope, audience, subject pattern, repository/owner/immutable ID binding, ref/environment restrictions, reusable workflow claims, provider policy evidence, fork/PR reachability, and a decision.
- Adds provider-specific checks for AWS IAM, Microsoft Entra/Azure federated credentials, Google Cloud Workload Identity Federation, and reusable workflows.
- Requires OIDC controls to be marked `Not Evaluable -- Missing Cloud Trust Policy` when workflow YAML is available but provider trust policy evidence is missing.
- Extends the report output with an OIDC / Workload Identity Trust Evidence table.
- Adds structured fixtures for broad AWS subjects, missing AWS audience checks, Azure subject/audience mismatch, Google WIF without organization conditions, reusable workflows without `job_workflow_ref`, and a complete least-privilege configuration.

### Validation

- `git diff --check`
- Content marker checks for issuer, workflow token permission, audience, subject, repository/owner binding, immutable repository ID, reusable workflow claims, provider trust evidence, fork/PR reachability, missing cloud trust policy handling, and all requested fixtures
- Markdown fence-balance checks for the updated skill and fixture file
- Ruby YAML parse for all six fixture blocks
- ASCII-only check for changed files
- Privacy scan for local paths/name fragments
- Live reference URL checks returned HTTP 200 for GitHub OIDC hardening, GitHub OIDC in AWS, AWS IAM condition keys, Microsoft Entra workload identity federation, and Google Cloud Workload Identity Federation

### Bounty Request

Requesting Improver Moderate consideration ($100) if accepted. Payment details can be provided privately after maintainer acceptance.

## Bounty Info

- [x] I have read and agree to the CONTRIBUTING.md bounty terms.
- Preferred payment method can be coordinated privately after maintainer acceptance.

/claim #1424
