### PR TITLE
Add GCP serverless Eventarc evidence gates

### DIFF
--- a/skills/cloud/gcp-review/SKILL.md
+++ b/skills/cloud/gcp-review/SKILL.md
@@ -3,7 +3,8 @@ name: gcp-review
 description: >
   Performs a GCP security posture review against the CIS Google Cloud Platform
   Foundation Benchmark v2.0.0. Auto-invoked when reviewing GCP infrastructure,
-  IAM bindings, VPC firewall rules, Cloud Audit Logs, or GCS bucket security.
+  IAM bindings, VPC firewall rules, Cloud Run, Cloud Functions v2, Eventarc,
+  Cloud Audit Logs, or GCS bucket security.
   Walks through all seven benchmark sections, evaluates each recommendation,
   and produces a prioritized findings report with remediation guidance mapped
   to specific CIS control IDs.
@@ -13,7 +14,7 @@ phase: [assess, operate]
 frameworks: [CIS-GCP-v2.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -53,6 +54,7 @@ The CIS Google Cloud Platform Foundation Benchmark v2.0.0 is a consensus-driven 
 - gcloud CLI output or configuration exports (if reviewing a live environment)
 - IAM policy bindings and org policy definitions
 - VPC and firewall rule definitions
+- Cloud Run, Cloud Functions v2, Eventarc trigger, Secret Manager, runtime service account, and Workload Identity Federation configuration when serverless workloads are in scope
 - Cloud Audit Logs configuration
 
 ---
@@ -88,6 +90,29 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
+### Step 8.5: Supplemental Serverless Identity, Secrets, and Eventarc Review
+
+Cloud Run and Cloud Functions v2 can expose public endpoints, privileged runtime service accounts, secret material, and event-driven access paths without VM public IP or firewall evidence. Review serverless resources separately before closing a GCP posture assessment.
+
+**Serverless evidence to record:**
+
+| Evidence Area | Required Detail | Risk if Missing |
+|---------------|-----------------|-----------------|
+| Resource Inventory | `google_cloud_run_v2_service`, `google_cloudfunctions2_function`, Cloud Run functions, Eventarc triggers, invoker IAM, runtime service accounts | Serverless attack paths are missed by VM-only checks |
+| Public Access | Cloud Run/Functions invoker IAM, `allUsers` / `allAuthenticatedUsers`, disabled Invoker IAM checks, ingress mode, load balancer/IAP context | Internal/admin APIs can be internet reachable |
+| Runtime Identity | Non-default service account, least-privilege IAM, Secret Manager access, cross-project secret access justification | Default or broad runtime identities expand blast radius |
+| Secret Source | Literal env var, Secret Manager env reference, Secret Manager volume, pinned version vs `latest`, accessor IAM scope | Secret-looking env names can be false positives, while literal secrets and broad access are missed |
+| Functions v2 / Eventarc | Trigger type, event filters, trigger service account, destination service, Pub/Sub/Storage/Audit Log source ACLs | Event-driven functions may be invoked through broad or spoofable sources |
+| Network / Egress | Ingress mode, VPC connector, egress setting, private backend access, public frontend rationale | Public ingress or unrestricted egress can bypass network assumptions |
+| Resource Controls | Concurrency, min/max instances, CPU/memory limits, timeout, request size expectations | High-concurrency or unbounded scale can create DoS or noisy-neighbor risk |
+| Workload Identity Federation | Issuer, audience, subject mapping, attribute condition, service-account impersonation binding | Keyless federation can over-trust external identities |
+
+Classify missing serverless IAM, Eventarc, ingress, resource-limit, or secret-source evidence as `Not Evaluable` rather than inferring safety from absent VM, firewall, or public-IP findings.
+
+Use `tests/serverless-identity-eventarc-edge-cases.md` for vulnerable and benign calibration examples.
+
+---
+
 ### Step 9: Compile Assessment Report
 
 
@@ -99,8 +124,8 @@ Produce the final report using the structure defined in the Output Format sectio
 
 | Severity | Definition | Examples |
 |----------|-----------|----------|
-| **Critical** | Immediate risk of data breach or unauthorized access | Public GCS buckets, firewall rules allowing 0.0.0.0/0 on SSH/RDP, Cloud SQL with public IP and no SSL, user-managed SA keys with admin roles |
-| **High** | Significant security gap that materially weakens posture | Default service accounts with broad scopes, missing Cloud Audit Logs, no VPC flow logs, instances with public IPs |
+| **Critical** | Immediate risk of data breach or unauthorized access | Public GCS buckets, firewall rules allowing 0.0.0.0/0 on SSH/RDP, Cloud SQL with public IP and no SSL, public serverless admin APIs, user-managed SA keys with admin roles |
+| **High** | Significant security gap that materially weakens posture | Default service accounts with broad scopes, missing Cloud Audit Logs, no VPC flow logs, instances with public IPs, literal serverless secrets, broad Eventarc trigger sources |
 | **Medium** | Control gap that should be addressed in normal cycle | Missing log metric filters, DNSSEC not enabled, Shielded VM not enabled, uniform bucket access not set |
 | **Low** | Hardening recommendation or defense-in-depth measure | OS Login not enabled, serial port access not explicitly disabled, BigQuery tables without CMEK |
 | **Informational** | Best practice observation, no direct security impact | Default network still exists (non-production), naming conventions, documentation gaps |
@@ -150,6 +175,12 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Evidence:** <specific configuration or code snippet>
 - **Remediation:** <specific fix with code example>
 
+### Supplemental Serverless Findings
+
+| Resource | Public Invoker | Ingress | Runtime Service Account | Secret Source | Eventarc / Trigger Evidence | Resource Limits | WIF Condition | Status |
+|----------|----------------|---------|-------------------------|---------------|-----------------------------|-----------------|---------------|--------|
+| <Cloud Run / Function> | allUsers / restricted / not evaluable | all / internal / not evaluable | <service account> | literal / Secret Manager pinned / latest / none | trigger filters + source ACLs / not applicable / not evaluable | concurrency + max instances + timeout | present / missing / N/A | Pass / Fail / Not Evaluable |
+
 ### Prioritized Remediation Plan
 
 1. **[Critical]** CIS X.Y -- <action item>
@@ -194,6 +225,10 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Cloud SQL authorized_networks vs. private IP.** CIS 6.5 flags `0.0.0.0/0` in authorized networks, but CIS 6.6 goes further and recommends disabling public IP entirely in favor of private networking.
 5. **BigQuery dataset-level vs. table-level CMEK.** CIS 7.2 checks table-level encryption, while CIS 7.3 checks the dataset default. Both should be evaluated independently.
 6. **Default compute service account identification.** The default SA follows the pattern `PROJECT_NUMBER-compute@developer.gserviceaccount.com`. Grep for this pattern, not just the string "default."
+7. **Serverless exposure without VM evidence.** Cloud Run and Cloud Functions v2 can be public through invoker IAM or disabled Invoker IAM checks even when no VM has a public IP. Review ingress, invoker IAM, runtime identity, and backend authorization together.
+8. **Eventarc triggers are not ordinary HTTP invokers.** Functions v2 and Cloud Run event receivers can be reached through Pub/Sub, Storage, Audit Logs, or Eventarc trigger paths. Review trigger filters, trigger service accounts, source resource ACLs, and destination permissions.
+9. **Assuming Secret Manager references are plaintext secrets.** `secret_key_ref` and `secret_environment_variables` are valid patterns when accessor IAM is scoped and versions are pinned. Literal values, broad secret access, and unpinned `latest` need separate findings.
+10. **Ignoring concurrency and scaling controls.** Public serverless endpoints with high concurrency, missing max instances, long timeouts, or weak authentication can produce resource exhaustion risk even when IAM is otherwise correct.
 
 ---
 
@@ -219,6 +254,11 @@ Produce the final report using the structure defined in the Output Format sectio
 - Google Cloud Audit Logs: https://cloud.google.com/logging/docs/audit
 - Google Cloud VPC Documentation: https://cloud.google.com/vpc/docs
 - Google Cloud SQL Security: https://cloud.google.com/sql/docs/mysql/configure-ssl-instance
+- Google Cloud Run Authentication: https://cloud.google.com/run/docs/authenticating/overview
+- Google Cloud Run Public Access: https://cloud.google.com/run/docs/authenticating/public
+- Google Cloud Run Secrets: https://cloud.google.com/run/docs/configuring/services/secrets
+- Cloud Run Functions and Eventarc Triggers: https://cloud.google.com/functions/docs/calling
+- Google Cloud Workload Identity Federation: https://cloud.google.com/iam/docs/workload-identity-federation
 - Terraform Google Provider Documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs
 
 ---
@@ -226,3 +266,4 @@ Produce the final report using the structure defined in the Output Format sectio
 ## Changelog
 
 - **1.0.0** -- Initial release. Full coverage of CIS Google Cloud Platform Foundation Benchmark v2.0.0 sections 1 through 7.
+- **1.0.1** -- Add supplemental Cloud Run, Cloud Functions v2, Eventarc, Secret Manager, resource-limit, and Workload Identity Federation evidence gates.

--- a/skills/cloud/gcp-review/benchmark-checklist.md
+++ b/skills/cloud/gcp-review/benchmark-checklist.md
@@ -152,7 +152,7 @@ Check Dataproc clusters for CMEK configuration.
 
 ### CIS 1.18 -- Ensure Secrets Are Not Stored in Cloud Functions Environment Variables by Using Secret Manager
 
-Check Cloud Functions for secrets in environment variables vs. Secret Manager references:
+Check Cloud Functions for secrets in environment variables vs. Secret Manager references. Include first-generation `google_cloudfunctions_function`, second-generation `google_cloudfunctions2_function`, and Cloud Run services used as function/runtime targets:
 
 ```hcl
 # BAD: Secret in env var
@@ -170,7 +170,222 @@ resource "google_cloudfunctions_function" {
     version = "latest"
   }
 }
+
+# BAD: Cloud Functions v2 literal secret in service_config
+resource "google_cloudfunctions2_function" "webhook" {
+  service_config {
+    environment_variables = {
+      STRIPE_WEBHOOK_SECRET = "whsec_plaintext_value"
+    }
+  }
+}
 ```
+
+For Cloud Functions v2, also evaluate Cloud Run runtime behavior: invoker IAM, ingress, runtime service account, Eventarc trigger source, and Secret Manager accessor grants.
+
+### Supplemental -- Cloud Run and Cloud Functions v2 Serverless Evidence
+
+Review Cloud Run v2, Cloud Functions v2, and Eventarc even when the CIS checklist item does not name them directly.
+
+**Discovery patterns:**
+
+```hcl
+resource "google_cloud_run_v2_service"
+resource "google_cloud_run_service_iam_member"
+resource "google_cloud_run_service_iam_binding"
+resource "google_cloudfunctions2_function"
+resource "google_cloudfunctions2_function_iam_member"
+resource "google_eventarc_trigger"
+resource "google_iam_workload_identity_pool_provider"
+resource "google_service_account_iam_member"
+```
+
+**Public invocation, ingress, and disabled Invoker IAM checks:**
+
+```hcl
+# BAD: Public Cloud Run invoker for an internal/admin service
+resource "google_cloud_run_service_iam_member" "public" {
+  role   = "roles/run.invoker"
+  member = "allUsers"
+}
+
+# BAD: Public internet ingress for an internal/admin service
+resource "google_cloud_run_v2_service" "admin_api" {
+  ingress = "INGRESS_TRAFFIC_ALL"
+}
+
+# GOOD: Private ingress plus named invoker
+resource "google_cloud_run_v2_service" "checkout_api" {
+  ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+}
+
+resource "google_cloud_run_service_iam_member" "private_invoker" {
+  role   = "roles/run.invoker"
+  member = "serviceAccount:edge-proxy@example.iam.gserviceaccount.com"
+}
+```
+
+Flag public invocation as **Critical** for admin, internal, payment, customer-data, or privileged automation APIs. Public access can be acceptable for public frontends only when the report records data classification, authentication expectations, ingress, backend authorization, and abuse controls. If platform exports indicate Invoker IAM checks are disabled, record that separately from IAM bindings.
+
+**Secret Manager references vs literal environment secrets:**
+
+```hcl
+# BAD: Literal secret value in Cloud Run env
+resource "google_cloud_run_v2_service" "api" {
+  template {
+    containers {
+      env {
+        name  = "PAYMENT_API_KEY"
+        value = "plain-text-secret"
+      }
+    }
+  }
+}
+
+# GOOD: Secret Manager reference with pinned version and scoped accessor
+resource "google_cloud_run_v2_service" "api" {
+  template {
+    service_account = google_service_account.runtime.email
+
+    containers {
+      env {
+        name = "PAYMENT_API_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.payment_api_key.secret_id
+            version = "2"
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "runtime_can_read_key" {
+  secret_id = google_secret_manager_secret.payment_api_key.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.runtime.email}"
+}
+```
+
+Do not flag a Secret Manager-backed `secret_key_ref` as plaintext merely because the environment variable name contains `KEY`, `TOKEN`, or `SECRET`. Do flag literal values, broad `roles/secretmanager.secretAccessor` grants, default runtime service accounts, cross-project secret access without justification, and unpinned `latest` versions for environment-variable secrets.
+
+**Cloud Functions v2 / Eventarc trigger checks:**
+
+```hcl
+# BAD: Broad Eventarc trigger without source resource filter
+resource "google_eventarc_trigger" "ingest" {
+  matching_criteria {
+    attribute = "type"
+    value     = "google.cloud.storage.object.v1.finalized"
+  }
+
+  destination {
+    cloud_run_service {
+      service = google_cloud_run_v2_service.processor.name
+      region  = "us-central1"
+    }
+  }
+}
+
+# GOOD: Trigger source and service account are explicit
+resource "google_eventarc_trigger" "ingest" {
+  service_account = google_service_account.eventarc_invoker.email
+
+  matching_criteria {
+    attribute = "type"
+    value     = "google.cloud.storage.object.v1.finalized"
+  }
+
+  matching_criteria {
+    attribute = "bucket"
+    value     = google_storage_bucket.approved_uploads.name
+  }
+}
+```
+
+For Functions v2 and Eventarc-backed Cloud Run receivers, record trigger type, event filters, trigger service account, destination service, source resource ACLs, and whether Pub/Sub, Storage, or Audit Log producers are restricted. Treat missing trigger-source evidence as **Not Evaluable** for event-driven workloads.
+
+**Resource limits and concurrency:**
+
+```hcl
+# BAD: Public service with high concurrency and no max instance cap
+resource "google_cloud_run_v2_service" "public_api" {
+  ingress = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    containers {
+      resources {
+        limits = {
+          cpu    = "4"
+          memory = "8Gi"
+        }
+      }
+    }
+
+    max_instance_request_concurrency = 1000
+    timeout                          = "3600s"
+  }
+}
+
+# GOOD: Concurrency, timeout, and scaling are bounded for expected traffic
+resource "google_cloud_run_v2_service" "frontend" {
+  template {
+    max_instance_request_concurrency = 80
+    timeout                          = "60s"
+    scaling {
+      max_instance_count = 20
+    }
+  }
+}
+```
+
+Record concurrency, timeout, min/max instances, CPU/memory limits, and expected traffic class for public or high-value services. Flag missing or excessive values when they can create resource exhaustion, cost-spike, or noisy-neighbor risk.
+
+**Workload Identity Federation checks:**
+
+```hcl
+# BAD: Missing attribute_condition for GitHub OIDC provider
+resource "google_iam_workload_identity_pool_provider" "github" {
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.repository" = "assertion.repository"
+  }
+}
+
+# GOOD: Provider scoped to the expected organization/repository/ref
+resource "google_iam_workload_identity_pool_provider" "github" {
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.repository" = "assertion.repository"
+    "attribute.ref"        = "assertion.ref"
+  }
+
+  attribute_condition = "attribute.repository == 'example/checkout-api' && attribute.ref == 'refs/heads/main'"
+}
+```
+
+Verify issuer, audience if configured, subject mapping, provider-specific attributes, `attribute_condition`, and the service-account impersonation binding. Treat keyless federation as lower risk than user-managed service account keys only when these trust constraints are present.
+
+**Serverless evidence matrix:**
+
+| Evidence Area | Pass Evidence | Fail / Not Evaluable Indicator |
+|---|---|---|
+| Runtime identity | Dedicated non-default service account with scoped IAM | Default service account, broad project role, or missing runtime identity |
+| Public invocation | Restricted invoker IAM or documented public frontend rationale | `allUsers`, `allAuthenticatedUsers`, disabled invoker IAM check, or unknown invoker policy |
+| Ingress | Internal, internal-load-balancer, or documented public ingress | Internet ingress for internal/admin service or missing ingress evidence |
+| Secret source | Secret Manager env/volume reference with scoped accessor IAM | Literal secret values, broad accessor IAM, unpinned `latest`, or unknown secret source |
+| Eventarc trigger | Source filters, trigger service account, destination, and source ACLs documented | Broad/missing filters, unknown source ACLs, or trigger service account missing |
+| Resource limits | Bounded concurrency, timeout, scaling, and resource limits tied to expected traffic | Excessive concurrency/timeout, no max instance cap for public endpoints, or missing evidence |
+| WIF trust | Issuer, mapping, conditions, and impersonation scope are constrained | Missing `attribute_condition`, broad subject trust, or project-wide impersonation |
 
 ---
 

--- a/skills/cloud/gcp-review/tests/serverless-identity-eventarc-edge-cases.md
+++ b/skills/cloud/gcp-review/tests/serverless-identity-eventarc-edge-cases.md
@@ -1,0 +1,151 @@
+# Serverless Identity, Secrets, Eventarc, and Resource-Limit Edge Cases
+
+These fixtures calibrate the supplemental `gcp-review` serverless evidence gate. Reviewers should evaluate Cloud Run / Cloud Functions v2 public access, runtime identity, Secret Manager usage, Eventarc trigger reachability, Workload Identity Federation, and concurrency/resource limits together.
+
+## Vulnerable: Public Cloud Run Admin API With Literal Secret and Weak Limits
+
+```yaml
+case: cloud-run-public-admin-literal-secret
+resource: google_cloud_run_v2_service.admin_api
+evidence:
+  ingress: INGRESS_TRAFFIC_ALL
+  invoker_iam:
+    role: roles/run.invoker
+    member: allUsers
+  runtime_service_account: default-compute@example.iam.gserviceaccount.com
+  env:
+    ADMIN_API_TOKEN:
+      type: literal
+      value: plain-text-token
+  resource_limits:
+    max_instance_request_concurrency: 1000
+    timeout: 3600s
+    max_instance_count: missing
+expected_result:
+  decision: Fail
+  severity: Critical
+  reason: Public unauthenticated admin API combines literal secret exposure, default runtime identity, high concurrency, long timeout, and no max instance cap.
+  required_evidence: Record public invoker, ingress, runtime service account, secret source, concurrency, timeout, and scaling limit findings.
+```
+
+## Vulnerable: Cloud Functions v2 Literal Secret and Broad Eventarc Source
+
+```yaml
+case: functions-v2-eventarc-broad-source
+resource: google_cloudfunctions2_function.webhook
+evidence:
+  service_config:
+    environment_variables:
+      STRIPE_WEBHOOK_SECRET: whsec_plaintext_value
+    service_account_email: default-compute@example.iam.gserviceaccount.com
+  event_trigger:
+    trigger_region: us-central1
+    event_type: google.cloud.storage.object.v1.finalized
+    event_filters:
+      bucket: missing
+    trigger_service_account: missing
+  destination: cloud-run-managed-function
+expected_result:
+  decision: Fail
+  severity: High
+  reason: Functions v2 uses Cloud Run/Eventarc semantics; literal secret, default service account, missing trigger service account, and missing source bucket filter should be caught.
+  required_evidence: Review service_config env vars, runtime service account, Eventarc filters, trigger identity, and source resource ACLs.
+```
+
+## Vulnerable: Secret Manager Reference With Broad Access and latest Version
+
+```yaml
+case: secret-manager-latest-broad-access
+resource: google_cloud_run_v2_service.worker
+evidence:
+  env:
+    PAYMENT_API_KEY:
+      type: secret_key_ref
+      secret: payment-api-key
+      version: latest
+  secret_iam:
+    role: roles/secretmanager.secretAccessor
+    member: allAuthenticatedUsers
+  runtime_service_account: checkout-runtime@example.iam.gserviceaccount.com
+expected_result:
+  decision: Fail
+  severity: High
+  reason: Secret Manager reference avoids plaintext but uses latest and grants broad accessor rights.
+  required_evidence: Distinguish Secret Manager reference from literal secret, then flag unpinned version and broad secretAccessor IAM.
+```
+
+## Vulnerable: Workload Identity Federation Without Attribute Conditions
+
+```yaml
+case: gcp-wif-missing-conditions
+resource: google_iam_workload_identity_pool_provider.github
+evidence:
+  issuer_uri: https://token.actions.githubusercontent.com
+  attribute_mapping:
+    google.subject: assertion.sub
+    attribute.repository: assertion.repository
+  attribute_condition: missing
+  impersonation_binding:
+    role: roles/iam.workloadIdentityUser
+    member: principalSet://iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/cicd/*
+expected_result:
+  decision: Fail
+  severity: High
+  reason: Keyless federation replaces service account keys but over-trusts the shared GitHub issuer without repository/ref conditions and has broad impersonation scope.
+  required_evidence: Record issuer, mapping, attribute_condition, and service-account impersonation binding scope.
+```
+
+## Vulnerable: Missing Evidence for Disabled Invoker IAM Check
+
+```yaml
+case: cloud-run-invoker-check-not-evaluable
+resource: google_cloud_run_v2_service.partner_callback
+evidence:
+  ingress: INGRESS_TRAFFIC_ALL
+  invoker_iam_bindings: none_in_iac
+  platform_export:
+    invoker_iam_check: unavailable
+  authentication_expectation: partner-signed-callback
+expected_result:
+  decision: Not Evaluable
+  severity: Medium
+  reason: Absence of IAM bindings in IaC does not prove the service is private when Invoker IAM check status and platform export are unavailable.
+  required_evidence: Obtain Cloud Run service IAM policy or platform export showing whether Invoker IAM checks are enforced or disabled.
+```
+
+## Benign: Private Checkout API With Scoped Secret, WIF, and Bounded Runtime
+
+```yaml
+case: private-checkout-api-scoped-secret-wif
+resource: google_cloud_run_v2_service.checkout_api
+evidence:
+  ingress: INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER
+  invoker_iam:
+    role: roles/run.invoker
+    member: serviceAccount:edge-proxy@example.iam.gserviceaccount.com
+  runtime_service_account: checkout-runtime@example.iam.gserviceaccount.com
+  env:
+    PAYMENT_API_KEY:
+      type: secret_key_ref
+      secret: payment-api-key
+      version: "2"
+  secret_iam:
+    role: roles/secretmanager.secretAccessor
+    member: serviceAccount:checkout-runtime@example.iam.gserviceaccount.com
+  resource_limits:
+    max_instance_request_concurrency: 80
+    timeout: 60s
+    max_instance_count: 20
+  workload_identity_federation:
+    issuer_uri: https://token.actions.githubusercontent.com
+    attribute_mapping:
+      google.subject: assertion.sub
+      attribute.repository: assertion.repository
+      attribute.ref: assertion.ref
+    attribute_condition: attribute.repository == 'example/checkout-api' && attribute.ref == 'refs/heads/main'
+expected_result:
+  decision: Pass
+  severity: Informational
+  reason: Private ingress, named invoker, scoped runtime identity, pinned Secret Manager reference, bounded runtime, and constrained WIF evidence are all present.
+  required_evidence: Populate the supplemental serverless matrix with pass evidence rather than flagging the secret-looking environment variable name.
+```


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified

**Skill name:** `gcp-review`
**Skill path:** `skills/cloud/gcp-review/`

### What Was Wrong

The GCP review skill covers IAM, logging, networking, VMs, storage, Cloud SQL, BigQuery, and a Cloud Functions v1 secret pattern, but it did not give first-class evidence gates for Cloud Run, Cloud Functions v2, Eventarc trigger reachability, serverless runtime identity, Secret Manager references, Workload Identity Federation, or concurrency/resource-limit risk.

Fixes #652.

### What This PR Fixes

- Adds `Step 8.5: Supplemental Serverless Identity, Secrets, and Eventarc Review`.
- Requires evidence for Cloud Run / Functions v2 inventory, public invoker policy, ingress, disabled Invoker IAM checks, runtime service account, secret source, Eventarc trigger filters, network/egress context, resource limits, and WIF trust constraints.
- Extends the GCP assessment output with a supplemental serverless findings matrix.
- Expands the benchmark checklist with Terraform review patterns for Cloud Run v2, Functions v2, invoker IAM, literal env secrets, Secret Manager pinned references, Eventarc trigger source filters, concurrency/resource limits, and WIF attribute conditions.
- Adds a structured fixture file covering public admin APIs, Functions v2/Eventarc broad sources, Secret Manager `latest` with broad access, weak WIF, missing disabled-Invoker-IAM evidence, and a benign private checkout API.

### Validation

- `git diff --check`
- Content marker checks for Step 8.5, Eventarc, resource controls, disabled Invoker IAM, Secret Manager classification, Workload Identity Federation, and all fixture cases
- Markdown fence-balance checks for changed files
- Ruby YAML parse for all six fixture blocks
- ASCII-only check for changed files
- Privacy scan for local paths/name fragments
- Live reference URL checks returned HTTP 200 for Cloud Run authentication, public access, secrets, Cloud Functions/Eventarc calling, and Workload Identity Federation

### Bounty Request

Requesting Improver Moderate consideration ($100) if accepted. Payment details can be provided privately after maintainer acceptance.

## Bounty Info

- [x] I have read and agree to the CONTRIBUTING.md bounty terms.
- Preferred payment method can be coordinated privately after maintainer acceptance.

/claim #652
