### PR TITLE
Add IAM downstream deprovisioning gates

### DIFF
--- a/skills/identity/iam-review/SKILL.md
+++ b/skills/identity/iam-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [design, operate]
 frameworks: [NIST-SP-800-63B, NIST-SP-800-207, CIS-Controls-v8]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -258,6 +258,41 @@ IAM-STALE-07: Accounts disabled but not deleted after retention period
 IAM-STALE-08: Access reviews not conducted on required cadence (quarterly for privileged, semi-annual for standard)
 ```
 
+#### Downstream Deprovisioning and Token Revocation Evidence Gate
+
+Do not mark deprovisioning complete based only on the IdP account status or a successful SCIM user disable event. Verify that relying-party accounts, sessions, app-local roles, refresh tokens, API tokens, mobile/device tokens, and owned machine identities no longer preserve effective access.
+
+```
+IAM-DEPROV-01: IdP disabled or SCIM event succeeded, but relying-party account/session state is not verified
+IAM-DEPROV-02: Browser, mobile, CLI, OAuth refresh, personal API, or device tokens remain active after termination or access change
+IAM-DEPROV-03: Group removal does not propagate to app-local RBAC, cached claims, entitlement tables, warehouse grants, or cloud roles
+IAM-DEPROV-04: Non-SCIM application lacks compensating lifecycle control and reconciliation evidence
+IAM-DEPROV-05: Owner termination or transfer does not trigger review of service accounts, OAuth apps, deploy keys, CI/CD secrets, OIDC trust policies, or static keys
+IAM-DEPROV-06: Break-glass, emergency, or excluded accounts lack owner, expiry, monitoring, test, and post-use rotation evidence
+IAM-DEPROV-07: Deprovisioning evidence lacks event IDs, timestamps, source-of-truth records, or residual-access decision
+IAM-DEPROV-08: Downstream lifecycle evidence is unavailable; deprovisioning must be Not Evaluable
+```
+
+**Required evidence matrix:**
+
+| Evidence Area | Required Detail | Risk if Missing |
+|---|---|---|
+| Source lifecycle event | Hire, transfer, termination, group removal, owner change, emergency access use, HRIS/IdP ticket, source-of-truth ID, event timestamp | Review cannot prove the access change is authoritative or timely |
+| IdP and provisioning evidence | Directory status, SCIM PATCH/DELETE event, IdP group delta, provisioning job result, failure queue, retry status, and event ID | SCIM may fail partially or disable only the identity object |
+| Relying-party state | App-local user state, roles/groups, entitlement table, data warehouse grants, cloud/SaaS role bindings, cache TTL, last sync, and audit event | Effective access can persist outside the IdP |
+| Token/session revocation | Browser sessions, mobile sessions, OAuth refresh tokens, personal API tokens, device tokens, CLI tokens, and service-specific sessions | Users can remain authenticated after account disablement |
+| Machine identity impact | Owned service accounts, deploy keys, OAuth apps, GitHub/GitLab tokens, CI/CD secrets, OIDC trust policies, static keys, workload identity bindings, and owner reassignment | Departed owners can leave non-human production access behind |
+| Non-SCIM compensating controls | Manual disable checklist, API revocation proof, periodic reconciliation, exception owner, review cadence, and residual access result | SSO-only apps can retain local access without lifecycle coverage |
+| Break-glass exceptions | Account owner, business purpose, expiry, monitoring, test result, vaulting, post-use password/key rotation, and approval evidence | Emergency access can become permanent ungoverned access |
+
+**Decision rules:**
+
+- Mark former employee, contractor, or vendor residual access **Critical** when active sessions, refresh tokens, API tokens, or app-local admin roles remain valid after termination.
+- Mark access-change propagation **High** when group removal or role change does not invalidate cached app-local RBAC, cloud grants, or entitlement tables within the required SLA.
+- Mark machine identity lifecycle **High** when a departed owner still controls service accounts, deploy keys, OAuth apps, OIDC trust policies, static keys, or CI/CD secrets.
+- Mark non-SCIM apps **Partial** only when compensating controls prove local account disablement, token/session revocation, reconciliation, and residual access review.
+- Mark deprovisioning **Not Evaluable** when only IdP status or SCIM success is available without relying-party state, token/session, and machine-identity evidence.
+
 **Platform-specific checks:**
 
 | Platform | Check | What to look for |
@@ -265,14 +300,18 @@ IAM-STALE-08: Access reviews not conducted on required cadence (quarterly for pr
 | **AWS** | IAM Credential Report: `password_last_used`, `access_key_last_used` | Inactive users, unused access keys |
 | **Azure / Entra ID** | Sign-in logs, last sign-in activity (requires Entra ID P1+) | Inactive users, stale guest accounts |
 | **Azure / Entra ID** | Access Reviews (Entra ID Governance) | Configured and completing on schedule |
+| **Azure / Entra ID** | Continuous Access Evaluation, refresh-token revocation, enterprise app assignments | Token/session revocation, app-local roles, stale service principals |
 | **GCP** | Policy Analyzer, Admin Activity audit logs | Service accounts with no API calls, unused IAM bindings |
+| **SaaS / IdP** | SCIM job logs, app audit logs, OAuth app/token inventory, session APIs | Downstream disablement, token/session revocation, group cache propagation |
 
 **Severity Classification:**
 
 | Finding | Severity | Rationale |
 |---|---|---|
 | Former employee with active admin access | **Critical** | Immediate unauthorized access risk |
+| Former employee with active token/session/API access | **Critical** | IdP disablement did not remove effective access |
 | Orphaned service account with production access | **High** | No owner to monitor or respond to abuse |
+| Group removal not reflected in relying-party roles | **High** | Access change has not propagated to effective authorization |
 | Inactive human account > 90 days | **Medium** | Credential stuffing / takeover target |
 | Disabled but not deleted account > 180 days | **Low** | Hygiene improvement |
 
@@ -414,6 +453,12 @@ For each finding, produce a row with:
 ### Detailed Findings
 [Findings table — see above]
 
+### Downstream Deprovisioning and Token Revocation
+
+| Lifecycle Event | IdP / SCIM Evidence | Relying Party State | Token / Session Revocation | Machine Identity Impact | Exception Evidence | Decision |
+|---|---|---|---|---|---|---|
+| [termination/group removal/owner change] | [event ID, timestamp, job result] | [app roles/groups/grants/cache state] | [browser/mobile/OAuth/API/device/CLI] | [service accounts, keys, apps, OIDC, CI/CD] | [non-SCIM or break-glass controls] | Pass / Fail / Partial / Not Evaluable |
+
 ### Remediation Roadmap
 [Prioritized actions: immediate (0-7 days), short-term (30 days), medium-term (90 days)]
 
@@ -508,4 +553,5 @@ This skill processes user-supplied content including IAM policies, access config
 
 | Version | Date | Changes |
 |---|---|---|
+| 1.0.1 | 2026-06-06 | Add downstream deprovisioning and token revocation evidence gates |
 | 1.0.0 | 2025-03-06 | Initial release |

--- a/skills/identity/iam-review/SKILL.md
+++ b/skills/identity/iam-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [design, operate]
 frameworks: [NIST-SP-800-63B, NIST-SP-800-207, CIS-Controls-v8]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.1"
+version: "1.0.2"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -260,7 +260,7 @@ IAM-STALE-08: Access reviews not conducted on required cadence (quarterly for pr
 
 #### Downstream Deprovisioning and Token Revocation Evidence Gate
 
-Do not mark deprovisioning complete based only on the IdP account status or a successful SCIM user disable event. Verify that relying-party accounts, sessions, app-local roles, refresh tokens, API tokens, mobile/device tokens, and owned machine identities no longer preserve effective access.
+Do not mark deprovisioning complete based only on the IdP account status or a successful SCIM user disable event. Verify that relying-party accounts, sessions, app-local roles, refresh tokens, API tokens, mobile/device tokens, and owned machine identities no longer preserve effective access. When standards apply, map SCIM PATCH/DELETE evidence to RFC 7644 behavior and token revocation evidence to RFC 7009 semantics.
 
 ```
 IAM-DEPROV-01: IdP disabled or SCIM event succeeded, but relying-party account/session state is not verified
@@ -280,7 +280,7 @@ IAM-DEPROV-08: Downstream lifecycle evidence is unavailable; deprovisioning must
 | Source lifecycle event | Hire, transfer, termination, group removal, owner change, emergency access use, HRIS/IdP ticket, source-of-truth ID, event timestamp | Review cannot prove the access change is authoritative or timely |
 | IdP and provisioning evidence | Directory status, SCIM PATCH/DELETE event, IdP group delta, provisioning job result, failure queue, retry status, and event ID | SCIM may fail partially or disable only the identity object |
 | Relying-party state | App-local user state, roles/groups, entitlement table, data warehouse grants, cloud/SaaS role bindings, cache TTL, last sync, and audit event | Effective access can persist outside the IdP |
-| Token/session revocation | Browser sessions, mobile sessions, OAuth refresh tokens, personal API tokens, device tokens, CLI tokens, and service-specific sessions | Users can remain authenticated after account disablement |
+| Token/session revocation | Browser sessions, mobile sessions, OAuth refresh tokens, personal API tokens, device tokens, CLI tokens, service-specific sessions, RFC 7009 token revocation response, and residual token validation result | Users can remain authenticated after account disablement |
 | Machine identity impact | Owned service accounts, deploy keys, OAuth apps, GitHub/GitLab tokens, CI/CD secrets, OIDC trust policies, static keys, workload identity bindings, and owner reassignment | Departed owners can leave non-human production access behind |
 | Non-SCIM compensating controls | Manual disable checklist, API revocation proof, periodic reconciliation, exception owner, review cadence, and residual access result | SSO-only apps can retain local access without lifecycle coverage |
 | Break-glass exceptions | Account owner, business purpose, expiry, monitoring, test result, vaulting, post-use password/key rotation, and approval evidence | Emergency access can become permanent ungoverned access |
@@ -302,7 +302,15 @@ IAM-DEPROV-08: Downstream lifecycle evidence is unavailable; deprovisioning must
 | **Azure / Entra ID** | Access Reviews (Entra ID Governance) | Configured and completing on schedule |
 | **Azure / Entra ID** | Continuous Access Evaluation, refresh-token revocation, enterprise app assignments | Token/session revocation, app-local roles, stale service principals |
 | **GCP** | Policy Analyzer, Admin Activity audit logs | Service accounts with no API calls, unused IAM bindings |
-| **SaaS / IdP** | SCIM job logs, app audit logs, OAuth app/token inventory, session APIs | Downstream disablement, token/session revocation, group cache propagation |
+| **SaaS / IdP** | SCIM job logs, app audit logs, OAuth app/token inventory, session APIs, RFC 7644 PATCH/DELETE evidence, RFC 7009 token revocation evidence | Downstream disablement, token/session revocation, group cache propagation |
+
+**Reference standards for this gate:**
+
+| Standard | Review use |
+|---|---|
+| **RFC 7009** | Confirm refresh/access token revocation endpoints exist, are called for affected clients, and are followed by residual-token validation evidence. |
+| **RFC 7644** | Confirm SCIM PATCH/DELETE/deactivate operations are not treated as complete until downstream relying-party state and failure queues are verified. |
+| **NIST SP 800-207** | Apply per-session access, continuous evaluation, and assume-breach principles to sessions, tokens, app-local roles, and machine identities. |
 
 **Severity Classification:**
 
@@ -553,5 +561,6 @@ This skill processes user-supplied content including IAM policies, access config
 
 | Version | Date | Changes |
 |---|---|---|
+| 1.0.2 | 2026-06-06 | Add RFC 7009, RFC 7644, and NIST SP 800-207 reference mapping for downstream deprovisioning evidence |
 | 1.0.1 | 2026-06-06 | Add downstream deprovisioning and token revocation evidence gates |
 | 1.0.0 | 2025-03-06 | Initial release |

--- a/skills/identity/iam-review/tests/downstream-deprovisioning-token-revocation.md
+++ b/skills/identity/iam-review/tests/downstream-deprovisioning-token-revocation.md
@@ -1,0 +1,148 @@
+# Downstream Deprovisioning and Token Revocation Edge Cases
+
+These fixtures calibrate the `iam-review` downstream deprovisioning gate. A review should verify relying-party account state, token/session revocation, app-local authorization, and owned machine identities before marking lifecycle removal complete.
+
+## Vulnerable: IdP Disabled But Tokens Still Active
+
+```yaml
+case: idp-disabled-tokens-still-active
+lifecycle_event:
+  type: termination
+  source_of_truth: hris
+  idp_user_status: disabled
+  scim_patch_sent: true
+downstream_app:
+  local_user_active: false
+  browser_sessions_active: true
+  oauth_refresh_tokens_active: true
+  personal_api_tokens_active: true
+  mobile_device_tokens_active: true
+expected_result:
+  finding_codes:
+    - IAM-DEPROV-01
+    - IAM-DEPROV-02
+  decision: Fail
+  severity: Critical
+  reason: Effective authentication remains possible after IdP disablement.
+```
+
+## Vulnerable: Group Removal Not Propagated To App-Local Role
+
+```yaml
+case: group-removal-app-local-role-cache
+access_change:
+  idp_group_removed: engineering-prod-admin
+  scim_user_active: true
+downstream_app:
+  scim_groups_synced: false
+  app_local_role_cache:
+    role: prod_admin
+    expires_in_hours: 24
+  last_full_sync: "2026-06-01T00:00:00Z"
+expected_result:
+  finding_codes:
+    - IAM-DEPROV-03
+  decision: Fail
+  severity: High
+  reason: The IdP group change has not removed effective app-local authorization.
+```
+
+## Vulnerable: Owner Termination Leaves Machine Identity Active
+
+```yaml
+case: owner-terminated-machine-identity-active
+service_account:
+  owner_user: alice@example.invalid
+  owner_status: terminated
+  cloud_role: prod-deploy
+  oidc_trust_policy: still_allows_repo_branch
+  static_key_count: 2
+  last_key_use: "2026-06-06T09:55:00Z"
+  owner_reassignment: missing
+  breakglass_exception: undocumented
+expected_result:
+  finding_codes:
+    - IAM-DEPROV-05
+  decision: Fail
+  severity: High
+  reason: Human owner lifecycle did not trigger service account, OIDC trust, key, and exception review.
+```
+
+## Vulnerable: Non-SCIM App Without Compensating Evidence
+
+```yaml
+case: non-scim-app-no-compensating-control
+application:
+  name: legacy-crm
+  supports_sso: true
+  supports_scim: false
+compensating_control:
+  manual_disable_checklist: missing
+  local_account_state: unknown
+  session_revocation: unknown
+  token_revocation: unknown
+  reconciliation_date: missing
+expected_result:
+  finding_codes:
+    - IAM-DEPROV-04
+    - IAM-DEPROV-08
+  decision: Not Evaluable
+  severity: Medium
+  reason: SSO-only integration cannot be passed without local account, token, session, and reconciliation evidence.
+```
+
+## Vulnerable: Break-Glass Exception Never Rotated
+
+```yaml
+case: breakglass-post-use-rotation-missing
+breakglass_account:
+  owner: security-operations
+  emergency_use_date: "2026-06-02T13:00:00Z"
+  expiry: missing
+  monitoring: enabled
+  test_evidence: present
+  post_use_password_rotation: missing
+  post_use_token_rotation: missing
+  approval_record: present
+expected_result:
+  finding_codes:
+    - IAM-DEPROV-06
+  decision: Partial
+  severity: High
+  reason: Emergency access was monitored but not time-bounded or rotated after use.
+```
+
+## Benign: Complete Downstream Deprovisioning Evidence
+
+```yaml
+case: complete-downstream-deprovisioning
+identity_lifecycle:
+  source_of_truth: okta
+  provisioning_protocol: scim
+  termination_event: user-disabled
+  event_id: evt-789
+  event_timestamp: "2026-06-06T10:12:00Z"
+downstream_apps:
+  - name: payroll-saas
+    scim_user_active: false
+    app_sessions_revoked: true
+    oauth_refresh_tokens_revoked: true
+    api_tokens_revoked: true
+    mobile_tokens_revoked: true
+    group_membership_removed: true
+    app_local_roles_removed: true
+    audit_event_id: audit-456
+machine_identities:
+  owned_service_accounts_reassigned: true
+  deploy_keys_revoked_or_reassigned: true
+  oidc_trust_policies_reviewed: true
+  static_keys_rotated: true
+verification:
+  residual_access: none_found
+  reconciled_at: "2026-06-06T10:20:00Z"
+expected_result:
+  finding_codes: []
+  decision: Pass
+  severity: Informational
+  reason: IdP, relying-party, token/session, role, and machine-identity evidence all show access removal.
+```


### PR DESCRIPTION
Closes #1441

## Summary

- Add downstream deprovisioning and token revocation evidence gates to `iam-review`
- Require relying-party account state, app-local roles/groups, token/session revocation, non-SCIM compensating controls, break-glass controls, and machine identity owner lifecycle evidence before marking deprovisioning complete
- Add named `IAM-DEPROV-*` checks with Critical/High/Partial/Not Evaluable decision rules
- Map token revocation and provisioning evidence to RFC 7009, RFC 7644, and NIST SP 800-207 reference semantics
- Add a downstream deprovisioning output matrix
- Add structured YAML fixtures for IdP-disabled-but-token-active, app-local role cache, terminated-owner machine identity, non-SCIM app gaps, break-glass post-use rotation, and a complete benign lifecycle case

## Validation

- `git diff --check -- skills/identity/iam-review/SKILL.md skills/identity/iam-review/tests/downstream-deprovisioning-token-revocation.md`
- Parsed all 6 YAML fixtures with Ruby `YAML.safe_load`
- Verified Markdown fence balance
- Verified RFC 7009/RFC 7644/NIST reference markers
- Confirmed added lines are ASCII-only
- Ran a privacy scan for local user/path leakage

## Bounty Info

- [x] I have read and agree to the CONTRIBUTING.md bounty terms.
- Preferred payment method can be coordinated privately after maintainer acceptance.

/claim #1441
