### PR TITLE
Add LLM08 retrieval authorization gates

### DIFF
--- a/skills/ai-security/llm-top-10/SKILL.md
+++ b/skills/ai-security/llm-top-10/SKILL.md
@@ -12,7 +12,7 @@ phase: [design, build, review]
 frameworks: [OWASP-LLM-Top-10-2025]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -313,6 +313,41 @@ Review the application against each of the ten OWASP LLM risk categories below. 
 - Do not store raw source text in vector metadata unless access controls are equivalent to the source document's classification.
 - Monitor vector store access patterns for anomalous query volumes or bulk extraction attempts.
 
+#### LLM08 Retrieval Authorization Evidence Gate
+
+Do not pass RAG authorization based only on a tenant filter in the first vector query or collection-level vector database ACLs. Prove that authorization survives every step that can add, reorder, cache, stitch, summarize, or stream retrieved context.
+
+```
+LLM08-RA-01: Pre-query authorization scope lacks tenant, user, group, role, document, chunk, or permission-version filters
+LLM08-RA-02: Returned chunks are not rechecked against current document/chunk ACL before prompt assembly
+LLM08-RA-03: Retrieval cache key omits tenant, user/group, permission version, collection, embedding model, or source ACL hash
+LLM08-RA-04: Reranker, hybrid search, graph expansion, or chunk stitching drops source authorization metadata
+LLM08-RA-05: Public/shared documents lack explicit immutable classification and source ownership evidence
+LLM08-RA-06: Group membership, document sharing, deletion, reclassification, or legal hold changes do not invalidate caches/indexes/context stores
+LLM08-RA-07: Chunk-level ACLs or redaction boundaries are required but only document-level ACLs are checked
+LLM08-RA-08: Post-retrieval authorization evidence is unavailable; retrieval authorization must be Not Evaluable
+```
+
+**Required evidence matrix:**
+
+| Evidence Area | Required Detail | Risk if Missing |
+|---|---|---|
+| Request identity | Authenticated tenant, user, groups, roles, entitlements, session, and permission version used for retrieval | Review cannot prove the query used the caller's current authorization |
+| Pre-query filters | Vector, keyword, graph, and hybrid-search filters for tenant, source collection, document ACL, chunk ACL, classification, and permission version | Initial retrieval can include unauthorized candidates |
+| Post-retrieval validation | ACL check after vector/keyword retrieval, after reranking/aggregation, and immediately before prompt assembly or streaming | Cached or transformed chunks can bypass the original filter |
+| Cache scope | Cache key includes tenant, user or permission scope, groups hash, query hash, collection, embedding model/version, source ACL hash, and permission version | One user's authorized context can be reused for another user or tenant |
+| Reranker/hybrid metadata | Reranker, BM25, graph expansion, and chunk stitching preserve document ID, chunk ID, tenant, ACL hash, source URI, classification, and permission version | Authorization metadata can disappear before the final prompt |
+| Public content exception | Public/shared classification, immutable source metadata, owner, approval date, and proof that no tenant-private content is mixed in | Shared collections can be mistaken for public access |
+| Invalidation | Events for group changes, document ACL updates, deletions, reclassification, legal holds, source reindex, embedding model changes, and permission-version bumps | Stale permissions can keep exposing previously authorized content |
+
+**Decision rules:**
+
+- Mark retrieval authorization **High** when unauthorized tenant/user/document/chunk content can reach prompt assembly, responses, tools, or downstream summaries.
+- Mark shared caches **High** when keyed only by query text, embedding hash, or normalized prompt without permission scope and permission version.
+- Mark reranker/hybrid-search metadata loss **High** when final context cannot be traced back to source ACLs before prompt assembly.
+- Mark public/shared content **Medium** unless explicit public classification and immutable source metadata are documented; raise to **High** if mixed with tenant-private content.
+- Mark retrieval authorization **Not Evaluable** when reviewers only have the initial vector query filter or collection ACLs and lack post-retrieval, cache, reranker, and prompt-assembly evidence.
+
 **CWE Mapping:** CWE-284 (Improper Access Control), CWE-311 (Missing Encryption of Sensitive Data)
 
 ---
@@ -435,6 +470,12 @@ Structure the findings report as follows:
 |----|---------------|----------|----------|--------|
 | FINDING-001 | LLM0X:2025 | High | P1 | Open |
 
+## RAG Retrieval Authorization
+
+| Pipeline | Identity Scope | Pre-query Filter | Post-retrieval ACL Checkpoints | Cache Scope | Reranker/Hybrid Metadata | Permission Invalidation | Decision |
+|----------|----------------|------------------|--------------------------------|-------------|--------------------------|-------------------------|----------|
+| [pipeline name] | [tenant/user/groups/permission version] | [tenant/user/group/doc/chunk/classification] | [after retrieval/after rerank/before prompt] | [tenant/user/groups/permission/source ACL/model] | [doc/chunk/tenant/ACL metadata preserved] | [group/doc/delete/reclassify/reindex events] | [Pass/Fail/Partial/Not Evaluable] |
+
 ## Recommendations
 
 [Prioritized list of remediation actions]
@@ -507,3 +548,9 @@ When performing a review using this skill:
 - LLM08:2025 Vector and Embedding Weaknesses: https://genai.owasp.org/llmrisk/llm08-vector-and-embedding-weaknesses/
 - LLM09:2025 Misinformation: https://genai.owasp.org/llmrisk/llm09-misinformation/
 - LLM10:2025 Unbounded Consumption: https://genai.owasp.org/llmrisk/llm10-unbounded-consumption/
+
+---
+
+## Changelog
+
+- **1.0.1** -- Add LLM08 retrieval authorization evidence gates for post-retrieval ACL validation, cache scoping, reranker metadata, public content exceptions, and permission invalidation.

--- a/skills/ai-security/llm-top-10/tests/retrieval-authorization-evidence-gates.md
+++ b/skills/ai-security/llm-top-10/tests/retrieval-authorization-evidence-gates.md
@@ -1,0 +1,223 @@
+# LLM08 Retrieval Authorization Evidence Gates
+
+These fixtures calibrate the `llm-top-10` LLM08 retrieval authorization gate. A review should prove that authorization is enforced before query construction, after retrieval, after reranking or aggregation, before prompt assembly, and across cache/index invalidation events.
+
+## Vulnerable: Tenant Filter Without Post-Retrieval ACL Check
+
+```yaml
+case: tenant-filter-no-post-retrieval-acl
+retrieval:
+  pre_query_filter:
+    tenant_id: request.tenant_id
+  vector_store_collection: shared_by_tenant
+  post_retrieval_acl_check:
+    after_vector_search: false
+    after_rerank: false
+    before_prompt_assembly: false
+prompt_assembly:
+  include_all_returned_chunks: true
+expected_result:
+  finding_codes:
+    - LLM08-RA-02
+    - LLM08-RA-08
+  decision: Fail
+  severity: High
+  reason: A tenant filter alone does not prove each returned chunk is authorized for the current user and permission version.
+```
+
+## Vulnerable: Shared Cache Keyed Only By Query
+
+```yaml
+case: shared-cache-query-only
+cache:
+  enabled: true
+  key_fields:
+    - normalized_query
+    - embedding_model
+  omitted_key_fields:
+    - tenant_id
+    - user_id
+    - groups_hash
+    - permission_version
+    - collection_id
+    - source_acl_hash
+expected_result:
+  finding_codes:
+    - LLM08-RA-03
+  decision: Fail
+  severity: High
+  reason: One user's authorized retrieval result can be reused for another user or tenant with the same query.
+```
+
+## Vulnerable: Reranker Drops Authorization Metadata
+
+```yaml
+case: reranker-drops-acl-metadata
+pipeline:
+  vector_results:
+    metadata:
+      - document_id
+      - chunk_id
+      - tenant_id
+      - acl_hash
+      - permission_version
+  reranker:
+    input_fields:
+      - text
+      - score
+    output_fields:
+      - text
+      - rerank_score
+  final_context:
+    uses_reranker_output_only: true
+expected_result:
+  finding_codes:
+    - LLM08-RA-04
+  decision: Fail
+  severity: High
+  reason: The final context cannot be rechecked against source document or chunk ACLs before prompt assembly.
+```
+
+## Vulnerable: Hybrid Search Merges Unauthorized Keyword Results
+
+```yaml
+case: hybrid-search-keyword-results-unscoped
+retrieval:
+  vector_query_filter:
+    tenant_id: tenant-a
+    permission_version: pv-42
+  bm25_query_filter:
+    tenant_id: missing
+    acl_filter: missing
+  merge_strategy: reciprocal_rank_fusion
+  post_merge_acl_check: false
+expected_result:
+  finding_codes:
+    - LLM08-RA-01
+    - LLM08-RA-04
+  decision: Fail
+  severity: High
+  reason: Hybrid search can reintroduce unauthorized keyword results after the vector path was filtered.
+```
+
+## Vulnerable: Shared Collection Assumed Public
+
+```yaml
+case: shared-collection-assumed-public
+collection:
+  name: shared-reference-docs
+  contains:
+    - public_docs
+    - tenant_private_docs
+public_exception_evidence:
+  classification: missing
+  immutable_source_metadata: missing
+  owner_approval: missing
+  mixed_content_check: missing
+expected_result:
+  finding_codes:
+    - LLM08-RA-05
+  decision: Partial
+  severity: High
+  reason: Shared collection membership is not proof that each retrieved chunk is public.
+```
+
+## Vulnerable: Permission Change Does Not Invalidate Cache
+
+```yaml
+case: group-membership-change-cache-not-invalidated
+identity:
+  user_id: user-123
+  previous_groups_hash: g-old
+  current_groups_hash: g-new
+  permission_version: pv-43
+cache:
+  stored_permission_version: pv-42
+  invalidation_events:
+    group_membership_changed: ignored
+    document_acl_changed: handled
+    document_deleted: handled
+prompt_context_store:
+  previous_context_reused: true
+expected_result:
+  finding_codes:
+    - LLM08-RA-06
+  decision: Fail
+  severity: High
+  reason: Previously authorized chunks can remain available after group membership changes.
+```
+
+## Vulnerable: Chunk-Level Redaction Boundary Missing
+
+```yaml
+case: document-acl-ignores-redacted-chunk
+document:
+  id: doc-789
+  document_acl: accessible_to_user
+  chunks:
+    - id: chunk-public
+      classification: internal
+      allowed: true
+    - id: chunk-redacted
+      classification: restricted
+      allowed: false
+retrieval:
+  checks_document_acl_only: true
+  checks_chunk_acl: false
+expected_result:
+  finding_codes:
+    - LLM08-RA-07
+  decision: Fail
+  severity: High
+  reason: Document-level access does not authorize restricted chunks or redacted sections.
+```
+
+## Benign: End-to-End Retrieval Authorization Chain
+
+```yaml
+case: complete-retrieval-authorization-chain
+identity:
+  tenant_id: tenant-a
+  user_id: user-123
+  groups_hash: groups-a1
+  permission_version: pv-44
+retrieval:
+  pre_query_filter:
+    tenant_id: tenant-a
+    user_id: user-123
+    groups_hash: groups-a1
+    permission_version: pv-44
+    classification_max: confidential
+  vector_results_metadata:
+    - document_id
+    - chunk_id
+    - tenant_id
+    - acl_hash
+    - classification
+    - permission_version
+  cache_key_fields:
+    - tenant_id
+    - user_id
+    - groups_hash
+    - permission_version
+    - query_hash
+    - embedding_model
+    - collection_id
+    - source_acl_hash
+  post_retrieval_acl_check:
+    after_vector_search: true
+    after_rerank: true
+    before_prompt_assembly: true
+  reranker_preserves_metadata: true
+  invalidation_events:
+    - group_membership_changed
+    - document_acl_changed
+    - document_deleted
+    - classification_changed
+    - embedding_model_changed
+expected_result:
+  finding_codes: []
+  decision: Pass
+  severity: Informational
+  reason: Authorization is enforced across query construction, cache scope, reranking, prompt assembly, and permission invalidation.
+```


### PR DESCRIPTION
Closes #1384

## Summary

- Add LLM08 retrieval authorization evidence gates to `llm-top-10`
- Require authorization proof across pre-query filters, post-retrieval ACL checks, cache scoping, reranker/hybrid metadata preservation, public-content exceptions, chunk ACLs, and permission-change invalidation
- Add named `LLM08-RA-*` checks with High/Medium/Not Evaluable decision rules
- Add a RAG Retrieval Authorization output matrix
- Add structured YAML fixtures for tenant-filter-only false positives, shared cache leakage, reranker metadata loss, hybrid-search merge bypass, shared collection public-content assumptions, stale permission cache, chunk-level redaction gaps, and a complete end-to-end authorization chain

## Validation

- `git diff --check -- skills/ai-security/llm-top-10/SKILL.md skills/ai-security/llm-top-10/tests/retrieval-authorization-evidence-gates.md`
- Parsed all 8 YAML fixtures with Ruby `YAML.safe_load`
- Confirmed added lines are ASCII-only
- Ran a privacy scan for local user/path leakage

## Bounty Info

- [x] I have read and agree to the CONTRIBUTING.md bounty terms.
- Preferred payment method can be coordinated privately after maintainer acceptance.

/claim #1384
