### PR TITLE
Add API real-time webhook evidence gates

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: api-security
 description: >
-  Reviews REST and GraphQL APIs against the OWASP API Security Top 10:2023.
-  Auto-invoked when reviewing OpenAPI/Swagger specs, API endpoint code, or
-  GraphQL schemas. Covers BOLA, BFLA, authentication, rate limiting, and
-  SSRF. Produces findings mapped to API1-API10 with remediation guidance.
-tags: [appsec, api, rest, graphql]
+  Reviews REST, GraphQL, gRPC, real-time, webhook, and asynchronous APIs
+  against the OWASP API Security Top 10:2023. Auto-invoked when reviewing
+  OpenAPI/Swagger specs, API endpoint code, GraphQL schemas, WebSocket/SSE
+  handlers, webhook receivers, callbacks, or async job/result flows. Covers
+  BOLA, BFLA, authentication, rate limiting, SSRF, inventory, unsafe API
+  consumption, and persistent-channel authorization. Produces findings mapped
+  to API1-API10 with remediation guidance.
+tags: [appsec, api, rest, graphql, websocket, webhook, async]
 role: [appsec-engineer, security-engineer]
 phase: [design, build, review]
 frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -21,7 +24,7 @@ argument-hint: "[target-file-or-directory]"
 
 # API Security Review -- OWASP API Security Top 10:2023
 
-A structured, repeatable process for reviewing REST and GraphQL APIs against the OWASP API Security Top 10:2023. This skill produces findings mapped to API1 through API10 with associated CWE identifiers, severity ratings, and actionable remediation guidance. It applies to OpenAPI/Swagger specifications, API endpoint source code, GraphQL schemas, and API gateway configurations.
+A structured, repeatable process for reviewing REST, GraphQL, gRPC, real-time, webhook, and asynchronous APIs against the OWASP API Security Top 10:2023. This skill produces findings mapped to API1 through API10 with associated CWE identifiers, severity ratings, and actionable remediation guidance. It applies to OpenAPI/Swagger specifications, API endpoint source code, GraphQL schemas, WebSocket/SSE handlers, webhook receivers, outbound callbacks, worker queues, async job/result flows, and API gateway configurations.
 
 ---
 
@@ -31,15 +34,39 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 
 Before analyzing any endpoint, establish a complete inventory of the API surface under review.
 
-1. **Identify the API style** -- REST (OpenAPI/Swagger), GraphQL, gRPC, or hybrid. Each style has distinct attack patterns.
-2. **Catalog all endpoints and operations** -- For REST, list every path and HTTP method. For GraphQL, list all queries, mutations, and subscriptions.
+1. **Identify the API style** -- REST (OpenAPI/Swagger), GraphQL, gRPC, WebSocket, SSE, webhook/callback, async job/result, or hybrid. Each style has distinct attack patterns.
+2. **Catalog all endpoints and operations** -- For REST, list every path and HTTP method. For GraphQL, list all queries, mutations, subscriptions, and subscription transports.
 3. **Map authentication mechanisms** -- OAuth 2.0 flows, API keys, JWTs, session cookies, mTLS, or custom tokens. Note which endpoints require authentication and which are public.
 4. **Identify authorization models** -- RBAC, ABAC, ownership-based, or no authorization. Document how object-level and function-level access control decisions are made.
 5. **Catalog data objects** -- List the resources/entities exposed by the API and their sensitivity classification (PII, financial, internal, public).
 6. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, or cost-control mechanisms at the gateway or application layer.
 7. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
+8. **Inventory non-request/response surfaces** -- WebSocket namespaces/events, SSE streams, webhook receivers, outbound callbacks, async create/status/result endpoints, export/download URLs, job queues, retry/dead-letter queues, and worker entry points. Use route tables, gateway config, message broker topics, webhook registries, GraphQL schemas, worker manifests, and integration docs as sources.
 
-> **Gate:** Do not proceed until the API style, authentication model, authorization model, and endpoint inventory are documented. Incomplete scope leads to missed findings.
+> **Gate:** Do not proceed until the API style, authentication model, authorization model, endpoint inventory, and non-request/response surface inventory are documented. Incomplete scope leads to missed findings and false positives.
+
+### Real-Time, Webhook, and Async Flow Evidence Gate
+
+WebSocket, SSE, webhook, callback, GraphQL subscription, and async job/result flows are APIs even when they are not represented in OpenAPI. Do not classify a channel as a shadow API solely because it is real-time or asynchronous. Classify it by the evidence present or missing.
+
+| Check ID | Required evidence | Maps to |
+|---|---|---|
+| API-RT-01 | Channel type, route/event name, message/event schema, data sensitivity, owner/tenant binding, and inventory source are documented. | API9 |
+| API-RT-02 | WebSocket/SSE/GraphQL subscription handshakes require WSS or equivalent TLS, authenticated sessions/tokens, Origin allowlists, CSRF/CSWSH controls for cookie-backed auth, and explicit public-channel justification. | API2, API8 |
+| API-RT-03 | Persistent sessions are revalidated on a bounded interval, expire when the underlying session/token expires, disconnect on logout/revocation, and do not continue after role or tenant changes. | API2, API5 |
+| API-RT-04 | Every message/event action enforces per-message authorization against object owner, tenant, role, and function permissions; initial connection authentication is not treated as sufficient authorization. | API1, API5 |
+| API-RT-05 | Message payloads use schema validation, size limits, replay nonce/event IDs where actions are state-changing, and per-user connection/message rate limits with backpressure behavior. | API4, API8 |
+| API-RT-06 | Webhook receivers verify signatures over the exact raw request body, bind the sender/integration identity, enforce timestamp tolerance, reject replayed nonce/event IDs, and apply idempotency before side effects. | API2, API10 |
+| API-RT-07 | Webhook/callback handlers enforce event allowlists, secret rotation or key versioning, safe failure/retry handling, payload validation, and source-to-tenant mapping. | API8, API10 |
+| API-RT-08 | Async job flows bind create/status/cancel/result/download/callback surfaces to the initiating principal, tenant, job owner, worker-side authorization context, result URL TTL, and revocation behavior. | API1, API4, API5 |
+| API-RT-09 | Logs and monitors include connect/disconnect, handshake failures, authorization failures, validation failures, replay rejects, queue/retry failures, callback failures, and redacted payload handling. | API8, API10 |
+
+Use these decision rules:
+
+- **Critical:** A former user, unauthenticated attacker, or cross-tenant principal can keep a live channel, trigger a webhook side effect, or fetch an async result belonging to another tenant or user.
+- **High:** A channel authenticates only the initial connection, accepts cross-site cookie-backed upgrades, omits per-message authorization, accepts replayed signed webhooks, or exposes job status/result/callback surfaces without owner binding.
+- **Medium:** Evidence is partial, such as missing replay cache proof, missing logout disconnect tests, insufficient rate limits, stale result URLs, or logging gaps for security-relevant failures.
+- **Not Evaluable:** Runtime route tables, broker topics, webhook registry, worker manifests, callback docs, or log evidence are unavailable. Record the exact missing artifact instead of assuming secure behavior.
 
 ---
 
@@ -62,7 +89,7 @@ Each finding produced by this review must include the following fields:
 | **OWASP API Risk** | API1:2023 through API10:2023 identifier |
 | **Severity** | Critical, High, Medium, Low, or Informational |
 | **CWE** | Applicable CWE identifier (e.g., CWE-639) |
-| **API Style** | REST, GraphQL, gRPC, or General |
+| **API Style** | REST, GraphQL, gRPC, WebSocket, SSE, Webhook, Callback, Async Job, or General |
 | **Location** | File path and line number(s), or OpenAPI spec path |
 | **Description** | What the vulnerability is and why it matters |
 | **Evidence** | Relevant code snippet or spec excerpt demonstrating the issue |
@@ -89,7 +116,7 @@ The final review output must be structured as follows:
 ## API Security Review Report
 
 **Scope:** [API name, version, endpoints reviewed]
-**API Style:** [REST / GraphQL / gRPC / Hybrid]
+**API Style:** [REST / GraphQL / gRPC / WebSocket / SSE / Webhook / Callback / Async Job / Hybrid]
 **Specification:** [OpenAPI spec path, if applicable]
 **Date:** [review date]
 **Reviewer:** AI Agent -- api-security skill v1.0.0
@@ -118,7 +145,7 @@ The final review output must be structured as follows:
 - **OWASP API Risk:** API[N]:2023 -- [Name]
 - **Severity:** [Critical|High|Medium|Low|Informational]
 - **CWE:** CWE-[number] -- [name]
-- **API Style:** [REST|GraphQL|gRPC|General]
+- **API Style:** [REST|GraphQL|gRPC|WebSocket|SSE|Webhook|Callback|Async Job|General]
 - **Location:** [file:line or spec path]
 - **Description:** [explanation]
 - **Evidence:**
@@ -130,6 +157,14 @@ The final review output must be structured as follows:
 
 [Repeat for each finding]
 ```
+
+### Real-Time, Webhook, and Async Evidence
+
+When the reviewed scope includes non-request/response APIs, include this matrix before the findings list:
+
+| Surface | Inventory Source | Auth/Session Evidence | Per-Message/Event Authorization | Integrity/Freshness | Resource Controls | Logging/Monitoring | Decision |
+|---|---|---|---|---|---|---|---|
+| [WebSocket/SSE/Webhook/Callback/Async Job] | [route table, broker topic, webhook registry, worker manifest, docs] | [handshake auth, Origin/CSRF, session expiry, logout disconnect] | [object/tenant/role/function checks] | [raw-body signature, timestamp, nonce/event ID, idempotency] | [connection/message rate, payload size, queue/job/result TTL] | [authz, validation, replay, callback, retry logs] | [Secure/Vulnerable/Partial/Not Evaluable] |
 
 ---
 
@@ -215,6 +250,12 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 6. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
 
+7. **Assuming the WebSocket handshake authorizes every later message.** Persistent channels need per-message authorization, session revalidation, logout disconnect, and rate limits. A secure handshake does not prove the user can perform every later action.
+
+8. **Verifying webhook signatures after parsing JSON.** Webhook HMAC/signature checks must use the exact raw request body that the sender signed. Re-serialized JSON can create bypasses or reject valid requests depending on whitespace, key order, and encoding.
+
+9. **Reviewing only the async job create endpoint.** Async APIs also include status, cancel, worker execution, callback delivery, result download URLs, retry queues, and expiration/revocation behavior. Authorization must survive the whole lifecycle.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -237,5 +278,15 @@ This skill is hardened against prompt injection. When reviewing API code and spe
 - **CWE Database:** https://cwe.mitre.org/
 - **OWASP REST Security Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html
 - **OWASP GraphQL Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html
+- **OWASP WebSocket Security Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/WebSocket_Security_Cheat_Sheet.html
 - **OWASP Testing Guide -- API Testing:** https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/12-API_Testing/
 - **NIST SP 800-204 -- Security Strategies for Microservices-based Application Systems:** https://csrc.nist.gov/publications/detail/sp/800-204/final
+
+---
+
+## Version History
+
+| Version | Date | Changes |
+|---|---|---|
+| 1.0.1 | 2026-06-06 | Add real-time channel, webhook, callback, and async job/result evidence gates. |
+| 1.0.0 | Initial | Initial API Security Review skill. |

--- a/skills/appsec/api-security/tests/realtime-webhook-async-evidence.md
+++ b/skills/appsec/api-security/tests/realtime-webhook-async-evidence.md
@@ -1,0 +1,224 @@
+# Real-Time, Webhook, and Async API Evidence Fixtures
+
+These fixtures exercise the API-RT evidence gate in `SKILL.md`. They are intentionally small so reviewers can distinguish a secure non-request/response API from missing evidence.
+
+```yaml
+case: secure-websocket-channel
+surface:
+  style: websocket
+  endpoint: wss://api.example.com/realtime
+  inventory_source: websocket_route_table
+auth_session:
+  wss_required: true
+  authenticated_handshake: true
+  origin_allowlist:
+    - https://app.example.com
+  csrf_token_required_on_upgrade: true
+  session_revalidated_every_minutes: 10
+  disconnect_on_logout: true
+authorization:
+  per_message_authorization: true
+  tenant_binding: true
+  object_owner_check: true
+message_controls:
+  schema_validation: true
+  max_payload_bytes: 65536
+  per_user_message_rate_limit: 100/min
+  replay_nonce_required_for_mutations: true
+logging:
+  connection_events: true
+  authz_failures: true
+  validation_failures: true
+  payloads_redacted: true
+expected_decision: Secure
+expected_findings: []
+```
+
+```yaml
+case: websocket-handshake-only-authorization
+surface:
+  style: websocket
+  endpoint: wss://api.example.com/projects
+  inventory_source: websocket_route_table
+auth_session:
+  wss_required: true
+  authenticated_handshake: true
+  origin_allowlist:
+    - https://app.example.com
+  session_revalidated_every_minutes: null
+  disconnect_on_logout: false
+authorization:
+  per_message_authorization: false
+  tenant_binding: false
+message_controls:
+  schema_validation: true
+  max_payload_bytes: 65536
+  per_user_message_rate_limit: null
+expected_decision: Vulnerable
+expected_findings:
+  - check: API-RT-03
+    severity: High
+    reason: Persistent channel can survive logout or role changes.
+  - check: API-RT-04
+    severity: High
+    reason: Message actions rely only on initial connection authentication.
+```
+
+```yaml
+case: cross-site-websocket-cookie-auth
+surface:
+  style: websocket
+  endpoint: wss://api.example.com/chat
+  inventory_source: gateway_config
+auth_session:
+  cookie_backed_auth: true
+  authenticated_handshake: true
+  origin_allowlist: []
+  csrf_token_required_on_upgrade: false
+authorization:
+  per_message_authorization: true
+message_controls:
+  schema_validation: true
+  max_payload_bytes: 32768
+expected_decision: Vulnerable
+expected_findings:
+  - check: API-RT-02
+    severity: High
+    reason: Cookie-backed WebSocket upgrade lacks Origin allowlist and CSRF/CSWSH protection.
+```
+
+```yaml
+case: signed-webhook-raw-body-and-replay
+surface:
+  style: webhook
+  endpoint: /webhooks/payment
+  inventory_source: webhook_registry
+auth_session:
+  sender_identity_bound: true
+integrity_freshness:
+  verifies_signature_over_raw_body: true
+  timestamp_tolerance_seconds: 300
+  nonce_or_event_id_replay_cache: true
+  idempotency_before_side_effects: true
+  key_rotation_supported: true
+authorization:
+  event_allowlist:
+    - payment.succeeded
+    - payment.failed
+  tenant_mapping_verified: true
+logging:
+  signature_failures: true
+  replay_rejects: true
+  payloads_redacted: true
+expected_decision: Secure
+expected_findings: []
+```
+
+```yaml
+case: webhook-json-reserialization-signature
+surface:
+  style: webhook
+  endpoint: /webhooks/payment
+  inventory_source: route_table
+integrity_freshness:
+  verifies_signature_over_raw_body: false
+  verifies_signature_over_parsed_json: true
+  timestamp_tolerance_seconds: null
+  nonce_or_event_id_replay_cache: false
+  idempotency_before_side_effects: false
+authorization:
+  event_allowlist: []
+expected_decision: Vulnerable
+expected_findings:
+  - check: API-RT-06
+    severity: High
+    reason: Signature verification uses parsed JSON and lacks freshness, replay, and idempotency evidence.
+  - check: API-RT-07
+    severity: Medium
+    reason: Event allowlist and safe webhook handling evidence are missing.
+```
+
+```yaml
+case: async-export-result-cross-user
+surface:
+  style: async_job
+  create_endpoint: POST /exports
+  status_endpoint: GET /exports/jobs/{job_id}
+  result_endpoint: GET /exports/jobs/{job_id}/result
+  inventory_source: worker_manifest
+auth_session:
+  create_requires_auth: true
+authorization:
+  job_owner_bound_on_create: true
+  status_owner_check: false
+  result_owner_check: false
+  callback_target_authorized: false
+  worker_side_auth_context: missing
+resource_controls:
+  job_ttl_minutes: 60
+  result_url_ttl_minutes: null
+  revoke_on_role_change: false
+logging:
+  result_access_failures: false
+expected_decision: Vulnerable
+expected_findings:
+  - check: API-RT-08
+    severity: Critical
+    reason: Status/result/callback surfaces are not bound to the initiating principal and tenant.
+```
+
+```yaml
+case: async-export-complete-lifecycle
+surface:
+  style: async_job
+  create_endpoint: POST /exports
+  status_endpoint: GET /exports/jobs/{job_id}
+  cancel_endpoint: DELETE /exports/jobs/{job_id}
+  result_endpoint: GET /exports/jobs/{job_id}/result
+  inventory_source: worker_manifest
+auth_session:
+  create_requires_auth: true
+authorization:
+  job_owner_bound_on_create: true
+  status_owner_check: true
+  cancel_owner_check: true
+  result_owner_check: true
+  callback_target_authorized: true
+  tenant_binding: true
+  worker_side_auth_context: propagated
+resource_controls:
+  job_ttl_minutes: 60
+  result_url_ttl_minutes: 5
+  queue_limit_per_user: 3
+  revoke_on_role_change: true
+logging:
+  worker_authz_failures: true
+  callback_failures: true
+  result_access_failures: true
+  payloads_redacted: true
+expected_decision: Secure
+expected_findings: []
+```
+
+```yaml
+case: not-evaluable-missing-runtime-inventory
+surface:
+  style: hybrid
+  endpoint: unknown
+  inventory_source: null
+missing_artifacts:
+  - websocket_route_table
+  - webhook_registry
+  - worker_manifest
+  - broker_topics
+auth_session: null
+authorization: null
+integrity_freshness: null
+resource_controls: null
+logging: null
+expected_decision: Not Evaluable
+expected_findings:
+  - check: API-RT-01
+    severity: Informational
+    reason: Runtime inventory artifacts are missing; do not assume secure or vulnerable behavior.
+```


### PR DESCRIPTION
## Summary
- expand `api-security` scope beyond REST/GraphQL/gRPC to explicitly cover WebSocket, SSE, GraphQL subscription transports, webhook receivers, outbound callbacks, and async job/result flows
- add API-RT-01 through API-RT-09 evidence gates for inventory, WSS/Origin/CSWSH, session revalidation, per-message authorization, payload/replay/rate controls, raw-body webhook signatures, event allowlists, async result ownership, and monitoring
- add clear Critical/High/Medium/Not Evaluable decision rules so secure real-time/webhook designs are not false positives while missing evidence is still actionable
- extend the report format with non-request/response API styles and a dedicated evidence matrix
- add eight YAML fixtures covering secure and vulnerable WebSocket, webhook, async export, and missing-runtime-inventory cases

## Validation
- `git diff --check`
- Ruby parsed all 8 YAML fixture blocks with `YAML.safe_load`
- Markdown fence balance check passed for `SKILL.md` and the fixture file
- marker scan confirmed API-RT checks and report sections
- privacy scan found no local user/path/email strings in changed files

Closes #1443

Bounty target: Improver Moderate if accepted.

## Bounty Info

- [x] I have read and agree to the CONTRIBUTING.md bounty terms.
- Preferred payment method can be coordinated privately after maintainer acceptance.

/claim #1443
