### PR TITLE
Add Lambda Function URL evidence fixtures

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -4,16 +4,17 @@ description: >
   Performs an AWS security posture review against the CIS Amazon Web Services
   Foundations Benchmark v3.0.0. Auto-invoked when reviewing AWS infrastructure,
   IAM policies, S3 configurations, CloudTrail settings, VPC security groups, or
-  RDS encryption. Walks through all five benchmark sections, evaluates each
-  recommendation, and produces a prioritized findings report with remediation
-  guidance mapped to specific CIS control IDs.
+  RDS encryption. Walks through all five benchmark sections, adds supplemental
+  Lambda Function URL invocation evidence gates, evaluates each recommendation,
+  and produces a prioritized findings report with remediation guidance mapped to
+  specific CIS and supplemental AWS control IDs.
 tags: [cloud, aws, cis-benchmark]
 role: [cloud-security-engineer, security-engineer]
 phase: [assess, operate]
 frameworks: [CIS-AWS-v3.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -38,7 +39,7 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 - Reviewing AWS infrastructure-as-code before deployment
 - Assessing an existing AWS environment's security posture against CIS benchmarks
 - Preparing for a CIS benchmark audit or compliance assessment
-- Evaluating IAM policies, S3 bucket configurations, CloudTrail settings, VPC security groups, or RDS encryption configurations
+- Evaluating IAM policies, S3 bucket configurations, CloudTrail settings, VPC security groups, Lambda Function URLs, or RDS encryption configurations
 - Onboarding a new AWS account into a security program
 
 ---
@@ -99,7 +100,22 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
-### Step 7: Compile Assessment Report
+### Step 7: Supplemental Lambda Function URL and Invocation Review
+
+Evaluate Lambda Function URL exposure separately from the CIS score. Function URLs can create internet-reachable HTTPS endpoints without API Gateway or security-group evidence, so review the URL configuration, resource-based invoke policy, caller identity policy, execution role, VPC/dependency access, event sources, and audit coverage together.
+
+Use the `AWS-LAMBDA-URL-*` checks in [benchmark-checklist.md](benchmark-checklist.md) for Terraform, CloudFormation, SAM, CDK, and AWS CLI exports. Keep these findings in a supplemental AWS service section so they do not inflate or reduce the CIS AWS Foundations denominator.
+
+Calibrate the result carefully:
+
+- Mark `authorization_type = "NONE"` as a finding when the public API justification, abuse controls, CORS, edge path, and audit evidence are absent or weak.
+- Do not fail an IAM-authenticated Function URL solely because it has a URL. Require evidence for `AWS_IAM`, caller permissions, scoped resource-based policy conditions, intended path, and monitoring.
+- Treat VPC configuration as dependency-egress evidence only. It does not make the Function URL private or protect inbound invocation.
+- If the URL exists but the resource policy, caller policy, CloudTrail coverage, or edge logs are missing from the review material, mark the supplemental check `Not Evaluable` rather than passing by absence.
+
+---
+
+### Step 8: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
 
@@ -158,6 +174,12 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Evidence:** <specific configuration or code snippet>
 - **Remediation:** <specific fix with code example>
 
+### Supplemental AWS Service Findings
+
+| Control | Service | Resource | Status | Severity | Evidence | Required Follow-up |
+|---------|---------|----------|--------|----------|----------|--------------------|
+| AWS-LAMBDA-URL-01 | Lambda | <function or alias> | Pass / Fail / Not Evaluable | Critical / High / Medium / Low | <URL auth, policy, caller, edge, and log evidence> | <fix, compensating control, or missing artifact> |
+
 ### Prioritized Remediation Plan
 
 1. **[Critical]** CIS X.Y -- <action item>
@@ -200,6 +222,8 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
 5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
 6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
+7. **Treating Lambda VPC config as inbound protection.** VPC-enabled functions can still expose public Function URLs. Record VPC config as dependency/egress context, not as proof the URL is private.
+8. **Passing `AWS_IAM` Function URLs without policy evidence.** IAM auth still requires caller identity permissions and scoped Lambda resource policy conditions such as function URL auth type, source account/ARN where applicable, and invoked-via-function-url context.
 
 ---
 
@@ -225,10 +249,16 @@ Produce the final report using the structure defined in the Output Format sectio
 - AWS CloudTrail Documentation: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/
 - AWS Security Hub: https://docs.aws.amazon.com/securityhub/latest/userguide/
 - AWS VPC Security: https://docs.aws.amazon.com/vpc/latest/userguide/security.html
+- AWS Lambda Function URL access control: https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html
+- AWS Lambda Function URL configuration and CORS: https://docs.aws.amazon.com/lambda/latest/dg/urls-configuration.html
+- AWS Lambda resource-based policies: https://docs.aws.amazon.com/lambda/latest/dg/access-control-resource-based.html
+- AWS Lambda VPC configuration: https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html
+- AWS Lambda event source mappings: https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventsourcemapping.html
 - Terraform AWS Provider Documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 
 ---
 
 ## Changelog
 
+- **1.0.1** -- Added supplemental Lambda Function URL and invocation evidence gates with reporting fields and calibration fixtures.
 - **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 (62 recommendations).

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -488,3 +488,141 @@ resource "aws_launch_template" {
   }
 }
 ```
+
+---
+
+## Supplemental AWS Service Review -- Lambda Function URL and Invocation Evidence
+
+These checks are not part of the CIS AWS Foundations v3.0.0 denominator. Report them in the supplemental AWS service findings section as `AWS-LAMBDA-URL-*` controls.
+
+### AWS-LAMBDA-URL-01 -- Discover every Lambda Function URL
+
+Search Terraform, CloudFormation, SAM, CDK, and AWS CLI exports for function URL resources. Include aliases and qualified ARNs when available.
+
+**Grep patterns:**
+
+```
+aws_lambda_function_url
+AWS::Lambda::Url
+FunctionUrlConfig
+addFunctionUrl
+create-function-url-config
+get-function-url-config
+```
+
+Record function name, alias/qualifier, URL auth type, CORS block, source file, and the intended public or private access path.
+
+### AWS-LAMBDA-URL-02 -- Verify URL auth type and intended public path
+
+`authorization_type = "NONE"` is not automatically wrong for intentionally public APIs, but it requires evidence for business justification, route purpose, data sensitivity, abuse controls, edge/WAF path, CORS, rate limits, and audit coverage.
+
+```hcl
+# Vulnerable: unauthenticated URL on sensitive function with no compensating evidence
+resource "aws_lambda_function_url" "admin" {
+  function_name      = aws_lambda_function.admin.function_name
+  authorization_type = "NONE"
+}
+
+# Benign only with complete caller, edge, CORS, and audit evidence
+resource "aws_lambda_function_url" "private_api" {
+  function_name      = aws_lambda_function.private_api.function_name
+  authorization_type = "AWS_IAM"
+}
+```
+
+Do not pass `AWS_IAM` by auth type alone. Confirm the caller identity policy, resource policy, and edge/invocation path are all in scope.
+
+### AWS-LAMBDA-URL-03 -- Scope the resource-based invoke policy
+
+Review every `lambda:InvokeFunctionUrl` statement. Flag broad principals, missing function URL auth constraints, missing invoked-via-function-url constraints where represented in policy exports, and absent source account/source ARN constraints when the caller is an AWS service or known edge distribution.
+
+```hcl
+# Vulnerable: broad principal without URL-specific constraints
+resource "aws_lambda_permission" "public_invoke" {
+  statement_id  = "PublicInvoke"
+  action        = "lambda:InvokeFunctionUrl"
+  function_name = aws_lambda_function.api.function_name
+  principal     = "*"
+}
+
+# Better: scoped service principal, source ARN, and auth type
+resource "aws_lambda_permission" "allow_cloudfront_function_url" {
+  statement_id           = "AllowCloudFrontFunctionUrl"
+  action                 = "lambda:InvokeFunctionUrl"
+  function_name          = aws_lambda_function.private_api.function_name
+  principal              = "cloudfront.amazonaws.com"
+  source_arn             = aws_cloudfront_distribution.api.arn
+  function_url_auth_type = "AWS_IAM"
+}
+```
+
+### AWS-LAMBDA-URL-04 -- Bind caller identity permissions to the intended path
+
+For `AWS_IAM` URLs, require evidence of who can call the function. Review IAM identity policies, STS role trust, CloudFront origin access patterns, service principal assumptions, cross-account callers, and session conditions.
+
+Flag cases where the resource policy is scoped but the caller identity policy grants `lambda:InvokeFunctionUrl` to `*` resources or broad principals can assume the caller role.
+
+### AWS-LAMBDA-URL-05 -- Combine invocation exposure with execution-role blast radius
+
+Severity should reflect what the function can do after invocation. Review the Lambda execution role for secrets access, data-store access, role assumption, infrastructure mutation, admin managed policies, and permissions boundaries.
+
+**Critical combinations:**
+
+```
+authorization_type = "NONE"
+principal = "*"
+policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+secretsmanager:GetSecretValue on Resource = "*"
+sts:AssumeRole on Resource = "*"
+```
+
+### AWS-LAMBDA-URL-06 -- Treat VPC configuration as dependency evidence, not inbound protection
+
+Lambda VPC configuration allows function code to reach VPC resources; it does not make a Function URL private. If a review claim says "private subnet" or security groups protect inbound Function URL access, mark that claim as false.
+
+Record VPC/subnet/security-group evidence only for downstream dependency reachability, egress restrictions, NAT exposure, and data-store impact.
+
+### AWS-LAMBDA-URL-07 -- Map event sources and alternate invocation paths
+
+Function URLs can coexist with API Gateway, ALB, EventBridge, S3, SNS, SQS, Step Functions, and cross-account event source mappings. Map each invocation path so the report does not over-focus on the URL and miss a broader trigger.
+
+**Grep patterns:**
+
+```
+aws_lambda_event_source_mapping
+AWS::Lambda::EventSourceMapping
+aws_apigatewayv2_integration
+aws_lb_target_group_attachment
+aws_s3_bucket_notification
+aws_cloudwatch_event_target
+aws_scheduler_schedule
+```
+
+### AWS-LAMBDA-URL-08 -- Require audit and change-monitoring evidence
+
+Supplement CIS CloudTrail/CloudWatch checks with Lambda URL and invoke-policy events:
+
+```
+CreateFunctionUrlConfig
+UpdateFunctionUrlConfig
+DeleteFunctionUrlConfig
+AddPermission
+RemovePermission
+UpdateFunctionConfiguration
+PutFunctionConcurrency
+```
+
+For sensitive or public URLs, also look for edge logs, WAF logs, Lambda application logs with redaction, data events where enabled, alert routing, and breakglass exception review.
+
+### AWS-LAMBDA-URL-09 -- Mark incomplete URL evidence as Not Evaluable
+
+If a Function URL is present but the review material omits the resource policy, caller policy, execution role, or audit path, do not infer safety from missing files. Mark the relevant supplemental controls `Not Evaluable` and list the missing artifacts.
+
+Minimum artifacts for a confident pass:
+
+- Function URL config with auth type and CORS
+- Lambda resource-based policy
+- Caller identity policy and trust policy for `AWS_IAM` URLs
+- Execution role policy
+- Intended public/edge path and abuse-control evidence for `NONE` URLs
+- CloudTrail or equivalent monitoring for URL and permission changes

--- a/skills/cloud/aws-review/tests/lambda-function-url-invocation-evidence.md
+++ b/skills/cloud/aws-review/tests/lambda-function-url-invocation-evidence.md
@@ -1,0 +1,200 @@
+# Lambda Function URL and Invocation Evidence Fixtures
+
+These fixtures calibrate the supplemental `AWS-LAMBDA-URL-*` evidence gates in `aws-review`. They are intentionally small so reviewers can distinguish an intended IAM-authenticated function URL from unauthenticated or under-documented exposure.
+
+```yaml
+case: iam_authenticated_cloudfront_function_url
+surface:
+  function: private_api
+  function_url:
+    authorization_type: AWS_IAM
+    cors:
+      allow_origins:
+        - https://app.example.com
+      allow_methods:
+        - POST
+      allow_headers:
+        - authorization
+        - content-type
+        - x-amz-date
+  intended_path:
+    edge: cloudfront
+    waf: enabled
+    public_api_justification: internal_authenticated_application
+resource_policy:
+  action: lambda:InvokeFunctionUrl
+  principal: cloudfront.amazonaws.com
+  source_arn: arn:aws:cloudfront::123456789012:distribution/E123EXAMPLE
+  function_url_auth_type: AWS_IAM
+caller_identity_policy:
+  allowed_principal: arn:aws:iam::123456789012:role/cloudfront-function-url-origin
+  allowed_action: lambda:InvokeFunctionUrl
+  resource_scoped_to_function: true
+execution_role:
+  admin_policy_attached: false
+  secrets_scope: named_parameter_only
+audit:
+  cloudtrail_management_events: true
+  lambda_url_change_alarm: true
+  edge_logs: true
+expected_decision: Pass
+expected_findings: []
+```
+
+```yaml
+case: unauthenticated_admin_url_with_admin_role
+surface:
+  function: admin_console
+  function_url:
+    authorization_type: NONE
+    cors: missing
+  intended_path:
+    public_api_justification: missing
+    edge: missing
+    abuse_controls: missing
+resource_policy:
+  action: lambda:InvokeFunctionUrl
+  principal: "*"
+  function_url_auth_type: missing
+caller_identity_policy: not_required_for_none_auth
+execution_role:
+  admin_policy_attached: true
+  managed_policy_arn: arn:aws:iam::aws:policy/AdministratorAccess
+audit:
+  cloudtrail_management_events: true
+  lambda_url_change_alarm: missing
+  edge_logs: missing
+expected_decision: Fail
+expected_findings:
+  - check: AWS-LAMBDA-URL-02
+    severity: Critical
+    reason: Unauthenticated sensitive Function URL lacks public justification, CORS, abuse-control, and edge-path evidence.
+  - check: AWS-LAMBDA-URL-03
+    severity: Critical
+    reason: Resource policy allows broad public invocation without URL-specific constraints.
+  - check: AWS-LAMBDA-URL-05
+    severity: Critical
+    reason: Public invocation is paired with AdministratorAccess execution-role blast radius.
+```
+
+```yaml
+case: iam_auth_broad_caller_policy
+surface:
+  function: partner_callback
+  function_url:
+    authorization_type: AWS_IAM
+    cors:
+      allow_origins:
+        - https://partners.example.com
+  intended_path:
+    public_api_justification: partner_signed_callback
+resource_policy:
+  action: lambda:InvokeFunctionUrl
+  principal: arn:aws:iam::123456789012:role/partner-callback
+  function_url_auth_type: AWS_IAM
+caller_identity_policy:
+  allowed_action: lambda:InvokeFunctionUrl
+  resource: "*"
+  role_trust_policy:
+    external_id_condition: missing
+    principal_account_scope: "*"
+execution_role:
+  admin_policy_attached: false
+  secrets_scope: partner_callback_secret
+audit:
+  cloudtrail_management_events: true
+  lambda_url_change_alarm: true
+expected_decision: Fail
+expected_findings:
+  - check: AWS-LAMBDA-URL-04
+    severity: High
+    reason: AWS_IAM URL has a scoped resource policy but the caller role can be broadly assumed and invokes any Function URL resource.
+```
+
+```yaml
+case: vpc_config_misread_as_private_url
+surface:
+  function: worker
+  function_url:
+    authorization_type: NONE
+  vpc_config:
+    subnet_type: private
+    security_group: worker-egress-only
+  review_claim: private subnet and security group make the Function URL private
+resource_policy:
+  action: lambda:InvokeFunctionUrl
+  principal: "*"
+execution_role:
+  downstream_access:
+    rds_cluster: customer_orders
+    redis: session_cache
+audit:
+  cloudtrail_management_events: true
+  lambda_url_change_alarm: missing
+expected_decision: Fail
+expected_findings:
+  - check: AWS-LAMBDA-URL-06
+    severity: High
+    reason: VPC configuration controls dependency access, not inbound Function URL reachability.
+  - check: AWS-LAMBDA-URL-05
+    severity: High
+    reason: Public invocation can reach VPC data stores through the function execution role and subnets.
+```
+
+```yaml
+case: event_source_and_url_path_incomplete_audit
+surface:
+  function: image_processor
+  function_url:
+    authorization_type: AWS_IAM
+  alternate_invocation_paths:
+    - type: s3_bucket_notification
+      source_account: 123456789012
+      source_arn: missing
+    - type: sqs_event_source_mapping
+      queue_policy_reviewed: false
+resource_policy:
+  action: lambda:InvokeFunctionUrl
+  principal: arn:aws:iam::123456789012:role/image-api
+  function_url_auth_type: AWS_IAM
+execution_role:
+  s3_access: arn:aws:s3:::customer-images/*
+audit:
+  cloudtrail_management_events: true
+  lambda_url_change_alarm: true
+  add_permission_alarm: missing
+  s3_trigger_change_alarm: missing
+  queue_policy_change_alarm: missing
+expected_decision: Fail
+expected_findings:
+  - check: AWS-LAMBDA-URL-07
+    severity: Medium
+    reason: Alternate S3 and SQS invocation paths are present but source constraints and queue policy evidence are incomplete.
+  - check: AWS-LAMBDA-URL-08
+    severity: Medium
+    reason: Monitoring covers URL changes but misses permission and alternate trigger changes.
+```
+
+```yaml
+case: function_url_missing_policy_exports
+surface:
+  function: reporting_api
+  function_url:
+    authorization_type: AWS_IAM
+    cors:
+      allow_origins:
+        - https://reports.example.com
+missing_artifacts:
+  - lambda_resource_policy
+  - caller_identity_policy
+  - execution_role_policy
+  - cloudtrail_metric_filters
+available_artifacts:
+  - aws_lambda_function_url Terraform resource
+  - CloudFront distribution origin
+expected_decision: Not Evaluable
+expected_findings:
+  - check: AWS-LAMBDA-URL-09
+    severity: Medium
+    reason: Function URL auth type is visible, but policy, caller, execution role, and audit artifacts are missing from the review evidence.
+```


### PR DESCRIPTION
## Summary
- adds supplemental `AWS-LAMBDA-URL-*` evidence gates for Lambda Function URL discovery, auth type, resource policy, caller policy, execution-role blast radius, VPC/dependency caveats, alternate event sources, and audit/change monitoring
- keeps Lambda Function URL findings outside the CIS AWS Foundations v3.0.0 denominator in a supplemental AWS service findings table
- adds calibration fixtures covering benign IAM-authenticated CloudFront/OAC-style access, unauthenticated admin URL exposure, broad caller policy, VPC-as-private false positives, alternate trigger/audit gaps, and Not Evaluable missing policy exports

## Validation
- `git diff --check`
- verified `SKILL.md` frontmatter fields
- verified Markdown fence balance and ASCII-only content for changed files
- parsed all 6 YAML fixture blocks
- verified required markers for `AWS-LAMBDA-URL-01` through `AWS-LAMBDA-URL-09`, `InvokeFunctionUrl`, `authorization_type`, `function_url_auth_type`, `AWS_IAM`, `NONE`, `VPC`, `CloudTrail`, `Not Evaluable`, `aws_lambda_function_url`, and `AWS::Lambda::Url`
- verified AWS Lambda reference links returned HTTP 200
- privacy scan passed for changed files

/claim #1477

Payment details can be coordinated privately after maintainer acceptance.
