### PR TITLE
Add agent memory integrity fixtures

### DIFF
--- a/skills/ai-security/agentic-top-10/SKILL.md
+++ b/skills/ai-security/agentic-top-10/SKILL.md
@@ -13,7 +13,7 @@ phase: [design, build, review]
 frameworks: [OWASP-Agentic-AI, MITRE-ATLAS, NIST-AI-RMF]
 difficulty: advanced
 time_estimate: "45-90min"
-version: "1.0.1"
+version: "1.0.2"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -183,6 +183,9 @@ In early 2024, researchers from UIUC demonstrated a multi-agent privilege escala
 - Shared memory spaces in multi-agent systems where any agent can write context that other agents consume.
 - RAG pipelines where the ingestion source includes user-submitted or externally-sourced documents that are embedded without content validation.
 - Agent "learning" mechanisms that update long-term memory based on interaction outcomes without human review.
+- Memory records missing actor identity, source URI or event ID, trust tier, approval state, TTL, integrity digest, or quarantine state.
+- Retrieval pipelines that mix system, developer, user, tool, and agent-generated memories in one vector index before enforcing trust or tenant boundaries.
+- Deletion workflows that remove only a primary vector row while derived summaries, embeddings, session context, prompt caches, or replicas remain reusable.
 
 **Real-World Failure Mode:**
 
@@ -195,6 +198,24 @@ In 2024, researchers demonstrated a persistent memory poisoning attack against a
 3. Separate memory by trust level. User-sourced context, agent-generated context, and system-provided context must be stored and retrieved with different trust labels.
 4. Implement memory decay and review cycles. Periodically audit long-term memory for anomalous entries. Apply TTLs to user-sourced memories.
 5. In multi-agent systems, isolate memory per agent. Shared memory must be mediated by a trusted memory broker that validates writes.
+
+**Persistent Memory Evidence Gates:**
+
+Do not rate AG04 as PASS solely because a system has a vector store, a delete endpoint, or a periodic memory review. For every persistent memory store, collect enough evidence to answer each gate below.
+
+| Gate | Evidence to require | Fail condition |
+|---|---|---|
+| AG04-MEM-01 write authorization | Allowed writers, approval workflow, deny-by-default rules for user documents and tool output, and audit records for create/update events | Untrusted input can be summarized or saved into long-term memory without explicit approval |
+| AG04-MEM-02 provenance chain | Source URI or event ID, actor identity, tenant, agent identity, ingestion time, raw source reference, sanitizer/reviewer step, trust tier, and approval state | The memory record only says which agent wrote it, not where the underlying content came from |
+| AG04-MEM-03 trust-tier retrieval | Tenant, user, agent, purpose, and required-trust filters applied before vector similarity ranking or re-ranking | Low-trust memory can enter a privileged prompt because it is semantically similar |
+| AG04-MEM-04 integrity proof | Append-only log, hash chain, Merkle proof, immutable event stream, signed record, or equivalent tamper-evident update trail | Memory can be edited, replaced, or re-embedded without a detectable audit event |
+| AG04-MEM-05 lifetime controls | TTL, review cadence, decay rules, owner disposition, and policy for promoting or demoting trust | User or tool memories persist indefinitely with no owner or review trigger |
+| AG04-MEM-06 quarantine semantics | Flag-or-tombstone behavior, immediate retrieval exclusion, audit preservation, and replay plan | Poisoned memory is deleted destructively or remains retrievable until a batch cleanup runs |
+| AG04-MEM-07 derived artifact cleanup | Cache invalidation for summaries, embeddings, prompt caches, session context, replicated indexes, and downstream stores | A vector delete leaves derived artifacts that can still influence future prompts |
+
+For tool-derived memory, provenance must follow the content rather than only the final writer. A useful chain is `agent -> tool(https://source.example) -> raw_response -> sanitizer -> memory_entry`. For retrieval, trust filtering should happen before similarity ranking; a common pattern is `filter trust_tier >= context.required_tier`, then rank by similarity, recency, and trust score. For quarantine, suspicious entries should be excluded from retrieval immediately while audit data is preserved.
+
+User-authored personal memory can be acceptable when it is isolated per user, labeled as user-sourced, never promoted to system or developer trust without approval, and removable with evidence. Ephemeral session memory is lower risk than cross-session memory, but it still needs prompt-injection handling before reuse inside the same task.
 
 **Framework Mapping:**
 
@@ -434,6 +455,16 @@ Grep: "approve|confirm|human_in_the_loop|hitl|review|authorize" in **/*.{py,ts,j
 
 For practical validation of OWASP Agentic AI risks against concrete exploits, use the **fabraix/playground** open-source exploit library (https://github.com/fabraix/playground). This provides consolidated AI agent exploit PoCs that can be used alongside the theoretical framework in Step 2 to test each AG01-AG10 category against real attack scenarios.
 
+### AG04 Memory Evidence Review
+
+Before assigning the AG04 rating, build an evidence table for each persistent memory store. Use the fixture cases in `skills/ai-security/agentic-top-10/tests/memory-integrity-edge-cases.md` to calibrate pass, fail, and not-evaluable decisions.
+
+| Store | Write sources | Provenance chain | Trust controls | Integrity proof | Retrieval filters | Quarantine/removal | Residual artifacts |
+|---|---|---|---|---|---|---|---|
+| [pgvector / Redis / conversation DB / scratchpad] | [user docs, tool output, agent notes, system seed] | [actor -> source -> raw artifact -> sanitizer -> memory entry] | [tenant, agent, user, trust tier, approval, TTL] | [hash chain, immutable log, checksum, signed event] | [tenant, agent, purpose, required trust tier, top-k constraints] | [flag, tombstone, cache invalidation, replay audit] | [none / tracked owner / unresolved] |
+
+Rate AG04 at least **MEDIUM** when persistent memory exists but any of write authorization, provenance/trust labels, or retrieval trust boundaries is missing. Rate it **HIGH** when untrusted content can be saved and later retrieved into privileged prompts across sessions. Rate it **CRITICAL** when poisoned memory can trigger privileged tool calls, data exfiltration, credential exposure, or autonomous actions without human approval.
+
 ### Step 2 — Threat Assessment
 
 For each of the 10 categories, assess the system and assign a risk rating:
@@ -492,6 +523,9 @@ Structure the final report as follows:
 - Agent framework: [framework name and version]
 - Tools registered: [count and categories]
 - Memory stores: [types]
+- Persistent memory write sources: [user input / tool output / agent notes / system seed]
+- Memory provenance and trust controls: [source chain, tenant/user/agent scope, trust tier, approval state, TTL, integrity proof]
+- Memory remediation controls: [quarantine, tombstone/delete, cache invalidation, replay audit, residual derived artifacts]
 - Human approval gates: [present/absent, description]
 - Multi-agent communication: [method]
 
@@ -501,6 +535,7 @@ Structure the final report as follows:
 - **Rating:** [rating]
 - **Finding:** [description]
 - **Evidence:** [file path, code reference]
+- **Memory evidence:** [write authorization, provenance chain, retrieval filters, integrity proof, quarantine/removal, residual artifacts]
 - **Impact:** [what could go wrong]
 - **Remediation:** [specific action]
 - **Priority:** [P0/P1/P2/P3]
@@ -581,6 +616,8 @@ An approval gate is only effective if the human reviewer has sufficient context,
 ### 4. Ignoring the Memory Attack Surface
 
 Persistent agent memory is a high-value target because it persists across sessions and influences all future agent behavior. Teams routinely deploy vector stores and conversation databases without access controls, integrity protections, or poisoning detection. Every persistent memory store must be treated as a security-critical data store with appropriate controls.
+
+Do not confuse vector deletion with memory removal. If a poisoned entry was summarized, embedded, cached, replicated, or copied into session context, a delete endpoint for the primary record is only partial remediation. The report should identify each derived artifact and whether it was invalidated, quarantined, replay-audited, or left as residual risk.
 
 ### 5. Assuming Tool Calls Are Safe Because the Tool Is Legitimate
 

--- a/skills/ai-security/agentic-top-10/tests/memory-integrity-edge-cases.md
+++ b/skills/ai-security/agentic-top-10/tests/memory-integrity-edge-cases.md
@@ -1,0 +1,228 @@
+# Persistent Memory Integrity Evidence Fixtures
+
+These fixtures calibrate the supplemental `AG04-MEM-*` evidence gates in `agentic-top-10`. They are intentionally small so reviewers can distinguish production-grade memory integrity controls from benign-looking vector-store configurations.
+
+```yaml
+case: approved_tool_memory_with_trust_tier_retrieval
+memory_store:
+  type: pgvector
+  persistence: cross_session
+write_path:
+  allowed_sources:
+    - trusted_tool_output
+  approval_required_for_untrusted_sources: true
+  deny_by_default: true
+provenance:
+  chain:
+    - agent: research_agent
+    - tool: "https://api.example.com/advisories"
+    - raw_response: s3://audit-bucket/raw/adv-123.json
+    - sanitizer: pii_and_prompt_injection_filter
+    - memory_entry: mem_123
+  actor_identity: svc-agent-research
+  tenant_id: tenant_a
+  trust_tier: verified_tool
+  approval_state: approved
+  ttl_days: 30
+integrity:
+  append_only_log: true
+  record_digest: sha256:1234abcd
+retrieval:
+  filters_before_similarity:
+    - tenant_id
+    - agent_id
+    - purpose
+    - "trust_tier >= context.required_tier"
+  rerank_signals:
+    - similarity
+    - recency
+    - trust_score
+quarantine:
+  immediate_exclusion: true
+  tombstone_preserves_audit: true
+  invalidates:
+    - session_context
+    - embedding_cache
+    - prompt_cache
+    - replica_index
+expected_decision: Pass
+expected_findings: []
+```
+
+```yaml
+case: untrusted_web_output_auto_saved_to_long_term_memory
+memory_store:
+  type: pgvector
+  persistence: cross_session
+write_path:
+  allowed_sources:
+    - user_uploaded_document
+    - web_search_result
+  approval_required_for_untrusted_sources: false
+  deny_by_default: false
+provenance:
+  chain: missing
+  actor_identity: agent
+  source_uri: missing
+  trust_tier: missing
+  approval_state: missing
+  ttl_days: missing
+retrieval:
+  filters_before_similarity:
+    - tenant_id
+  top_k: 8
+expected_decision: Fail
+expected_findings:
+  - category: AG04
+    check: AG04-MEM-01
+    severity: High
+    reason: Untrusted documents and web results can be promoted into cross-session memory without approval or deny-by-default enforcement.
+  - category: AG04
+    check: AG04-MEM-02
+    severity: High
+    reason: Saved memory lacks source URI, full provenance chain, trust tier, approval state, and TTL evidence.
+  - category: AG04
+    check: AG04-MEM-05
+    severity: Medium
+    reason: User and tool memories persist without TTL, review cadence, owner disposition, or trust promotion rules.
+```
+
+```yaml
+case: similarity_only_retrieval_mixes_trust_boundaries
+memory_store:
+  type: chroma
+  persistence: cross_session
+contents:
+  - system_seed_memory
+  - developer_policy_note
+  - user_personal_memory
+  - agent_generated_note
+  - external_tool_summary
+provenance:
+  trust_tiers_present: true
+  approval_state_present: true
+retrieval:
+  filters_before_similarity: []
+  ranking: vector_similarity_only
+  tenant_filter: present
+  required_tier_filter: missing
+  agent_scope_filter: missing
+expected_decision: Fail
+expected_findings:
+  - category: AG04
+    check: AG04-MEM-03
+    severity: High
+    reason: Low-trust memories can displace system or developer context because retrieval applies no trust-tier or agent-scope filter before similarity ranking.
+```
+
+```yaml
+case: vector_delete_leaves_derived_memory_artifacts
+memory_store:
+  type: pinecone
+  persistence: cross_session
+remediation:
+  delete_endpoint: "/memory/{id}"
+  tombstone: missing
+  audit_replay: missing
+  immediate_retrieval_exclusion: missing
+derived_artifacts:
+  summary_cache: not_invalidated
+  embedding_cache: not_invalidated
+  prompt_cache: unknown
+  session_context: not_invalidated
+  replica_index: not_reviewed
+expected_decision: Fail
+expected_findings:
+  - category: AG04
+    check: AG04-MEM-06
+    severity: High
+    reason: Poisoned memory removal depends on destructive row deletion with no tombstone, immediate retrieval exclusion, or replay audit.
+  - category: AG04
+    check: AG04-MEM-07
+    severity: High
+    reason: Derived summaries, embeddings, prompt caches, session context, and replicas remain usable after the primary vector row is deleted.
+```
+
+```yaml
+case: ephemeral_session_memory_with_injection_handling
+memory_store:
+  type: in_process_session
+  persistence: current_task_only
+write_path:
+  allowed_sources:
+    - current_user_message
+    - tool_output
+  cross_session_promotion: disabled
+provenance:
+  source_event_id: present
+  trust_tier: session_untrusted
+  approval_state: not_promoted
+  ttl: session_end
+retrieval:
+  filters_before_reuse:
+    - session_id
+    - task_id
+  prompt_injection_filter_before_reuse: true
+quarantine:
+  clear_session_memory_on_detection: true
+expected_decision: Pass
+expected_findings: []
+```
+
+```yaml
+case: user_personal_memory_isolated_from_system_trust
+memory_store:
+  type: conversation_db
+  persistence: cross_session
+write_path:
+  allowed_sources:
+    - authenticated_user_preference
+  system_or_developer_promotion: requires_manual_approval
+provenance:
+  actor_identity: user_123
+  tenant_id: tenant_a
+  trust_tier: user_personal
+  approval_state: user_authored
+  ttl_days: 365
+retrieval:
+  filters_before_similarity:
+    - user_id
+    - tenant_id
+    - "trust_tier <= user_personal"
+  excluded_from_system_prompts: true
+removal:
+  user_delete: true
+  tombstone_preserves_audit: true
+  caches_invalidated: true
+expected_decision: Pass
+expected_findings: []
+```
+
+```yaml
+case: memory_store_visible_but_security_artifacts_missing
+memory_store:
+  type: redis_vector
+  persistence: cross_session
+available_evidence:
+  - redis_index_configuration
+  - memory_write_function_name
+missing_artifacts:
+  - allowed_writer_policy
+  - source_provenance_schema
+  - trust_tier_schema
+  - approval_workflow
+  - retrieval_filter_code
+  - integrity_or_audit_log
+  - quarantine_runbook
+  - cache_invalidation_plan
+expected_decision: Not Evaluable
+expected_findings:
+  - category: AG04
+    check: AG04-MEM-01
+    severity: Medium
+    reason: The memory store and write path are visible, but authorization, provenance, retrieval, integrity, and remediation evidence is missing from the review package.
+  - category: AG04
+    check: AG04-MEM-04
+    severity: Medium
+    reason: No tamper-evident log, digest, immutable event stream, or equivalent integrity artifact was provided for memory writes and updates.
+```


### PR DESCRIPTION
## Summary
- adds AG04 persistent memory evidence gates for write authorization, provenance chains, trust-tier retrieval, tamper evidence, TTL/review controls, quarantine semantics, and derived artifact cleanup
- adds a dedicated AG04 memory evidence review table and report fields so reviewers capture write sources, trust controls, remediation controls, and residual artifacts
- adds seven YAML fixtures covering pass, fail, and not-evaluable memory integrity cases

## Validation
- git diff --check
- frontmatter parse check
- Markdown fence balance check
- YAML fixture parse check: 7 blocks
- required marker check for AG04-MEM-01 through AG04-MEM-07
- privacy marker scan

/claim #1374

Payment details can be coordinated privately after maintainer acceptance.
