### PR TITLE
Add access review SoD evidence fixtures

### DIFF
--- a/skills/identity/access-review/SKILL.md
+++ b/skills/identity/access-review/SKILL.md
@@ -12,7 +12,7 @@ phase: [operate]
 frameworks: [CIS-Controls-v8, NIST-SP-800-53-AC]
 difficulty: intermediate
 time_estimate: "45-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -252,7 +252,36 @@ AR-SOD-04: SoD analysis not automated (manual review only)
 AR-SOD-05: Emergency/break-glass access bypasses SoD without post-hoc review
 AR-SOD-06: Role combinations that create SoD conflicts not flagged during provisioning
 AR-SOD-07: SoD conflicts in service accounts (single account spans multiple functions)
+AR-SOD-08: SoD conflict rule lacks owner, version, approval date, last review, or applicable scope
+AR-SOD-09: Role-name conflict is scored without proving a shared transaction path
+AR-SOD-10: Cross-system toxic combination not evaluated across procurement, ERP, banking, CI/CD, or security tooling
+AR-SOD-11: Environment, legal entity, approval limit, or workflow state makes the apparent conflict non-production or non-executable
+AR-SOD-12: Compensating control accepted without independent reviewer, sample evidence, monitoring, cadence, or expiry
+AR-SOD-13: JIT or emergency SoD exception lacks activation log, approval ticket, duration, action record, post-use review, or revocation evidence
+AR-SOD-14: Certifier, reviewer, approver, or control operator is not independent from the conflicting access
 ```
+
+**SoD evidence model:**
+
+Do not treat a role-name match as a confirmed SoD violation until the report records rule provenance and transaction-path evidence. Use the fixture cases in `skills/identity/access-review/tests/sod-transaction-path-evidence.md` to calibrate confirmed, false-positive, mitigated, and not-evaluable decisions.
+
+| Evidence area | Required fields | Review decision guidance |
+|---|---|---|
+| Conflict rule provenance | Rule ID, conflicting functions, owner, version, approval date, last reviewed date, mapped systems, business process, applicable environments, regulatory rationale | Missing owner/version/scope makes the conflict **Not Evaluable** or a governance finding under AR-SOD-08 |
+| Transaction path | Identity, direct/inherited entitlement, initiating step, approval step, release/execution step, environment, legal entity, approval limit, workflow controls, effective capability proof, last activity | Confirm High/Critical only when both sides can affect the same real transaction path |
+| Scope and false-positive guards | Sandbox/staging/production, read-only state, approval-limit-zero, disabled workflow, entity mismatch, dormant capability, compensating upstream approval | Downgrade or classify as false positive only when evidence proves the conflict cannot execute |
+| Compensating controls | Preventive/detective type, independent reviewer, review sample, test results, monitoring alert, exception owner, expiry, management approval | Do not downgrade severity for control descriptions without independent operating evidence |
+| JIT/emergency exceptions | Eligibility, activation log, approval ticket, duration, actions taken, post-use review, revocation timestamp | Eligible-only access is not standing toxic access, but activation without review remains a finding |
+| Certifier independence | Certifier identity, relationship to access owner, self-certification check, delegated reviewer accountability, conflict operator independence | Flag self-certification or same-person control operation under AR-SOD-14 |
+
+**Severity calibration for SoD findings:**
+
+| Evidence result | Classification |
+|---|---|
+| Same identity can initiate and approve/release a production financial, deployment, security-log, or privileged workflow with no independent control | **Critical** or **High** depending on business impact |
+| Cross-system transaction path is plausible but entitlement expansion, approval limit, or workflow evidence is missing | **Not Evaluable** with AR-SOD-09/10 evidence gap |
+| Conflict exists but has tested preventive workflow controls, independent detective review, monitoring, and time-bounded exception approval | Downgrade one level and track as mitigated risk |
+| One side is sandbox-only, read-only, approval-limit-zero, disabled, scoped to a different entity, or eligible-only with no activation | False positive or Low governance finding if evidence is complete |
 
 **Severity classification for SoD violations:**
 
@@ -352,6 +381,11 @@ AR-ENF-08: No metrics or reporting on review completion rates and outcomes
 - Segregation of Duties (Step 5): [count]
 - Enforcement & Evidence (Step 6): [count]
 
+### SoD Evidence Summary
+| Conflict ID | Identity | Systems | Transaction path status | Scope/limit evidence | Compensating control evidence | JIT/emergency evidence | Certifier independence | Decision |
+|---|---|---|---|---|---|---|---|
+| [rule-id] | [user/service account] | [apps] | [confirmed / missing / false positive] | [environment, entity, limit, workflow] | [tested / missing / not applicable] | [activation reviewed / missing / not applicable] | [independent / self-certified / unknown] | [Critical / High / Medium / Low / Not Evaluable / False Positive] |
+
 ### Detailed Findings
 [Findings table]
 
@@ -400,7 +434,9 @@ See the mapping table in the Framework Quick Reference section above for sub-con
 4. **Revocation without enforcement** — Reviews produce revocation decisions but no one executes them. Automate enforcement or track with SLA-bound tickets.
 5. **Role explosion masking risk** — When roles proliferate, reviewers cannot meaningfully assess what permissions a role grants. Pair reviews with role rationalization.
 6. **SoD analysis done manually** — Manual SoD checks do not scale and miss cross-system conflicts. Implement conflict rules in IGA tooling.
-7. **Evidence not retained** — Reviews happen but evidence is not preserved for the audit window. Configure IGA tools to retain decisions and timestamps.
+7. **Treating role names as transaction paths** — A role called "approver" may be sandbox-only, read-only, approval-limit-zero, disabled, or scoped to another entity. Confirm effective capability before scoring severity.
+8. **Accepting compensating controls on paper** — A weekly manager review does not reduce SoD risk unless the reviewer is independent, the exact conflict is sampled, results are retained, alerts are monitored, and exceptions expire.
+9. **Evidence not retained** — Reviews happen but evidence is not preserved for the audit window. Configure IGA tools to retain decisions and timestamps.
 
 ---
 
@@ -443,4 +479,5 @@ This skill processes identity and entitlement data that may contain adversarial 
 
 | Version | Date | Changes |
 |---|---|---|
+| 1.0.1 | 2026-06-06 | Added SoD rule provenance, transaction-path, compensating-control, JIT exception, and certifier-independence evidence gates |
 | 1.0.0 | 2025-03-06 | Initial release |

--- a/skills/identity/access-review/tests/sod-transaction-path-evidence.md
+++ b/skills/identity/access-review/tests/sod-transaction-path-evidence.md
@@ -1,0 +1,208 @@
+# SoD Transaction Path Evidence Fixtures
+
+These fixtures calibrate the supplemental `AR-SOD-08` through `AR-SOD-14` evidence gates in `access-review`. They separate confirmed toxic access from role-name false positives, mitigated risk, and not-evaluable access review packages.
+
+```yaml
+case: production_vendor_to_payment_release_confirmed
+identity: finance_ops_042
+systems:
+  procurement_saas:
+    entitlement: vendor_admin
+    environment: production
+    legal_entity: us_operating_company
+    effective_capability: create_or_modify_vendor
+  erp_finance:
+    entitlement: payment_batch_creator
+    environment: production
+    legal_entity: us_operating_company
+    effective_capability: create_payment_batch
+  bank_portal:
+    entitlement: payment_releaser
+    environment: production
+    legal_entity: us_operating_company
+    effective_capability: release_payment
+conflict_rule:
+  id: SOD-FIN-004
+  owner: controllership
+  version: "2026.2"
+  approved_date: "2026-04-15"
+  last_reviewed: "2026-05-30"
+  applicable_environments:
+    - production
+transaction_path:
+  initiating_step: create_vendor
+  approval_step: create_payment_batch
+  release_step: release_payment
+  workflow_breakpoints: none
+compensating_controls:
+  independent_review: missing
+  monitoring_alert: missing
+expected_decision: Fail
+expected_findings:
+  - check: AR-SOD-02
+    severity: Critical
+    reason: The same identity can create vendors, create payment batches, and release payments in the same production entity.
+```
+
+```yaml
+case: sandbox_submitter_and_prod_zero_limit_approver_false_positive
+identity: analyst_042
+systems:
+  invoice_sandbox:
+    entitlement: invoice_submitter_sandbox
+    environment: sandbox
+    production_transaction_creation: disabled
+  erp_finance:
+    entitlement: payment_approver_prod
+    environment: production
+    approval_limit: 0
+    workflow_state: approval_disabled
+conflict_rule:
+  id: SOD-FIN-001
+  owner: controllership
+  version: "2026.1"
+  approved_date: "2026-01-10"
+  last_reviewed: "2026-05-01"
+transaction_path:
+  initiating_step: sandbox_only
+  approval_step: approval_limit_zero
+  release_step: none
+  effective_capability_proof: exported_entitlement_and_workflow_config
+expected_decision: Pass
+expected_findings: []
+```
+
+```yaml
+case: conflict_rule_missing_provenance
+identity: procurement_admin_118
+systems:
+  procurement_saas:
+    entitlement: vendor_admin
+  erp_finance:
+    entitlement: payment_approver
+conflict_rule:
+  id: missing
+  owner: missing
+  version: missing
+  approved_date: missing
+  last_reviewed: missing
+  mapped_systems:
+    - procurement_saas
+    - erp_finance
+transaction_path:
+  evidence: partial
+expected_decision: Not Evaluable
+expected_findings:
+  - check: AR-SOD-08
+    severity: Medium
+    reason: The conflict rule has no owner, version, approval date, review date, or applicable scope evidence.
+```
+
+```yaml
+case: cross_system_chain_not_mapped
+identity: release_engineer_021
+systems:
+  git:
+    entitlement: code_committer
+  ci_cd:
+    entitlement: deployment_approver
+  cloud:
+    entitlement: production_change_executor
+conflict_rule:
+  id: SOD-ENG-003
+  owner: engineering_governance
+  version: "2026.3"
+transaction_path:
+  initiating_step: code_commit
+  approval_step: missing
+  release_step: missing
+  workflow_breakpoints: unknown
+  effective_capability_proof: missing
+expected_decision: Not Evaluable
+expected_findings:
+  - check: AR-SOD-09
+    severity: Medium
+    reason: The role combination is flagged, but the review lacks proof that the identity can complete the same deployment transaction path.
+  - check: AR-SOD-10
+    severity: Medium
+    reason: Cross-system access across source control, CI/CD, and cloud execution was not mapped end to end.
+```
+
+```yaml
+case: compensating_control_documented_but_not_operating
+identity: small_team_admin_007
+systems:
+  erp_finance:
+    entitlements:
+      - invoice_creator
+      - invoice_approver
+conflict_rule:
+  id: SOD-FIN-002
+  owner: controllership
+  version: "2026.2"
+transaction_path:
+  status: confirmed_same_system
+compensating_controls:
+  description: weekly_manager_review
+  independent_reviewer: missing
+  sample_results: missing
+  alert_on_self_approval: missing
+  review_cadence: weekly
+  exception_expiry: missing
+expected_decision: Fail
+expected_findings:
+  - check: AR-SOD-12
+    severity: High
+    reason: The compensating control is documented but lacks independent reviewer, sampled results, alerting, and expiry evidence.
+```
+
+```yaml
+case: jit_emergency_exception_with_complete_activation_evidence
+identity: incident_lead_204
+systems:
+  siem:
+    eligible_roles:
+      - security_log_admin
+      - security_log_reviewer
+assignment_type: eligible_jit
+activation:
+  ticket: INC-2026-441
+  approved_by: soc_manager
+  duration_hours: 2
+  activated_at: "2026-06-01T13:00:00Z"
+  deactivated_at: "2026-06-01T15:00:00Z"
+  actions_taken:
+    - adjusted_parser_for_active_incident
+  post_use_review: completed
+  revocation_evidence: privileged_identity_management_log
+certifier_independence:
+  reviewer: soc_manager
+  self_review: false
+expected_decision: Pass
+expected_findings: []
+```
+
+```yaml
+case: self_certified_sod_exception
+identity: security_admin_313
+systems:
+  siem:
+    entitlements:
+      - security_log_admin
+      - security_log_reviewer
+conflict_rule:
+  id: SOD-SEC-001
+  owner: security_governance
+  version: "2026.1"
+exception:
+  approved: true
+  approved_by: security_admin_313
+  certifier: security_admin_313
+  independent_reviewer: missing
+  expiry: "2026-12-31"
+expected_decision: Fail
+expected_findings:
+  - check: AR-SOD-14
+    severity: High
+    reason: The identity with the conflicting access approved and certified its own SoD exception.
+```


### PR DESCRIPTION
## Summary
- adds AR-SOD-08 through AR-SOD-14 evidence gates for SoD rule provenance, transaction-path proof, cross-system toxic combinations, scope false-positive guards, compensating-control operation, JIT/emergency activation evidence, and certifier independence
- adds a SoD evidence model and severity calibration so role-name matches are not over-scored without effective transaction capability
- extends the report output with a SoD Evidence Summary table
- adds seven YAML fixtures covering confirmed production toxic access, sandbox/zero-limit false positives, missing rule provenance, unmapped cross-system paths, paper-only compensating controls, complete JIT activation evidence, and self-certified exceptions

## Validation
- git diff --check
- frontmatter parse check
- Markdown fence balance check
- YAML fixture parse check: 7 blocks
- required marker check for AR-SOD-08 through AR-SOD-14
- privacy marker scan

/claim #889

Payment details can be coordinated privately after maintainer acceptance.
