### PR TITLE
Add Azure Key Vault evidence fixtures

### DIFF
--- a/skills/cloud/azure-review/SKILL.md
+++ b/skills/cloud/azure-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-Azure-v2.1.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -154,6 +154,14 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Evidence:** <specific configuration or code snippet>
 - **Remediation:** <specific fix with code example>
 
+### Key Vault Effective Evidence
+
+For Section 8 findings, include a Key Vault evidence table before scoring recovery or private-access controls. Use `skills/cloud/azure-review/tests/key-vault-recovery-private-access.md` to calibrate pass, fail, and not-evaluable decisions.
+
+| Vault | Evidence source | Soft-delete retention | Purge protection | Public network access | Firewall/trusted services | Private endpoint state | Private DNS/client path | Decision |
+|---|---|---|---|---|---|---|---|---|
+| [name] | [Terraform / Bicep / ARM / CLI / inventory] | [days / missing] | [enabled / disabled / justified exception] | [disabled / selected networks / enabled] | [default action, bypass, exceptions] | [approved / pending / missing] | [zone link, VNet link, client route] | [Pass / Fail / Not Evaluable] |
+
 ### Prioritized Remediation Plan
 
 1. **[Critical]** CIS X.Y.Z -- <action item>
@@ -199,7 +207,8 @@ Produce the final report using the structure defined in the Output Format sectio
 3. **Overlooking `allow_nested_items_to_be_public` on storage accounts.** CIS 3.7 checks the account-level setting, not individual container access levels. The account setting must be `false` to prevent any container from being public.
 4. **NSG rules using service tags.** A rule with `source_address_prefix = "Internet"` is equivalent to `0.0.0.0/0`. Both must be flagged for CIS 6.1 and 6.2.
 5. **Key Vault purge protection is irreversible.** CIS 8.5 requires `purge_protection_enabled = true`. Note this cannot be disabled once enabled -- flag this for awareness during remediation.
-6. **App Service TLS version on both Linux and Windows.** Check `azurerm_linux_web_app` and `azurerm_windows_web_app` resources separately.
+6. **Private endpoint presence is not private-only access.** Confirm `public_network_access_enabled`, firewall default action, trusted-service exceptions, private endpoint approval, `privatelink.vaultcore.azure.net` DNS linkage, and client path evidence before passing CIS 8.7.
+7. **App Service TLS version on both Linux and Windows.** Check `azurerm_linux_web_app` and `azurerm_windows_web_app` resources separately.
 
 ---
 
@@ -231,4 +240,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Added Key Vault effective recovery and private-access evidence table with fixture-backed decision guidance.
 - **1.0.0** -- Initial release. Full coverage of CIS Microsoft Azure Foundations Benchmark v2.1.0 sections 1 through 9.

--- a/skills/cloud/azure-review/benchmark-checklist.md
+++ b/skills/cloud/azure-review/benchmark-checklist.md
@@ -609,6 +609,15 @@ resource "azurerm_key_vault" {
 }
 ```
 
+Supplemental effective-recovery evidence:
+
+| Check | Evidence to require | Fail or Not Evaluable condition |
+|---|---|---|
+| AZ-KV-REC-01 retention source | Terraform/Bicep/ARM plus CLI or inventory evidence for imported/existing vaults | IaC omits live retention state for an existing vault |
+| AZ-KV-REC-02 retention duration | `soft_delete_retention_days`, recovery policy, data classification, and exception rationale | Production or high-value vault has minimal retention without approved exception |
+| AZ-KV-REC-03 purge protection | `purge_protection_enabled = true` or live inventory proof, plus rollout impact note because the setting is irreversible | Purge protection is disabled for production/customer-managed-key vaults |
+| AZ-KV-REC-04 recovery operations | Evidence that delete, recover, purge, and restore permissions are separated and monitored | Same principal can delete and purge without alerting or approval |
+
 ### CIS 8.6 -- Enable Role Based Access Control for Azure Key Vault
 
 ```hcl
@@ -629,6 +638,18 @@ resource "azurerm_private_endpoint" {
   }
 }
 ```
+
+Supplemental private-access evidence:
+
+| Check | Evidence to require | Fail or Not Evaluable condition |
+|---|---|---|
+| AZ-KV-NET-01 public access state | `public_network_access_enabled`, firewall `default_action`, IP/VNet rules, and trusted-service bypass | Private endpoint exists but public network access remains broadly enabled |
+| AZ-KV-NET-02 exception scope | Named trusted-service or public-network exception, owner, expiry, data path, and compensating control | Exception is broad, ownerless, or unbounded |
+| AZ-KV-NET-03 private endpoint approval | `private_service_connection` target, subresource `vault`, connection state, subscription/VNet, and approval evidence | Endpoint is pending, rejected, points to the wrong vault, or missing |
+| AZ-KV-NET-04 private DNS | `privatelink.vaultcore.azure.net` zone, zone group, VNet links, and resolver/client lookup evidence | Clients can still resolve the public Key Vault endpoint |
+| AZ-KV-NET-05 client path | Workload subnet, route, DNS resolver, firewall/proxy path, and live inventory source | IaC shows a private endpoint but no evidence clients actually use it |
+
+Keep these supplemental checks out of the CIS score denominator when evidence is unavailable; record them as Key Vault evidence gaps or Not Evaluable findings.
 
 ---
 

--- a/skills/cloud/azure-review/tests/key-vault-recovery-private-access.md
+++ b/skills/cloud/azure-review/tests/key-vault-recovery-private-access.md
@@ -1,0 +1,170 @@
+# Key Vault Recovery and Private Access Fixtures
+
+These fixtures calibrate supplemental `AZ-KV-REC-*` and `AZ-KV-NET-*` evidence checks in `azure-review`.
+
+```yaml
+case: private_recoverable_production_vault
+vault:
+  name: prod-payments-kv
+  data_classification: high_value_cmk
+evidence_source:
+  terraform: present
+  cli_inventory: present
+recovery:
+  soft_delete_retention_days: 90
+  purge_protection_enabled: true
+  delete_and_purge_separation: true
+  purge_alerting: true
+network:
+  public_network_access_enabled: false
+  firewall_default_action: Deny
+  trusted_services_bypass: none
+  private_endpoint:
+    subresource: vault
+    connection_state: Approved
+    target_vault: prod-payments-kv
+  private_dns:
+    zone: privatelink.vaultcore.azure.net
+    vnet_linked: true
+    client_lookup_returns_private_ip: true
+expected_decision: Pass
+expected_findings: []
+```
+
+```yaml
+case: private_endpoint_but_public_access_enabled
+vault:
+  name: shared-prod-kv
+  data_classification: production_secrets
+recovery:
+  soft_delete_retention_days: 90
+  purge_protection_enabled: true
+network:
+  public_network_access_enabled: true
+  firewall_default_action: Allow
+  private_endpoint:
+    subresource: vault
+    connection_state: Approved
+  private_dns:
+    zone: privatelink.vaultcore.azure.net
+    vnet_linked: true
+expected_decision: Fail
+expected_findings:
+  - check: AZ-KV-NET-01
+    severity: High
+    reason: A private endpoint exists, but public network access and firewall allow remain broadly enabled.
+```
+
+```yaml
+case: private_endpoint_missing_dns_link
+vault:
+  name: customer-data-kv
+network:
+  public_network_access_enabled: false
+  firewall_default_action: Deny
+  private_endpoint:
+    subresource: vault
+    connection_state: Approved
+  private_dns:
+    zone: missing
+    vnet_linked: false
+    client_lookup_returns_private_ip: false
+expected_decision: Fail
+expected_findings:
+  - check: AZ-KV-NET-04
+    severity: High
+    reason: The private endpoint is approved, but private DNS zone linkage and client lookup evidence are missing.
+```
+
+```yaml
+case: purge_protection_disabled_minimal_retention
+vault:
+  name: prod-app-kv
+  data_classification: production_secrets
+evidence_source:
+  terraform: present
+recovery:
+  soft_delete_retention_days: 7
+  purge_protection_enabled: false
+  exception:
+    owner: missing
+    rationale: missing
+network:
+  public_network_access_enabled: false
+expected_decision: Fail
+expected_findings:
+  - check: AZ-KV-REC-02
+    severity: High
+    reason: Production vault has minimal soft-delete retention without approved exception evidence.
+  - check: AZ-KV-REC-03
+    severity: High
+    reason: Purge protection is disabled for a production secrets vault.
+```
+
+```yaml
+case: imported_vault_iac_omits_live_recovery_state
+vault:
+  name: imported-legacy-kv
+evidence_source:
+  terraform_import: present
+  cli_inventory: missing
+  azure_policy_export: missing
+recovery:
+  soft_delete_retention_days: unknown
+  purge_protection_enabled: unknown
+network:
+  public_network_access_enabled: unknown
+expected_decision: Not Evaluable
+expected_findings:
+  - check: AZ-KV-REC-01
+    severity: Medium
+    reason: Imported vault IaC is present, but live retention, purge protection, and network state evidence is missing.
+```
+
+```yaml
+case: scoped_trusted_service_exception
+vault:
+  name: cmk-analytics-kv
+network:
+  public_network_access_enabled: true
+  firewall_default_action: Deny
+  trusted_services_bypass:
+    enabled: true
+    services:
+      - AzureStorage
+    owner: data_platform
+    expiry: "2026-09-30"
+    monitoring: diagnostic_logs_and_alerts
+  private_endpoint:
+    subresource: vault
+    connection_state: Approved
+expected_decision: Pass
+expected_findings: []
+```
+
+```yaml
+case: pending_private_endpoint_and_no_client_path
+vault:
+  name: finance-kv
+network:
+  public_network_access_enabled: false
+  firewall_default_action: Deny
+  private_endpoint:
+    subresource: vault
+    connection_state: Pending
+  private_dns:
+    zone: privatelink.vaultcore.azure.net
+    vnet_linked: true
+  client_path:
+    workload_subnet: missing
+    route_evidence: missing
+    resolver_evidence: missing
+expected_decision: Not Evaluable
+expected_findings:
+  - check: AZ-KV-NET-03
+    severity: Medium
+    reason: Private endpoint exists but is not approved.
+  - check: AZ-KV-NET-05
+    severity: Medium
+    reason: Client network path evidence is missing, so private-only access cannot be proven.
+```


### PR DESCRIPTION
## Summary
- adds a Key Vault effective evidence table for recovery and private-access scoring
- extends Section 8 with supplemental `AZ-KV-REC-*` and `AZ-KV-NET-*` checks for retention source, retention duration, purge protection, recovery operations, public network access, exception scope, private endpoint approval, private DNS, and client path evidence
- adds seven YAML fixtures covering private recoverable vaults, private endpoints with public access still enabled, missing private DNS, disabled purge protection with minimal retention, imported vault evidence gaps, scoped trusted-service exceptions, and pending private endpoints without client path evidence

## Validation
- git diff --check
- frontmatter parse check
- Markdown fence balance check
- YAML fixture parse check: 7 blocks
- required marker check for AZ-KV-REC-01 through AZ-KV-REC-04 and AZ-KV-NET-01 through AZ-KV-NET-05
- privacy marker scan

/claim #999

Payment details can be coordinated privately after maintainer acceptance.
