### PR TITLE
Add patch readiness evidence fixtures

### DIFF
--- a/skills/vuln-management/patch-prioritization/SKILL.md
+++ b/skills/vuln-management/patch-prioritization/SKILL.md
@@ -13,7 +13,7 @@ phase: [operate]
 frameworks: [SSVC-2.1, EPSS-v3, CISA-KEV]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -48,6 +48,7 @@ Before starting, collect or confirm:
 - [ ] **Current SLA assignments:** Existing SLA tiers and deadlines for each finding, if previously triaged
 - [ ] **Asset inventory context:** Business criticality, exposure (internet-facing, internal, air-gapped), owner, and environment (production, staging, dev) for affected systems
 - [ ] **Patch availability:** Whether vendor patches, hotfixes, or workarounds exist for each CVE
+- [ ] **Patch readiness evidence:** Vendor advisory/source, affected installed version, fixed version or KB, package/artifact availability for the deployed platform, dependency impact, EOL/support state, backup/snapshot freshness, and rollback test evidence
 - [ ] **Change management constraints:** Maintenance windows, freeze periods, change advisory board (CAB) schedules
 - [ ] **Compensating controls inventory:** WAF rules, network segmentation, EDR policies, disabled features currently in place
 - [ ] **Compliance mandates:** Applicable regulatory requirements (CISA BOD 22-01, PCI DSS 4.0 Requirement 6.3.3, HIPAA, FedRAMP)
@@ -82,6 +83,8 @@ Vulnerability Inventory Entry:
 - CISA KEV:            [Yes | No]
 - SSVC Decision:       [Immediate | Out-of-Cycle | Scheduled | Defer]
 - Patch Available:     [Yes (version) | No | Workaround Only]
+- Patch Readiness:     [Ready | Blocked | Workaround Only | No Patch | EOL | Not Evaluable]
+- Rollback Readiness:  [Ready | Untested | Not Applicable | Blocked | Not Evaluable]
 - Current SLA:         [Tier and deadline]
 - SLA Status:          [Within SLA | At Risk | Breached]
 ```
@@ -188,6 +191,31 @@ Map prioritized patches to available maintenance windows, respecting change mana
 4. Evaluate rollback procedures and test coverage for each patch
 5. Account for change freeze periods (fiscal close, peak traffic, regulatory audits)
 
+#### Patch Availability and Rollback Readiness Gate
+
+Do not schedule a patch solely because a scanner says "patch available." First classify implementation readiness using evidence from the vendor, package manager, image registry, managed-service provider, change plan, and rollback test. Use `skills/vuln-management/patch-prioritization/tests/patch-readiness-edge-cases.md` to calibrate ready, blocked, workaround-only, no-patch, EOL, and Not Evaluable decisions.
+
+| Gate | Evidence to require | Fail or blocked condition |
+|---|---|---|
+| PATCH-READY-01 vendor source | Vendor advisory URL, fixed version/KB, release note, affected installed version, and applicability proof | Advisory does not match deployed product/version/platform |
+| PATCH-READY-02 package/artifact availability | OS package, container base image, application dependency, firmware, or managed-service rollout evidence for the deployed artifact | Fix exists upstream but no installable package/artifact is available for the deployed environment |
+| PATCH-READY-03 dependency and regression impact | Dependency tree, breaking-change notes, known regressions, maintenance contract, and owner signoff | Fixed version is known to break required dependency or has unresolved regression notes |
+| PATCH-READY-04 EOL/support status | Product lifecycle state, extended support contract, upgrade/replacement path, and risk owner | Product is EOL with no vendor fix, but is still scheduled as a normal patch |
+| PATCH-READY-05 workaround/no-patch handling | Workaround source, compensating control, monitoring owner, expiry, and reevaluation cadence | Workaround-only or no-patch finding enters normal patch scheduling without reevaluation date |
+| PATCH-READY-06 rollback evidence | Backup/snapshot timestamp, restore method, rollback test date/environment, migration reversal plan, and data-loss/RPO impact | Rollback is assumed but not tested, stale, or incompatible with data migrations |
+| PATCH-READY-07 change blockers | Change freeze, CAB/TAC/vendor window, maintenance contract, dependency sequencing, and emergency-change authority | SLA plan ignores a known blocker that prevents execution inside the window |
+
+Classify readiness as:
+
+| Readiness | Meaning |
+|---|---|
+| **Ready** | Fixed artifact is applicable and available, dependencies are understood, and rollback is tested or formally accepted |
+| **Blocked** | A fix exists but package, contract, dependency, rollback, provider rollout, or change-window evidence prevents safe scheduling |
+| **Workaround Only** | No deployable patch exists; compensating control must have owner, expiry, monitoring, and reevaluation cadence |
+| **No Patch** | Vendor has no fix; route to monitoring, risk exception, upgrade/replacement planning, or feature disablement |
+| **EOL** | Product is unsupported; normal patch SLA is not executable without upgrade/replacement or paid extended support |
+| **Not Evaluable** | Evidence is missing for vendor source, deployed version, artifact availability, rollback, or dependency impact |
+
 #### Scheduling Priority Rules
 
 | Priority | Scheduling Rule |
@@ -202,10 +230,14 @@ Patch Schedule Entry:
 - CVE ID(s):           [List of CVEs addressed]
 - Target System(s):    [Hostname(s) / application(s)]
 - Patch Version:       [Vendor patch version or KB number]
+- Patch Readiness:     [Ready | Blocked | Workaround Only | No Patch | EOL | Not Evaluable]
+- Readiness Evidence:  [Vendor source, deployed version, package/artifact, dependency impact]
 - Scheduled Window:    [YYYY-MM-DD HH:MM - HH:MM TZ]
 - Change Type:         [Emergency | Expedited | Standard]
 - Change Ticket:       [Ticket ID]
 - Rollback Plan:       [Description or "snapshot/restore"]
+- Rollback Readiness:  [Ready | Untested | Not Applicable | Blocked]
+- Rollback Test:       [Date/environment or accepted gap]
 - SLA Deadline:        [YYYY-MM-DD]
 - Days Remaining:      [N days]
 ```
@@ -309,9 +341,15 @@ findings requiring immediate action.]
 
 ### Prioritized Patch Schedule
 
-| Priority | CVE ID(s) | Target System | Patch | Scheduled Window | SLA Deadline | Status |
-|---|---|---|---|---|---|---|
-| P0 | [CVE-ID] | [system] | [version] | [date/time] | [date] | [Scheduled/Pending/Complete] |
+| Priority | CVE ID(s) | Target System | Patch | Readiness | Rollback | Scheduled Window | SLA Deadline | Status |
+|---|---|---|---|---|---|---|---|---|
+| P0 | [CVE-ID] | [system] | [version] | [Ready/Blocked/etc.] | [Ready/Untested/etc.] | [date/time] | [date] | [Scheduled/Pending/Complete] |
+
+### Patch Readiness and Rollback Gate
+
+| CVE ID | Vendor source | Deployed version | Fixed artifact | Dependency impact | EOL/support | Workaround/no-patch cadence | Rollback evidence | Decision |
+|---|---|---|---|---|---|---|---|---|
+| [CVE-ID] | [URL/source] | [version] | [KB/package/image/firmware] | [none/known] | [supported/EOL] | [expiry/review] | [tested/untested/blocked] | [Ready/Blocked/Workaround Only/No Patch/EOL/Not Evaluable] |
 
 ### Compensating Controls in Effect
 [List all active compensating controls with effectiveness ratings]
@@ -373,6 +411,10 @@ Known Exploited Vulnerabilities catalog maintained by CISA. Contains CVEs with c
 4. **Ignoring EPSS trend direction.** A CVE with a low absolute EPSS score but a rapidly rising trend (e.g., from 0.02 to 0.15 in two weeks) signals that exploit development is progressing. Treating EPSS as a static snapshot rather than a time series misses emerging threats. Always evaluate 7/30/90-day trends.
 
 5. **Scheduling patches without rollback plans.** Patch deployment failures without rollback procedures cause unplanned outages that erode trust in the patching program. Every patch window must include a validated rollback procedure, tested in a non-production environment where possible.
+
+6. **Treating patch availability as binary.** A vendor may have released a fix that is not packaged for the deployed distribution, not present in a container base image, not rolled out for a managed service, or unsafe due to known regressions. Readiness evidence decides whether scheduling is executable.
+
+7. **Letting no-patch findings drift.** Workaround-only and no-patch findings need monitoring owners, expiry dates, and reevaluation cadence. Otherwise they become invisible permanent exceptions.
 
 ---
 

--- a/skills/vuln-management/patch-prioritization/tests/patch-readiness-edge-cases.md
+++ b/skills/vuln-management/patch-prioritization/tests/patch-readiness-edge-cases.md
@@ -1,0 +1,178 @@
+# Patch Readiness and Rollback Evidence Fixtures
+
+These fixtures calibrate the supplemental `PATCH-READY-*` evidence gates in `patch-prioritization`.
+
+```yaml
+case: vendor_patch_ready_with_tested_rollback
+cve: CVE-2026-10001
+asset:
+  name: payments-api-01
+  environment: production
+  installed_version: "2.4.1"
+vendor_source:
+  advisory_url: https://vendor.example/advisories/CVE-2026-10001
+  affected_versions:
+    - "<2.4.4"
+  fixed_version: "2.4.4"
+artifact:
+  package_available: true
+  package_name: payments-api
+  repository: internal-prod-yum
+dependency_impact:
+  breaking_changes: none
+rollback:
+  backup_timestamp: "2026-06-06T01:00:00Z"
+  method: blue_green_rollback
+  tested_at: "2026-06-05T18:00:00Z"
+  rpo_minutes: 5
+expected_decision: Ready
+expected_findings: []
+```
+
+```yaml
+case: upstream_fix_not_packaged_for_deployed_os
+cve: CVE-2026-10002
+asset:
+  os: ubuntu_22_04
+  installed_version: "1.8.0-ubuntu1"
+vendor_source:
+  advisory_url: https://upstream.example/security/CVE-2026-10002
+  fixed_upstream_version: "1.8.3"
+artifact:
+  distro_package_available: false
+  ppa_or_backport: missing
+  container_base_image: not_rebuilt
+rollback:
+  method: snapshot_restore
+  tested_at: missing
+expected_decision: Blocked
+expected_findings:
+  - check: PATCH-READY-02
+    severity: High
+    reason: Upstream fix exists, but no deployable package or rebuilt artifact is available for the deployed OS/image.
+  - check: PATCH-READY-06
+    severity: Medium
+    reason: Rollback method is listed but has no test evidence.
+```
+
+```yaml
+case: no_patch_workaround_needs_reevaluation
+cve: CVE-2026-10003
+asset:
+  component: legacy_gateway
+vendor_source:
+  advisory_url: https://vendor.example/advisories/CVE-2026-10003
+  fixed_version: none
+  vendor_status: investigating
+workaround:
+  type: disable_vulnerable_feature
+  owner: network-team
+  monitoring: waf_rule_and_log_alert
+  expiry: missing
+  reevaluation_date: missing
+expected_decision: Workaround Only
+expected_findings:
+  - check: PATCH-READY-05
+    severity: Medium
+    reason: Workaround-only remediation lacks expiry and reevaluation cadence.
+```
+
+```yaml
+case: eol_product_scheduled_as_normal_patch
+cve: CVE-2026-10004
+asset:
+  product: legacy_cms
+  installed_version: "7.2"
+support:
+  lifecycle: eol
+  extended_support_contract: missing
+  upgrade_path: missing
+vendor_source:
+  advisory_url: https://vendor.example/eol/security
+  fixed_version: not_available_for_7_2
+schedule:
+  proposed_action: apply_normal_patch
+expected_decision: EOL
+expected_findings:
+  - check: PATCH-READY-04
+    severity: High
+    reason: Product is EOL with no vendor fix or extended support, but the plan treats it as a normal patch.
+```
+
+```yaml
+case: container_needs_base_image_and_dependency_rebuild
+cve: CVE-2026-10005
+asset:
+  image: registry.example/app:2026-05-31
+  base_image: debian:12.3
+  app_dependency: libfoo 3.1.0
+vendor_source:
+  fixed_base_image: debian:12.5
+  fixed_dependency: libfoo 3.1.3
+artifact:
+  image_rebuild_pipeline: pending
+  sbom_updated: false
+  registry_image_available: false
+dependency_impact:
+  integration_tests: not_run
+expected_decision: Blocked
+expected_findings:
+  - check: PATCH-READY-02
+    severity: High
+    reason: Fixed base image and dependency exist, but no rebuilt deployment image is available.
+  - check: PATCH-READY-03
+    severity: Medium
+    reason: Dependency impact and integration tests are not complete.
+```
+
+```yaml
+case: firmware_patch_requires_vendor_tac_window
+cve: CVE-2026-10006
+asset:
+  product: edge_firewall
+  installed_firmware: "9.1.2"
+vendor_source:
+  fixed_firmware: "9.1.5"
+  advisory_url: https://vendor.example/security/fw-915
+artifact:
+  firmware_download_available: true
+change_blockers:
+  maintenance_contract: active
+  vendor_tac_window: missing
+  ha_failover_test: not_run
+rollback:
+  method: firmware_downgrade
+  tested_at: missing
+expected_decision: Blocked
+expected_findings:
+  - check: PATCH-READY-07
+    severity: Medium
+    reason: Firmware patch requires a vendor TAC or maintenance window that has not been scheduled.
+  - check: PATCH-READY-06
+    severity: Medium
+    reason: Firmware rollback and HA failover have not been tested.
+```
+
+```yaml
+case: database_migration_rollback_not_snapshot_safe
+cve: CVE-2026-10007
+asset:
+  application: billing-platform
+  installed_version: "5.6.0"
+vendor_source:
+  fixed_version: "5.6.2"
+artifact:
+  package_available: true
+dependency_impact:
+  includes_database_migration: true
+rollback:
+  method: snapshot_restore
+  tested_at: "2026-06-01T12:00:00Z"
+  data_migration_reverse_plan: missing
+  rpo_minutes: 240
+expected_decision: Blocked
+expected_findings:
+  - check: PATCH-READY-06
+    severity: High
+    reason: Rollback relies on snapshot restore but the patch includes data migrations with no reverse plan and high RPO impact.
+```


### PR DESCRIPTION
## Summary
- adds patch availability and rollback readiness gates for vendor source, deployed version applicability, package/artifact availability, dependency/regression impact, EOL/support state, workaround/no-patch cadence, rollback evidence, and change blockers
- adds readiness classifications: Ready, Blocked, Workaround Only, No Patch, EOL, and Not Evaluable
- extends patch schedule and report output with readiness and rollback evidence
- adds seven YAML fixtures covering ready rollback-tested patching, upstream fixes not packaged for deployed OS, no-patch workaround cadence, EOL products, container rebuild dependency chains, firmware/vendor windows, and data-migration rollback gaps

## Validation
- git diff --check
- frontmatter parse check
- Markdown fence balance check
- YAML fixture parse check: 7 blocks
- required marker check for PATCH-READY-01 through PATCH-READY-07
- privacy marker scan

/claim #899

Payment details can be coordinated privately after maintainer acceptance.
