### PR TITLE
Improve AI privacy transfer and subprocessor gates

### DIFF
--- a/skills/ai-security/ai-data-privacy/SKILL.md
+++ b/skills/ai-security/ai-data-privacy/SKILL.md
@@ -74,6 +74,7 @@ Before beginning the assessment, gather the following. If any item is unavailabl
 | Data flow diagram for the AI system | Architecture docs, design docs | Maps where personal data enters, persists, and exits |
 | LLM provider and terms of service | Vendor contracts, API docs, DPAs | Determines whether user data is used for provider training |
 | Data processing agreements (DPAs) | Legal/compliance documentation | Establishes legal basis for data processing |
+| Processor, subprocessor, and transfer evidence | DPA annexes, subprocessor list, region settings, SCCs, adequacy/DPF evidence, transfer impact assessment | Proves who processes AI data, where it is processed or remotely accessed, and which transfer mechanism applies |
 | Privacy policy | Public-facing policy documents | Defines commitments to users about data handling |
 | Data retention policies | Internal governance docs, code configs | Determines how long AI-processed data persists |
 | Logging configuration | Application code, infrastructure configs | Reveals what prompt/completion data is captured |
@@ -379,12 +380,67 @@ Grep: "consent_check|is_consented|has_consent|filter_consented|exclude_opted_out
 
 ---
 
+### Step 7 -- Processor, Subprocessor, and International Transfer Evidence
+
+Assess whether each AI data flow that uses a third-party provider, managed service, human review vendor, analytics platform, evaluation tool, vector database, or model gateway has documented processor/subprocessor roles, region evidence, and international-transfer safeguards. Provider retention and "not used for training" statements are not enough to clear privacy risk when personal data can be stored, processed, remotely accessed, logged, moderated, reviewed, or onward-transferred outside the expected region.
+
+**What to evaluate:**
+
+- Which parties are controllers, processors, subprocessors, joint controllers, or independent controllers for each AI data flow.
+- Which AI data types each party handles: prompts, completions, embeddings, files, RAG snippets, vector metadata, evaluation rows, fine-tuning datasets, telemetry, abuse-review samples, or human-review queues.
+- Storage region, processing region, support/admin access region, telemetry/logging region, model-evaluation region, and onward-transfer destinations.
+- Whether GDPR Article 28 processor terms include subprocessor authorization, audit rights, deletion/return, breach notice, assistance with data subject rights, and technical/organizational measures.
+- Which Chapter V transfer mechanism applies to each non-EEA transfer or remote-access path: adequacy decision, EU-US Data Privacy Framework, standard contractual clauses, binding corporate rules, derogation, or Not Evaluable.
+- Whether SCC module, annexes, transfer impact assessment, supplementary measures, and encryption/key-control evidence are tied to the actual provider role and data path.
+- Whether EU-US Data Privacy Framework reliance was verified against the official list for the covered legal entity/service and date checked.
+
+**Detection methods using allowed tools:**
+
+```
+# Find vendor and subprocessor evidence
+Grep: "subprocessor|processor|controller|dpa|data.processing|data.processing.agreement" in **/*.{md,txt,yaml,yml,json}
+Grep: "region|data.region|processing.region|support.access|telemetry|logging.region|abuse.review" in **/*.{md,txt,yaml,yml,json}
+
+# Check transfer mechanism evidence
+Grep: "scc|standard.contractual|data.privacy.framework|dpf|adequacy|transfer.impact|tia|binding.corporate|bcr" in **/*.{md,txt,yaml,yml,json}
+Grep: "encryption|cmk|customer.managed.key|key.control|supplementary.measure" in **/*.{md,txt,yaml,yml,json}
+
+# Check AI-adjacent tooling vendors
+Grep: "vector.database|embedding|eval|evaluation|monitoring|analytics|moderation|human.review|mcp|gateway" in **/*.{md,txt,yaml,yml,json,py,ts,js}
+```
+
+**Processor and subprocessor matrix:**
+
+| Entity / Service | Role | AI Data Types | Purpose | Storage Region | Processing / Support Region | Onward Transfer | Evidence |
+|---|---|---|---|---|---|---|---|
+| [LLM provider] | [Processor/Subprocessor/etc.] | [Prompts, completions, files] | [Inference, safety review] | [Region] | [Region/access path] | [Yes/No/details] | [DPA, subprocessor list, settings] |
+
+**Transfer mechanism matrix:**
+
+| Data Flow | Transfer Path | Mechanism | Required Evidence | Status |
+|---|---|---|---|---|
+| [EU app -> LLM API] | [EEA -> US] | [Adequacy / DPF / SCC / BCR / derogation / Not Evaluable] | [DPF entity check, SCC module, TIA, supplementary measures, annexes] | [Pass/Gap/Not Evaluable] |
+
+**What constitutes a finding:**
+
+| Condition | Severity |
+|---|---|
+| EU personal data sent to a third-country provider with no transfer mechanism evidence | Critical |
+| Processor or subprocessor chain missing for AI data stores or AI-adjacent tooling | High |
+| EU region claim lacks storage, processing, support-access, telemetry, and onward-transfer evidence | High |
+| SCC/DPF/BCR evidence is not tied to the actual legal entity, service, role, and data flow | High |
+| TIA or supplementary measures missing when SCCs or other Article 46 safeguards are used for high-risk AI data | High |
+| DPA lacks Article 28 subprocessor authorization, deletion/return, audit, or breach-notice evidence | Medium |
+| Customer-managed encryption keys are treated as transfer legality evidence without role/transfer documentation | Medium |
+| Synthetic/anonymized eval data claim lacks evidence that data is truly anonymized rather than pseudonymized | Medium |
+| Transfer review cannot inspect provider regions, subprocessor list, or transfer mechanism | Not Evaluable |
+
 ## Findings Classification
 
 | Severity | Criteria | Response SLA |
 |---|---|---|
-| **Critical** | Personal data processed without legal basis, PHI exposed without HIPAA controls, or regulatory non-compliance with immediate enforcement risk. | Immediate -- halt processing |
-| **High** | Significant privacy risk with clear exposure path: PII in prompts without redaction, missing retention policies on PII-containing stores, or no consent mechanism for training data. | 7 days -- remediate before next release |
+| **Critical** | Personal data processed without legal basis, PHI exposed without HIPAA controls, EU personal data transferred without Chapter V mechanism evidence, or regulatory non-compliance with immediate enforcement risk. | Immediate -- halt processing |
+| **High** | Significant privacy risk with clear exposure path: PII in prompts without redaction, missing retention policies on PII-containing stores, missing processor/subprocessor evidence, or no consent mechanism for training data. | 7 days -- remediate before next release |
 | **Medium** | Moderate privacy gap requiring specific conditions: incomplete documentation, missing memorization testing, or partial consent implementation. | 30 days -- schedule remediation |
 | **Low** | Minor gap with limited direct privacy risk: defense-in-depth recommendations, documentation improvements, or best practice deviations. | 90 days -- track in backlog |
 | **Informational** | Recommendations for improvement with no current privacy risk. | No SLA -- advisory |
@@ -433,6 +489,20 @@ user input -> prompt assembly -> LLM API -> completion -> output -> logging/stor
 | Memorization risk | [Yes/Partial/No] | [description] | [severity] |
 | EU AI Act compliance | [Yes/Partial/No/N/A] | [description] | [severity] |
 | Consent management | [Yes/Partial/No] | [description] | [severity] |
+| Processor/subprocessor evidence | [Yes/Partial/No/Not Evaluable] | [description] | [severity] |
+| International transfer safeguards | [Yes/Partial/No/Not Evaluable] | [description] | [severity] |
+
+## Processor and Subprocessor Matrix
+
+| Entity / Service | Role | AI Data Types | Purpose | Storage Region | Processing / Support Region | Onward Transfer | Evidence |
+|---|---|---|---|---|---|---|---|
+| [LLM provider] | [Processor/Subprocessor/etc.] | [Prompts/completions/etc.] | [Purpose] | [Region] | [Region/access path] | [Details] | [DPA/subprocessor list/settings] |
+
+## Transfer Mechanism Matrix
+
+| Data Flow | Transfer Path | Mechanism | Required Evidence | Status |
+|---|---|---|---|---|
+| [EU app -> provider] | [EEA -> third country] | [Adequacy/DPF/SCC/BCR/Derogation/Not Evaluable] | [Evidence] | [Pass/Gap/Not Evaluable] |
 
 ## Recommendations
 [Prioritized list of remediation actions with regulatory alignment]
@@ -450,7 +520,7 @@ user input -> prompt assembly -> LLM API -> completion -> output -> logging/stor
 | NIST AI RMF 1.0 | MANAGE 2.4 | Mechanisms for tracking and responding to AI privacy risks |
 | NIST AI RMF 1.0 | GOVERN 1.1 | Legal and regulatory requirements applicable to the AI system |
 | OWASP Top 10 for LLMs (2025) | LLM02 | Sensitive Information Disclosure -- model reveals training data, PII, or confidential information |
-| GDPR | Art. 5, 6, 13, 17, 22, 25, 35 | Principles, legal basis, transparency, erasure, automated decisions, privacy by design, DPIA |
+| GDPR | Art. 5, 6, 13, 17, 22, 25, 28, 35, 44, 46 | Principles, legal basis, transparency, erasure, automated decisions, privacy by design, processor terms, DPIA, international transfers, safeguards |
 | EU AI Act | Art. 10, 11, 13 | Data governance for high-risk AI, technical documentation, transparency |
 | CCPA/CPRA | Sec. 1798.100-199 | Consumer rights regarding personal information used in AI systems |
 
@@ -472,6 +542,8 @@ user input -> prompt assembly -> LLM API -> completion -> output -> logging/stor
 
 5. **Ignoring model memorization as a privacy risk.** Organizations that use pre-trained or fine-tuned models often do not test for memorization of personal data. A model that has memorized PII from its training corpus is effectively a data store containing personal data -- it can reproduce that data on specific prompts. This has regulatory implications: if the model contains memorized PII of EU residents, GDPR obligations apply to the model weights themselves, not just the training dataset.
 
+6. **Assuming an EU region or DPA clears every transfer risk.** A provider may store prompts in an EU region while support access, abuse review, telemetry, evaluation tooling, or subprocessors operate elsewhere. Record the processor chain, regions, support-access paths, transfer mechanism, and evidence date for every AI data flow. Do not treat customer-managed encryption keys, training opt-out, or "not used for training" statements as substitutes for Article 28 and Chapter V evidence.
+
 ---
 
 ## References
@@ -480,6 +552,10 @@ user input -> prompt assembly -> LLM API -> completion -> output -> logging/stor
 - OWASP Top 10 for LLM Applications (2025), LLM02: Sensitive Information Disclosure -- https://genai.owasp.org/llmrisk/llm02-sensitive-information-disclosure/
 - EU AI Act, Regulation (EU) 2024/1689 -- https://eur-lex.europa.eu/eli/reg/2024/1689
 - GDPR, Regulation (EU) 2016/679 -- https://eur-lex.europa.eu/eli/reg/2016/679
+- European Commission Standard Contractual Clauses -- https://commission.europa.eu/law/law-topic/data-protection/international-dimension-data-protection/standard-contractual-clauses-scc_en
+- EDPB Recommendations 01/2020 on supplementary measures for transfers -- https://www.edpb.europa.eu/our-work-tools/our-documents/recommendations/recommendations-012020-measures-supplement-transfer_en
+- European Commission EU-US data transfers -- https://commission.europa.eu/law/law-topic/data-protection/international-dimension-data-protection/eu-us-data-transfers_en
+- Data Privacy Framework official program -- https://www.dataprivacyframework.gov/
 - CCPA/CPRA, California Civil Code Sec. 1798.100-199 -- https://leginfo.legislature.ca.gov/
 - Carlini, N. et al. (2021). "Extracting Training Data from Large Language Models." USENIX Security Symposium. arXiv:2012.07805
 - Carlini, N. et al. (2023). "Quantifying Memorization Across Neural Language Models." ICLR 2023. arXiv:2202.07646

--- a/skills/ai-security/ai-data-privacy/tests/transfer-subprocessor-edge-cases.md
+++ b/skills/ai-security/ai-data-privacy/tests/transfer-subprocessor-edge-cases.md
@@ -1,0 +1,138 @@
+# Transfer and Subprocessor Evidence Edge Cases
+
+These fixtures validate that AI privacy reviews do not clear third-party LLM or AI tooling risk from provider retention statements alone. Processor/subprocessor role evidence, region evidence, transfer mechanism proof, and Not Evaluable outcomes must be recorded per AI data flow.
+
+## Case 1: EU Region Claim Without Support or Telemetry Evidence
+
+**Input evidence:**
+
+```yaml
+ai_system:
+  users: EU customers
+  provider: third-party LLM API
+  deployment_region: eu-west
+  data_sent:
+    - prompts
+    - completions
+    - retrieved_rag_snippets
+evidence_collected:
+  provider_dpa: present
+  no_provider_training_statement: present
+  prompt_retention_policy: present
+missing:
+  processor_subprocessor_chain: missing
+  support_access_region: missing
+  abuse_review_region: missing
+  telemetry_region: missing
+  transfer_mechanism: missing
+result_claimed:
+  privacy_risk: Low
+```
+
+**Expected result:**
+
+- Finding: EU region claim does not prove all processing and remote access stays in the EEA.
+- Severity: High.
+- Rationale: Primary storage, support access, abuse review, telemetry, and onward transfers need separate evidence.
+
+## Case 2: SCC Evidence Not Bound to Actual Provider Role
+
+**Input evidence:**
+
+```yaml
+vendor:
+  marketing_claim: GDPR-ready DPA available
+  role_claimed: processor
+  actual_flow:
+    app_controller_to_llm_processor: EU -> US
+    llm_processor_to_moderation_subprocessor: US -> third_country
+evidence:
+  dpa: present
+  scc_module: unknown
+  subprocessor_authorization: missing
+  onward_transfer_terms: missing
+  transfer_impact_assessment: missing
+  supplementary_measures: missing
+```
+
+**Expected result:**
+
+- Finding: transfer mechanism evidence is not tied to provider role, subprocessor chain, or onward transfer.
+- Severity: Critical if EU personal data is transferred with no valid mechanism evidence; otherwise High until evidence is produced.
+- Rationale: Article 28 processor terms and Chapter V transfer safeguards answer different questions and both must be evidenced.
+
+## Case 3: EU-US DPF Assumed From Marketing Copy
+
+**Input evidence:**
+
+```yaml
+vendor:
+  claim: participates in EU-US Data Privacy Framework
+  service: hosted evaluation dataset platform
+  legal_entity: Example AI Analytics Inc.
+review:
+  official_dpf_list_checked: false
+  covered_entity_or_service: unknown
+  privacy_policy_commitment: unknown
+  fallback_sccs: missing
+  transfer_impact_assessment: missing
+```
+
+**Expected result:**
+
+- Finding: DPF reliance is assumed but not verified for the covered entity/service.
+- Severity: High.
+- Rationale: DPF evidence must be official, entity/service-specific, and date-checked; otherwise use SCC/TIA evidence or mark Not Evaluable.
+
+## Case 4: Complete Processor and Transfer Evidence
+
+**Input evidence:**
+
+```yaml
+ai_system:
+  users: EU customers
+  data_flows:
+    - name: inference
+      data_types:
+        - prompts
+        - completions
+      processor_matrix:
+        entity: Example LLM EU Ltd.
+        role: processor
+        storage_region: eu-central
+        processing_region: eu-central
+        support_access_region: eea
+        subprocessors:
+          - name: Example Safety Review GmbH
+            role: subprocessor
+            purpose: abuse monitoring
+            region: eu-central
+        dpa_article_28:
+          subprocessor_authorization: present
+          audit_rights: present
+          deletion_return: present
+          breach_notice: present
+          toms: present
+      transfer:
+        path: EEA -> EEA
+        mechanism: not_required_no_third_country_transfer
+        evidence_date: "2026-06-06"
+    - name: support_export
+      data_types:
+        - redacted_support_sample
+      transfer:
+        path: EEA -> US
+        mechanism: SCC
+        scc_module: controller_to_processor
+        transfer_impact_assessment: present
+        supplementary_measures:
+          - field_level_redaction
+          - customer_managed_encryption_keys
+          - support_access_logging
+        evidence_date: "2026-06-06"
+```
+
+**Expected result:**
+
+- No finding for processor/subprocessor or transfer evidence.
+- Record residual risk only for unredacted support exports, subprocessor changes after the evidence date, or missing recurrence review of transfer documentation.


### PR DESCRIPTION
Implements #1122.

## Summary
- Adds processor/subprocessor and international-transfer evidence gates to `ai-data-privacy` for third-party LLM APIs and AI-adjacent tooling.
- Requires AI data-flow region evidence, GDPR Article 28 processor terms, Chapter V transfer mechanisms, DPF/SCC/TIA/supplementary-measure proof, and Not Evaluable outcomes when evidence is missing.
- Adds output matrices plus fixtures covering EU-region overtrust, unbound SCC evidence, assumed DPF reliance, and a complete governed transfer evidence set.

## Validation
- Markdown fence balance check passed for changed files.
- Required marker check passed for `Processor, Subprocessor, and International Transfer Evidence`, processor/subprocessor matrix, transfer mechanism matrix, international transfer safeguards, and all four fixture cases.
- Trailing whitespace check passed for changed files.
- New fixture prompt-injection phrase scan returned no matches.
- Privacy scan for local goal folder returned no matches.
- Reference reachability checks returned HTTP 200 for GDPR, European Commission SCCs, EDPB Recommendations 01/2020, European Commission EU-US data transfers, and the official Data Privacy Framework program.
- Remote commit contains only the intended two files.

Payment details can be provided privately after maintainer acceptance.