### PR TITLE
Add IAM recovery and exception path fixtures

### DIFF
--- a/skills/identity/iam-review/SKILL.md
+++ b/skills/identity/iam-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [design, operate]
 frameworks: [NIST-SP-800-63B, NIST-SP-800-207, CIS-Controls-v8]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -153,6 +153,63 @@ IAM-AUTH-10: Composition rules used instead of length-based policy (NIST SP 800-
 | **Azure / Entra ID** | Conditional Access policies, Security Defaults | MFA gaps in conditional access, legacy auth protocols allowed |
 | **Azure / Entra ID** | Authentication methods policy | Phishing-resistant methods (FIDO2, Windows Hello) adoption rate |
 | **GCP** | Organization Policy constraints, 2-Step Verification enforcement | MFA not enforced at org level, allowed authentication methods |
+
+### Step 2.5: Authentication Recovery and Exception Path Review
+
+**Objective:** Verify that MFA and assurance claims cover the full account lifecycle, not only the normal sign-in prompt.
+
+**NIST SP 800-63B Reference:** Authenticator binding, account recovery, reauthentication, and verifier impersonation resistance
+**NIST SP 800-207 Reference:** Tenets 3 and 6 -- per-session access and dynamic authentication/authorization enforcement
+**CIS Controls v8 Reference:** Controls 5.4, 6.3, 6.4, 6.5, and 6.6
+
+Normal login MFA is not enough if a weaker path can reset the password, re-enroll MFA, register a trusted device, refresh tokens, grant admin consent, or use an exception group. Review every path that can restore, bypass, or extend access after the primary authenticator is unavailable or compromised.
+
+#### Recovery and Exception Path Matrix
+
+| Path | Required Evidence | Finding IDs |
+|---|---|---|
+| **Normal sign-in** | MFA enforcement policy, included users/groups, excluded users/groups, assurance level, phishing-resistant method coverage, conditional-access result logs | IAM-AUTH-01 to IAM-AUTH-05 |
+| **Password reset / account recovery** | Identity proofing method, second-factor requirement, helpdesk script, approval record, reset audit logs, post-reset session/token revocation | IAM-AUTH-11, IAM-AUTH-12 |
+| **MFA enrollment / re-enrollment** | Enrollment policy, allowed methods, new-device quarantine, admin/helpdesk approval, audit logs, notification to user/security team | IAM-AUTH-13, IAM-AUTH-14 |
+| **Device registration / trusted device join** | Device compliance requirement, join restrictions, excluded groups, device trust source, stale/unknown device handling | IAM-AUTH-15 |
+| **Privileged role activation** | PIM/JIT policy, MFA-at-activation, approver, justification, duration, emergency activation path, alerting | IAM-AUTH-16 |
+| **Legacy protocols and app passwords** | Basic auth/legacy protocol inventory, app password status, POP/IMAP/SMTP/EWS/OAuth exception evidence, block policy logs | IAM-AUTH-17 |
+| **Session and refresh-token renewal** | Session lifetime, continuous access evaluation, refresh-token revocation test, risk-change reauth, remembered-device duration | IAM-AUTH-18 |
+| **Admin consent and OAuth grants** | Consent workflow, app-risk review, publisher verification, tenant-wide grant audit, delegated/admin consent separation | IAM-AUTH-19 |
+| **Break-glass / emergency accounts** | Count, scope, excluded policies, compensating controls, hardware credential custody, monitoring, last test date, rotation record | IAM-AUTH-20 |
+| **External IdP / guest / vendor paths** | Federation assurance, home-tenant MFA evidence, guest access policy, cross-tenant trust settings, vendor recovery process | IAM-AUTH-21 |
+
+#### Additional Finding IDs
+
+```
+IAM-AUTH-11: Password reset can bypass MFA or lacks independent identity proofing
+IAM-AUTH-12: Helpdesk recovery lacks approval, recording, callback, or post-reset token revocation
+IAM-AUTH-13: MFA re-enrollment can be initiated with only password/session access
+IAM-AUTH-14: New authenticator/device enrollment lacks quarantine, notification, or risk review
+IAM-AUTH-15: Device join/trusted-device exceptions bypass MFA without compliance evidence
+IAM-AUTH-16: Privileged activation path has weaker assurance than normal admin sign-in
+IAM-AUTH-17: Legacy protocols, app passwords, or OAuth exceptions bypass enforced MFA
+IAM-AUTH-18: Session/refresh-token lifetime allows access to persist after risk or recovery events
+IAM-AUTH-19: Admin consent workflow allows tenant-wide OAuth grants without security review
+IAM-AUTH-20: Break-glass accounts lack monitoring, compensating controls, or periodic test evidence
+IAM-AUTH-21: Guest/vendor/federated IdP recovery path has lower assurance than local policy
+```
+
+```
+Authentication Path Record:
+- Path:                 [Normal sign-in | Password reset | MFA re-enrollment | Device join | Privileged activation | Legacy protocol | Session/token | Admin consent | Break-glass | External IdP]
+- Population:           [Users/groups/roles/apps affected]
+- Assurance Level:      [AAL1 | AAL2 | AAL3 | Unknown]
+- Policy Owner:         [Team/person responsible]
+- Exceptions:           [None | users/groups/apps/locations/devices]
+- Evidence:             [Policy IDs, logs, approval records, test results]
+- Last Tested:          [YYYY-MM-DD or Not tested]
+- Logging/Alerting:     [Signals generated and monitored]
+- Compensating Controls: [Controls that reduce accepted exception risk]
+- Finding:              [Pass | Gap | Not Evaluable, with finding ID]
+```
+
+Do not mark MFA coverage as complete unless the normal sign-in path and every recovery or exception path have matching or compensating assurance. If evidence is missing for a recovery path, classify that path as `Not Evaluable` and avoid broad "MFA enforced" conclusions.
 
 ---
 
@@ -380,6 +437,7 @@ For each finding, produce a row with:
 | **Framework Ref** | NIST SP 800-63B section, NIST SP 800-207 tenet, or CIS Control ID |
 | **Affected Scope** | Accounts, roles, policies, or platforms impacted |
 | **Evidence** | Specific configuration, policy, or data supporting the finding |
+| **Recovery/Exception Path** | Relevant authentication path when the finding involves reset, re-enrollment, device, token, consent, break-glass, or external IdP access |
 | **Remediation** | Prioritized fix with implementation guidance |
 | **Effort** | Low (< 1 day) / Medium (1-5 days) / High (> 5 days) |
 
@@ -405,6 +463,7 @@ For each finding, produce a row with:
 
 ### Findings by Category
 - Authentication (Step 2): [count]
+- Recovery/Exception Paths (Step 2.5): [count]
 - Least Privilege (Step 3): [count]
 - Service Accounts (Step 4): [count]
 - Stale Accounts (Step 5): [count]
@@ -508,4 +567,5 @@ This skill processes user-supplied content including IAM policies, access config
 
 | Version | Date | Changes |
 |---|---|---|
+| 1.0.1 | 2026-06-06 | Added authentication recovery and MFA exception path evidence gates |
 | 1.0.0 | 2025-03-06 | Initial release |

--- a/skills/identity/iam-review/tests/recovery-exception-edge-cases.md
+++ b/skills/identity/iam-review/tests/recovery-exception-edge-cases.md
@@ -1,0 +1,164 @@
+# Authentication Recovery and Exception Path Edge Cases
+
+These fixtures verify that iam-review does not treat normal sign-in MFA as complete coverage when recovery, enrollment, token, consent, or emergency paths have weaker assurance.
+
+```yaml
+case_id: IAM-RECOVERY-01
+title: Password reset bypasses MFA through helpdesk callback weakness
+identity_provider: Entra ID
+path: password_reset
+population:
+  users: 1840
+  privileged_users: 42
+normal_sign_in:
+  mfa_required: true
+  phishing_resistant_for_admins: true
+recovery_flow:
+  identity_proofing: employee_id_and_manager_name
+  second_factor_required: false
+  approval_record_required: false
+  post_reset_token_revocation: false
+  audit_log_source: helpdesk_ticket
+expected_finding:
+  id: IAM-AUTH-11
+  severity: High
+  disposition: gap
+  reason: "Password reset can restore access with weaker assurance than normal sign-in MFA."
+```
+
+```yaml
+case_id: IAM-RECOVERY-02
+title: MFA re-enrollment from active session allows attacker device registration
+identity_provider: Okta
+path: mfa_reenrollment
+population:
+  groups:
+    - all_employees
+normal_sign_in:
+  mfa_required: true
+  allowed_methods:
+    - WebAuthn
+    - push
+mfa_reenrollment:
+  requires_existing_factor: false
+  requires_admin_approval: false
+  user_notification: email_only
+  new_device_quarantine_hours: 0
+  risk_signal_review: absent
+expected_finding:
+  id: IAM-AUTH-13
+  severity: High
+  disposition: gap
+  reason: "A stolen password or session can register a new authenticator without independent approval."
+```
+
+```yaml
+case_id: IAM-RECOVERY-03
+title: Break-glass account is intentionally excluded but controlled
+identity_provider: Entra ID
+path: break_glass
+accounts:
+  count: 2
+  roles:
+    - Global Administrator
+conditional_access:
+  excluded_from_mfa: true
+compensating_controls:
+  hardware_credential_custody: dual_control_safe
+  sign_in_alerting: security_pager_and_siem
+  last_tested: "2026-05-15"
+  password_rotation_after_test: true
+  network_location_restriction: true
+expected_finding:
+  id: IAM-AUTH-20
+  severity: Informational
+  disposition: pass_with_exception
+  reason: "Emergency bypass is documented, monitored, tested, and compensated."
+```
+
+```yaml
+case_id: IAM-RECOVERY-04
+title: Legacy protocol exception bypasses conditional access MFA
+identity_provider: Microsoft 365
+path: legacy_protocol
+normal_sign_in:
+  conditional_access_mfa: enforced
+legacy_protocols:
+  pop3: disabled
+  imap: disabled
+  smtp_auth:
+    enabled: true
+    exception_group: finance-shared-mailboxes
+  app_passwords: enabled
+evidence:
+  sign_in_logs_show_basic_auth: true
+  exception_owner: missing
+expected_finding:
+  id: IAM-AUTH-17
+  severity: High
+  disposition: gap
+  reason: "SMTP/app-password exception allows access outside the MFA-enforced sign-in path."
+```
+
+```yaml
+case_id: IAM-RECOVERY-05
+title: Refresh tokens persist after recovery and risk changes
+identity_provider: Google Workspace
+path: session_token
+session_policy:
+  max_session_hours: 720
+  remembered_device_days: 90
+  risk_change_reauth: false
+  token_revocation_after_password_reset: false
+recovery_event:
+  password_reset_date: "2026-06-01"
+  existing_oauth_tokens_remain_valid: true
+expected_finding:
+  id: IAM-AUTH-18
+  severity: Medium
+  disposition: gap
+  reason: "Recovery does not invalidate existing sessions or force reauthentication after risk changes."
+```
+
+```yaml
+case_id: IAM-RECOVERY-06
+title: Admin consent allows tenant-wide OAuth grants without review
+identity_provider: Entra ID
+path: admin_consent
+oauth_policy:
+  users_can_consent: false
+  admins_can_grant_tenant_wide_consent: true
+  security_review_required: false
+  publisher_verification_required: false
+  app_risk_scoring: absent
+recent_grant:
+  app_name: reporting-exporter
+  scopes:
+    - Mail.Read
+    - Files.Read.All
+  approval_ticket: missing
+expected_finding:
+  id: IAM-AUTH-19
+  severity: High
+  disposition: gap
+  reason: "Tenant-wide OAuth grant can bypass least-privilege and MFA expectations without app-risk review."
+```
+
+```yaml
+case_id: IAM-RECOVERY-07
+title: External vendor IdP recovery assurance is unknown
+identity_provider: Okta
+path: external_idp
+federation:
+  vendor_domain: vendor.example
+  guest_count: 76
+  cross_tenant_trust_enabled: true
+  home_tenant_mfa_trusted: true
+  recovery_policy_evidence: missing
+  vendor_helpdesk_process: unknown
+expected_finding:
+  id: IAM-AUTH-21
+  severity: Medium
+  disposition: not_evaluable
+  reason: "Local policy trusts external MFA, but the vendor recovery path assurance is not evidenced."
+```


### PR DESCRIPTION
## Summary
- adds a Step 2.5 authentication recovery and exception path review so IAM MFA claims cover the full account lifecycle, not only normal sign-in
- adds an evidence matrix for password reset, MFA re-enrollment, device join, privileged activation, legacy protocols, session/token renewal, admin consent, break-glass accounts, and external IdP paths
- adds IAM-AUTH-11 through IAM-AUTH-21 finding IDs plus an Authentication Path Record template
- extends output findings with a Recovery/Exception Path field and category count
- adds seven YAML fixtures covering weak helpdesk recovery, unsafe MFA re-enrollment, controlled break-glass, legacy SMTP/app-password exceptions, persistent refresh tokens, unreviewed OAuth admin consent, and unknown vendor IdP recovery assurance

## Validation
- git diff --check
- frontmatter parse check
- Markdown fence balance check
- YAML fixture parse check: 7 blocks
- required marker check for Step 2.5, IAM-AUTH-11 through IAM-AUTH-21, Recovery/Exception Path, and recovery fixture cases
- privacy marker scan

/claim #894

Payment details can be coordinated privately after maintainer acceptance.
