### PR TITLE
Add SaaS OAuth containment fixtures

### DIFF
--- a/skills/incident-response/containment/SKILL.md
+++ b/skills/incident-response/containment/SKILL.md
@@ -12,7 +12,7 @@ phase: [respond]
 frameworks: [NIST-SP-800-61r2, MITRE-ATT&CK]
 difficulty: intermediate
 time_estimate: "15-30min"
-version: "1.0.1"
+version: "1.0.2"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -53,6 +53,7 @@ Before selecting a containment strategy, gather or confirm:
 - [ ] **Affected systems inventory** -- Hostnames, IPs, cloud resource IDs, services running on affected systems, and their business function.
 - [ ] **Attack vector and techniques** -- Known MITRE ATT&CK techniques in use (initial access, lateral movement, persistence, C2).
 - [ ] **Attacker access scope** -- What accounts, systems, and network segments has the attacker accessed or potentially compromised?
+- [ ] **Identity/SaaS access scope** -- Affected IdP users, OAuth apps, consent grants, service principals, app passwords, mailbox rules, SaaS admin sessions, cloud STS tokens, and file-sharing links.
 - [ ] **Business criticality of affected systems** -- Revenue impact, customer impact, SLA obligations, regulatory implications of downtime.
 - [ ] **Network topology** -- VLANs, subnets, firewall zones, cloud VPCs, segmentation boundaries relevant to the affected systems.
 - [ ] **Evidence preservation status** -- Has volatile evidence been captured? (Reference forensics-checklist.) Containment actions may destroy evidence if not collected first.
@@ -121,6 +122,47 @@ Short-term containment aims to stop the immediate threat with minimal preparatio
 | **Service account reset** | Reset service account passwords and regenerate keys | Lateral movement via service accounts | Downstream services may break |
 | **Kerberos ticket reset** | Reset krbtgt account password (twice, per Microsoft guidance) | Golden ticket attack, domain compromise | Domain-wide impact; requires careful planning |
 | **MFA token reset** | Deregister and re-enroll MFA devices | MFA bypass, SIM swap, device compromise | Individual users |
+| **OAuth grant revocation** | Revoke delegated/app grants, disable malicious enterprise apps, remove tenant-wide consent | BEC, SaaS token theft, malicious consent app | User, app, or tenant-wide depending on grant scope |
+| **SaaS admin session revocation** | Invalidate active SaaS sessions and admin refresh tokens, force reauthentication | SaaS admin or IdP compromise | Tenant/app admin population |
+| **Service principal credential rotation** | Remove leaked client secrets/certificates, rotate workload identity credentials, audit app role assignments | OAuth app/service principal misuse | Application and downstream integrations |
+
+### Step 2b: SaaS / OAuth Containment Branch
+
+Use this branch for BEC, IdP compromise, malicious OAuth consent, SaaS token theft, cloud-control-plane compromise, or any incident where password reset alone may leave delegated or refresh-token access alive.
+
+#### SaaS / OAuth Revocation Checklist
+
+| Area | Containment Action | Validation Evidence |
+|---|---|---|
+| **Refresh tokens and sessions** | Revoke user refresh tokens, invalidate SaaS sessions, force reauthentication, and document residual token lifetime if the platform cannot revoke immediately | Sign-in/session logs show old tokens rejected and no post-revocation API activity |
+| **OAuth grants and consent apps** | Inventory delegated/admin consent grants, disable suspicious enterprise apps, revoke risky scopes, and remove tenant-wide consent where abused | App audit logs show grants removed; app cannot call APIs with previous refresh/access tokens |
+| **App passwords and legacy auth** | Disable app passwords/basic auth exceptions, rotate legacy protocol credentials, and block POP/IMAP/SMTP/EWS paths used by the actor | Legacy-auth sign-in logs stop and exception groups are empty or owner-approved |
+| **Mailbox persistence** | Remove forwarding rules, inbox rules, delegates, transport rules, hidden mailbox permissions, and external sharing links | Mailbox audit/DLP logs show no new forwarding, delegate access, or exfiltration after cleanup |
+| **SaaS admin sessions** | Revoke admin sessions across Microsoft 365, Google Workspace, Okta, GitHub, Slack, Salesforce, and similar SaaS control planes | Admin audit logs show forced logout and no new privileged actions from old sessions |
+| **Service principals and API keys** | Rotate client secrets/certificates, disable abused service principals, remove app role assignments, and review workload identity federation | Service principal sign-in/API logs show no post-rotation use of old credentials |
+| **Cloud STS/session tokens** | Revoke/expire cloud sessions where supported and document unavoidable expiration windows for AWS STS, Azure, or GCP tokens | Cloud audit logs show no new actions from compromised sessions after revocation/expiry |
+| **File-sharing and exfil paths** | Revoke anonymous links, external shares, repository tokens, and SaaS API export permissions tied to the incident | DLP/cloud audit logs show no new downloads, shares, or export jobs after revocation |
+
+Choose the narrowest scope that contains the access path without leaving persistence:
+
+- **Per-user:** Use when a single compromised user or mailbox is confirmed and OAuth grants are user-delegated only.
+- **Per-app:** Use when one OAuth application, service principal, or SaaS integration is abused across users.
+- **Tenant-wide:** Use when admin consent, IdP admin compromise, malicious enterprise applications, or unknown grant scope creates broad residual access.
+- **Residual-risk monitored:** Use only when the platform cannot revoke existing tokens immediately; record the token lifetime, compensating detections, and next validation time.
+
+```
+SaaS / OAuth Revocation Plan:
+- Incident Path:         [BEC | IdP compromise | OAuth consent abuse | SaaS token theft | Cloud control plane]
+- Scope:                 [Per-user | Per-app | Tenant-wide | Residual-risk monitored]
+- Affected Identities:   [Users, groups, admins, service principals]
+- OAuth Apps/Grants:     [App IDs, scopes, consent type, owner]
+- Tokens/Sessions:       [Refresh tokens, SaaS sessions, STS tokens, residual lifetime]
+- Mailbox/File Paths:    [Forwarding rules, delegates, sharing links, export jobs]
+- Revocation Actions:    [Actions and owners]
+- Business Impact:       [Expected disruption and approved exceptions]
+- Validation Evidence:   [Logs proving no post-revocation activity]
+- Residual Risk:         [Known token windows, unrecoverable sessions, compensating controls]
+```
 
 ### Step 3: Long-Term Containment
 
@@ -213,6 +255,7 @@ After implementing containment, verify effectiveness before proceeding to eradic
 | Lateral movement blocked | Monitor authentication logs and network flows between segments | No unauthorized cross-segment authentication |
 | Compromised credentials revoked | Attempt authentication with known-compromised credentials | Authentication fails |
 | Attacker persistence neutralized | Scan for known persistence mechanisms | No active persistence artifacts |
+| SaaS/OAuth persistence removed | Review OAuth grants, app passwords, service principals, mailbox rules, SaaS sessions, cloud STS tokens, and file-sharing links | No post-revocation activity from old apps/tokens/sessions |
 | Business services operational (if surgical containment) | Verify critical service health checks | Services responding normally |
 | Evidence preserved | Verify forensic images and memory dumps are intact and hashed | Hash verification passes |
 
@@ -256,7 +299,7 @@ Produce the containment plan with these exact sections:
 ```markdown
 ## Containment Plan: [Incident ID]
 **Date:** [YYYY-MM-DD]
-**Skill:** containment v1.0.0
+**Skill:** containment v1.0.2
 **Frameworks:** NIST SP 800-61 Rev 2, MITRE ATT&CK
 **Incident Commander:** [Name]
 
@@ -283,6 +326,16 @@ threat severity and business criticality, and expected impact on operations.]
 | Action | Target | Duration | Status | Owner |
 |---|---|---|---|---|
 | [Action] | [Scope] | [Duration] | [Planned/In Progress/Complete] | [Name] |
+
+### SaaS / OAuth Revocation Plan
+| Scope | App/User/Token Path | Revocation Action | Owner | Residual Risk |
+|---|---|---|---|---|
+| [Per-user/Per-app/Tenant-wide] | [OAuth app, user, session, STS token, mailbox/file-sharing path] | [Action] | [Owner] | [Residual token lifetime or none] |
+
+### SaaS / OAuth Validation
+| Evidence Source | Expected Signal | Result | Timestamp |
+|---|---|---|---|
+| [Sign-in, audit, DLP, mailbox, cloud API, SaaS admin log] | [No post-revocation activity from old token/app/session] | [Pass/Fail/Pending] | [timestamp] |
 
 ### Business Impact Assessment
 | Service/System | Impact of Containment | Mitigation | Acceptable |
@@ -347,6 +400,10 @@ Disconnecting a business-critical production system from the network stops the a
 ### Pitfall 4: Not Validating Containment Effectiveness
 
 Implementing containment actions without verifying they work is a common failure mode. Firewall rules may not apply to the correct interface or direction. DNS sinkholes may not affect systems using hardcoded DNS servers. Credential resets may not invalidate existing Kerberos tickets. After every containment action, validate effectiveness through monitoring -- confirm that the specific attacker activity the action was intended to block has actually stopped.
+
+### Pitfall 5: Treating Password Reset as Complete SaaS Containment
+
+In BEC, IdP, OAuth consent, and SaaS token theft incidents, password resets and session invalidation may not remove refresh tokens, malicious consent grants, app passwords, service principal credentials, mailbox rules, cloud STS tokens, or file-sharing links. Validate each delegated access path and document residual token windows before declaring containment complete.
 
 ---
 

--- a/skills/incident-response/containment/tests/saas-oauth-containment-edge-cases.md
+++ b/skills/incident-response/containment/tests/saas-oauth-containment-edge-cases.md
@@ -1,0 +1,150 @@
+# SaaS and OAuth Containment Edge Cases
+
+These fixtures verify that containment does not stop at password reset when SaaS, OAuth, mailbox, service-principal, or cloud session persistence can keep access alive.
+
+```yaml
+case_id: CONTAIN-OAUTH-01
+title: BEC password reset leaves malicious OAuth consent active
+incident_path: BEC
+platform: Microsoft 365
+initial_actions:
+  password_reset: complete
+  user_sessions_revoked: complete
+oauth_grants:
+  app_id: 11111111-2222-3333-4444-555555555555
+  app_name: invoice-sync
+  scopes:
+    - Mail.Read
+    - offline_access
+  consent_type: delegated
+  grant_revoked: false
+post_reset_activity:
+  api_calls_after_password_reset: true
+  last_call: "2026-06-06T03:22:00Z"
+expected_containment:
+  action: revoke_oauth_grant_and_refresh_tokens
+  validation: "No post-revocation Graph API calls from the app."
+  residual_risk: "Password reset alone is incomplete containment."
+```
+
+```yaml
+case_id: CONTAIN-OAUTH-02
+title: Tenant-wide malicious consent app requires per-app containment
+incident_path: oauth_consent_abuse
+platform: Entra ID
+oauth_app:
+  publisher_verified: false
+  consent_type: admin_tenant_wide
+  risky_scopes:
+    - Files.Read.All
+    - Mail.ReadWrite
+    - Directory.Read.All
+affected_users: 740
+revocation_plan:
+  scope: per_app
+  disable_enterprise_app: true
+  remove_admin_consent: true
+  review_app_role_assignments: true
+expected_validation:
+  app_sign_in_status: blocked
+  previous_refresh_tokens_rejected: true
+```
+
+```yaml
+case_id: CONTAIN-OAUTH-03
+title: Mailbox forwarding and delegate rules survive session revocation
+incident_path: BEC
+platform: Exchange Online
+mailbox_persistence:
+  forwarding_smtp_address: attacker@example.net
+  inbox_rules:
+    - name: move invoices
+      action: forward_and_delete
+  delegates:
+    - external.partner@example.org
+initial_actions:
+  password_reset: complete
+  session_revocation: complete
+  mailbox_rules_removed: false
+expected_containment:
+  action: remove_forwarding_rules_delegates_and_external_shares
+  validation: "Mailbox audit shows no forwarding, delegate access, or external share activity after cleanup."
+```
+
+```yaml
+case_id: CONTAIN-OAUTH-04
+title: SaaS admin session remains active after IdP password reset
+incident_path: idp_admin_compromise
+platform: Okta_and_Salesforce
+affected_admin:
+  user: admin@example.com
+  idp_password_reset: true
+saas_sessions:
+  salesforce_admin_session_active: true
+  slack_owner_session_active: true
+  github_org_owner_session_active: unknown
+expected_containment:
+  scope: tenant_wide_admin_sessions
+  actions:
+    - revoke_saas_admin_sessions
+    - force_reauthentication
+    - verify_admin_audit_logs
+  residual_risk: "Unknown SaaS session APIs require monitored residual-risk window."
+```
+
+```yaml
+case_id: CONTAIN-OAUTH-05
+title: Service principal secret leak continues cloud API access
+incident_path: cloud_control_plane
+platform: Azure
+service_principal:
+  app_id: 99999999-aaaa-bbbb-cccc-dddddddddddd
+  role_assignments:
+    - Contributor
+  leaked_client_secret: true
+  secret_removed: false
+  certificate_credentials_present: true
+api_activity:
+  post_user_password_reset_activity: true
+expected_containment:
+  action: rotate_service_principal_credentials_and_review_role_assignments
+  validation: "No sign-ins with old secret or certificate thumbprint after rotation."
+```
+
+```yaml
+case_id: CONTAIN-OAUTH-06
+title: Cloud STS token cannot be revoked immediately and needs residual monitoring
+incident_path: cloud_sts_token_theft
+platform: AWS
+sts_session:
+  role: arn:aws:iam::123456789012:role/prod-admin
+  issued_at: "2026-06-06T01:00:00Z"
+  expires_at: "2026-06-06T13:00:00Z"
+  immediate_revocation_supported: false
+containment_actions:
+  disable_source_access_key: true
+  tighten_role_policy: true
+  alert_on_session_activity_until_expiry: true
+expected_containment:
+  scope: residual_risk_monitored
+  validation: "CloudTrail shows no actions from the compromised session until expiry."
+```
+
+```yaml
+case_id: CONTAIN-OAUTH-07
+title: File-sharing links remain after OAuth app revocation
+incident_path: saas_token_theft
+platform: Google Workspace
+oauth_revoked: true
+file_exfil_paths:
+  anonymous_links:
+    count: 18
+    revoked: false
+  external_collaborators:
+    count: 6
+    reviewed: false
+  drive_export_jobs_after_revocation: true
+expected_containment:
+  action: revoke_file_sharing_links_and_external_collaborators
+  validation: "Drive audit and DLP logs show no new downloads or external sharing after cleanup."
+```


### PR DESCRIPTION
## Summary
- adds a SaaS / OAuth containment branch so password resets are not treated as complete containment for BEC, IdP compromise, OAuth consent abuse, SaaS token theft, or cloud-control-plane incidents
- adds OAuth grant revocation, SaaS admin session revocation, and service-principal credential rotation to credential containment strategies
- adds revocation scope guidance for per-user, per-app, tenant-wide, and residual-risk monitored cases
- extends validation and report output with SaaS / OAuth Revocation Plan and SaaS / OAuth Validation sections
- adds seven YAML fixtures covering malicious delegated consent, tenant-wide admin consent, mailbox forwarding/delegation persistence, SaaS admin sessions, service principal secret leakage, cloud STS residual windows, and file-sharing exfil paths

## Validation
- git diff --check
- frontmatter parse check
- Markdown fence balance check
- YAML fixture parse check: 7 blocks
- required marker check for v1.0.2, SaaS / OAuth Containment Branch, OAuth grant revocation, revocation plan, validation output, and fixture cases
- privacy marker scan

/claim #896

Payment details can be coordinated privately after maintainer acceptance.
