### PR TITLE
Add alert triage evidence handoff fixtures

### DIFF
--- a/skills/secops/alert-triage/SKILL.md
+++ b/skills/secops/alert-triage/SKILL.md
@@ -13,7 +13,7 @@ phase: [operate, respond]
 frameworks: [MITRE-ATT&CK-v16, NIST-SP-800-61-Rev2]
 difficulty: beginner
 time_estimate: "10-20min per alert"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -57,6 +57,8 @@ Before beginning triage, gather or confirm:
 - [ ] **User context:** Who is the associated user? (Role, department, normal working hours, recent activity patterns.)
 - [ ] **Historical context:** Has this alert fired before? What was the previous disposition? Has this user or host generated related alerts recently?
 - [ ] **Threat intelligence:** Do any indicators in the alert (IPs, domains, hashes) appear in threat intelligence feeds?
+- [ ] **Data classification and handoff status:** Whether affected data includes PII, PHI, PCI, HR, customer, regulated, confidential, or unknown data; first-detected time; privacy/legal owner; and current handoff acknowledgment.
+- [ ] **Evidence preservation status:** Raw alert export, SIEM query/time range, DLP/cloud audit export, EDR/network context, approval evidence, case attachment IDs, hashes/export IDs, and retention risk.
 
 If some context is unavailable, proceed with available information and note gaps as assumptions.
 
@@ -172,7 +174,63 @@ Escalation Notice:
 - Escalated To:       [Name/role of escalation recipient]
 - Escalated By:       [Analyst name]
 - Escalated At:       [Timestamp]
+- Acknowledged By:    [Recipient name/queue or PENDING]
+- Acknowledged At:    [Timestamp or PENDING]
+- Current Owner:      [Team/person responsible for next action]
+- Next Decision Due:  [Timestamp or SLA]
+- Unresolved Gaps:    [Missing evidence or context that affects disposition/reportability]
 ```
+
+#### Evidence Preservation and Regulated-Data Handoff Gate
+
+Use this gate before closing a regulated-data, crown-jewel, customer-data, or unknown-classification alert as BTP/FP, and before declaring that escalation is complete. The SOC analyst does not need to decide whether a breach is reportable, but the triage report must preserve the notification-candidate clock and the evidence needed by IR, privacy, legal, or compliance teams.
+
+**Evidence preservation requirements:**
+
+| Evidence Type | Required Fields |
+|---|---|
+| **Raw alert payload** | Preserved yes/no, case ID/location, export ID or hash, retention window |
+| **SIEM query and time range** | Query text or saved search ID, time bounds, analyst, result count |
+| **DLP / cloud audit export** | Export ID, source system, hash, data classification, retention risk |
+| **EDR / network context** | Artifact location, sensor/log source, hash or query ID, coverage gaps |
+| **Approval / asset-owner evidence** | Approver, ticket/comment ID, approval scope, expiration, recurrence allowed |
+| **Screenshots / case notes** | Location, redaction status, timestamp, author |
+
+**Regulated Data / Notification Candidate record:**
+
+```
+Regulated Data / Notification Candidate:
+- Data Classification:          [PII | PHI | PCI | HR | Customer | Confidential | Unknown]
+- First Detected At:            [Timestamp from alert or earliest correlated event]
+- Potential Notification Regime: [HIPAA | GDPR | state breach law | PCI | contract | Unknown | N/A]
+- Privacy/Legal Handoff Required: [Yes | No | Unknown]
+- Handoff Owner:                [Named role, queue, or PENDING]
+- Handoff Timestamp:            [Timestamp or PENDING]
+- Reportability Decision Owner: [Named role or PENDING]
+- Decision Deadline/Next Update: [Timestamp or Unknown]
+- Missing Impact Evidence:      [DLP export, file names, recipient list, exfil confirmation, asset-owner approval, etc.]
+- Breach Status Language:       [Notification candidate | Confirmed breach | Not reportable | Not evaluable]
+```
+
+**Escalation acknowledgment requirements:**
+
+```
+Escalation Handoff:
+- Escalated To:          [Named recipient, team, or queue]
+- Escalated At:          [Timestamp]
+- Acknowledged By:       [Recipient or PENDING]
+- Acknowledged At:       [Timestamp or PENDING]
+- Current Owner:         [Team/person owning next action]
+- Next Decision Deadline: [Timestamp or SLA]
+- Unresolved Evidence Gaps: [List]
+```
+
+Disposition guardrails:
+
+- Do not close regulated-data, crown-jewel, or unknown-classification alerts as BTP/FP until evidence preservation status and approval/asset-owner evidence are recorded.
+- If data classification is unknown, mark the regulated-data handoff as `Not Evaluable` rather than lowering priority silently.
+- If privacy/legal handoff is required but unacknowledged, keep the alert open or pending handoff, even when technical triage suggests BTP/FP.
+- Preserve notification-candidate facts without overstating breach status. Use `Notification candidate` until privacy/legal confirms reportability.
 
 ---
 
@@ -194,7 +252,7 @@ Produce the triage decision as a structured report:
 ```markdown
 ## Alert Triage Report
 **Date:** [YYYY-MM-DD HH:MM UTC]
-**Skill:** alert-triage v1.0.0
+**Skill:** alert-triage v1.0.1
 **Frameworks:** MITRE ATT&CK v16, NIST SP 800-61 Rev 2
 **Analyst:** [Name or AI-assisted]
 
@@ -228,6 +286,29 @@ Produce the triage decision as a structured report:
 2. [Key finding 2 -- corroborating or contradicting evidence]
 3. [Key finding 3 -- threat intel or historical context]
 
+### Evidence Preservation
+| Evidence Type | Preserved? | Location / Case ID | Hash or Export ID | Retention Risk |
+|---|---|---|---|---|
+| Raw alert payload | [Yes/No] | [Ticket/artifact] | [sha256/export ID] | [Low/Medium/High] |
+| SIEM query and time range | [Yes/No] | [Saved search/query ID] | [N/A] | [Low/Medium/High] |
+| DLP/cloud audit export | [Yes/No/N/A] | [Export/artifact] | [sha256/export ID] | [Low/Medium/High] |
+| EDR/network context | [Yes/No/N/A] | [Case artifact] | [sha256/query ID] | [Low/Medium/High] |
+| Approval/asset-owner evidence | [Yes/No/N/A] | [Ticket/comment] | [N/A] | [Low/Medium/High] |
+
+### Regulated Data / Notification Candidate
+| Field | Value |
+|---|---|
+| Data Classification | [PII/PHI/PCI/HR/Customer/Confidential/Unknown/N/A] |
+| First Detected At | [Timestamp] |
+| Potential Notification Regime | [HIPAA/GDPR/state breach law/PCI/contract/Unknown/N/A] |
+| Privacy/Legal Handoff Required | [Yes/No/Unknown] |
+| Handoff Owner | [Role/queue/PENDING] |
+| Handoff Timestamp | [Timestamp/PENDING] |
+| Reportability Decision Owner | [Role/PENDING] |
+| Decision Deadline or Next Update | [Timestamp/Unknown] |
+| Missing Impact Evidence | [List] |
+| Breach Status Language | [Notification candidate/Confirmed breach/Not reportable/Not evaluable] |
+
 ### Correlation Results
 - **Temporal:** [Related events within +/- 30 min window]
 - **Lateral:** [Related alerts on other hosts/users]
@@ -238,6 +319,17 @@ Produce the triage decision as a structured report:
 - [ ] [Action 1 -- e.g., isolate host, disable account, block IP]
 - [ ] [Action 2 -- e.g., collect forensic artifacts, memory dump]
 - [ ] [Action 3 -- e.g., notify asset owner, update ticket]
+
+### Escalation Handoff
+| Field | Value |
+|---|---|
+| Escalated To | [Recipient/team/queue] |
+| Escalated At | [Timestamp] |
+| Acknowledged By | [Recipient/PENDING] |
+| Acknowledged At | [Timestamp/PENDING] |
+| Current Owner | [Team/person] |
+| Next Decision Deadline | [Timestamp/SLA] |
+| Unresolved Evidence Gaps | [List] |
 
 ### Tuning Recommendation (if BTP or FP)
 [If disposition is BTP or FP, describe the recommended rule tuning
@@ -318,6 +410,10 @@ Investigating an alert in isolation without checking for activity before and aft
 ### Pitfall 5: Delaying Escalation While Seeking Perfect Information
 
 Waiting for complete certainty before escalating a high-priority alert costs response time. NIST SP 800-61 recommends erring on the side of over-notification. If 20 minutes of investigation has not resolved the disposition and the alert involves a critical asset or privileged account, escalate to Tier 2 or the IR team with your current findings and continue investigation in parallel.
+
+### Pitfall 6: Confusing Notification Candidates with Confirmed Breaches
+
+Alerts involving regulated or unknown data may require privacy/legal handoff before exfiltration is proven. Do not overstate a suspicious alert as a confirmed breach, but also do not close it without preserving first-detected time, data classification, raw evidence, missing impact evidence, and handoff acknowledgment.
 
 ---
 

--- a/skills/secops/alert-triage/tests/evidence-handoff-edge-cases.md
+++ b/skills/secops/alert-triage/tests/evidence-handoff-edge-cases.md
@@ -1,0 +1,145 @@
+# Evidence Preservation and Notification Handoff Edge Cases
+
+These fixtures verify that alert-triage preserves volatile evidence, notification-candidate facts, and escalation ownership without forcing the SOC analyst to make a final breach determination.
+
+```yaml
+case_id: ALERT-HANDOFF-01
+title: Regulated data alert is notification candidate, not confirmed breach
+alert:
+  rule: Possible bulk download from document repository
+  data_classification: HR
+  first_detected_at: "2026-06-05T01:10:00Z"
+  matched_events: 45_file_reads_in_10_minutes
+missing_impact_evidence:
+  - file_names_exported
+  - external_sharing_event
+  - dlp_export
+handoff:
+  privacy_legal_required: true
+  owner: privacy_officer_queue
+  acknowledged_at: null
+expected_triage:
+  breach_status_language: Notification candidate
+  disposition: pending_handoff
+  reason: "Preserve clock and missing evidence without claiming confirmed breach."
+```
+
+```yaml
+case_id: ALERT-HANDOFF-02
+title: Benign migration still needs evidence preservation before BTP closure
+alert:
+  rule: Bulk SharePoint reads
+  data_classification: Customer
+  proposed_disposition: BTP
+business_context:
+  migration_ticket: MIG-2026-441
+  asset_owner_approval: present
+evidence_preservation:
+  raw_alert_payload: missing
+  siem_query_time_range: preserved
+  dlp_cloud_export: missing
+  approval_evidence: present
+expected_triage:
+  action: block_closure_until_preserved
+  reason: "A BTP decision on sensitive data must preserve raw alert and DLP/cloud export evidence."
+```
+
+```yaml
+case_id: ALERT-HANDOFF-03
+title: Unknown data classification remains not evaluable
+alert:
+  rule: Large SaaS export by contractor
+  data_classification: unknown
+  user_type: contractor
+  destination: external_ip
+asset_context:
+  owner: missing
+  data_inventory_match: missing
+handoff:
+  privacy_legal_required: unknown
+expected_triage:
+  priority_floor: P3
+  regulated_data_status: Not evaluable
+  reason: "Unknown classification should not silently decrease priority or bypass handoff review."
+```
+
+```yaml
+case_id: ALERT-HANDOFF-04
+title: Escalation to IR lacks recipient acknowledgment
+alert:
+  rule: Suspected ransomware staging
+  priority: P1
+  disposition: TP
+escalation:
+  escalated_to: IR_team_queue
+  escalated_at: "2026-06-05T02:00:00Z"
+  acknowledged_by: null
+  current_owner: null
+  next_decision_deadline: null
+expected_triage:
+  action: keep_open_pending_acknowledgment
+  reason: "P1/P2 handoff is incomplete until recipient acknowledgment, owner, and next deadline are recorded."
+```
+
+```yaml
+case_id: ALERT-HANDOFF-05
+title: Volatile cloud audit logs have high retention risk
+alert:
+  rule: Suspicious object storage enumeration
+  source_system: cloud_security
+  data_classification: Confidential
+evidence_preservation:
+  raw_alert_payload: preserved
+  siem_query_time_range: preserved
+  cloud_audit_export:
+    preserved: false
+    retention_hours_remaining: 18
+  edr_network_context: not_applicable
+expected_triage:
+  action: preserve_cloud_audit_export_before_closure
+  retention_risk: High
+```
+
+```yaml
+case_id: ALERT-HANDOFF-06
+title: False positive on crown-jewel asset still needs approval evidence
+alert:
+  rule: Admin query against customer database
+  asset_criticality: crown_jewel
+  proposed_disposition: FP
+rule_logic_issue:
+  confirmed: true
+approval_evidence:
+  asset_owner_approval: missing
+  maintenance_window_ticket: CHG-2026-778
+evidence_preservation:
+  raw_alert_payload: preserved
+  siem_query_time_range: preserved
+expected_triage:
+  action: require_asset_owner_evidence
+  reason: "FP/BTP closure on crown-jewel assets needs approval or owner context, not only rule-logic evidence."
+```
+
+```yaml
+case_id: ALERT-HANDOFF-07
+title: Legal hold required for suspicious PHI access
+alert:
+  rule: Unusual EHR record access
+  data_classification: PHI
+  first_detected_at: "2026-06-05T04:15:00Z"
+  user_context: nurse_float_pool
+notification_candidate:
+  potential_regime: HIPAA
+  reportability_decision_owner: privacy_officer
+  legal_hold_required: true
+evidence_preservation:
+  raw_alert_payload: preserved
+  siem_query_time_range: preserved
+  dlp_cloud_export: not_applicable
+  ehr_audit_export:
+    preserved: true
+    export_id: EHR-20260605-0415
+expected_triage:
+  breach_status_language: Notification candidate
+  action: handoff_to_privacy_and_record_decision_deadline
+```


### PR DESCRIPTION
## Summary
- adds an evidence-preservation and regulated-data handoff gate so alert triage preserves notification-candidate facts without overstating confirmed breach status
- adds required fields for raw alert payloads, SIEM query/time range, DLP/cloud exports, EDR/network context, approval evidence, retention risk, reportability owner, decision deadlines, and missing impact evidence
- extends escalation notices and final output with acknowledgment, current owner, next decision deadline, and unresolved evidence gaps
- adds disposition guardrails for regulated-data, crown-jewel, and unknown-classification alerts before BTP/FP closure
- adds seven YAML fixtures covering notification candidates, BTP evidence preservation, unknown classification, unacknowledged P1 handoff, cloud-audit retention risk, crown-jewel FP approval evidence, and PHI legal hold

## Validation
- git diff --check
- frontmatter parse check
- Markdown fence balance check
- YAML fixture parse check: 7 blocks
- required marker check for Evidence Preservation and Regulated-Data Handoff Gate, Regulated Data / Notification Candidate, Escalation Handoff, Notification candidate, Not evaluable, and fixture cases
- privacy marker scan

/claim #915

Payment details can be coordinated privately after maintainer acceptance.
