### PR TITLE
Add detection lifecycle evidence fixtures

### DIFF
--- a/skills/secops/detection-engineering/SKILL.md
+++ b/skills/secops/detection-engineering/SKILL.md
@@ -13,7 +13,7 @@ phase: [operate]
 frameworks: [MITRE-ATT&CK-v16, Sigma, Palantir-ADS]
 difficulty: advanced
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -56,6 +56,7 @@ Before beginning, gather or confirm:
 - [ ] **SIEM platform(s):** Target SIEM for rule deployment (Microsoft Sentinel, Splunk, Elastic, Chronicle, QRadar) -- determines Sigma backend conversion target.
 - [ ] **Environment context:** Operating systems, domain structure, cloud providers, key applications in the environment.
 - [ ] **Existing detection coverage:** Current rules, known gaps, previous false positive history for similar detections.
+- [ ] **Rule lifecycle evidence:** Current Sigma status, validation method/date, sample event IDs, backend conversion target/version, production field coverage, deployment scope, false-positive health, owner, review cadence, and demotion criteria.
 - [ ] **Detection priority:** Is this for a known active threat, proactive coverage expansion, or compliance requirement?
 - [ ] **Organizational naming conventions:** Rule ID format, severity taxonomy, and tagging standards used by the detection engineering team.
 
@@ -182,6 +183,33 @@ fields:
 | `level` | Yes | `informational`, `low`, `medium`, `high`, `critical` |
 | `fields` | Recommended | Fields to include in alert output for analyst context |
 
+#### Sigma Status Promotion Evidence
+
+Treat Sigma `status` as an evidence-backed lifecycle claim. A syntactically valid rule or one lab test is not enough to call a rule `stable` if production telemetry, backend conversion, field mappings, or false-positive health are unknown.
+
+| Status | Required Evidence | Disallowed Claim |
+|---|---|---|
+| **experimental** | Rule logic drafted, ATT&CK mapping selected, expected log source identified, assumptions and blind spots documented | Do not claim production coverage or stable heatmap score |
+| **test** | Rule linted, synthetic true-positive and true-negative tests run, backend conversion attempted, field mappings reviewed against target SIEM | Do not claim operational coverage until deployed telemetry proves required fields exist |
+| **stable** | Production deployment confirmed, backend query validated, required fields present in production logs, sample event IDs retained, false-positive review completed, owner/review cadence set, and demotion criteria documented | Do not mark stable when field coverage, deployment scope, FP rate, or conversion fidelity is unknown |
+
+```
+Lifecycle Promotion Record:
+- Rule ID/Title:          [Sigma id and title]
+- Current Status:         [experimental | test | stable | deprecated | unsupported]
+- Requested Status:       [experimental | test | stable]
+- Status Rationale:       [Why the requested status is justified]
+- Validation Date/Method: [Date and Atomic/manual/replay method]
+- Sample Event IDs:       [Known TP/TN event IDs or test artifacts]
+- Backend Conversion:     [Target SIEM, backend version, conversion result]
+- Field Mapping Evidence: [Required fields and production availability]
+- Telemetry Scope:        [Segments/hosts/cloud accounts covered and excluded]
+- False-Positive Health:  [FP rate, review date, budget, known noisy sources]
+- Owner/Review Cadence:   [Owner and next review date]
+- Demotion Criteria:      [Conditions that move rule back to test/experimental]
+- Promotion Decision:     [Promote | Hold | Demote | Not Evaluable]
+```
+
 **Sigma detection logic operators:**
 
 | Operator | Usage | Example |
@@ -278,10 +306,37 @@ Map detection coverage against the ATT&CK matrix to identify gaps.
 | Level | Color | Definition |
 |-------|-------|------------|
 | **None** | White | No detection rule exists for this technique |
-| **Theoretical** | Light Yellow | A rule exists but has not been validated or tested |
-| **Tested** | Light Green | Rule has been validated with synthetic test data (e.g., Atomic Red Team) |
-| **Operational** | Green | Rule is deployed in production, has been tuned, and has generated actionable alerts |
-| **Robust** | Dark Green | Multiple complementary rules cover different procedure examples; rule has caught real-world activity |
+| **Theoretical** | Light Yellow | A rule exists but has not been validated, converted, or tested against the target telemetry |
+| **Tested** | Light Green | Rule has been validated with synthetic test data and backend conversion evidence, but deployment or production field coverage is not yet proven |
+| **Operational** | Green | Rule is deployed in production, required fields are present for the claimed scope, false-positive health is acceptable, and lifecycle evidence supports `stable` |
+| **Robust** | Dark Green | Multiple complementary stable/operational rules cover different procedure examples, segmented scope is explicit, and at least one rule has caught or replayed real-world activity |
+
+#### ATT&CK Coverage Evidence Gate
+
+Do not let rule existence alone drive heatmap scores. Score each technique by environment segment and cap the score when lifecycle evidence is weaker than the claimed coverage.
+
+| Evidence Gap | Maximum Coverage Level |
+|---|---|
+| Rule exists but no validation evidence | Theoretical |
+| Synthetic validation exists but backend conversion or field mapping is unproven | Tested |
+| Deployed only to a subset of the claimed population | Operational only for that segment; Theoretical/None elsewhere |
+| Production fields are missing, truncated, or parser-dependent | Tested or Not Evaluable until field coverage is fixed |
+| False-positive budget exceeded or rule disabled | Demote to Test or Theoretical |
+| No owner, review cadence, or demotion criteria | Tested until lifecycle ownership is documented |
+
+```
+ATT&CK Coverage Segment Record:
+- Technique:          [Txxxx[.xxx]]
+- Segment:            [Servers | Workstations | Cloud | Identity | SaaS | OT | Tenant/account]
+- Rule IDs:           [Rules contributing to coverage]
+- Deployment State:   [Not deployed | Test | Production | Disabled]
+- Telemetry Scope:    [Included/excluded host groups, accounts, products]
+- Required Fields:    [Fields and production availability]
+- Lifecycle Evidence: [Promotion record references]
+- FP Health:          [Within budget | Exceeds budget | Unknown]
+- Coverage Level:     [None | Theoretical | Tested | Operational | Robust | Not Evaluable]
+- Score Cap Reason:   [If downgraded from requested score]
+```
 
 **Heatmap construction process:**
 
@@ -365,7 +420,7 @@ Produce detection engineering deliverables in this structure:
 ```markdown
 ## Detection Engineering Report: [ATT&CK Technique ID]
 **Date:** [YYYY-MM-DD]
-**Skill:** detection-engineering v1.0.0
+**Skill:** detection-engineering v1.0.1
 **Frameworks:** MITRE ATT&CK v16, Sigma, Palantir ADS
 
 ### ATT&CK Technique Summary
@@ -388,6 +443,26 @@ Produce detection engineering deliverables in this structure:
 | Current Coverage | [None / Theoretical / Tested / Operational / Robust] |
 | Target Coverage | [Operational / Robust] |
 | Validation Method | [Atomic Red Team test ID / manual test procedure] |
+
+### Lifecycle Promotion Evidence
+| Field | Value |
+|---|---|
+| Current / Requested Status | [experimental/test/stable/deprecated/unsupported] |
+| Status Rationale | [Evidence-backed rationale] |
+| Validation Date / Method | [Date and method] |
+| Sample Event IDs | [TP/TN event IDs or artifacts] |
+| Backend Conversion | [Target/backend version/result] |
+| Field Mapping Evidence | [Required fields and availability] |
+| Telemetry Scope | [Included and excluded segments] |
+| False-Positive Health | [Rate, budget, last review] |
+| Owner / Review Cadence | [Owner and next review] |
+| Demotion Criteria | [Conditions] |
+| Promotion Decision | [Promote/Hold/Demote/Not Evaluable] |
+
+### ATT&CK Coverage Segment Matrix
+| Technique | Segment | Rule IDs | Deployment State | Required Fields | Coverage Level | Score Cap Reason |
+|---|---|---|---|---|---|---|
+| [Txxxx] | [Segment] | [Rules] | [State] | [Fields] | [None/Theoretical/Tested/Operational/Robust/Not Evaluable] | [Reason or N/A] |
 
 ### Deployment Notes
 - **Target SIEM:** [Platform]
@@ -489,6 +564,10 @@ A detection rule that has never been tested against a known-true-positive event 
 ### Pitfall 4: Ignoring Detection Rule Lifecycle Management
 
 Detection rules are not write-once artifacts. Log sources change, environments evolve, adversary techniques mutate, and SIEM platforms update their query syntax. Rules that are not periodically reviewed become stale, accumulate false positives, or silently stop working. Implement a review cadence (quarterly minimum) and track rule health metrics (fire count, TP/FP ratio, last triggered date).
+
+### Pitfall 4b: Promoting Stable Rules Without Production Evidence
+
+Do not mark a Sigma rule `stable` or score ATT&CK coverage as operational when backend conversion, production field availability, deployment scope, false-positive health, owner, or demotion criteria are missing. Segment coverage by environment so a server-only rule does not overstate workstation, cloud, or SaaS coverage.
 
 ### Pitfall 5: Mapping Detections to ATT&CK Techniques Incorrectly
 

--- a/skills/secops/detection-engineering/tests/lifecycle-promotion-edge-cases.md
+++ b/skills/secops/detection-engineering/tests/lifecycle-promotion-edge-cases.md
@@ -1,0 +1,166 @@
+# Detection Lifecycle Promotion Edge Cases
+
+These fixtures verify that detection-engineering ties Sigma status and ATT&CK heatmap scores to lifecycle evidence, backend conversion, field coverage, deployment scope, and false-positive health.
+
+```yaml
+case_id: DET-LIFECYCLE-01
+title: Stable Sigma status blocked by missing production field coverage
+rule:
+  title: Suspicious PowerShell Encoded Command Execution
+  status: stable
+  logsource:
+    product: windows
+    category: process_creation
+  required_fields:
+    - Image
+    - CommandLine
+production_field_coverage:
+  Image: present
+  CommandLine: unknown
+backend_conversion:
+  target: splunk
+  tested: false
+validation:
+  last_true_positive_test: null
+expected_decision:
+  promotion_decision: Hold
+  max_coverage_level: Theoretical
+  reason: "Stable status lacks field coverage, conversion, and validation evidence."
+```
+
+```yaml
+case_id: DET-LIFECYCLE-02
+title: Synthetic validation permits test status but not operational coverage
+rule:
+  title: Encoded PowerShell
+  status: test
+validation:
+  method: Atomic Red Team T1059.001
+  date: "2026-06-05"
+  sample_event_ids:
+    - lab-sysmon-001
+backend_conversion:
+  target: Microsoft Sentinel
+  version: pySigma-0.11.14
+  result: success
+deployment:
+  production_enabled: false
+expected_decision:
+  promotion_decision: Hold
+  coverage_level: Tested
+  reason: "Synthetic validation and conversion passed, but production deployment is not proven."
+```
+
+```yaml
+case_id: DET-LIFECYCLE-03
+title: Server-only deployment must not score global workstation coverage
+technique: T1059.001
+coverage_claim:
+  requested_level: Operational
+  claimed_population: all_windows
+deployment:
+  included_segments:
+    - windows_servers
+  excluded_segments:
+    - VDI
+    - developer_workstations
+field_mapping:
+  CommandLine:
+    windows_servers: present
+    developer_workstations: missing
+expected_decision:
+  server_segment_level: Operational
+  workstation_segment_level: None
+  score_cap_reason: "Coverage is operational only for servers."
+```
+
+```yaml
+case_id: DET-LIFECYCLE-04
+title: Backend conversion loses Sigma condition semantics
+rule:
+  title: Suspicious Registry Run Key Modification
+  status: test
+sigma_condition: selection and not 1 of filter_*
+backend_conversion:
+  target: QRadar
+  result: success_with_warning
+  warning: "Wildcard filter list not translated"
+validation:
+  true_positive_replay: pass
+  false_positive_filter_test: fail
+expected_decision:
+  promotion_decision: Hold
+  max_coverage_level: Tested
+  reason: "Conversion fidelity is incomplete and FP filter semantics are lost."
+```
+
+```yaml
+case_id: DET-LIFECYCLE-05
+title: Stable rule should be demoted when false-positive budget is exceeded
+rule:
+  title: Suspicious Service Creation
+  status: stable
+false_positive_health:
+  budget_per_day: 5
+  observed_per_day: 86
+  last_review: "2026-06-04"
+deployment:
+  production_enabled: true
+owner: detection-engineering
+demotion_criteria:
+  fp_budget_exceeded: true
+expected_decision:
+  promotion_decision: Demote
+  new_status: test
+  reason: "Rule health no longer supports stable operational coverage."
+```
+
+```yaml
+case_id: DET-LIFECYCLE-06
+title: Robust coverage requires complementary rules and real-world/replay evidence
+technique: T1059.001
+coverage_claim:
+  requested_level: Robust
+rules:
+  - id: powershell_encoded_command
+    status: stable
+    catches_real_world_activity: true
+  - id: powershell_download_cradle
+    status: stable
+    replay_validated: true
+  - id: powershell_amsi_bypass
+    status: test
+    replay_validated: true
+telemetry_scope:
+  windows_servers: present
+  windows_workstations: present
+false_positive_health:
+  within_budget: true
+expected_decision:
+  coverage_level: Robust
+  reason: "Complementary stable/tested rules cover multiple procedure examples with production telemetry and FP health."
+```
+
+```yaml
+case_id: DET-LIFECYCLE-07
+title: Missing owner and review cadence blocks stable promotion
+rule:
+  title: Suspicious CloudTrail Console Login
+  status: test
+validation:
+  date: "2026-06-05"
+  method: replayed_cloudtrail_fixture
+backend_conversion:
+  target: Chronicle
+  result: success
+field_mapping:
+  userAgent: present
+  sourceIPAddress: present
+owner: null
+review_cadence: null
+demotion_criteria: null
+expected_decision:
+  promotion_decision: Hold
+  max_coverage_level: Tested
+  reason: "Lifecycle ownership and demotion criteria are required before stable status."
+```


### PR DESCRIPTION
## Summary
- adds Sigma status-promotion evidence gates so `experimental`, `test`, and `stable` lifecycle claims require validation, backend conversion, field mapping, production scope, FP health, owner, review cadence, and demotion criteria
- adds an ATT&CK coverage evidence gate so heatmap scores are capped by lifecycle evidence and segmented telemetry scope instead of rule existence alone
- extends output with Lifecycle Promotion Evidence and ATT&CK Coverage Segment Matrix sections
- adds seven YAML fixtures covering missing production field coverage, synthetic-only validation, server-only deployment scope, backend conversion fidelity loss, FP-budget demotion, robust complementary coverage, and missing owner/review cadence

## Validation
- git diff --check
- frontmatter parse check
- Markdown fence balance check
- YAML fixture parse check: 7 blocks
- required marker check for Sigma Status Promotion Evidence, Lifecycle Promotion Record, ATT&CK Coverage Evidence Gate, coverage segment records, promotion decision, score cap reason, and fixture cases
- privacy marker scan

/claim #1006

Payment details can be coordinated privately after maintainer acceptance.
