### PR TITLE
Improve IAM external trust session evidence

### DIFF
--- a/skills/identity/iam-review/SKILL.md
+++ b/skills/identity/iam-review/SKILL.md
@@ -199,6 +199,62 @@ IAM-PRIV-08: Resource-based policies granting public or overly broad access
 
 ---
 
+### Step 3A: External Trust and Session Attribution
+
+**Objective:** Verify that external, cross-account, and federated access paths are
+bounded by enforceable trust policy conditions and attributable session evidence.
+
+**NIST SP 800-207 Reference:** Tenet 3 — Access is granted on a per-session basis;
+Tenet 6 — Authentication and authorization are dynamic and strictly enforced
+**CIS Controls v8 Reference:** Control 6.1 — Establish an Access Granting Process;
+Control 6.7 — Centralize Access Control
+
+#### Review Checklist
+
+```
+IAM-TRUST-01: External principal is broad (account root, wildcard, org-wide) without narrow principal constraints
+IAM-TRUST-02: External ID, audience, issuer, or subject constraint is documented but not enforced in policy
+IAM-TRUST-03: Role/session assumption lacks source identity, actor attribution, or equivalent session binding
+IAM-TRUST-04: Required session tags, transitive tag keys, or workload attributes are missing or optional
+IAM-TRUST-05: Maximum session duration exceeds operational need for partner, CI/CD, or break-glass access
+IAM-TRUST-06: External access finding is archived without recording the exact trusted principal and condition set
+IAM-TRUST-07: No CloudTrail / audit-log evidence showing recent assumption source, tags, and session identity
+IAM-TRUST-08: External trust review has no expiry, evidence owner, or revalidation trigger
+```
+
+**Evidence gate:** Treat external trust as acceptable only when the trust policy
+itself enforces the expected principal and conditions. Tags, spreadsheet notes,
+runbook text, or tribal knowledge are supporting context; they do not replace
+policy-level enforcement.
+
+**Platform-specific checks:**
+
+| Platform | Check | What to verify |
+|---|---|---|
+| **AWS** | IAM role trust policy | `Principal` is scoped to the exact role/provider; `sts:ExternalId`, `sts:SourceIdentity`, `aws:PrincipalOrgID`, `aws:PrincipalArn`, session tag conditions, and `sts:TagSession` allowance are enforced where applicable |
+| **AWS** | IAM Access Analyzer external access findings | Findings are reviewed with the exact trusted principal, resource, condition keys, and review expiry recorded |
+| **AWS** | CloudTrail `AssumeRole` / `AssumeRoleWithWebIdentity` | Recent sessions include expected source identity, session tags, role session name pattern, MFA context where applicable, and no unexpected principals |
+| **Azure / Entra ID** | Workload identity federation and enterprise apps | Issuer, subject, audience, app role assignment, and tenant restrictions are enforced in configuration |
+| **Azure / Entra ID** | Sign-in and audit logs | Federated sign-ins map to the expected service principal, workload, and conditional access result |
+| **GCP** | Workload Identity Federation provider | Issuer, audience, subject, attribute mapping, and attribute conditions narrow the external principal |
+| **GCP** | IAM Policy Analyzer and audit logs | External identities have the expected binding, condition, service account impersonation path, and recent usage trail |
+
+**Severity Classification:**
+
+| Finding | Severity | Rationale |
+|---|---|---|
+| Broad external principal with admin or production data access | **Critical** | A partner, CI/CD, or federated identity compromise can directly reach high-value resources |
+| Missing external ID / subject / audience enforcement | **High** | Confused-deputy or token-substitution risk in cross-account or federated access |
+| Missing source identity or session tags | **High** | Incident response cannot attribute actions to a workload, user, ticket, or vendor path |
+| Long external session duration without revalidation | **Medium** | Stolen session credentials remain useful longer than the operational task requires |
+| External trust review without expiry | **Low** | Governance gap that allows stale partner access to persist |
+
+**Output requirement:** For every external trust finding, include the trusted
+principal, enforced and missing condition keys, observed session evidence,
+maximum session duration, evidence owner, and next review date.
+
+---
+
 ### Step 4: Service Account Hygiene
 
 **Objective:** Assess service account security posture and credential management.
@@ -406,6 +462,7 @@ For each finding, produce a row with:
 ### Findings by Category
 - Authentication (Step 2): [count]
 - Least Privilege (Step 3): [count]
+- External Trust (Step 3A): [count]
 - Service Accounts (Step 4): [count]
 - Stale Accounts (Step 5): [count]
 - JIT Access (Step 6): [count]

--- a/skills/identity/iam-review/tests/benign/federated-trust-with-session-guardrails.md
+++ b/skills/identity/iam-review/tests/benign/federated-trust-with-session-guardrails.md
@@ -1,0 +1,67 @@
+# Benign: federated trust with session guardrails
+
+## Scenario
+
+A production AWS role is available to a named partner automation role through a
+federated access workflow. The trust policy narrows the principal, requires the
+external ID, requires source identity and session tags, and stores evidence from
+Access Analyzer plus CloudTrail.
+
+```yaml
+role_name: prod-billing-reconciliation
+provider: aws
+trust_policy:
+  Statement:
+    - Effect: Allow
+      Principal:
+        AWS: arn:aws:iam::222222222222:role/vendor-billing-runner
+      Action:
+        - sts:AssumeRole
+        - sts:TagSession
+      Condition:
+        StringEquals:
+          sts:ExternalId: billing-prod-2026
+          aws:PrincipalOrgID: o-abc123
+        StringLike:
+          sts:SourceIdentity: vendor-billing-*
+        ForAllValues:StringEquals:
+          aws:TagKeys:
+            - workload
+            - environment
+            - ticket
+session_controls:
+  max_session_duration_minutes: 60
+  required_session_tags:
+    workload: billing-reconciliation
+    environment: production
+    ticket: required
+  transitive_tag_keys:
+    - workload
+    - environment
+  mfa_required: service-to-service exception documented
+observability:
+  access_analyzer_finding:
+    status: reviewed
+    trusted_principal: arn:aws:iam::222222222222:role/vendor-billing-runner
+    condition_keys:
+      - sts:ExternalId
+      - sts:SourceIdentity
+      - aws:PrincipalOrgID
+      - aws:TagKeys
+  cloudtrail_assume_role_query:
+    window: last_30_days
+    source_identity_present: true
+    required_tags_present: true
+    unexpected_principals: 0
+review_decision:
+  disposition: acceptable
+  review_expiry: 2026-07-06
+  evidence_owner: identity-security@example.com
+```
+
+## Expected Assessment
+
+Do not flag `IAM-TRUST-01` through `IAM-TRUST-08` when the review proves the exact
+trusted principal, enforced external ID, source identity, session tags, bounded
+duration, Access Analyzer review, CloudTrail assumption evidence, and an expiry
+date for re-review.

--- a/skills/identity/iam-review/tests/vulnerable/cross-account-trust-without-session-evidence.md
+++ b/skills/identity/iam-review/tests/vulnerable/cross-account-trust-without-session-evidence.md
@@ -1,0 +1,54 @@
+# Vulnerable: cross-account trust without session evidence
+
+## Scenario
+
+A production AWS role can be assumed from a partner account. The trust policy allows
+the partner root principal and mentions an external ID in a tag, but the trust policy
+does not enforce that external ID, session tags, source identity, or bounded session
+duration. The review closes the role as acceptable because the partner account is
+known.
+
+```yaml
+role_name: prod-billing-reconciliation
+provider: aws
+trust_policy:
+  Statement:
+    - Effect: Allow
+      Principal:
+        AWS: arn:aws:iam::222222222222:root
+      Action: sts:AssumeRole
+      Condition:
+        StringEquals:
+          aws:PrincipalOrgID: o-abc123
+role_tags:
+  external_id_expected: billing-prod-2026
+session_controls:
+  max_session_duration_hours: 12
+  require_source_identity: false
+  require_session_tags: false
+  transitive_tag_keys: []
+  mfa_required: unknown
+observability:
+  cloudtrail_assume_role_query: missing
+  access_analyzer_finding: archived_as_intended
+  last_assumed_by: unknown
+review_decision:
+  disposition: acceptable
+  reason: partner account is known and belongs to our organization
+```
+
+## Expected Findings
+
+- `IAM-TRUST-01`: External principal is broad and lacks a required `sts:ExternalId` condition.
+- `IAM-TRUST-02`: Trust is accepted from metadata instead of an enforceable trust-policy condition.
+- `IAM-TRUST-03`: Role assumption does not require `sts:SourceIdentity` or equivalent attribution.
+- `IAM-TRUST-04`: Required session tags and transitive tag keys are missing.
+- `IAM-TRUST-05`: Session duration exceeds the bounded duration expected for partner access.
+- `IAM-TRUST-06`: Access Analyzer evidence is archived without showing the exact trusted principal and condition set.
+- `IAM-TRUST-07`: CloudTrail evidence for recent `AssumeRole` use is missing.
+
+## Expected Assessment
+
+Do not close the role as acceptable until the trust policy enforces the partner
+principal, external ID, source identity, required session tags, bounded duration,
+and CloudTrail / Access Analyzer evidence that proves actual assumption behavior.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `iam-review`
**Skill path:** `skills/identity/iam-review/`

### What Was Wrong

The IAM review skill already covered broad cross-account access and JIT access, but it did not provide a dedicated evidence gate for external, cross-account, and federated trust paths.

That gap can let a review accept partner or CI/CD access based on metadata, known account ownership, or runbook notes even when the actual trust policy does not enforce:

- exact external principal scope
- `sts:ExternalId` / issuer / audience / subject constraints
- source identity or equivalent actor attribution
- required session tags and transitive tag keys
- bounded session duration
- Access Analyzer and CloudTrail evidence for recent assumption behavior

### What This PR Fixes

This PR adds `Step 3A: External Trust and Session Attribution` to `iam-review`.

It introduces `IAM-TRUST-01` through `IAM-TRUST-08`, covering:

- broad external principals
- documented-but-unenforced external trust conditions
- missing source identity or actor attribution
- missing session tags / workload attributes
- excessive session duration
- incomplete Access Analyzer evidence
- missing CloudTrail / audit-log assumption evidence
- missing expiry, evidence owner, or revalidation trigger

It also adds AWS, Azure / Entra ID, and GCP checks for external trust and federation paths, including AWS `sts:TagSession` handling for required session tags.

### Evidence

**Before (skill misses this):**
```yaml
Principal:
  AWS: arn:aws:iam::222222222222:root
Action: sts:AssumeRole
Condition:
  StringEquals:
    aws:PrincipalOrgID: o-abc123
role_tags:
  external_id_expected: billing-prod-2026
session_controls:
  max_session_duration_hours: 12
  require_source_identity: false
  require_session_tags: false
observability:
  cloudtrail_assume_role_query: missing
  access_analyzer_finding: archived_as_intended
review_decision:
  disposition: acceptable
```

**After (now correctly handled):**
The review should flag the missing policy-enforced `sts:ExternalId`, missing `sts:SourceIdentity`, missing required session tags, broad principal, long session duration, incomplete Access Analyzer evidence, and missing CloudTrail assumption evidence.

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing checks still pass

New fixtures:

- `skills/identity/iam-review/tests/vulnerable/cross-account-trust-without-session-evidence.md`
- `skills/identity/iam-review/tests/benign/federated-trust-with-session-guardrails.md`

### Bounty Tier
- [ ] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** I can provide payment details privately after maintainer acceptance.

### Validation

- `rg -n "IAM-TRUST-" skills/identity/iam-review/SKILL.md` returned exit code 1 before implementation
- `git diff --check`
- marker check for `IAM-TRUST-*`, `External Trust`, and `sts:TagSession`
- frontmatter required-field check across `skills/**/SKILL.md` and `roles/**/SKILL.md`
- prompt-injection pattern scan across `skills/` and `roles/`
