### PR TITLE
Add .NET forwarded header trust fixtures

### DIFF
--- a/skills/appsec/api-security/csharp-dotnet.md
+++ b/skills/appsec/api-security/csharp-dotnet.md
@@ -739,11 +739,69 @@ if (!app.Environment.IsDevelopment())
 }
 ```
 
+#### ASP.NET Core Forwarded Header Trust Gate
+
+APIs behind reverse proxies, ingress controllers, load balancers, IIS/ANCM, Azure App Service, or Kubernetes ingress often need `X-Forwarded-*` processing. Do not flag every proxied API as header-spoofable, but require evidence that forwarded headers are trusted only from the intended proxy boundary and are processed before downstream security decisions.
+
+**Secure proxy trust example:**
+
+```csharp
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders =
+        ForwardedHeaders.XForwardedFor |
+        ForwardedHeaders.XForwardedProto |
+        ForwardedHeaders.XForwardedHost;
+    options.KnownProxies.Add(IPAddress.Parse("10.0.0.10"));
+    options.AllowedHosts.Add("api.example.com");
+});
+
+app.UseForwardedHeaders();
+app.UseRouting();
+app.UseCors();
+app.UseAuthentication();
+app.UseAuthorization();
+```
+
+**High-risk patterns:**
+
+```csharp
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.All;
+    options.KnownNetworks.Clear();
+    options.KnownProxies.Clear();
+});
+
+app.UseAuthentication();
+app.UseAuthorization();
+app.UseForwardedHeaders(); // Too late for auth/rate-limit/tenant decisions
+```
+
+Forwarded-header evidence to collect:
+
+| Evidence | Review Question |
+|---|---|
+| **Middleware order** | Does `UseForwardedHeaders()` run before `UseRouting`, CORS, authentication, authorization, rate limiting, tenant resolution, link generation, and audit attribution that depend on scheme, host, path base, or remote IP? |
+| **Trusted proxy scope** | Are `KnownProxies` or `KnownNetworks` populated, or is a managed hosting integration documented? Treat `KnownNetworks.Clear()` / `KnownProxies.Clear()` as high risk unless direct client access to Kestrel is impossible. |
+| **Host trust** | If `X-Forwarded-Host` is processed, are `AllowedHosts`, Host Filtering Middleware, or upstream host allowlists documented? |
+| **Security decision impact** | Do forwarded host, proto, prefix, or client IP influence HTTPS redirects, OAuth callbacks, password-reset links, tenant routing, rate limiting, IP allowlists, generated absolute URLs, OpenAPI server URLs, or audit logs? |
+| **Runtime behavior** | What .NET/ASP.NET Core runtime version is deployed, and does unknown-proxy forwarded-header hardening apply? |
+| **Ingress ownership** | Which reverse proxy/load balancer/ingress owns and sanitizes incoming `X-Forwarded-*` headers? Are duplicate inbound headers dropped or overwritten at the edge? |
+
+Classify findings:
+
+- **Benign / controlled:** Trusted proxy or network is explicit, host allowlisting exists when forwarded host is used, middleware order is correct, and direct app access is blocked.
+- **High risk:** Forwarded headers are accepted from any client, proxy trust lists are cleared, or forwarded host/proto/client IP influences security decisions without a documented boundary.
+- **Medium risk:** Trust boundary appears managed but runtime version, ingress sanitization, or host allowlisting evidence is missing.
+- **Not evaluable:** The deployment path is unknown and forwarded headers appear in code or hosting configuration.
+
 #### Security Misconfiguration Review Checklist -- .NET
 
 - [ ] Swagger/OpenAPI is disabled or authentication-gated in non-development environments.
 - [ ] Security headers middleware is registered before endpoint routing.
 - [ ] CORS policy specifies explicit origins, methods, and headers.
+- [ ] Forwarded headers are processed before downstream security middleware and constrained by trusted proxies/networks plus host allowlisting when `X-Forwarded-Host` is used.
 - [ ] `Server` and `X-Powered-By` response headers are removed.
 - [ ] `UseExceptionHandler` is configured in production to prevent stack trace leakage.
 - [ ] Kestrel server limits are set for request body size, header count, and timeouts.
@@ -1204,6 +1262,13 @@ AllowAnyOrigin\(\)
 # Detailed errors in production
 IncludeExceptionDetails\s*=\s*true
 EnableDetailedErrors\s*=\s*true
+# Forwarded headers accepted broadly or configured late
+UseForwardedHeaders\(\)
+ForwardedHeaders\.All
+KnownNetworks\.Clear\(\)
+KnownProxies\.Clear\(\)
+XForwardedHost
+AllowedHosts
 ```
 
 ### Unsafe Upstream Consumption
@@ -1240,5 +1305,7 @@ MapPost\(.*password.*\)(?![\s\S]*?RequireRateLimiting)
 - [CWE-295: Improper Certificate Validation](https://cwe.mitre.org/data/definitions/295.html)
 - [Microsoft ASP.NET Core Security Documentation](https://learn.microsoft.com/en-us/aspnet/core/security/)
 - [Microsoft Rate Limiting Middleware](https://learn.microsoft.com/en-us/aspnet/core/performance/rate-limit)
+- [Microsoft ASP.NET Core proxy and load balancer configuration](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/proxy-load-balancer)
+- [Microsoft ASP.NET Core forwarded headers unknown-proxy behavior](https://learn.microsoft.com/en-us/aspnet/core/breaking-changes/8/forwarded-headers-unknown-proxies)
 - [HotChocolate GraphQL Security](https://chillicream.com/docs/hotchocolate/security)
 - [ASP.NET Core gRPC Authentication](https://learn.microsoft.com/en-us/aspnet/core/grpc/authn-and-authz)

--- a/skills/appsec/api-security/tests/dotnet-forwarded-headers-edge-cases.md
+++ b/skills/appsec/api-security/tests/dotnet-forwarded-headers-edge-cases.md
@@ -1,0 +1,153 @@
+# ASP.NET Core Forwarded Header Edge Cases
+
+These fixtures verify that the C#/.NET API supplement distinguishes secure reverse-proxy forwarding from header spoofing, ordering, and host-trust gaps.
+
+```yaml
+case_id: DOTNET-FWD-01
+title: Known proxy and allowed host before auth is controlled
+runtime: ".NET 8.0.17"
+configuration:
+  forwarded_headers:
+    - XForwardedFor
+    - XForwardedProto
+    - XForwardedHost
+  known_proxies:
+    - 10.0.0.10
+  known_networks: []
+  allowed_hosts:
+    - api.example.com
+middleware_order:
+  - UseForwardedHeaders
+  - UseRouting
+  - UseCors
+  - UseAuthentication
+  - UseAuthorization
+security_decisions:
+  uses_forwarded_host_for_oauth_callbacks: true
+  uses_forwarded_for_for_rate_limit: true
+expected_classification:
+  status: Benign / controlled
+  reason: "Explicit proxy trust, host allowlisting, and correct middleware order are evidenced."
+```
+
+```yaml
+case_id: DOTNET-FWD-02
+title: ForwardedHeaders.All with cleared trust lists is high risk
+runtime: ".NET 7"
+configuration:
+  forwarded_headers:
+    - All
+  known_proxies_cleared: true
+  known_networks_cleared: true
+  direct_client_access_to_kestrel_blocked: false
+security_decisions:
+  uses_forwarded_proto_for_https_redirect: true
+  uses_remote_ip_for_rate_limit: true
+expected_classification:
+  status: High risk
+  reason: "Untrusted clients can spoof scheme and client IP because proxy trust lists are cleared."
+```
+
+```yaml
+case_id: DOTNET-FWD-03
+title: Forwarded headers run after authentication and authorization
+runtime: ".NET 8"
+configuration:
+  known_proxies:
+    - 10.0.0.10
+  allowed_hosts:
+    - api.example.com
+middleware_order:
+  - UseRouting
+  - UseAuthentication
+  - UseAuthorization
+  - UseForwardedHeaders
+downstream_controls:
+  tenant_resolution_before_forwarding: true
+  audit_attribution_before_forwarding: true
+expected_classification:
+  status: High risk
+  reason: "Security controls evaluate pre-forwarded host/scheme/IP because middleware order is wrong."
+```
+
+```yaml
+case_id: DOTNET-FWD-04
+title: Trusted proxy but X-Forwarded-Host lacks host allowlisting
+runtime: ".NET 8"
+configuration:
+  forwarded_headers:
+    - XForwardedHost
+    - XForwardedProto
+  known_proxies:
+    - 10.0.0.10
+  allowed_hosts: []
+  upstream_host_allowlist_evidence: missing
+security_decisions:
+  generates_password_reset_links: true
+  generates_openapi_server_urls: true
+expected_classification:
+  status: Medium risk
+  reason: "Proxy is trusted, but forwarded host influences generated links without host allowlist evidence."
+```
+
+```yaml
+case_id: DOTNET-FWD-05
+title: Managed hosting path supplies forwarded headers safely
+runtime: ".NET 9.0.6"
+hosting:
+  platform: Azure App Service
+  aspnetcore_module_or_integration: documented
+  direct_kestrel_access_blocked: true
+  edge_overwrites_x_forwarded_headers: true
+configuration:
+  manual_use_forwarded_headers: false
+security_decisions:
+  uses_forwarded_proto_for_redirects: true
+expected_classification:
+  status: Benign / controlled
+  reason: "Managed hosting integration and edge sanitization document the trust boundary."
+```
+
+```yaml
+case_id: DOTNET-FWD-06
+title: Kubernetes ingress requires CIDR KnownNetworks evidence
+runtime: ".NET 8"
+hosting:
+  platform: Kubernetes
+  ingress_controller: nginx
+configuration:
+  forwarded_headers:
+    - XForwardedFor
+    - XForwardedProto
+  known_proxies: []
+  known_networks:
+    - 10.42.0.0/16
+  ingress_sanitizes_inbound_headers: true
+middleware_order:
+  - UseForwardedHeaders
+  - UseRouting
+  - UseRateLimiter
+  - UseAuthentication
+expected_classification:
+  status: Benign / controlled
+  reason: "CIDR-based ingress network trust is documented and processing precedes rate limiting/auth."
+```
+
+```yaml
+case_id: DOTNET-FWD-07
+title: Logging-only forwarded headers are lower risk but still need boundary evidence
+runtime: ".NET 8"
+configuration:
+  forwarded_headers:
+    - XForwardedFor
+  known_proxies: []
+  known_networks: []
+security_decisions:
+  influences_auth: false
+  influences_rate_limit: false
+  influences_redirects: false
+  logging_only: true
+expected_classification:
+  status: Medium risk
+  reason: "Header spoofing affects audit attribution even when not used for authorization."
+```


### PR DESCRIPTION
## Summary
- adds an ASP.NET Core forwarded-header trust gate to the C#/.NET API security supplement
- requires evidence for `UseForwardedHeaders()` middleware order, `KnownProxies` / `KnownNetworks`, managed hosting integration, `AllowedHosts` / host filtering, runtime behavior, ingress ownership, and security decisions that depend on forwarded scheme/host/IP
- adds high-risk guidance for `ForwardedHeaders.All`, cleared proxy trust lists, late middleware ordering, and forwarded host use without host allowlisting
- adds grep patterns and Microsoft proxy/load-balancer references
- adds seven YAML fixtures covering controlled known-proxy config, broad untrusted forwarding, late middleware order, missing host allowlist, managed hosting, Kubernetes ingress CIDR trust, and logging-only forwarded headers

## Validation
- git diff --check
- Markdown fence balance check
- YAML fixture parse check: 7 blocks
- required marker check for ASP.NET Core Forwarded Header Trust Gate, `KnownProxies`, `KnownNetworks`, `AllowedHosts`, `UseForwardedHeaders`, `XForwardedHost`, and fixture cases
- privacy marker scan

/claim #981

Payment details can be coordinated privately after maintainer acceptance.
