### PR TITLE
Add Java repository source fixtures

### DIFF
--- a/skills/appsec/dependency-scanning/SKILL.md
+++ b/skills/appsec/dependency-scanning/SKILL.md
@@ -12,7 +12,7 @@ phase: [build, deploy]
 frameworks: [SLSA-v1.0, CycloneDX, SPDX, CISA-KEV]
 difficulty: intermediate
 time_estimate: "15-30min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -181,6 +181,42 @@ Typosquatting (also called dependency confusion or combosquatting) is a supply c
 - Implement dependency confusion protections: claim your internal package names on public registries, or use registry proxy tools like Artifactory or Nexus with routing rules.
 - Run `socket.dev`, `npm audit signatures`, or `sigstore` verification to validate package provenance.
 
+## Java Repository Source Evidence
+
+Gradle and Maven builds can leak private coordinates or resolve internal artifacts from the wrong source when public and private repositories are mixed without filtering, mirrors, or repository-manager routing. SBOM output proves what resolved after the fact, but it does not prove which repositories were queried or whether internal groups/plugin IDs can fall through to public sources.
+
+Collect this evidence when Java builds use private groups, custom repositories, plugin repositories, parent POMs, profiles, or enterprise package proxies:
+
+- **Gradle dependencies:** `repositories {}` order, repository content filters, `mavenContent`, `exclusiveContent`, and private group/module coverage.
+- **Gradle plugins:** `pluginManagement.repositories`, plugin IDs, plugin marker artifacts, and whether internal plugins can resolve from the Gradle Plugin Portal.
+- **Maven effective graph:** `help:effective-pom`, `help:effective-settings`, active profiles, mirrors, repository order, parent POM repositories, and plugin repositories.
+- **Repository manager policy:** Artifactory/Nexus/CodeArtifact/Cloudsmith routing rules, group allowlists, proxy repository order, and cache/fallback behavior.
+- **Private coordinates:** Internal group IDs, plugin IDs, parent POMs, BOMs, and module names from manifests and lock/resolution evidence.
+- **CI evidence:** Build-agent settings, Gradle init scripts, Maven `settings.xml`, and environment-specific repository overrides.
+
+Classify Java repository source posture:
+
+| Status | Criteria | Finding Guidance |
+|---|---|---|
+| **Benign / controlled** | Internal groups/plugins are constrained by Gradle `exclusiveContent`, content filters, Maven mirrors, or repository-manager allowlists, and CI effective settings prove public fallback cannot receive private coordinates | Record evidence; do not flag dependency-confusion risk |
+| **Private coordinate leak** | Public repositories can be queried for internal group IDs, plugin IDs, parent POMs, or BOMs | High supply-chain finding |
+| **Fallback leak risk** | Private repository appears first but public fallback can satisfy or observe private coordinates when the private repo misses | Medium/High depending on coordinate sensitivity |
+| **Plugin repository leak risk** | Dependency repositories are filtered but `pluginManagement.repositories` or Maven plugin repositories are not constrained | Medium supply-chain finding |
+| **Not evaluable** | Effective Maven/Gradle/CI repository evidence is missing | Request evidence before concluding safe or unsafe |
+
+```
+Java Repository Source Evidence:
+- Build Tool:             [Gradle | Maven | Mixed]
+- Private Coordinates:    [Groups, modules, plugins, parent POMs, BOMs]
+- Dependency Repositories: [Order, URLs, filters, exclusiveContent/mirrors]
+- Plugin Repositories:    [Order, URLs, filters, plugin IDs]
+- Effective Settings:     [Gradle/Maven/CI evidence source]
+- Repository Manager:     [Routing, allowlist, fallback policy]
+- Public Fallback Path:   [Can public repositories receive private coordinates? yes/no/unknown]
+- Status:                 [Benign / controlled | Private coordinate leak | Fallback leak risk | Plugin repository leak risk | Not evaluable]
+- Remediation:            [exclusiveContent, content filters, mirrors, repository-manager allowlist, CI settings]
+```
+
 ## Assessment Output Template
 
 When performing a dependency scan, produce findings in the following structure:
@@ -212,6 +248,13 @@ When performing a dependency scan, produce findings in the following structure:
 - [ ] Packages with install scripts
 - [ ] Unmaintained packages (no release in 2+ years)
 - [ ] Dependency confusion risk (internal name collisions)
+- [ ] Java private repository/source confusion risk
+
+### Private Registry / Proxy Evidence
+
+| Ecosystem | Private Prefix / Scope | Proxy / Registry Chain | Privacy Controls | Public Fallback Risk | Status |
+|---|---|---|---|---|---|
+| Java / Gradle / Maven | [Group/plugin scope] | [Repositories/mirrors/proxy chain] | [exclusiveContent/content filters/mirrors/allowlists] | [Yes/No/Unknown] | [Controlled/Risk/Not Evaluable] |
 
 ### Recommendations
 
@@ -226,8 +269,9 @@ When performing a dependency scan, produce findings in the following structure:
 4. **Vulnerability scan**: Cross-reference packages and versions against known CVE databases. Apply the EPSS+CVSS+KEV triage model.
 5. **License audit**: Extract license declarations from lockfiles or registry metadata. Flag copyleft and unlicensed packages.
 6. **Typosquatting check**: Review dependency names for patterns described in the detection section.
-7. **Supply chain assessment**: Evaluate SLSA posture -- lockfile presence, pinned versions, provenance availability.
-8. **Report**: Produce the assessment using the output template above, with prioritized remediation recommendations.
+7. **Private registry/proxy assessment**: For npm/pip/Java/Go ecosystems with private packages or custom repositories, capture registry/proxy routing and privacy controls. For Java, include Gradle `repositories`, `pluginManagement.repositories`, content filters or `exclusiveContent`, Maven effective POM/settings, mirrors, profiles, plugin repositories, and repository-manager routing evidence.
+8. **Supply chain assessment**: Evaluate SLSA posture -- lockfile presence, pinned versions, provenance availability.
+9. **Report**: Produce the assessment using the output template above, with prioritized remediation recommendations.
 
 ## Prompt Injection Safety Notice
 
@@ -251,3 +295,7 @@ This skill processes user-supplied content including package manifests, lockfile
 - [NIST NVD](https://nvd.nist.gov/)
 - [OpenSSF Scorecard](https://securityscorecards.dev/)
 - [Executive Order 14028 - Improving the Nation's Cybersecurity](https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/)
+- [Gradle Filtering Repository Content](https://docs.gradle.org/current/userguide/filtering_repository_content.html)
+- [Gradle Best Practices for Dependencies](https://docs.gradle.org/current/userguide/best_practices_dependencies.html)
+- [Maven Setting up Multiple Repositories](https://maven.apache.org/guides/mini/guide-multiple-repositories.html)
+- [Maven Introduction to Repositories](https://maven.apache.org/guides/introduction/introduction-to-repositories)

--- a/skills/appsec/dependency-scanning/tests/java-repository-source-edge-cases.md
+++ b/skills/appsec/dependency-scanning/tests/java-repository-source-edge-cases.md
@@ -1,0 +1,150 @@
+# Java Repository Source Edge Cases
+
+These fixtures verify that dependency-scanning captures Gradle and Maven repository-source evidence before judging dependency-confusion or private-coordinate disclosure risk.
+
+```yaml
+case_id: JAVA-REPO-01
+title: Gradle exclusiveContent constrains internal group to private repository
+build_tool: Gradle
+repositories:
+  - type: mavenCentral
+  - type: exclusiveContent
+    repository: https://repo.example.internal/maven2
+    filter:
+      include_groups:
+        - com.example.internal
+dependencies:
+  - com.example.internal:payments-client:1.4.0
+expected_classification:
+  status: Benign / controlled
+  reason: "exclusiveContent prevents public repositories from being queried for the internal group."
+```
+
+```yaml
+case_id: JAVA-REPO-02
+title: Gradle public repository can see internal coordinates
+build_tool: Gradle
+repositories:
+  - https://repo.maven.apache.org/maven2
+  - https://repo.example.internal/maven2
+filters: missing
+dependencies:
+  - com.example.internal:payments-client:1.4.0
+expected_classification:
+  status: Private coordinate leak
+  severity: High
+  reason: "No content filter or exclusiveContent prevents public repository lookup for private group."
+```
+
+```yaml
+case_id: JAVA-REPO-03
+title: Maven POM order cannot prove private groups avoid Central
+build_tool: Maven
+pom_repositories:
+  - id: central
+    url: https://repo.maven.apache.org/maven2
+  - id: internal
+    url: https://repo.example.internal/maven2
+effective_settings:
+  mirrors: missing
+  active_profiles: missing
+effective_pom: missing
+dependencies:
+  - com.example.internal:payments-client:1.4.0
+expected_classification:
+  status: Not evaluable
+  reason: "Raw POM repository order is insufficient without effective settings, mirrors, and active profile evidence."
+```
+
+```yaml
+case_id: JAVA-REPO-04
+title: Gradle dependency repositories filtered but plugin repositories are not
+build_tool: Gradle
+dependency_repositories:
+  exclusive_content:
+    repository: https://repo.example.internal/maven2
+    include_groups:
+      - com.example.internal
+plugin_management_repositories:
+  - gradlePluginPortal
+  - https://repo.example.internal/gradle-plugins
+internal_plugins:
+  - com.example.internal.release
+expected_classification:
+  status: Plugin repository leak risk
+  severity: Medium
+  reason: "Internal plugin IDs may resolve through the public plugin portal without pluginManagement filtering."
+```
+
+```yaml
+case_id: JAVA-REPO-05
+title: Repository manager routes public and private artifacts with allowlists
+build_tool: Mixed
+repository_manager:
+  product: Nexus
+  group_repository: https://repo.example.internal/maven-all
+  routing_rules:
+    internal_group_allowlist:
+      - com.example.internal
+    public_proxy_allowlist:
+      - org.apache.*
+      - com.fasterxml.jackson.*
+    public_fallback_for_internal_groups: false
+gradle_repositories:
+  - https://repo.example.internal/maven-all
+maven_effective_settings:
+  mirrors:
+    - mirrorOf: "*"
+      url: https://repo.example.internal/maven-all
+dependencies:
+  - com.example.internal:payments-client:1.4.0
+expected_classification:
+  status: Benign / controlled
+  reason: "Repository-manager routing and effective build settings prove internal groups cannot fall through to public repositories."
+```
+
+```yaml
+case_id: JAVA-REPO-06
+title: Maven effective settings mirror controls a risky-looking POM
+build_tool: Maven
+pom_repositories:
+  - id: central
+    url: https://repo.maven.apache.org/maven2
+  - id: internal
+    url: https://repo.example.internal/maven2
+effective_settings:
+  mirrors:
+    - mirrorOf: "*"
+      url: https://repo.example.internal/maven-all
+repository_manager_policy:
+  public_fallback_for_internal_groups: false
+dependencies:
+  - com.example.internal:payments-client:1.4.0
+expected_classification:
+  status: Benign / controlled
+  reason: "Effective settings are stronger evidence than a raw POM and route all resolution through the internal manager."
+```
+
+```yaml
+case_id: JAVA-REPO-07
+title: Maven CI profile may add a public fallback repository
+build_tool: Maven
+pom_repositories:
+  - id: internal
+    url: https://repo.example.internal/maven2
+profiles:
+  ci-public-fallback:
+    activation: property:ci
+    repositories:
+      - id: central
+        url: https://repo.maven.apache.org/maven2
+private_coordinates:
+  - com.example.internal:auth-client
+ci_evidence:
+  active_profiles: missing
+  effective_pom: missing
+  effective_settings: missing
+expected_classification:
+  status: Not evaluable
+  reason: "Active profile evidence is required before deciding whether CI adds public fallback for internal groups."
+```


### PR DESCRIPTION
## Summary

- Adds a Java repository-source evidence gate to `dependency-scanning` for Gradle and Maven builds.
- Requires reviewers to capture Gradle repository filters, `exclusiveContent`, `pluginManagement.repositories`, Maven effective POM/settings, mirrors, active profiles, plugin repositories, CI overrides, and repository-manager routing/allowlist evidence.
- Adds seven YAML edge-case fixtures covering benign controls, public fallback risk, plugin repository leakage, repository-manager allowlists, Maven mirrors, and missing CI profile evidence.

## Validation

- `git diff --check`
- Frontmatter YAML parse passed
- Fixture YAML parse passed: 7 blocks
- Markdown fence balance passed
- Required Java repository-source markers present
- Reference URLs returned HTTP 200
- Privacy scan passed for public files

/claim #984

Payment details can be coordinated privately after maintainer acceptance.
