### PR TITLE
Add S3 object ownership fixtures

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-AWS-v3.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -158,6 +158,12 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Evidence:** <specific configuration or code snippet>
 - **Remediation:** <specific fix with code example>
 
+### S3 Object Ownership Evidence
+
+| Bucket | Object Ownership | Public Access Block | ACL Dependency | Evidence Source | Status |
+|--------|------------------|--------------------|----------------|-----------------|--------|
+| <bucket> | BucketOwnerEnforced / BucketOwnerPreferred / ObjectWriter / Unknown | Account + bucket / partial / missing | None / documented / unknown | Terraform / CloudFormation / AWS CLI / guardrail | Pass / Fail / Not Evaluable |
+
 ### Prioritized Remediation Plan
 
 1. **[Critical]** CIS X.Y -- <action item>
@@ -195,7 +201,7 @@ Produce the final report using the structure defined in the Output Format sectio
 ## Common Pitfalls
 
 1. **Checking only Terraform state, not all resource definitions.** Security groups and IAM policies may be defined across dozens of files. Always use Glob to find all `.tf` files before evaluating.
-2. **Missing account-level vs. bucket-level S3 public access blocks.** CIS 2.1.4 requires both. An account-level block can override permissive bucket settings, but the bucket-level block should also be set.
+2. **Confusing S3 Block Public Access with Object Ownership.** CIS 2.1.4 requires both account-level and bucket-level public access blocks, but those settings do not prove ACLs are disabled or that the bucket owner owns every object. Record S3 Object Ownership separately: `BucketOwnerEnforced` disables ACLs, while `BucketOwnerPreferred` and `ObjectWriter` require additional ACL, upload-policy, and migration evidence.
 3. **Confusing CloudTrail multi-region with organization trail.** CIS 3.1 requires multi-region, not necessarily an organization trail. Both are valid, but the control checks `is_multi_region_trail`.
 4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
 5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
@@ -226,9 +232,14 @@ Produce the final report using the structure defined in the Output Format sectio
 - AWS Security Hub: https://docs.aws.amazon.com/securityhub/latest/userguide/
 - AWS VPC Security: https://docs.aws.amazon.com/vpc/latest/userguide/security.html
 - Terraform AWS Provider Documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
+- AWS S3 Object Ownership: https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html
+- AWS S3 Object Ownership for new buckets: https://docs.aws.amazon.com/AmazonS3/latest/userguide/ensure-object-ownership.html
+- AWS S3 access control best practices: https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-best-practices.html
+- Terraform `aws_s3_bucket_ownership_controls`: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls
 
 ---
 
 ## Changelog
 
+- **1.0.1** -- Added S3 Object Ownership evidence handling for ACL-disabled buckets, cross-account upload modes, existing-bucket proof, and calibration fixtures.
 - **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 (62 recommendations).

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -215,6 +215,27 @@ Also verify account-level public access block:
 aws_s3_account_public_access_block
 ```
 
+#### S3 Object Ownership and ACL-Disabled Evidence
+
+Block Public Access reduces public ACL and policy exposure, but it does not prove ACLs are disabled or that the bucket owner owns every object. For each bucket, record S3 Object Ownership evidence alongside CIS 2.1.4.
+
+| Evidence Source | What to Verify | Pass / Follow-Up |
+|---|---|---|
+| Terraform `aws_s3_bucket_ownership_controls` | `rule.object_ownership` | `BucketOwnerEnforced` is ACL-disabled evidence |
+| CloudFormation `OwnershipControls` | `ObjectOwnership` rule | `BucketOwnerEnforced` is ACL-disabled evidence |
+| AWS CLI / inventory | `get-bucket-ownership-controls` result | Existing or imported buckets have verified ownership mode |
+| Guardrail policy | IAM/SCP condition on `s3:x-amz-object-ownership` | New buckets are required to use `BucketOwnerEnforced` |
+
+Classify ownership posture:
+
+- **Pass:** `BucketOwnerEnforced` is proven for the bucket, or account/SCP guardrails plus per-bucket evidence prove ACLs are disabled.
+- **Fail:** `ObjectWriter` is used without a documented legacy exception, ACL review, and ownership remediation plan.
+- **Fail:** `BucketOwnerPreferred` is used without bucket policy or client evidence requiring `bucket-owner-full-control` on cross-account `PutObject`.
+- **Not Evaluable:** No ownership-controls evidence is available for existing or imported buckets and new-bucket defaults cannot be proven.
+- **Benign:** Historical ACL resources are present, but `BucketOwnerEnforced` is proven and ACL PUTs are expected to fail with `AccessControlListNotSupported`.
+
+Record migration exceptions for static website hosting, legacy log delivery, and third-party upload flows that still require ACLs. Include bucket policy, Public Access Block, writer inventory, owner approval, and target migration date.
+
 ### CIS 2.2.1 -- Ensure EBS Volume Encryption is Enabled in all Regions
 
 Check for default EBS encryption:

--- a/skills/cloud/aws-review/tests/s3-object-ownership-edge-cases.md
+++ b/skills/cloud/aws-review/tests/s3-object-ownership-edge-cases.md
@@ -1,0 +1,128 @@
+# S3 Object Ownership Edge Cases
+
+These fixtures verify that `aws-review` records S3 Object Ownership separately from Block Public Access before judging ACL exposure or bucket-owner control.
+
+```yaml
+case_id: S3-OWN-01
+title: BucketOwnerEnforced disables ACLs with bucket and account public access blocks
+bucket: prod-logs
+evidence:
+  terraform:
+    ownership_controls: BucketOwnerEnforced
+    bucket_public_access_block:
+      block_public_acls: true
+      ignore_public_acls: true
+      block_public_policy: true
+      restrict_public_buckets: true
+    account_public_access_block: present
+  aws_cli:
+    get_bucket_ownership_controls: BucketOwnerEnforced
+expected_classification:
+  status: Pass
+  reason: "ACLs are disabled and both bucket/account public access block evidence are present."
+```
+
+```yaml
+case_id: S3-OWN-02
+title: ObjectWriter remains enabled despite Block Public Access
+bucket: partner-uploads
+evidence:
+  terraform:
+    ownership_controls: ObjectWriter
+    bucket_public_access_block:
+      block_public_acls: true
+      ignore_public_acls: true
+  acl_review: missing
+  migration_plan: missing
+expected_classification:
+  status: Fail
+  severity: Medium
+  reason: "Block Public Access does not disable ACLs or prove bucket-owner control when ObjectWriter is configured."
+```
+
+```yaml
+case_id: S3-OWN-03
+title: BucketOwnerPreferred lacks bucket-owner-full-control upload policy
+bucket: cross-account-ingest
+evidence:
+  terraform:
+    ownership_controls: BucketOwnerPreferred
+  bucket_policy:
+    requires_bucket_owner_full_control: false
+  client_upload_contract: missing
+expected_classification:
+  status: Fail
+  severity: Medium
+  reason: "Cross-account writers may create objects the bucket owner does not fully control."
+```
+
+```yaml
+case_id: S3-OWN-04
+title: Imported legacy bucket has no ownership-controls evidence
+bucket: legacy-archive
+evidence:
+  terraform:
+    aws_s3_bucket: imported
+    ownership_controls: missing
+  cloudformation:
+    ownership_controls: missing
+  aws_cli:
+    get_bucket_ownership_controls: missing
+  new_bucket_default_claim: unproven
+expected_classification:
+  status: Not Evaluable
+  reason: "Existing or imported buckets need explicit ownership-controls evidence; new-bucket defaults cannot be assumed."
+```
+
+```yaml
+case_id: S3-OWN-05
+title: SCP guardrail plus per-bucket CLI evidence proves enforced ownership
+bucket: app-artifacts
+evidence:
+  scp_guardrail:
+    condition_key: s3:x-amz-object-ownership
+    required_value: BucketOwnerEnforced
+  aws_cli:
+    get_bucket_ownership_controls: BucketOwnerEnforced
+  bucket_public_access_block: complete
+expected_classification:
+  status: Pass
+  reason: "Guardrail covers new buckets and CLI evidence proves the reviewed bucket is ACL-disabled."
+```
+
+```yaml
+case_id: S3-OWN-06
+title: Static website ACL exception is documented and bounded
+bucket: public-website-assets
+evidence:
+  ownership_controls: BucketOwnerPreferred
+  public_access_block:
+    block_public_policy: false
+    restrict_public_buckets: false
+  exception:
+    owner: web-platform
+    business_reason: static website hosting
+    bucket_policy_reviewed: true
+    writer_inventory: documented
+    migration_target_date: "2026-09-30"
+expected_classification:
+  status: Documented exception
+  severity: Informational
+  reason: "ACL-dependent public website use is documented with ownership, policy, and migration evidence."
+```
+
+```yaml
+case_id: S3-OWN-07
+title: Historical ACL resource should not create a false positive when ACLs are disabled
+bucket: audit-exports
+evidence:
+  terraform:
+    aws_s3_bucket_acl: present
+    ownership_controls: BucketOwnerEnforced
+  aws_behavior:
+    acl_put_error: AccessControlListNotSupported
+  bucket_policy_controls_access: true
+expected_classification:
+  status: Pass
+  reason: "BucketOwnerEnforced makes historical ACL resources non-authoritative; policy/IAM controls access."
+```


### PR DESCRIPTION
## Summary

- Adds S3 Object Ownership evidence to `aws-review` so Block Public Access is not mistaken for ACL-disabled proof.
- Extends the CIS 2.1.4 checklist with `BucketOwnerEnforced`, `BucketOwnerPreferred`, `ObjectWriter`, imported/existing bucket, guardrail, and documented exception handling.
- Adds seven YAML edge-case fixtures covering benign ACL-disabled buckets, ObjectWriter risk, missing `bucket-owner-full-control`, imported-bucket uncertainty, SCP guardrails, static website exceptions, and historical ACL false positives.

## Validation

- `git diff --check`
- Frontmatter YAML parse passed
- Fixture YAML parse passed: 7 blocks
- Markdown fence balance passed
- Required S3 Object Ownership markers present
- Reference URLs returned HTTP 200
- ASCII scan passed for changed public files
- Privacy scan passed for public files

/claim #995

Payment details can be coordinated privately after maintainer acceptance.
