### PR TITLE
Improve Azure Key Vault RBAC evidence gates

### DIFF
--- a/skills/cloud/azure-review/SKILL.md
+++ b/skills/cloud/azure-review/SKILL.md
@@ -154,6 +154,12 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Evidence:** <specific configuration or code snippet>
 - **Remediation:** <specific fix with code example>
 
+### Key Vault RBAC Evidence
+
+| Vault | Permission Model | Principal | Role | Scope | Role Capability | Justification / Owner | Last Reviewed | Migration / Drift Status |
+|-------|------------------|-----------|------|-------|-----------------|-----------------------|---------------|--------------------------|
+| <vault name> | RBAC / Access Policy / Not Evaluable | <user/group/service principal/managed identity> | <role name> | <vault/RG/subscription/MG> | <read/manage/grant/admin> | <ticket/owner/reason> | <date> | <clean/stale access policy/outside IaC/live export missing> |
+
 ### Prioritized Remediation Plan
 
 1. **[Critical]** CIS X.Y.Z -- <action item>
@@ -199,7 +205,8 @@ Produce the final report using the structure defined in the Output Format sectio
 3. **Overlooking `allow_nested_items_to_be_public` on storage accounts.** CIS 3.7 checks the account-level setting, not individual container access levels. The account setting must be `false` to prevent any container from being public.
 4. **NSG rules using service tags.** A rule with `source_address_prefix = "Internet"` is equivalent to `0.0.0.0/0`. Both must be flagged for CIS 6.1 and 6.2.
 5. **Key Vault purge protection is irreversible.** CIS 8.5 requires `purge_protection_enabled = true`. Note this cannot be disabled once enabled -- flag this for awareness during remediation.
-6. **App Service TLS version on both Linux and Windows.** Check `azurerm_linux_web_app` and `azurerm_windows_web_app` resources separately.
+6. **Key Vault RBAC is not least privilege by itself.** `enable_rbac_authorization = true` proves the permission model, not that data-plane roles are narrow. Review role assignments, scope inheritance, grant-capable roles, management-plane role grants, break-glass access, and migration drift before marking CIS 8.6 as fully evidenced.
+7. **App Service TLS version on both Linux and Windows.** Check `azurerm_linux_web_app` and `azurerm_windows_web_app` resources separately.
 
 ---
 
@@ -224,6 +231,8 @@ Produce the final report using the structure defined in the Output Format sectio
 - Microsoft Entra ID Security: https://learn.microsoft.com/en-us/entra/identity/
 - Azure Storage Security: https://learn.microsoft.com/en-us/azure/storage/common/storage-security-guide
 - Azure Key Vault Best Practices: https://learn.microsoft.com/en-us/azure/key-vault/general/best-practices
+- Azure Key Vault RBAC Guide: https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-guide
+- Azure Key Vault RBAC Migration: https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-migration
 - Azure App Service Security: https://learn.microsoft.com/en-us/azure/app-service/overview-security
 - Terraform AzureRM Provider Documentation: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
 

--- a/skills/cloud/azure-review/benchmark-checklist.md
+++ b/skills/cloud/azure-review/benchmark-checklist.md
@@ -617,6 +617,27 @@ resource "azurerm_key_vault" {
 }
 ```
 
+RBAC enabled is only the permission model. Also collect Key Vault data-plane role evidence so the review does not replace access-policy sprawl with RBAC sprawl.
+
+| Evidence | What to Verify | Risk if Missing |
+|---|---|---|
+| Vault permission model | `enable_rbac_authorization = true` in IaC or live `properties.enableRbacAuthorization = true` | Cannot tell whether the vault uses Azure RBAC or legacy access policies |
+| Data-plane role assignments | `azurerm_role_assignment`, Bicep/ARM role assignments, or live `az role assignment list --scope <vault-id>` export | RBAC is enabled but principals and effective data access are unknown |
+| Role scope | Assignment scope is vault, resource group, subscription, or management group | Broad inherited assignments may grant unintended secret/key access |
+| Principal identity | User, group, service principal, managed identity, workload identity, or break-glass account | Orphaned or overly broad principals may retain sensitive access |
+| Role capability | Distinguish `Key Vault Secrets User`, `Key Vault Crypto User`, `Key Vault Certificates Officer`, `Key Vault Administrator`, `Key Vault Data Access Administrator`, and custom roles | Admin or grant-capable roles may be treated as ordinary read access |
+| Justification and owner | Business reason, data owner, grant owner, ticket/change ID, and last review date | Role assignment cannot be tied to approved need |
+| Break-glass path | Emergency account owner, MFA/PIM requirement, monitoring, expiry, and post-use review | Emergency access becomes unmanaged standing privilege |
+| Migration drift | Legacy `azurerm_key_vault_access_policy`, portal-managed access policies, stale role assignments, and assignments outside IaC | Migration from access policies to RBAC is incomplete or not evaluable |
+
+Flag these conditions:
+
+- `enable_rbac_authorization = true` with no role-assignment matrix or live role export.
+- `Key Vault Administrator` or `Key Vault Data Access Administrator` assigned to broad engineering, application, or all-user groups without justification.
+- Management-plane roles such as `Owner`, `Contributor`, or `User Access Administrator` are not reviewed alongside Key Vault data-plane roles, because they can grant or change access.
+- Access-policy resources remain after an RBAC migration without a documented migration plan and validation evidence.
+- Private endpoint claims are treated as sufficient even though role assignments still allow overbroad data-plane access.
+
 ### CIS 8.7 -- Ensure that Private Endpoints are used for Azure Key Vault
 
 Check for private endpoint connections to Key Vault:


### PR DESCRIPTION
## Summary
- adds a focused Key Vault RBAC data-plane evidence matrix for CIS 8.6
- distinguishes RBAC enablement from actual least-privilege role assignment evidence
- requires principal, role, scope, capability, justification, owner, break-glass, live-role-export, and migration-drift evidence
- separates management-plane grant risk from Key Vault data-plane secret/key/certificate access
- extends the report output with a Key Vault RBAC Evidence table

This intentionally complements, rather than duplicates, existing Key Vault private-access/recovery work by focusing on RBAC transition and effective data-plane authorization evidence.

## Validation
- git diff --check
- rg -n "Key Vault RBAC Evidence|data-plane role|role-assignment matrix|enable_rbac_authorization|Key Vault Data Access Administrator|management-plane|Migration drift|private endpoint claims|rbac-guide|rbac-migration|live role export" skills/cloud/azure-review/SKILL.md skills/cloud/azure-review/benchmark-checklist.md
- verified Markdown fence counts remain even: SKILL.md=4, benchmark-checklist.md=92

Closes #1511

Bounty target: Improver Moderate if accepted.
Preferred payout: Base USDC 0x6CBF4b5cb88b8C2B7af776Bc2B073163B5d3C08A
