### PR TITLE
Add Azure identity PIM fixtures

### DIFF
--- a/skills/cloud/azure-review/SKILL.md
+++ b/skills/cloud/azure-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-Azure-v2.1.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -88,6 +88,41 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, Bic
 
 ---
 
+### Step 10.5: Managed Identity, Effective Access, and PIM Evidence
+
+Static role assignments are not enough to judge Azure identity risk. For managed identities, service principals, privileged users, and Key Vault access paths, collect effective access evidence before assigning severity.
+
+For each privileged assignment or managed identity, record:
+
+- **Principal evidence:** principal type, object ID, user-assigned vs system-assigned managed identity, app/service principal, group membership, and whether the identity can be attached to new compute.
+- **Effective scope:** management group, subscription, resource group, resource, inherited assignment, deny assignment, eligible assignment, active assignment, and data-plane vs control-plane permission.
+- **Role impact:** Owner, User Access Administrator, Privileged Role Administrator, Key Vault Administrator, Key Vault Secrets Officer, custom role actions/dataActions, or Reader/Monitoring Reader.
+- **PIM controls:** eligibility vs active assignment, activation duration, MFA/authentication strength, approval, justification, ticket, alerting, and activation/audit logs.
+- **Key Vault mode:** RBAC authorization vs access-policy mode; do not recommend RBAC-only fixes when the vault still uses access policies.
+
+Classify identity posture:
+
+| Status | Criteria | Finding Guidance |
+|---|---|---|
+| **Benign / least privilege** | Low-impact role at documented scope with no privileged data-plane actions and current owner evidence | Record evidence; do not flag solely because the principal is a managed identity |
+| **High-impact managed identity** | Workload identity has admin, data-plane secret/key, Owner, or User Access Administrator rights without scope/justification/attachability controls | High finding |
+| **PIM evidence gap** | Privileged eligibility exists but activation policy, MFA, approval, duration, justification, or audit logs are missing | Not Evaluable or Medium/High depending on active privilege |
+| **Inherited-scope blind spot** | Subscription-local IaC misses management-group or group-inherited role assignments | Not Evaluable until effective assignment export is provided |
+| **Key Vault mode mismatch** | Remediation assumes RBAC while the vault uses access policies, or access-policy evidence is missing | Medium/High based on exposed secrets/keys |
+
+```
+Azure Identity / PIM Evidence:
+- Principal:              [type, object ID, managed identity mode]
+- Effective Scope:        [management group/subscription/RG/resource; inherited?]
+- Role / Data Actions:    [role name, actions, dataActions]
+- PIM State:              [eligible/active/permanent; activation controls]
+- Key Vault Mode:         [RBAC authorization/access policies/not applicable]
+- Attachability Controls: [which compute can attach this identity]
+- Status:                 [Benign / least privilege | High-impact managed identity | PIM evidence gap | Inherited-scope blind spot | Key Vault mode mismatch]
+- Remediation:            [scope reduction, custom role, PIM controls, identity isolation, Key Vault mode-specific fix]
+```
+
+---
 
 ---
 
@@ -152,7 +187,14 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration or code snippet>
+- **Identity/PIM Evidence:** <principal, effective scope, role/dataActions, PIM activation, Key Vault mode, or Not Evaluable reason>
 - **Remediation:** <specific fix with code example>
+
+### Azure Identity / PIM Evidence
+
+| Principal | Principal Type | Effective Scope | Role / Data Actions | PIM State | Key Vault Mode | Status |
+|-----------|----------------|-----------------|---------------------|-----------|----------------|--------|
+| <object ID/name> | Managed identity / service principal / user / group | Scope and inheritance | Role/actions/dataActions | Eligible/active/permanent/unknown | RBAC/access policy/n/a | Pass/Fail/Not Evaluable |
 
 ### Prioritized Remediation Plan
 
@@ -200,6 +242,7 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **NSG rules using service tags.** A rule with `source_address_prefix = "Internet"` is equivalent to `0.0.0.0/0`. Both must be flagged for CIS 6.1 and 6.2.
 5. **Key Vault purge protection is irreversible.** CIS 8.5 requires `purge_protection_enabled = true`. Note this cannot be disabled once enabled -- flag this for awareness during remediation.
 6. **App Service TLS version on both Linux and Windows.** Check `azurerm_linux_web_app` and `azurerm_windows_web_app` resources separately.
+7. **Treating role assignment files as effective access.** Role assignments can be inherited from management groups or groups, and managed identities can gain new reach when attached to compute. Require effective assignment exports, PIM activation evidence, and Key Vault mode evidence before closing identity findings.
 
 ---
 
@@ -226,9 +269,13 @@ Produce the final report using the structure defined in the Output Format sectio
 - Azure Key Vault Best Practices: https://learn.microsoft.com/en-us/azure/key-vault/general/best-practices
 - Azure App Service Security: https://learn.microsoft.com/en-us/azure/app-service/overview-security
 - Terraform AzureRM Provider Documentation: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
+- Microsoft Entra Privileged Identity Management: https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/
+- Managed identities for Azure resources: https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview
+- Azure Key Vault RBAC guide: https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-guide
 
 ---
 
 ## Changelog
 
+- **1.0.1** -- Added managed identity, effective access, PIM, and Key Vault mode evidence gates with calibration fixtures.
 - **1.0.0** -- Initial release. Full coverage of CIS Microsoft Azure Foundations Benchmark v2.1.0 sections 1 through 9.

--- a/skills/cloud/azure-review/benchmark-checklist.md
+++ b/skills/cloud/azure-review/benchmark-checklist.md
@@ -95,6 +95,20 @@ resource "azuread_directory_role_assignment" { ... }
 
 #### CIS 1.3.3 -- Ensure that 'Restrict access to Microsoft Entra admin center' is set to 'Yes'
 
+#### Managed Identity, Effective Access, and PIM Evidence Gates
+
+For privileged role assignments, managed identities, service principals, and Key Vault access, capture effective access rather than only static IaC declarations.
+
+| Evidence Area | What to Verify | Risk if Missing |
+|---|---|---|
+| Managed identity scope | User-assigned/system-assigned identity, role, scope, dataActions, and attachable compute resources | High-impact identity may be reusable on new workloads |
+| Effective assignments | Direct, group-inherited, management-group inherited, deny assignments, and custom role actions/dataActions | Subscription-local IaC can miss inherited privilege |
+| PIM activation | Eligible vs active assignment, MFA/authentication strength, approval, justification, duration, alerting, and audit logs | Eligibility may become privileged active access without governance |
+| Key Vault mode | RBAC authorization vs access-policy mode, role assignments or access policies, private endpoint/logging context | RBAC remediation may not affect access-policy-mode vaults |
+| Workload federation | Federated credentials and app registrations that can use or modify the identity path | External workload can activate an assumed safe principal |
+
+Classify Reader or Monitoring Reader at narrow scope as benign when owner and purpose are documented. Flag Owner, User Access Administrator, Privileged Role Administrator, Key Vault Administrator, broad custom roles, or secret/key dataActions without scope reduction, PIM controls, and justification.
+
 ---
 
 ## Section 2 -- Microsoft Defender for Cloud

--- a/skills/cloud/azure-review/tests/managed-identity-pim-edge-cases.md
+++ b/skills/cloud/azure-review/tests/managed-identity-pim-edge-cases.md
@@ -1,0 +1,135 @@
+# Managed Identity and PIM Edge Cases
+
+These fixtures verify that `azure-review` evaluates effective identity access, managed-identity attachability, PIM controls, inherited scope, and Key Vault authorization mode before scoring Azure identity findings.
+
+```yaml
+case_id: AZ-ID-01
+title: Reader managed identity at subscription scope is benign
+principal:
+  type: user_assigned_managed_identity
+  role: Reader
+  scope: subscription
+  data_actions: []
+  owner: app-platform
+attachability:
+  allowed_compute:
+    - app-prod-vmss
+  change_control: MI-2026-044
+expected_classification:
+  status: Benign / least privilege
+  reason: "Reader has no privileged dataActions and the attachable compute/purpose are documented."
+```
+
+```yaml
+case_id: AZ-ID-02
+title: Managed identity has Key Vault Administrator without attachability controls
+principal:
+  type: user_assigned_managed_identity
+  role: Key Vault Administrator
+  scope: /subscriptions/0000/resourceGroups/prod/providers/Microsoft.KeyVault/vaults/payments
+  data_actions:
+    - Microsoft.KeyVault/vaults/secrets/*
+attachability:
+  allowed_compute: unknown
+  assignment_guardrail: missing
+justification: missing
+expected_classification:
+  status: High-impact managed identity
+  severity: High
+  reason: "A workload identity can administer Key Vault secrets without scope justification or attachability controls."
+```
+
+```yaml
+case_id: AZ-ID-03
+title: PIM eligibility lacks activation evidence
+principal:
+  type: user
+  role: Privileged Role Administrator
+  scope: tenant
+pim:
+  state: eligible
+  activation_duration: missing
+  mfa_on_activation: missing
+  approval_required: missing
+  justification_required: missing
+  audit_logs: missing
+expected_classification:
+  status: PIM evidence gap
+  reason: "Eligibility cannot be treated as governed privileged access without activation policy and audit evidence."
+```
+
+```yaml
+case_id: AZ-ID-04
+title: PIM activation is controlled and auditable
+principal:
+  type: group
+  role: User Access Administrator
+  scope: subscription
+pim:
+  state: eligible
+  activation_duration: PT2H
+  authentication_strength: phishing-resistant MFA
+  approval_required: true
+  justification_required: true
+  alerting_enabled: true
+  audit_log_sample: present
+expected_classification:
+  status: Benign / controlled
+  reason: "Privileged activation has duration, strong MFA, approval, justification, alerting, and logs."
+```
+
+```yaml
+case_id: AZ-ID-05
+title: Management-group inherited role is missing from subscription IaC
+principal:
+  type: group
+  role: Owner
+  direct_subscription_assignment: missing
+effective_assignment_export:
+  management_group_inherited: present
+  member_accounts_reviewed: missing
+expected_classification:
+  status: Inherited-scope blind spot
+  severity: Not Evaluable
+  reason: "Subscription-local IaC is insufficient when Owner is inherited from a management group."
+```
+
+```yaml
+case_id: AZ-ID-06
+title: Key Vault access-policy mode makes RBAC-only remediation incomplete
+key_vault:
+  name: legacy-vault
+  enable_rbac_authorization: false
+access_policy:
+  principal: app-sp
+  permissions:
+    secrets:
+      - get
+      - list
+      - set
+rbac_role_assignments: none
+expected_classification:
+  status: Key Vault mode mismatch
+  severity: Medium
+  reason: "The vault uses access policies, so RBAC-only review/remediation will miss effective secret permissions."
+```
+
+```yaml
+case_id: AZ-ID-07
+title: Federated workload credential can use privileged app path
+principal:
+  type: service_principal
+  role: Contributor
+  scope: resource_group
+federated_credentials:
+  issuer: https://token.actions.githubusercontent.com
+  subject: repo:example/payments:ref:refs/heads/main
+controls:
+  branch_protection_evidence: missing
+  environment_approval: missing
+  credential_owner: missing
+expected_classification:
+  status: High-impact managed identity
+  severity: High
+  reason: "Federated workload identity can exercise privileged access without source control and approval evidence."
+```


### PR DESCRIPTION
## Summary

- Adds managed identity, effective access, PIM, and Key Vault mode evidence gates to `azure-review`.
- Extends the Azure checklist with managed identity scope, effective assignments, PIM activation, Key Vault RBAC/access-policy mode, and workload federation evidence.
- Adds seven YAML edge-case fixtures covering benign Reader managed identity, high-impact Key Vault admin identity, PIM eligibility gaps, controlled PIM activation, inherited management-group roles, Key Vault access-policy mode, and federated workload credential risk.

## Validation

- `git diff --check`
- Frontmatter YAML parse passed
- Fixture YAML parse passed: 7 blocks
- Markdown fence balance passed
- Required Azure identity/PIM markers present
- Microsoft reference URLs returned HTTP 200
- ASCII scan passed for new fixture file
- Privacy scan passed for public files

/claim #1175

Payment details can be coordinated privately after maintainer acceptance.
