### PR TITLE
Add firewall rule evidence fixtures

### DIFF
--- a/skills/network/firewall-review/SKILL.md
+++ b/skills/network/firewall-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [operate]
 frameworks: [CIS-Controls-v8, NIST-SP-800-41-Rev1]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -254,7 +254,59 @@ Egress filtering prevents compromised internal hosts from establishing unrestric
 
 ---
 
-### Step 3: Compile Assessment Report
+### Step 3: Rule Evidence Matrix and Confidence
+
+Before assigning severity, build a normalized evidence matrix for material rules. This prevents speculative findings when the available evidence is a mix of IaC, exported firewall configuration, firewall-manager output, runtime counters, flow logs, tickets, and design documentation.
+
+#### 3.1 Evidence Confidence Levels
+
+| Confidence | Evidence Standard |
+|---|---|
+| **High** | Source-controlled configuration or exported device policy plus expanded objects, NAT/security-policy context, and current runtime/log evidence |
+| **Medium** | Exported configuration or IaC plus partial runtime evidence or documented owner/ticket context |
+| **Low** | Design document, screenshot, stale export, or narrative evidence only |
+| **Not Evaluable** | Required policy or runtime evidence is unavailable |
+
+Use Not Evaluable reason codes instead of silently omitting gaps:
+
+| Code | Reason |
+|---|---|
+| `FW-NE-01` | Object groups, address groups, service groups, dynamic tags, or FQDN objects were not expanded |
+| `FW-NE-02` | Runtime counters, last-hit data, or counter reset/failover baseline were unavailable |
+| `FW-NE-03` | NAT, route, or security policy evaluation stage was unavailable |
+| `FW-NE-04` | IPv6 policy was missing or not exported |
+| `FW-NE-05` | Egress path, proxy path, or DNS resolver path could not be confirmed |
+| `FW-NE-06` | Firewall export age or source-of-truth freshness could not be verified |
+| `FW-NE-07` | Rule owner, business justification, expiration, or change-ticket evidence was missing |
+| `FW-NE-08` | Log destination, SIEM ingestion, or rule-level logging evidence was missing |
+
+#### 3.2 Rule Evidence Matrix
+
+| Field | Required Evidence |
+|---|---|
+| Rule ID / position | Rule number, priority, chain position, or policy order |
+| Action and direction | Allow/deny/log action plus ingress, egress, east-west, management-plane, or endpoint direction |
+| Zones and interfaces | Source and destination zone/interface where supported |
+| Source and destination | Raw object name plus expanded IPs, CIDRs, tags, users, workloads, or FQDN resolution timestamp |
+| Service | Protocol, port range, application ID, or service group with expansion status |
+| Owner and ticket | Business owner, change ticket, expiration date, and temporary-access marker |
+| Hit count / last used | Hit count, last-hit timestamp, and counter reset/failover baseline |
+| Logging | Rule-level logging setting, log destination, and SIEM/flow-log proof |
+| NAT / related policy | Pre-NAT/post-NAT context, route dependency, paired NAT rule, or related security policy |
+| Evidence source | IaC path, exported config, firewall manager export, runtime command, flow log, SIEM query, or design document |
+| Confidence | High, Medium, Low, or Not Evaluable |
+| Not Evaluable reason | `FW-NE-*` code and exact evidence needed |
+
+Evidence-driven rules:
+
+- Do not mark a rule unused from hit count alone unless the counter baseline is older than the review window and no failover/reset event invalidates the data.
+- Do not downgrade an any/any rule solely because the object name looks narrow; expand the object group or mark `FW-NE-01`.
+- Do not declare default-deny complete until inbound, outbound, IPv6, and relevant cloud/provider implicit defaults are evaluated or marked Not Evaluable.
+- Do not claim logging coverage from a rule flag alone; confirm log destination or SIEM/flow ingestion when available.
+
+---
+
+### Step 4: Compile Assessment Report
 
 Produce the final report using the following structure.
 
@@ -294,17 +346,24 @@ Produce the final report using the following structure.
 #### [F-001] <Finding Title>
 - **Severity:** Critical / High / Medium / Low
 - **Control Reference:** CIS 4.4 / NIST SP 800-41 Section X.X
+- **Evidence Confidence:** High / Medium / Low / Not Evaluable
 - **File:** <path to config file>
 - **Rule(s):** <rule number(s) or line(s)>
 - **Description:** <what was found>
 - **Evidence:** <specific rule text or configuration snippet>
+- **Not Evaluable Reason:** <FW-NE code, if applicable>
 - **Remediation:** <concrete fix with example>
 
+### Rule Evidence Matrix
+| Rule ID | Action | Direction | Source | Destination | Service | Owner/Ticket | Hit Count / Last Used | Logging | NAT / Related Policy | Evidence Source | Confidence | Not Evaluable Reason |
+|---------|--------|-----------|--------|-------------|---------|--------------|-----------------------|---------|----------------------|-----------------|------------|----------------------|
+
 ### Default Deny Status
-| Direction | Status | Evidence |
-|-----------|--------|----------|
-| Inbound   | Pass/Fail | <rule reference> |
-| Outbound  | Pass/Fail | <rule reference> |
+| Direction | Status | Evidence | Confidence | Not Evaluable Reason |
+|-----------|--------|----------|------------|----------------------|
+| Inbound   | Pass/Fail/Not Evaluable | <rule reference> | <level> | <FW-NE code> |
+| Outbound  | Pass/Fail/Not Evaluable | <rule reference> | <level> | <FW-NE code> |
+| IPv6      | Pass/Fail/Not Evaluable | <rule reference> | <level> | <FW-NE code> |
 
 ### Shadowed Rules Summary
 | Shadowed Rule | Position | Shadowing Rule | Position | Impact |
@@ -361,6 +420,12 @@ Produce the final report using the following structure.
 
 5. **Conflating network ACLs with security groups in cloud environments.** In AWS, NACLs are stateless and operate at the subnet level; security groups are stateful and operate at the instance level. Both must be audited. A permissive NACL can undermine restrictive security group rules for responses.
 
+6. **Treating object names as evidence.** Object groups, address groups, service groups, user groups, FQDN objects, and dynamic tags must be expanded before severity is assigned. Friendly names can hide broad CIDRs, stale hosts, or mixed environments.
+
+7. **Ignoring NAT and route stage.** A security policy may protect pre-NAT addresses while the effective exposure exists after translation or routing. Record the NAT stage and related policy before declaring a rule safe.
+
+8. **Using stale exports as source of truth.** Firewall manager exports, screenshots, and ticket attachments can be outdated. Record export time, source, and confidence; mark `FW-NE-06` when freshness cannot be verified.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -386,4 +451,5 @@ This skill processes firewall configurations that may contain user-supplied comm
 
 ## Changelog
 
+- **1.0.1** -- Added evidence confidence levels, Not Evaluable reason codes, rule evidence matrix fields, and calibration fixtures.
 - **1.0.0** -- Initial release. Full coverage of CIS Controls v8 (4.4, 4.5) and NIST SP 800-41 Rev 1 firewall audit methodology.

--- a/skills/network/firewall-review/tests/rule-evidence-matrix-edge-cases.md
+++ b/skills/network/firewall-review/tests/rule-evidence-matrix-edge-cases.md
@@ -1,0 +1,132 @@
+# Firewall Rule Evidence Matrix Edge Cases
+
+These fixtures verify that `firewall-review` records evidence confidence, object expansion, NAT stage, counter baselines, logging proof, and Not Evaluable reason codes before assigning severity.
+
+```yaml
+case_id: FW-EVID-01
+title: Private east-west HTTPS rule is controlled with high-confidence evidence
+rule:
+  id: sg-private-endpoint
+  action: allow
+  direction: ingress
+  source: 10.20.0.0/16
+  destination: app-private-endpoint
+  service: tcp/443
+evidence:
+  owner: platform-networking
+  ticket: CHG-1842
+  logging: siem_query_present
+  source_of_truth: terraform
+  flow_logs: observed_expected_traffic
+expected_classification:
+  status: Benign / controlled
+  confidence: High
+  reason: "Private source, owner/ticket, logging, and flow evidence support the rule."
+```
+
+```yaml
+case_id: FW-EVID-02
+title: Object group hides broad network member
+rule:
+  id: outside-in-120
+  action: allow
+  source: any
+  destination_object: APP_PROD
+  service: tcp/443
+object_expansion:
+  APP_PROD:
+    - 10.0.0.0/8
+    - 10.2.3.4/32
+expected_classification:
+  status: Overly permissive
+  severity: High
+  confidence: High
+  reason: "Expanded object includes a broad private CIDR behind an inbound permit."
+```
+
+```yaml
+case_id: FW-EVID-03
+title: Missing object expansion blocks severity assignment
+rule:
+  id: outside-in-121
+  action: allow
+  source: any
+  destination_object: TRUSTED_NETS
+  service_group: WEB-SVC
+object_expansion: missing
+service_expansion: missing
+expected_classification:
+  status: Not Evaluable
+  not_evaluable_reason: FW-NE-01
+  reason: "Object and service groups must be expanded before judging exposure."
+```
+
+```yaml
+case_id: FW-EVID-04
+title: Hit count reset makes unused-rule conclusion unsafe
+rule:
+  id: 120
+  action: allow
+  source: any
+  destination: 10.5.10.20
+  service: tcp/22
+runtime_counters:
+  hit_count: 0
+  counter_reset: "2026-06-06T16:00:00Z"
+  review_window_days: 90
+expected_classification:
+  status: Not Evaluable
+  not_evaluable_reason: FW-NE-02
+  reason: "Recent counter reset invalidates zero-hit unused-rule evidence."
+```
+
+```yaml
+case_id: FW-EVID-05
+title: NAT exposes internal service through translated public path
+nat:
+  original_destination: 203.0.113.10
+  original_service: tcp/443
+  translated_destination: 10.0.20.15
+  translated_service: tcp/8443
+security_policy:
+  destination: 10.0.20.15
+  service: tcp/8443
+  action: allow
+expected_classification:
+  status: Public exposure via NAT
+  severity: High
+  confidence: High
+  reason: "Effective internet-facing path is pre-NAT 203.0.113.10:443 to internal tcp/8443."
+```
+
+```yaml
+case_id: FW-EVID-06
+title: IPv6 policy missing while IPv6 is enabled
+platform:
+  ipv6_enabled: true
+exports:
+  ipv4_policy: present
+  ipv6_policy: missing
+expected_classification:
+  status: Not Evaluable
+  not_evaluable_reason: FW-NE-04
+  reason: "IPv6 policy must be reviewed or explicitly disabled before default-deny can pass."
+```
+
+```yaml
+case_id: FW-EVID-07
+title: Logging flag present but SIEM ingestion proof missing
+rule:
+  id: db-permit-44
+  action: allow
+  destination_zone: database
+  service: tcp/5432
+logging:
+  rule_log_end: true
+  log_destination: missing
+  siem_ingestion: missing
+expected_classification:
+  status: Not Evaluable
+  not_evaluable_reason: FW-NE-08
+  reason: "Rule logging flag alone does not prove logs reach a destination or SIEM."
+```


### PR DESCRIPTION
## Summary

Adds a structured rule evidence matrix to `firewall-review` so findings are tied to concrete source-of-truth evidence before severity is assigned.

This includes:
- Evidence confidence levels for source-controlled policy, exported config, runtime/log evidence, screenshots, stale exports, and missing evidence.
- Not Evaluable reason codes for missing object expansion, runtime counters, NAT or route context, IPv6 policy, egress path, export freshness, owner/ticket evidence, and logging proof.
- Output fields for evidence confidence, Not Evaluable reasons, IPv6 default-deny status, and NAT/related policy context.
- Seven YAML calibration fixtures covering controlled private traffic, object-group expansion, missing expansions, counter reset baselines, NAT exposure, missing IPv6 policy, and missing SIEM/log destination proof.

## Validation

- `git diff --check`
- Skill frontmatter YAML parse
- Fixture YAML parse: 7 YAML blocks
- Markdown fence balance check
- Public-file privacy scan

/claim #59

Payment details can be coordinated privately after maintainer acceptance.
