### PR TITLE
Add AWS third-party trust fixtures

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-AWS-v3.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -55,6 +55,7 @@ The CIS Amazon Web Services Foundations Benchmark v3.0.0 is a consensus-driven s
 - S3 bucket policies and ACL configurations
 - VPC, security group, and NACL definitions
 - CloudTrail and CloudWatch configuration files
+- Third-party role trust policies, STS AssumeRole evidence, IAM Access Analyzer findings, role last-used data, and vendor/offboarding records when reviewing external AWS access
 
 ---
 
@@ -152,11 +153,18 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Status:** Pass / Fail / Not Evaluable
 - **Severity:** Critical / High / Medium / Low
 - **CIS Profile:** Level 1 / Level 2
+- **Evidence Confidence:** High / Medium / Low / Not Evaluable
 - **File:** <path to relevant config>
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration or code snippet>
+- **Not Evaluable Reason:** <reason code and exact evidence needed>
 - **Remediation:** <specific fix with code example>
+
+### Third-Party AWS Trust Evidence
+
+| Role | Trusted Principal | ExternalId / Source Constraint | Permission Scope | Last Used | Session Duration | Owner / Contract | Offboarding Status | Status |
+|------|-------------------|--------------------------------|------------------|-----------|------------------|------------------|--------------------|--------|
 
 ### Prioritized Remediation Plan
 
@@ -200,6 +208,9 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
 5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
 6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
+7. **Over-crediting read-only third-party roles.** `SecurityAudit` or `ReadOnlyAccess` can still expose S3 object metadata, CloudTrail, Security Hub, IAM, or secrets inventory. Review sensitive read scope, not only administrator access.
+8. **Missing confused-deputy controls.** Vendor account-root trust needs a vendor-generated `sts:ExternalId`; AWS service principals need service-specific `aws:SourceArn`, `aws:SourceAccount`, `aws:SourceOrgID`, or equivalent constraints where supported.
+9. **Ignoring vendor lifecycle evidence.** A disabled SaaS integration does not remove the AWS role. Require owner, contract, last-used, rotation, and offboarding evidence before passing stale third-party access.
 
 ---
 
@@ -222,6 +233,9 @@ Produce the final report using the structure defined in the Output Format sectio
 - CIS Amazon Web Services Foundations Benchmark v3.0.0: https://www.cisecurity.org/benchmark/amazon_web_services
 - AWS Security Best Practices: https://docs.aws.amazon.com/security/
 - AWS IAM Best Practices: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
+- AWS Confused Deputy Guidance: https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html
+- AWS Third-Party Role Access: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_common-scenarios_third-party.html
+- AWS STS AssumeRole API: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
 - AWS CloudTrail Documentation: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/
 - AWS Security Hub: https://docs.aws.amazon.com/securityhub/latest/userguide/
 - AWS VPC Security: https://docs.aws.amazon.com/vpc/latest/userguide/security.html
@@ -231,4 +245,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Added third-party AssumeRole trust evidence gates, report fields, and calibration fixtures.
 - **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 (62 recommendations).

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -160,6 +160,37 @@ aws_organizations_organization
 
 Look for policies restricting CloudShell access.
 
+### Supplemental IAM Review -- Third-Party AssumeRole Trust Evidence
+
+Review third-party cross-account roles for confused-deputy, lifecycle, and sensitive read-only exposure risk. This supplements CIS Section 1 when an IAM role trusts an external AWS account, vendor, MSP, scanner, SIEM, CSPM, support provider, OIDC provider, SAML provider, or AWS service principal.
+
+Build a third-party AWS trust evidence matrix:
+
+| Field | Required Evidence |
+|---|---|
+| Role and source | Role name, ARN, IaC path, live role export timestamp, and trust policy document |
+| Trusted principal | External AWS account, root/account principal, role ARN, service principal, OIDC/SAML provider, or organization principal |
+| Confused-deputy control | Vendor-generated `sts:ExternalId`, or service-specific `aws:SourceArn`, `aws:SourceAccount`, `aws:SourceOrgID`, `aws:SourceOrgPaths`, audience, subject, and issuer constraints |
+| Permission scope | Attached/inline policies, sensitive read scope, cross-account data exposure, and whether read-only grants expose secrets, CloudTrail, Security Hub, IAM, or S3 inventory |
+| Session controls | `MaxSessionDuration`, session tag requirements, transitive tag limits, and CloudTrail evidence for assumed-role sessions |
+| Lifecycle evidence | Owner, vendor contract, ticket, ExternalId rotation date, role last-used timestamp, and offboarding status |
+| Access Analyzer | Finding status, archive reason, and reviewed external access path |
+| Status | Pass, Fail, or Not Evaluable with reason code |
+
+Use these Not Evaluable codes when evidence is incomplete:
+
+| Code | Reason |
+|---|---|
+| `AWS-TP-NE-01` | Live role trust policy or attached permission export is missing |
+| `AWS-TP-NE-02` | Vendor-generated ExternalId value, uniqueness, or rotation evidence is missing |
+| `AWS-TP-NE-03` | Service principal trust lacks SourceArn/SourceAccount/SourceOrg evidence or applicability proof |
+| `AWS-TP-NE-04` | OIDC or SAML issuer, audience, subject, thumbprint, or claim constraints are missing |
+| `AWS-TP-NE-05` | Role last-used, CloudTrail AssumeRole, or session-duration evidence is missing |
+| `AWS-TP-NE-06` | Owner, contract, ticket, or offboarding evidence is missing |
+| `AWS-TP-NE-07` | Sensitive read-only exposure scope is not documented |
+
+Fail the review when a vendor or third-party account-root principal can assume a role without `sts:ExternalId` or an explicit documented exception. Fail AWS service principal trust when supported confused-deputy conditions are absent. Mark stale vendor roles High when offboarding is complete but the role remains assumable or last-used activity continues after termination.
+
 ---
 
 ## Section 2 -- Storage

--- a/skills/cloud/aws-review/tests/third-party-role-trust-edge-cases.md
+++ b/skills/cloud/aws-review/tests/third-party-role-trust-edge-cases.md
@@ -1,0 +1,145 @@
+# Third-Party AWS Role Trust Edge Cases
+
+These fixtures verify that `aws-review` records ExternalId, source constraints, lifecycle, session, and sensitive read-only exposure evidence before passing third-party AssumeRole trust.
+
+```yaml
+case_id: AWS-TP-01
+title: Vendor scanner role has ExternalId and lifecycle evidence
+trust_policy:
+  principal: arn:aws:iam::123456789012:root
+  action: sts:AssumeRole
+  condition:
+    StringEquals:
+      sts:ExternalId: vendor-generated-customer-guid
+permissions:
+  managed_policies:
+    - SecurityAudit
+session:
+  max_session_duration_seconds: 3600
+evidence:
+  owner: cloud-security
+  contract: VRM-2026-044
+  external_id_rotation: "2026-05-01"
+  role_last_used: "2026-06-01T10:00:00Z"
+  access_analyzer_status: reviewed
+expected_classification:
+  status: Pass
+  confidence: High
+  reason: "ExternalId, owner, contract, rotation, session duration, and reviewed external access evidence are present."
+```
+
+```yaml
+case_id: AWS-TP-02
+title: Vendor account root trust lacks ExternalId
+trust_policy:
+  principal: arn:aws:iam::123456789012:root
+  action: sts:AssumeRole
+  condition: {}
+permissions:
+  managed_policies:
+    - SecurityAudit
+    - ReadOnlyAccess
+expected_classification:
+  status: Fail
+  severity: High
+  confidence: High
+  reason: "Third-party account-root trust without sts:ExternalId exposes confused-deputy risk even when permissions are read-only."
+```
+
+```yaml
+case_id: AWS-TP-03
+title: Stale vendor role remains assumable after contract termination
+trust_policy:
+  principal: arn:aws:iam::123456789012:root
+  condition:
+    StringEquals:
+      sts:ExternalId: vendor-generated-customer-guid
+lifecycle:
+  contract_status: terminated
+  offboarding_ticket: complete
+  role_last_used: "2026-06-05T12:00:00Z"
+  termination_date: "2026-05-31"
+expected_classification:
+  status: Fail
+  severity: High
+  confidence: High
+  reason: "Role remained assumable and active after vendor offboarding completed."
+```
+
+```yaml
+case_id: AWS-TP-04
+title: AWS service principal lacks SourceArn and SourceAccount constraints
+trust_policy:
+  principal:
+    Service: cloudtrail.amazonaws.com
+  action: sts:AssumeRole
+  condition: {}
+service_context:
+  expected_source_account: "111122223333"
+  expected_source_arn: arn:aws:cloudtrail:us-east-1:111122223333:trail/org-trail
+expected_classification:
+  status: Not Evaluable
+  not_evaluable_reason: AWS-TP-NE-03
+  reason: "Service-principal confused-deputy applicability or SourceArn/SourceAccount evidence is missing."
+```
+
+```yaml
+case_id: AWS-TP-05
+title: OIDC role allows broad subject and audience
+trust_policy:
+  federated_principal: arn:aws:iam::111122223333:oidc-provider/token.actions.githubusercontent.com
+  action: sts:AssumeRoleWithWebIdentity
+  condition:
+    StringLike:
+      token.actions.githubusercontent.com:sub: repo:example-org/*:*
+    StringEquals:
+      token.actions.githubusercontent.com:aud: sts.amazonaws.com
+expected_classification:
+  status: Fail
+  severity: High
+  confidence: Medium
+  reason: "OIDC subject allows every repository in the organization instead of the intended repo, branch, or environment."
+```
+
+```yaml
+case_id: AWS-TP-06
+title: Long vendor session duration lacks CloudTrail session review
+trust_policy:
+  principal: arn:aws:iam::123456789012:root
+  condition:
+    StringEquals:
+      sts:ExternalId: vendor-generated-customer-guid
+session:
+  max_session_duration_seconds: 43200
+evidence:
+  cloudtrail_assume_role_review: missing
+  session_tags_required: false
+expected_classification:
+  status: Not Evaluable
+  not_evaluable_reason: AWS-TP-NE-05
+  reason: "Long vendor sessions need AssumeRole activity and session-control evidence before acceptance."
+```
+
+```yaml
+case_id: AWS-TP-07
+title: Read-only vendor scope includes sensitive inventories without review
+trust_policy:
+  principal: arn:aws:iam::123456789012:root
+  condition:
+    StringEquals:
+      sts:ExternalId: vendor-generated-customer-guid
+permissions:
+  managed_policies:
+    - ReadOnlyAccess
+  sensitive_read_scope:
+    - s3_inventory
+    - cloudtrail_events
+    - securityhub_findings
+    - secretsmanager_metadata
+evidence:
+  data_exposure_review: missing
+expected_classification:
+  status: Not Evaluable
+  not_evaluable_reason: AWS-TP-NE-07
+  reason: "Read-only access can expose sensitive security and data inventory and needs documented scope review."
+```


### PR DESCRIPTION
## Summary

Adds AWS-specific third-party AssumeRole trust evidence gates to `aws-review`.

This includes:
- A third-party AWS trust evidence table covering trusted principal scope, ExternalId/source constraints, permission scope, session duration, last-used data, owner/contract evidence, Access Analyzer review, and offboarding status.
- Not Evaluable reason codes for missing live role exports, ExternalId rotation evidence, service-principal source constraints, OIDC/SAML claim constraints, AssumeRole/session evidence, lifecycle records, and sensitive read-only exposure scope.
- Report output fields for evidence confidence and Not Evaluable reasons.
- Seven YAML calibration fixtures covering valid vendor ExternalId evidence, missing ExternalId, stale post-offboarding access, missing SourceArn/SourceAccount constraints, broad OIDC subjects, long vendor sessions, and sensitive read-only exposure.

## Validation

- `git diff --check`
- Skill frontmatter YAML parse
- Fixture YAML parse: 7 YAML blocks
- Markdown fence balance check
- Public-file privacy scan
- AWS documentation references checked for confused deputy, third-party role access, and STS AssumeRole

/claim #1330

Payment details can be coordinated privately after maintainer acceptance.
