### PR TITLE
Add secrets bootstrap recovery gates

### DIFF
--- a/skills/devsecops/secrets-management/SKILL.md
+++ b/skills/devsecops/secrets-management/SKILL.md
@@ -6,7 +6,8 @@ description: >
   Key Management). Auto-invoked when reviewing secret handling patterns, vault
   configurations, .env files, or credential rotation policies. Produces a secrets
   management assessment covering detection patterns, rotation automation, vault
-  integration, and agent-specific credential handling.
+  integration, bootstrap identity, recovery paths, and agent-specific credential
+  handling.
 tags: [devsecops, secrets, vault, rotation]
 role: [security-engineer, devsecops]
 phase: [build, operate]
@@ -85,9 +86,17 @@ Use Glob and Grep to locate files that commonly contain or reference secrets.
 
 # Vault and secrets manager configurations
 **/vault*
+**/vault/**/*.hcl
+**/vault/**/*.json
 **/*-secret*
 **/external-secrets*
 **/sealed-secrets*
+**/workload-identity*
+**/oidc*
+**/federation*
+**/break-glass*
+**/breakglass*
+**/recovery*
 
 # CI/CD configuration (may reference secrets)
 **/.github/workflows/*.yml
@@ -352,13 +361,75 @@ spec:
 
 ---
 
+### Step 5.5: Bootstrap Secret-Zero and Recovery Evidence
+
+Centralized secret storage does not remove the need for an initial bootstrap identity. Review how the first credential is obtained, scoped, rotated, and recovered after compromise.
+
+#### 5.5.1 Secret-Zero Source and Constraints
+
+Inventory every bootstrap path that allows a workload, pipeline, or agent to retrieve secrets from Vault or a cloud secrets manager.
+
+**Safe patterns to verify:**
+
+- OIDC or workload identity federation is used instead of a long-lived bootstrap token.
+- Trust policy is constrained by issuer, audience, repository/project, branch or tag, environment, namespace, and service account where applicable.
+- The bootstrap identity can retrieve only the specific secret paths needed by the workload.
+- Bootstrap material is not baked into container images, VM images, repo files, Terraform state, CI variables, or runbooks.
+
+**Risky patterns to flag:**
+
+```sh
+# BAD: long-lived bootstrap token read from disk and used to fetch all secrets
+VAULT_TOKEN=$(cat /var/run/bootstrap-token)
+vault kv get -format=json secret/prod/*
+```
+
+```yaml
+# BAD: unconstrained workload identity condition
+workload_identity:
+  enabled: true
+  allowed_repositories: ["*"]
+  allowed_branches: ["*"]
+  vault_policy: "prod-read-all"
+```
+
+**Finding classification:** Long-lived bootstrap material that can retrieve broad secret paths is **High**. Bootstrap credentials baked into images or committed files are **Critical** if still valid. Workload identity without issuer/audience/subject constraints is **High**.
+
+#### 5.5.2 Bootstrap Token TTL, Rotation, and Revocation
+
+For each bootstrap mechanism, verify:
+
+- Token TTL matches the bootstrap window and is not reused as a runtime credential.
+- Failed bootstrap attempts trigger logging, alerting, and revocation where supported.
+- Bootstrap credentials rotate automatically after image build, deploy, or incident recovery.
+- Vault AppRole secret IDs, Kubernetes service account tokens, and CI OIDC sessions are single-use or short-lived where feasible.
+- Audit logs show which workload identity retrieved which secret path.
+
+**Finding classification:** Bootstrap token TTL exceeding the deployment window by more than 10x is **Medium**. No revocation path after failed bootstrap or suspected compromise is **High**.
+
+#### 5.5.3 Recovery and Break-Glass Custody
+
+Break-glass credentials are secrets and must be reviewed as such.
+
+Verify:
+
+- Break-glass credentials are stored in a dedicated emergency access system or sealed escrow, not in PDFs, tickets, wikis, or shared drives.
+- Access requires dual control or explicit approval, and every retrieval is logged.
+- The runbook names an owner, test cadence, expiration/rotation cadence, and post-use rotation steps.
+- Recovery drills prove the credential works without exposing the value in logs or screenshots.
+- Post-incident recovery includes revocation of old bootstrap tokens and re-seeding of workload identities.
+
+**Finding classification:** Break-glass passwords in documents, screenshots, or tickets are **Critical** if usable. Missing owner/test/rotation evidence is **High** for production systems and **Medium** for lower environments.
+
+---
+
 ## Findings Classification
 
 | Severity | Definition |
 |----------|-----------|
-| **Critical** | Committed secrets in current codebase or git history (unrotated); no secret detection tooling; .env with production credentials committed. |
-| **High** | No centralized secrets manager; no rotation automation; long-lived static credentials for agents; secrets in CI logs; no git history scanning; audit logging disabled on vault. |
-| **Medium** | Detection in CI only (no pre-commit); manual rotation process; excessive detection allowlists; token TTL mismatch; rotation not monitored; plaintext secrets in environment variables (vs. vault injection). |
+| **Critical** | Committed secrets in current codebase or git history (unrotated); no secret detection tooling; .env with production credentials committed; valid bootstrap or break-glass credentials stored in images, docs, tickets, or repo files. |
+| **High** | No centralized secrets manager; no rotation automation; long-lived static credentials for agents; unconstrained bootstrap identity; broad secret-zero policy; missing break-glass owner/test/rotation evidence; secrets in CI logs; no git history scanning; audit logging disabled on vault. |
+| **Medium** | Detection in CI only (no pre-commit); manual rotation process; excessive detection allowlists; token TTL mismatch; rotation not monitored; missing bootstrap revocation evidence; plaintext secrets in environment variables (vs. vault injection). |
 | **Low** | Missing secret type documentation; secret naming convention inconsistencies; development-only secrets in non-.gitignored example files. |
 
 ---
@@ -388,6 +459,13 @@ spec:
 | DB credentials | Vault dynamic | On-demand | Yes | N/A (dynamic) |
 | API key (Stripe) | AWS SM | 90 days | Yes | 2024-01-15 |
 | TLS cert | cert-manager | 60 days | Yes | Auto |
+
+### Bootstrap and Recovery Evidence
+
+| Workload/Pipeline | Bootstrap Method | Constraints Verified | TTL | Secret Scope | Recovery Evidence |
+|-------------------|------------------|----------------------|-----|--------------|-------------------|
+| deploy-prod | GitHub OIDC to Vault JWT auth | repo, branch, environment, audience | 15m | `secret/prod/payments/*` | dual-control break-glass tested quarterly |
+| legacy-worker | file-mounted bootstrap token | none | 30d | `secret/prod/*` | runbook password, no owner |
 
 ### Findings
 
@@ -442,6 +520,12 @@ spec:
 
 4. **Ignoring secret sprawl across multiple secrets managers.** Large organizations often have Vault, AWS Secrets Manager, Azure Key Vault, and application-specific secret stores running simultaneously. Without a unified inventory, secrets expire unmonitored and rotation gaps emerge. Maintain a single source of truth for secret metadata (type, owner, rotation schedule, storage location).
 
+5. **Treating workload identity as automatically safe.** OIDC and workload identity federation are only safe when trust policies are constrained. A wildcard repository, branch, namespace, or service account can become a broad secret-zero path.
+
+6. **Centralizing secrets but ignoring the first credential.** Vault, cloud secret managers, and External Secrets still need an initial identity. Reviewers must verify how that bootstrap identity is delivered, scoped, expired, and revoked.
+
+7. **Break-glass credentials without recovery drills.** A sealed emergency credential that is never tested may fail during an incident; a tested credential that is not rotated after use becomes a long-lived backdoor.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -465,11 +549,16 @@ This skill processes configuration files and code that may contain secret values
 - TruffleHog: https://github.com/trufflesecurity/trufflehog
 - detect-secrets: https://github.com/Yelp/detect-secrets
 - HashiCorp Vault Documentation: https://developer.hashicorp.com/vault/docs
+- HashiCorp Vault AppRole Auth Method: https://developer.hashicorp.com/vault/docs/auth/approle
+- HashiCorp Vault JWT/OIDC Auth Method: https://developer.hashicorp.com/vault/docs/auth/jwt
+- GitHub Actions OIDC Hardening: https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect
+- Kubernetes Service Account Tokens: https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/
 - External Secrets Operator: https://external-secrets.io/
 
 ---
 
 ## Changelog
 
+- **1.1.0** -- Add bootstrap secret-zero and break-glass recovery evidence gates.
 - **1.0.1** -- Add false positive filtering guidance: distinguish real secrets from placeholders/examples, verify entropy, scope findings to actual secrets (not architectural gaps).
 - **1.0.0** -- Initial release. Full coverage of OWASP Secrets Management Cheat Sheet and NIST SP 800-57 Part 1 Rev 5 for secrets management review.

--- a/skills/devsecops/secrets-management/tests/benign/oidc-bootstrap-recovery-evidence.md
+++ b/skills/devsecops/secrets-management/tests/benign/oidc-bootstrap-recovery-evidence.md
@@ -1,0 +1,64 @@
+# Benign: constrained OIDC bootstrap with tested recovery evidence
+
+This fixture should pass the bootstrap and recovery gates because the pipeline
+uses OIDC to obtain short-lived Vault access, trust conditions are constrained,
+and break-glass recovery evidence is documented without exposing credential
+values.
+
+```yaml
+github_actions_oidc:
+  issuer: https://token.actions.githubusercontent.com
+  audience: vault://prod-secrets
+  subject: repo:example/payments:environment:production
+  branch: refs/heads/main
+  workflow: .github/workflows/deploy.yml
+
+vault_jwt_role:
+  role: payments-prod-deploy
+  bound_audiences:
+    - vault://prod-secrets
+  bound_subject: repo:example/payments:environment:production
+  bound_claims:
+    repository: example/payments
+    ref: refs/heads/main
+    environment: production
+  token_ttl: 15m
+  token_max_ttl: 20m
+  policies:
+    - payments-prod-read
+```
+
+```hcl
+path "secret/data/prod/payments/*" {
+  capabilities = ["read"]
+}
+
+path "secret/data/prod/*" {
+  capabilities = ["deny"]
+}
+```
+
+```yaml
+bootstrap_controls:
+  revocation_on_failed_bootstrap: true
+  audit_log_sink: siem-prod
+  token_reuse_allowed: false
+  image_contains_bootstrap_material: false
+
+break_glass:
+  storage: sealed emergency access vault
+  approval: two-person review
+  owner: security-operations
+  last_tested: 2026-05-30
+  rotation_after_use: required within 1h
+  credential_value_recorded_here: false
+```
+
+Expected result:
+
+- Pass: bootstrap identity is short-lived and constrained by issuer, audience,
+  repository, branch, environment, and workflow.
+- Pass: Vault policy scopes access to the workload-specific secret path.
+- Pass: failed bootstrap revocation and audit evidence are present.
+- Pass: break-glass custody, owner, test cadence, and post-use rotation are
+  documented without exposing a secret value.

--- a/skills/devsecops/secrets-management/tests/vulnerable/long-lived-bootstrap-token.md
+++ b/skills/devsecops/secrets-management/tests/vulnerable/long-lived-bootstrap-token.md
@@ -1,0 +1,42 @@
+# Vulnerable: long-lived bootstrap token and unowned break-glass recovery
+
+This fixture should be flagged by the secrets-management skill because the
+workload uses file-mounted bootstrap material with broad secret access and
+documents break-glass recovery without custody, owner, test, or rotation
+evidence. Placeholder strings are used; no real secret value is included.
+
+```dockerfile
+FROM node:22-alpine
+COPY bootstrap-token /var/run/bootstrap-token
+RUN chmod 0400 /var/run/bootstrap-token
+CMD ["node", "server.js"]
+```
+
+```sh
+# Entrypoint snippet
+VAULT_TOKEN=$(cat /var/run/bootstrap-token)
+vault kv get -format=json secret/prod/*
+```
+
+```yaml
+vault_bootstrap:
+  auth_method: static_token
+  token_ttl: 30d
+  policy: prod-read-all
+  revocation_on_failed_bootstrap: false
+  audit_log_sink: disabled
+
+break_glass:
+  storage: runbook.pdf
+  owner: ""
+  last_tested: ""
+  rotation_after_use: ""
+```
+
+Expected findings:
+
+- Critical: bootstrap material is copied into the image filesystem.
+- High: bootstrap token is long-lived and grants broad `secret/prod/*` access.
+- High: failed bootstrap attempts do not trigger revocation or audit logging.
+- High: break-glass recovery has no owner, test evidence, or post-use rotation
+  plan.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

Closes #1577

### Skill Modified
**Skill name:** secrets-management
**Skill path:** `skills/devsecops/secrets-management/`

### What Was Wrong
The skill covered secret detection, rotation, vault integration, and agent credential handling, but did not explicitly require review evidence for the first credential used to reach the secrets manager. That can miss realistic secret-zero failures: file-mounted bootstrap tokens, unconstrained workload identity, broad Vault policies, missing revocation after failed bootstrap, and break-glass credentials stored in runbooks without owner/test/rotation evidence.

### What This PR Fixes
This PR adds bootstrap and recovery gates for:

- Secret-zero source inventory and workload identity constraints.
- Long-lived bootstrap tokens, image-baked bootstrap material, and broad secret path policies.
- Bootstrap TTL, reuse, failed-attempt revocation, and audit logging evidence.
- Break-glass custody, dual-control/approval, recovery drill, and post-use rotation evidence.

It also expands discovery patterns, severity guidance, output reporting, common pitfalls, and references for Vault AppRole/JWT auth, GitHub OIDC hardening, and Kubernetes service account token handling.

### Evidence
**Before (skill misses this):**

```sh
VAULT_TOKEN=$(cat /var/run/bootstrap-token)
vault kv get -format=json secret/prod/*
```

```yaml
vault_bootstrap:
  auth_method: static_token
  token_ttl: 30d
  policy: prod-read-all
  revocation_on_failed_bootstrap: false
  audit_log_sink: disabled

break_glass:
  storage: runbook.pdf
  owner: ""
  last_tested: ""
  rotation_after_use: ""
```

**After (now correctly handled):**

```yaml
github_actions_oidc:
  issuer: https://token.actions.githubusercontent.com
  audience: vault://prod-secrets
  subject: repo:example/payments:environment:production
  branch: refs/heads/main

vault_jwt_role:
  token_ttl: 15m
  token_max_ttl: 20m
  bound_claims:
    repository: example/payments
    ref: refs/heads/main
    environment: production
  policies:
    - payments-prod-read
```

### Test Cases Added/Updated
- [x] Added vulnerable test case: `skills/devsecops/secrets-management/tests/vulnerable/long-lived-bootstrap-token.md`
- [x] Added benign test case: `skills/devsecops/secrets-management/tests/benign/oidc-bootstrap-recovery-evidence.md`
- [x] Existing checks still pass locally for changed files

### Bounty Tier
- [ ] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Validation
- `git diff --check`
- `git diff --cached --check`
- `rg -n "Step 5\.5|secret-zero|break-glass|Bootstrap and Recovery|OIDC|revocation|VAULT_TOKEN" skills/devsecops/secrets-management`
- Injection-pattern scan over `skills/devsecops/secrets-management` returned no matches for the repository's prohibited phrases.

### Bounty Info
Bounty target: skill improvement, moderate tier. Payment details can be provided privately after maintainer acceptance.
