### PR TITLE
Add SOC 2 subservice and CUEC evidence gates

### DIFF
--- a/skills/compliance/soc2-gap/SKILL.md
+++ b/skills/compliance/soc2-gap/SKILL.md
@@ -112,6 +112,16 @@ System Description Boundary:
 - Data: ___
 ```
 
+#### 1.4 Subservice Organization Scope Matrix
+
+For every critical provider in the system boundary, classify whether it is a vendor, carved-out subservice organization, or included subservice organization. Collecting a vendor SOC 2 report is not enough for readiness; the system description must show which controls are operated by the service organization, which controls are relied on at the provider, and which complementary controls remain the customer's responsibility.
+
+| Provider | System dependency | Data touched | Role | Reporting method | Controls relied on | CUECs/CSOCs mapped | Report period coverage |
+|----------|-------------------|--------------|------|------------------|--------------------|--------------------|------------------------|
+| [AWS/Stripe/Okta/etc.] | [hosting/payment/idp/etc.] | [none/PII/confidential/etc.] | [vendor/carved-out subservice/included subservice] | [carve-out/inclusive/N/A] | [criteria/control areas] | [Yes/No/Partial] | [covered/bridge letter needed/gap] |
+
+Mark vendor-management readiness as provisional when a critical provider has no documented subservice method, no CUEC/CSOC mapping, or a vendor report period that does not cover the observation period.
+
 ---
 
 ### Step 2: Common Criteria Review (CC1-CC9)
@@ -366,8 +376,10 @@ When performing a SOC 2 gap analysis, produce the following deliverables:
 3. **Category Summary**: Average maturity score per category with narrative assessment.
 4. **Critical Findings**: List of all criteria scored 0 or 1, with specific gap descriptions and remediation recommendations.
 5. **Evidence Checklist**: Customized evidence requirements based on in-scope criteria, marking items as Exists / Partial / Missing.
-6. **90-Day Remediation Roadmap**: Prioritized action items with owners, deadlines, and dependencies.
-7. **Overall Readiness Assessment**: Go/no-go recommendation for engaging a SOC 2 auditor.
+6. **Subservice Organization Matrix**: Provider role, reporting method, controls relied on, report period coverage, and readiness gaps for every critical service provider.
+7. **CUEC/CSOC Mapping Worksheet**: Complementary User Entity Controls and Complementary Subservice Organization Controls mapped to internal control owners, frequencies, and evidence artifacts.
+8. **90-Day Remediation Roadmap**: Prioritized action items with owners, deadlines, and dependencies.
+9. **Overall Readiness Assessment**: Go/no-go recommendation for engaging a SOC 2 auditor.
 
 ## Prompt Injection Safety Notice
 

--- a/skills/compliance/soc2-gap/tsc-criteria.md
+++ b/skills/compliance/soc2-gap/tsc-criteria.md
@@ -327,17 +327,37 @@ This file contains the detailed Trust Services Criteria evaluation questions, ev
   - Is there a vendor management program?
   - Are vendors assessed for security risk before onboarding?
   - Are vendor SOC 2 reports or equivalent assurance reports collected and reviewed?
+  - For each critical service provider, is it classified as a vendor, carved-out subservice organization, or included subservice organization in the system description?
+  - Has the reviewer extracted CUECs and CSOCs from vendor SOC reports and mapped each one to an internal control owner, frequency, and evidence artifact?
+  - Does each vendor report period cover the SOC 2 observation period, or is a bridge letter or other current assurance evidence documented?
+  - Were report opinions, exceptions, relevant criteria, complementary controls, and nested subservice carve-outs reviewed before scoring vendor-management readiness?
 - Evidence to look for:
   - Vendor management policy
   - Vendor risk assessment questionnaires (completed)
   - Vendor SOC 2 report review records
   - Vendor inventory with risk classifications
   - Contract provisions for security requirements (data processing agreements, BAAs)
+  - Subservice organization scope matrix with provider role, data touched, control reliance, and carve-out or inclusive method
+  - CUEC/CSOC extraction worksheet mapped to internal control IDs, owners, frequencies, and evidence artifacts
+  - Vendor report period coverage check, bridge letters, or current assurance alternatives for observation-period gaps
+  - Review notes for vendor report opinion, exceptions, relevant TSC criteria, nested subservice organizations, and residual risks
 - Common gaps:
   - No formal vendor management program
   - Vendor SOC 2 reports are not collected or reviewed
   - No vendor risk assessment performed prior to onboarding
   - Contracts lack security and data protection provisions
+  - Critical providers have vendor SOC 2 PDFs on file but no documented subservice method or system-description treatment
+  - CUECs or CSOCs from vendor reports are not mapped to internal controls, owners, frequencies, or evidence
+  - Vendor report periods do not align with the observation period and no bridge letter or current assurance evidence is retained
+  - Cloud shared-responsibility controls are assumed to be covered by the provider even though customer IAM, logging, encryption, backup, or network controls remain internal responsibilities
+
+**Subservice and complementary-control worksheet:**
+
+| Provider | Role | Method | Report period | Bridge coverage | CUEC/CSOC | Internal control owner | Evidence artifact | Readiness impact |
+|----------|------|--------|---------------|-----------------|-----------|------------------------|-------------------|------------------|
+| [AWS/Stripe/Okta/etc.] | [vendor/carved-out/included] | [N/A/carve-out/inclusive] | [dates] | [none/letter/alternative] | [control text] | [team/person] | [policy/ticket/log/review] | [ready/provisional/gap] |
+
+Score CC9.2 as provisional or incomplete when critical providers lack subservice classification, complementary-control mapping, or report-period coverage, even if annual vendor SOC 2 reports were collected.
 
 ---
 
@@ -553,7 +573,7 @@ After scoring, calculate:
 | CC7.5 | DR plan; BC plan; backup configs; backup restoration test records |
 | CC8.1 | Change management policy; CI/CD pipeline configs with approval gates; PR review records; CAB minutes; segregation of duties evidence |
 | CC9.1 | Risk treatment plans; business impact analysis; risk acceptance sign-off records |
-| CC9.2 | Vendor management policy; vendor risk assessments; vendor SOC 2 review records; vendor inventory; DPAs/BAAs |
+| CC9.2 | Vendor management policy; vendor risk assessments; vendor SOC 2 review records including opinion/exceptions/period/criteria; vendor inventory; subservice organization scope matrix; CUEC/CSOC mapping worksheet; bridge letters or current assurance alternatives; DPAs/BAAs |
 | A1.1 | Capacity monitoring dashboards; auto-scaling configs; capacity planning documentation |
 | A1.2 | Backup policy with RPO/RTO; backup monitoring records; restoration test results; redundancy configs |
 | A1.3 | DR test plan; DR test execution records; DR test findings and remediation |


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** soc2-gap
**Skill path:** `skills/compliance/soc2-gap/`

### What Was Wrong
The skill asked reviewers to collect and review vendor SOC 2 reports, but it did not require the SOC 2 scoping mechanics that make those reports audit-useful. A readiness packet could look green while critical providers had no subservice method, no CUEC/CSOC mapping, and no report-period coverage for the observation period.

Specific gaps from #1124:

- Critical providers were not classified as vendors, carved-out subservice organizations, or included subservice organizations.
- Vendor SOC 2 CUECs/CSOCs were not required to be extracted and mapped to internal control owners, frequencies, and evidence artifacts.
- Vendor report periods, bridge letters, opinions, exceptions, relevant criteria, and nested subservice carve-outs were not part of CC9.2 evidence expectations.

### What This PR Fixes
Refs #1124.

This PR updates the SOC 2 readiness workflow to add:

- A `Subservice Organization Scope Matrix` in the main scope step.
- Readiness calibration that marks vendor-management readiness provisional when subservice method, CUEC/CSOC mapping, or report-period coverage is missing.
- CC9.2 questions for provider classification, CUEC/CSOC extraction, report-period coverage, bridge letters, opinions, exceptions, criteria coverage, and nested subservice carve-outs.
- CC9.2 evidence requirements for subservice scope matrix, complementary-control worksheet, bridge letters/current assurance alternatives, and residual-risk notes.
- CC9.2 common gaps for vendor SOC 2 PDFs without subservice treatment, unmapped CUECs/CSOCs, report-period gaps, and cloud shared-responsibility assumptions.
- Output deliverables for the subservice matrix and CUEC/CSOC mapping worksheet.
- Evidence artifact mapping updates for CC9.2.

### Evidence
**Before (skill misses this / false positive on this):**
```yaml
vendors:
  - name: AWS
    soc2_report_collected: true
    report_period: "2025-01-01 to 2025-12-31"
    subservice_method: "not documented"
    complementary_subservice_controls: []
    cuecs_mapped_to_internal_controls: false
controls:
  cc9_2_vendor_reviews: "Vendor SOC 2 reports collected annually"
```
The prior workflow could score vendor management as substantially complete because the vendor report existed.

**After (now correctly handled):**
```text
The reviewer must classify each critical provider as vendor, carved-out
subservice, or included subservice; verify report-period coverage or bridge
letters; extract CUECs/CSOCs; map each complementary control to an internal owner,
frequency, and evidence artifact; and mark readiness provisional/incomplete when
those pieces are missing.
```

### Test Cases Added/Updated
- [x] Added inline evidence gates, matrix fields, and explicit gap conditions in `SKILL.md` and `tsc-criteria.md`.
- [x] Existing documentation structure still validates.
- [ ] Did not add a separate `tests/` directory because this skill currently uses Markdown guidance files.

### Validation
- `git diff --check` -> no whitespace errors; Windows Git emitted only the existing LF/CRLF warning.
- Marker grep confirmed `Subservice Organization Scope Matrix`, `CUEC`, `CSOC`, `bridge letter`, `carved-out`, `included subservice`, `report period coverage`, and `provisional` are present.
- Markdown fence balance check -> `SKILL.md fence_count=2`, `tsc-criteria.md fence_count=2`, both even.
- Frontmatter smoke check confirmed `name`, `version`, `allowed-tools`, and `injection-hardened` remain present.
- `git diff --stat` -> two files changed, 35 insertions, 3 deletions.

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Crypto; details can be provided privately after maintainer acceptance.
