### PR TITLE
Add GCP audit log export integrity gates

### DIFF
--- a/skills/cloud/gcp-review/SKILL.md
+++ b/skills/cloud/gcp-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-GCP-v2.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -86,6 +86,8 @@ Evaluate all GCP configurations against CIS GCP v2.0.0 Sections 1 through 7, cov
 
 For detailed CIS benchmark checklist items with specific Terraform patterns, grep patterns, and configuration examples for all seven sections, see [benchmark-checklist.md](benchmark-checklist.md) in this skill directory.
 
+For Section 2 logging controls, do not stop at the existence of audit logging or a log sink resource. Verify the complete audit-log export path: sink scope, sink filters and exclusions, `_Default` bucket exclusions, destination IAM, retention lock or equivalent immutability, CMEK/default KMS where policy requires it, and a sample security-relevant audit event observed at the destination or explicitly marked Not Evaluable.
+
 ---
 
 ### Step 9: Compile Assessment Report
@@ -150,6 +152,12 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Evidence:** <specific configuration or code snippet>
 - **Remediation:** <specific fix with code example>
 
+### Logging Export Integrity
+
+| Scope | Sink | Filter / Exclusions | Destination | Destination IAM | Retention / Lock | CMEK / KMS | Sample Event at Destination | Status |
+|-------|------|---------------------|-------------|-----------------|------------------|------------|-----------------------------|--------|
+| project/folder/org | <sink name> | <all logs or documented filter> | <bucket/topic/dataset> | <least privilege evidence> | <duration + locked/equivalent> | <key evidence or N/A> | <event id/query or Not Evaluable> | Pass/Fail/Not Evaluable |
+
 ### Prioritized Remediation Plan
 
 1. **[Critical]** CIS X.Y -- <action item>
@@ -193,7 +201,8 @@ Produce the final report using the structure defined in the Output Format sectio
 3. **VPC flow logs must be per-subnet.** CIS 3.8 requires flow logs on every subnet, not just the VPC. Each `google_compute_subnetwork` must have a `log_config` block.
 4. **Cloud SQL authorized_networks vs. private IP.** CIS 6.5 flags `0.0.0.0/0` in authorized networks, but CIS 6.6 goes further and recommends disabling public IP entirely in favor of private networking.
 5. **BigQuery dataset-level vs. table-level CMEK.** CIS 7.2 checks table-level encryption, while CIS 7.3 checks the dataset default. Both should be evaluated independently.
-6. **Default compute service account identification.** The default SA follows the pattern `PROJECT_NUMBER-compute@developer.gserviceaccount.com`. Grep for this pattern, not just the string "default."
+6. **Assuming log export works because a sink exists.** A `google_logging_*_sink` resource is only the start of the evidence chain. Review sink filters, exclusions, `_Default` bucket exclusions, destination IAM, retention immutability, CMEK requirements, and at least one destination-observed audit event before marking logging export controls healthy.
+7. **Default compute service account identification.** The default SA follows the pattern `PROJECT_NUMBER-compute@developer.gserviceaccount.com`. Grep for this pattern, not just the string "default."
 
 ---
 
@@ -217,6 +226,8 @@ Produce the final report using the structure defined in the Output Format sectio
 - Google Cloud Security Best Practices: https://cloud.google.com/security/best-practices
 - Google Cloud IAM Documentation: https://cloud.google.com/iam/docs
 - Google Cloud Audit Logs: https://cloud.google.com/logging/docs/audit
+- Google Cloud aggregated sinks and exclusions: https://cloud.google.com/logging/docs/export/aggregated_sinks
+- Google Cloud log bucket retention: https://cloud.google.com/logging/docs/buckets
 - Google Cloud VPC Documentation: https://cloud.google.com/vpc/docs
 - Google Cloud SQL Security: https://cloud.google.com/sql/docs/mysql/configure-ssl-instance
 - Terraform Google Provider Documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs
@@ -225,4 +236,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.1.0** -- Add logging export integrity gates for sink scope, exclusions, destination IAM, retention, CMEK, and destination sample-event evidence.
 - **1.0.0** -- Initial release. Full coverage of CIS Google Cloud Platform Foundation Benchmark v2.0.0 sections 1 through 7.

--- a/skills/cloud/gcp-review/benchmark-checklist.md
+++ b/skills/cloud/gcp-review/benchmark-checklist.md
@@ -208,6 +208,56 @@ resource "google_logging_project_sink" {
 }
 ```
 
+**Export integrity evidence gates:**
+
+| Gate | Pass Evidence | Fail / Not Evaluable Pattern |
+|------|---------------|------------------------------|
+| Sink scope | Project, folder, or organization sink scope matches the environment's audit boundary | Project-only sink for regulated folder/org activity without separate higher-scope export |
+| Filter completeness | Empty filter, or a documented allowlist that still includes Admin Activity, IAM policy, KMS, VPC firewall, Cloud SQL, GCS IAM, and Data Access events required by policy | Filters such as `severity>=ERROR` or narrow service filters that drop routine audit events |
+| Sink exclusions | No sink exclusion removes security-relevant audit logs, or exclusions are documented and risk-accepted | `google_logging_*_exclusion` drops Data Access, KMS, IAM, VPC firewall, Cloud SQL, or GCS IAM evidence |
+| `_Default` exclusions | Default bucket exclusions are reviewed when local retention is part of the evidence chain | `_Default` bucket exclusions remove audit records before retention/export assumptions are verified |
+| Destination IAM | Sink writer identity has least privilege to write logs only; readers/admins are scoped to logging/security roles | Broad `roles/storage.admin`, `roles/bigquery.admin`, or public/allUsers access on the destination |
+| Destination proof | At least one security-relevant audit event is observed at the destination, or the report marks this Not Evaluable | Sink exists in IaC but no destination sample/event query is reviewed |
+
+**Grep patterns:**
+
+```text
+google_logging_project_sink
+google_logging_folder_sink
+google_logging_organization_sink
+google_logging_.*_exclusion
+exclusion
+_Default
+roles/storage.admin
+roles/bigquery.admin
+allUsers
+allAuthenticatedUsers
+```
+
+**Problematic examples:**
+
+```hcl
+# BAD: drops routine Admin Activity / IAM events
+resource "google_logging_project_sink" "security_logs" {
+  destination = "storage.googleapis.com/${google_storage_bucket.logs.name}"
+  filter      = "severity>=ERROR"
+}
+
+# BAD: removes data-access evidence needed for investigations
+resource "google_logging_project_exclusion" "drop_data_access" {
+  name        = "drop-data-access"
+  filter      = "protoPayload.serviceName=\"storage.googleapis.com\""
+  description = "Reduce logging volume"
+}
+
+# BAD: broad destination administration instead of sink-writer-only access
+resource "google_storage_bucket_iam_member" "sink_admin" {
+  bucket = google_storage_bucket.logs.name
+  role   = "roles/storage.admin"
+  member = google_logging_project_sink.security_logs.writer_identity
+}
+```
+
 ### CIS 2.3 -- Ensure that Retention Policies on Cloud Storage Buckets Used for Exporting Logs Are Configured Using Bucket Lock
 
 ```hcl
@@ -218,6 +268,36 @@ resource "google_storage_bucket" {
   }
 }
 ```
+
+For GCS log destinations, require `retention_policy.is_locked = true` and a retention period consistent with policy or regulatory requirements. For non-GCS destinations, record equivalent immutability evidence such as BigQuery table expiration controls, Pub/Sub downstream retention, SIEM/archive WORM controls, or vendor retention-lock settings. If CMEK or default KMS is required by organizational policy, verify the destination key configuration and key IAM separately from the sink.
+
+**Additional Terraform patterns:**
+
+```hcl
+# GOOD: locked GCS retention for exported logs
+resource "google_storage_bucket" "logs" {
+  name = "prod-security-logs"
+
+  retention_policy {
+    retention_period = 2678400
+    is_locked        = true
+  }
+
+  encryption {
+    default_kms_key_name = google_kms_crypto_key.log_archive.id
+  }
+}
+
+# REVIEW: BigQuery destination needs retention/expiration evidence
+resource "google_logging_project_sink" "bq_logs" {
+  destination = "bigquery.googleapis.com/projects/${var.project_id}/datasets/${google_bigquery_dataset.logs.dataset_id}"
+}
+```
+
+**Finding classification:**
+
+- **High** if production or regulated projects lack durable export for security-relevant audit events, security-relevant events are excluded from export, or destination IAM grants broad read/admin access.
+- **Medium** if retention is present but not locked, destination retention is not evidenced, CMEK/default KMS is missing where policy requires it, or no destination sample event was reviewed.
 
 ### CIS 2.4 -- Ensure Log Metric Filter and Alerts Exist for Project Ownership Assignments/Changes
 


### PR DESCRIPTION
## Summary

- Updates `gcp-review` to require full audit-log export path validation for CIS Section 2 logging controls.
- Adds a Logging Export Integrity report table covering sink scope, filters/exclusions, destination IAM, retention/lock, CMEK/KMS, and destination sample-event evidence.
- Extends `benchmark-checklist.md` with concrete Terraform review patterns for sink filters, sink exclusions, `_Default` exclusions, broad destination IAM, locked GCS retention, CMEK, and non-GCS retention evidence.
- Adds finding classification guidance for High vs Medium logging export failures.

## Related issue

Closes #1621

## Validation

- `git diff --check`
- Required frontmatter field check for `skills/cloud/gcp-review/SKILL.md`
- Prompt-injection pattern scan on the modified GCP review files
- Markdown fence balance check on the modified GCP review files

## Pull Request Checklist

- [x] Skill follows the format specification in CONTRIBUTING.md
- [x] At least one real framework is cited with correct control IDs
- [x] Prompt Injection Safety Notice retained
- [x] `injection-hardened: true` remains set in frontmatter
- [x] `allowed-tools` remains scoped to minimum necessary permissions
- [x] No prohibited patterns found by local injection-pattern scan
- [x] `index.yaml` not updated because this improves an existing skill, not a new skill
- [ ] Live AI-agent execution test not run; this is a focused guidance/checklist improvement validated statically

## Bounty note

This implements the requested logging-export integrity evidence gates from #1621 and should qualify as a focused skill improvement if accepted.