### PR TITLE
Add CVE compensating-control exploit-path gates

### DIFF
--- a/skills/vuln-management/cve-triage/SKILL.md
+++ b/skills/vuln-management/cve-triage/SKILL.md
@@ -12,7 +12,7 @@ phase: [operate, respond]
 frameworks: [CVSS-4.0, SSVC-2.1, CISA-KEV, EPSS]
 difficulty: intermediate
 time_estimate: "10-20min per CVE"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob, WebFetch
@@ -269,7 +269,38 @@ SSVC 2.1 Decision:
 - Rationale:           [1-2 sentences explaining the decision path]
 ```
 
-### Step 6: SLA Assignment and Remediation Recommendation
+### Step 6: Compensating Control Exploit-Path Verification
+
+Before using any compensating control to lower the SLA, verify that the control blocks the specific exploit path for the affected deployment. Generic statements such as "WAF present", "segmented network", "EDR installed", "feature disabled", or "not internet-facing" are not enough unless they are tied to the CVE prerequisites, affected asset scope, and runtime path.
+
+#### 6.1 Required Evidence Gates
+
+For each claimed compensating control, require all of the following:
+
+- **Control-to-vector mapping**: Map the control to the CVSS/SSVC exploit path it is supposed to change, including attack vector, required privileges, user interaction, attack requirements, and affected component.
+- **Exploit prerequisite coverage**: Show which exploit prerequisites are blocked, such as unauthenticated endpoint access, malicious payload shape, vulnerable protocol, vulnerable parser, exposed management interface, enabled feature flag, or reachable internal route.
+- **Runtime and fleet scope**: Prove the control covers every affected asset, region, cluster, container image, host package instance, ingress path, IPv4/IPv6 path, internal path, batch/offline processor, and alternate endpoint in scope for the SLA decision.
+- **Effectiveness evidence**: Retain current evidence such as WAF rule IDs and match logs, deny logs, service mesh or firewall decisions, EDR prevention telemetry, feature flag/config state, signed VEX, package/runtime inventory, safe negative test, or vendor advisory.
+- **Bypass review**: Check known and plausible bypass paths, including authenticated routes, alternate content types, JSON/XML variants, internal traffic, direct-to-origin access, shadow APIs, scheduled jobs, or rollback paths.
+- **Owner and expiry**: Identify the mitigation owner, review/expiry date, monitoring signal, rollback criteria, and the date the SLA decision must be revisited.
+
+If any gate is missing or only partially scoped, do not let the mitigation reduce an Immediate or Out-of-Cycle decision. Mark the control as `Unverified` or `Partial`, keep the higher SLA, and list the missing evidence.
+
+#### 6.2 Compensating Control Finding IDs
+
+Use these finding/check IDs when compensating-control evidence is weak:
+
+| ID | Trigger | Triage Impact |
+|----|---------|---------------|
+| CVE-COMP-01 | Control is named but not mapped to the CVE exploit vector or prerequisites. | Mitigation cannot reduce SLA. |
+| CVE-COMP-02 | Control scope does not cover all affected assets, regions, endpoints, packages, or runtime paths. | Treat uncovered scope at original severity. |
+| CVE-COMP-03 | Effectiveness evidence is missing, stale, or only asserts configuration intent without runtime signal. | Mark mitigation unverified. |
+| CVE-COMP-04 | Bypass paths such as authenticated routes, internal traffic, alternate payloads, direct-to-origin access, or rollback are not reviewed. | Keep higher SLA until bypass review is complete. |
+| CVE-COMP-05 | Mitigation lacks owner, expiry/review date, monitoring, or rollback criteria. | Do not accept long-term de-escalation. |
+
+---
+
+### Step 7: SLA Assignment and Remediation Recommendation
 
 Combine all assessment data to assign a remediation SLA and produce a final recommendation.
 
@@ -302,6 +333,8 @@ The following conditions may justify a longer SLA (document the justification):
 - Affected component is disabled or not deployed in your environment
 - Network segmentation prevents attacker access to the vulnerable system
 - VEX (Vulnerability Exploitability eXchange) status is "not_affected" or "fixed"
+
+Do not apply any de-escalation factor unless Step 6 proves the mitigation blocks the specific exploit path for the affected deployment. Unverified, partial, expired, or narrow mitigations must be listed as assumptions or open evidence gaps, not as SLA reducers.
 
 ---
 
@@ -362,11 +395,17 @@ recommended SLA tier. Lead with the most critical fact.]
 | Mission Prevalence | [Minimal/Support/Essential] |
 | **Decision** | **[Defer/Scheduled/Out-of-Cycle/Immediate]** |
 
+### Compensating Control Verification
+| Control | Exploit Vector / Prerequisite Blocked | Affected Scope Covered | Effectiveness Evidence | Bypass Review | Owner / Expiry | Verification Status | SLA Impact |
+|---|---|---|---|---|---|---|---|
+| [WAF / segmentation / EDR / feature flag / VEX / other] | [CVSS/SSVC path and prerequisite] | [assets, regions, endpoints, package instances, IPv4/IPv6/internal paths] | [logs, rule IDs, telemetry, safe negative test, config state, advisory] | [reviewed bypasses or gaps] | [owner and review date] | [Verified / Partial / Unverified / Expired] | [No reduction / reduce to Scheduled / defer with review date] |
+
 ### Remediation Recommendation
 - **SLA Tier:** [Immediate (24h) / Out-of-Cycle (72h) / Scheduled (30d) / Defer (90d)]
 - **Recommended Action:** [Specific action -- patch to version X, apply workaround Y, disable feature Z]
 - **Escalation Factors:** [List any factors that elevated the SLA tier]
 - **De-escalation Factors:** [List any compensating controls or mitigating factors]
+- **Compensating Control Gaps:** [List CVE-COMP-* findings and missing evidence]
 - **Assumptions Made:** [List any assumptions due to missing context]
 
 ### Risk Acceptance (If Deferring)
@@ -407,6 +446,12 @@ When triaging multiple CVEs (e.g., from a scan report), produce a summary table 
 2. [CVE with Out-of-Cycle SLA -- full assessment below]
 3. [Remaining CVEs -- scheduled per standard patch cycle]
 ```
+
+---
+
+## Common Pitfalls
+
+1. **Letting generic mitigations reduce the SLA.** A WAF, EDR, segmentation rule, disabled feature, or VEX statement only changes triage when it blocks the specific exploit vector and covers the affected deployment scope. If the evidence does not cover alternate endpoints, authenticated/internal paths, payload variants, package instances, rollback, and expiry, keep the original SLA and record a `CVE-COMP-*` gap.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #1629.

This strengthens `cve-triage` so compensating controls cannot lower a CVE SLA unless they are proven to block the specific exploit path for the affected deployment. Generic mitigations such as WAF, segmentation, EDR, disabled features, or VEX statements now need scoped evidence before they count as de-escalation factors.

## Changes

- Added a compensating-control exploit-path verification step before SLA assignment.
- Required control-to-vector mapping, exploit prerequisite coverage, fleet/runtime scope, effectiveness evidence, bypass review, owner, expiry, monitoring, and rollback criteria.
- Added `CVE-COMP-01` through `CVE-COMP-05` finding IDs for weak compensating-control evidence.
- Added a `Compensating Control Verification` report table and a `Compensating Control Gaps` output field.
- Added a common pitfall warning against generic SLA reductions from unproven mitigations.

## Validation

- `git diff --check`
- frontmatter required-field check
- prompt-injection pattern scan for the modified skill
- markdown fence balance check
