### PR TITLE
Add Azure diagnostic pipeline evidence gates

### DIFF
--- a/skills/cloud/azure-review/SKILL.md
+++ b/skills/cloud/azure-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-Azure-v2.1.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -91,7 +91,33 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, Bic
 
 ---
 
-### Step 11: Compile Assessment Report
+### Step 11: Diagnostic Pipeline Integrity Review
+
+For CIS Section 5 logging and monitoring checks, do not mark a subscription or resource as passing from the existence of `azurerm_monitor_diagnostic_setting` alone. Prove the full diagnostic pipeline for each in-scope subscription and critical resource type.
+
+Verify:
+
+- **Resource coverage:** Activity Log diagnostics cover each subscription, and resource diagnostics cover in-scope Key Vault, Storage, SQL, NSG, App Service, and other critical resource instances.
+- **Category and category-group coverage:** Security-relevant categories such as `Administrative`, `Security`, `Policy`, `ServiceHealth`, `ResourceHealth`, Key Vault `AuditEvent`, and supported `category_group = "allLogs"` or equivalent are enabled. Partial category lists must not pass when supported category groups are expected.
+- **Destination evidence:** Logs route to an approved Log Analytics workspace, Storage Account, or Event Hub with the destination resource ID recorded.
+- **Retention evidence:** Destination retention meets the environment requirement. Record Log Analytics retention, Storage lifecycle/immutability retention, or Event Hub downstream consumer retention. If retention cannot be proven, mark the item `Not Evaluable`.
+- **Destination hardening:** Diagnostic destinations are not public or broadly readable, and storage destinations use private access, CMK, immutability/retention lock, or equivalent controls where policy requires them.
+- **Authorization evidence:** Event Hub authorization rules, Storage access, and Log Analytics roles are scoped to the minimum required principals for log writers and readers.
+- **Sample delivery:** Retain evidence of at least one sample Activity Log or resource log such as Key Vault `AuditEvent` arriving at the destination for the reviewed period, or mark sample delivery `Not Evaluable`.
+
+Use these finding/check IDs when the diagnostic pipeline is incomplete:
+
+| ID | Trigger | Severity Guidance |
+|----|---------|-------------------|
+| AZ-DIAG-01 | Diagnostic settings exist only at subscription scope and omit required critical resource diagnostics. | High for production/regulated critical services; Medium otherwise. |
+| AZ-DIAG-02 | Required category, category group, or security-relevant resource log is missing. | High for missing security categories or Key Vault `AuditEvent`; Medium for partial category coverage. |
+| AZ-DIAG-03 | Destination retention or downstream consumer retention is missing, below requirement, or not evidenced. | Medium; High where regulated retention is required. |
+| AZ-DIAG-04 | Diagnostic destination is public, broadly readable, lacks required CMK/private access, or lacks retention lock where policy requires it. | High. |
+| AZ-DIAG-05 | No sample Activity Log or resource log delivery evidence is available for the destination. | Medium; `Not Evaluable` if no runtime evidence is provided. |
+
+---
+
+### Step 12: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
 
@@ -102,8 +128,8 @@ Produce the final report using the structure defined in the Output Format sectio
 | Severity | Definition | Examples |
 |----------|-----------|----------|
 | **Critical** | Immediate risk of data breach or unauthorized access | NSGs open to 0.0.0.0/0 on RDP/SSH, SQL databases publicly accessible, Defender for Cloud disabled |
-| **High** | Significant security gap that materially weakens posture | Missing MFA enforcement, storage accounts with public access, Key Vault without purge protection |
-| **Medium** | Control gap that should be addressed in normal cycle | Missing activity log alerts, soft delete not enabled, TLS below 1.2 |
+| **High** | Significant security gap that materially weakens posture | Missing MFA enforcement, storage accounts with public access, Key Vault without purge protection, missing diagnostics for critical resources, diagnostic destination broadly readable |
+| **Medium** | Control gap that should be addressed in normal cycle | Missing activity log alerts, soft delete not enabled, TLS below 1.2, diagnostic retention/sample delivery not evidenced |
 | **Low** | Hardening recommendation or defense-in-depth measure | HTTP/2 not enabled, FTP not fully disabled, missing CMK on non-sensitive storage |
 | **Informational** | Best practice observation, no direct security impact | Naming conventions, tag policies, documentation gaps |
 
@@ -154,6 +180,12 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Evidence:** <specific configuration or code snippet>
 - **Remediation:** <specific fix with code example>
 
+### Diagnostic Pipeline Evidence
+
+| Scope / Resource | Required Categories | Enabled Categories | Destination | Retention Evidence | Destination Hardening | Sample Delivery | Status |
+|------------------|---------------------|--------------------|-------------|--------------------|-----------------------|-----------------|--------|
+| <subscription or resource ID> | <required categories/category groups> | <enabled categories/category groups> | <Log Analytics / Storage / Event Hub ID> | <retention setting or Not Evaluable> | <private access, CMK, RBAC, lock> | <sample log evidence or Not Evaluable> | Pass / Fail / Not Evaluable |
+
 ### Prioritized Remediation Plan
 
 1. **[Critical]** CIS X.Y.Z -- <action item>
@@ -200,6 +232,7 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **NSG rules using service tags.** A rule with `source_address_prefix = "Internet"` is equivalent to `0.0.0.0/0`. Both must be flagged for CIS 6.1 and 6.2.
 5. **Key Vault purge protection is irreversible.** CIS 8.5 requires `purge_protection_enabled = true`. Note this cannot be disabled once enabled -- flag this for awareness during remediation.
 6. **App Service TLS version on both Linux and Windows.** Check `azurerm_linux_web_app` and `azurerm_windows_web_app` resources separately.
+7. **Treating any diagnostic setting as full logging coverage.** A single subscription Activity Log diagnostic setting does not prove Key Vault, Storage, SQL, NSG, App Service, or other resource logs are exported. Verify category coverage, destination hardening, retention, and sample delivery for each in-scope resource.
 
 ---
 
@@ -231,4 +264,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Added diagnostic pipeline integrity gates for resource coverage, category/category-group coverage, destination retention, destination hardening, authorization evidence, and sample log delivery.
 - **1.0.0** -- Initial release. Full coverage of CIS Microsoft Azure Foundations Benchmark v2.1.0 sections 1 through 9.

--- a/skills/cloud/azure-review/benchmark-checklist.md
+++ b/skills/cloud/azure-review/benchmark-checklist.md
@@ -396,7 +396,7 @@ Evaluate logging configurations against Section 5 recommendations.
 
 #### CIS 5.1.1 -- Ensure that a 'Diagnostic Setting' exists
 
-Check for diagnostic settings on subscriptions:
+Check for diagnostic settings on subscriptions and critical resources. Subscription Activity Log diagnostics are necessary but not sufficient for resource-level services such as Key Vault, Storage, SQL, NSGs, and App Service.
 
 ```hcl
 resource "azurerm_monitor_diagnostic_setting" {
@@ -405,17 +405,89 @@ resource "azurerm_monitor_diagnostic_setting" {
 }
 ```
 
+**Coverage checks:**
+
+- Subscription Activity Log diagnostic setting targets each in-scope subscription.
+- Resource diagnostic settings target each in-scope critical resource instance, not only the subscription.
+- Resource IDs are explicit or generated from a complete inventory; do not accept one example diagnostic setting as proof for all resources.
+
 #### CIS 5.1.2 -- Ensure Diagnostic Setting captures appropriate categories
 
 Verify that Administrative, Security, ServiceHealth, Alert, Recommendation, Policy, Autoscale, and ResourceHealth categories are enabled.
+
+For resources that support category groups, prefer `category_group = "allLogs"` or explicitly prove every required security category is enabled:
+
+```hcl
+resource "azurerm_monitor_diagnostic_setting" "key_vault" {
+  target_resource_id         = azurerm_key_vault.example.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.security.id
+
+  enabled_log {
+    category = "AuditEvent"
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "resource_all_logs" {
+  target_resource_id         = azurerm_storage_account.example.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.security.id
+
+  enabled_log {
+    category_group = "allLogs"
+  }
+}
+```
+
+**Failure patterns:**
+
+```hcl
+# BAD: Diagnostic setting exists, but no enabled_log block is present.
+resource "azurerm_monitor_diagnostic_setting" "bad_exists_only" {
+  target_resource_id         = azurerm_key_vault.example.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.security.id
+}
+
+# BAD: Key Vault diagnostics omit AuditEvent.
+resource "azurerm_monitor_diagnostic_setting" "bad_key_vault_partial" {
+  target_resource_id         = azurerm_key_vault.example.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.security.id
+
+  enabled_log {
+    category = "AzurePolicyEvaluationDetails"
+  }
+}
+```
 
 #### CIS 5.1.3 -- Ensure the storage container storing the activity logs is not publicly accessible
 
 Check storage account access level for the diagnostic logs container.
 
+For Storage destinations, cross-reference the diagnostic destination with account public access, network rules, container ACLs, and reader role assignments. Flag public containers, `allow_nested_items_to_be_public = true`, default network access `Allow`, or broad `Storage Blob Data Reader` assignments.
+
 #### CIS 5.1.4 -- Ensure the storage account containing the container with activity logs is encrypted with a Customer Managed Key
 
 Cross-reference the diagnostics storage account with CMK encryption.
+
+Where policy requires CMK/private access/immutability, check:
+
+```hcl
+resource "azurerm_storage_account_customer_managed_key" "diagnostic_logs" {
+  storage_account_id = azurerm_storage_account.diag.id
+  key_vault_id       = azurerm_key_vault.security.id
+  key_name           = azurerm_key_vault_key.logs.name
+}
+
+resource "azurerm_storage_management_policy" "diagnostic_retention" {
+  storage_account_id = azurerm_storage_account.diag.id
+  rule {
+    enabled = true
+    actions {
+      base_blob {
+        delete_after_days_since_modification_greater_than = 365
+      }
+    }
+  }
+}
+```
 
 #### CIS 5.1.5 -- Ensure that logging for Azure Key Vault is 'Enabled'
 
@@ -427,6 +499,26 @@ resource "azurerm_monitor_diagnostic_setting" {
   }
 }
 ```
+
+#### Diagnostic Destination Retention and Delivery Evidence
+
+For every diagnostic setting, record one destination and prove retention:
+
+| Destination Type | Evidence to Require |
+|------------------|---------------------|
+| Log Analytics | Workspace ID, `retention_in_days`, table retention if overridden, reader roles |
+| Storage Account | Account/container ID, network/public access state, CMK if required, lifecycle or immutability policy |
+| Event Hub | Event Hub namespace/topic, authorization rule scope, downstream SIEM/consumer retention evidence |
+
+If runtime output is available, require a sample event at the destination for the reviewed period:
+
+- Activity Log sample for subscription diagnostics.
+- Key Vault `AuditEvent` sample for Key Vault diagnostics.
+- Storage, SQL, NSG, App Service, or other resource log sample for resource diagnostics.
+
+If no sample event or destination retention evidence is available, mark the diagnostic control `Not Evaluable` rather than passing from IaC intent alone.
+
+**Finding IDs:** Use `AZ-DIAG-01` through `AZ-DIAG-05` from `SKILL.md` for missing resource coverage, category gaps, retention gaps, destination hardening gaps, and missing sample delivery.
 
 ### CIS 5.2 -- Activity Log Alerts
 


### PR DESCRIPTION
## Summary

Fixes #1624.

This strengthens `azure-review` so diagnostic settings cannot pass CIS Section 5 from existence alone. It requires evidence for subscription and resource diagnostic coverage, required categories/category groups, destination retention, destination hardening, authorization scope, and sample log delivery.

## Changes

- Added a Diagnostic Pipeline Integrity Review step.
- Added `AZ-DIAG-01` through `AZ-DIAG-05` finding IDs for missing resource coverage, category gaps, retention gaps, destination hardening gaps, and missing sample delivery.
- Added a Diagnostic Pipeline Evidence report table.
- Expanded Section 5 checklist patterns for Azure diagnostics, Key Vault `AuditEvent`, `category_group = "allLogs"`, destination retention/hardening, CMK, and Not Evaluable sample delivery.
- Added a common pitfall and changelog entry.

## Validation

- `git diff --check`
- frontmatter required-field check
- prompt-injection pattern scan for the modified files
- markdown fence balance check
