### PR TITLE
Add AWS Access Analyzer finding review gates

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -99,6 +99,38 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
+### Step 6b: IAM Access Analyzer Finding Review
+
+CIS 1.20 checks whether IAM Access Analyzer is enabled, but an enabled analyzer
+is not enough evidence that external, internal, or unused access findings are
+being reviewed and remediated. When Access Analyzer configuration or exports are
+available, collect analyzer scope, finding status, and archive-rule evidence.
+
+**What to verify:**
+
+- [ ] External access analyzers exist for the intended account or organization trust boundary in each required region.
+- [ ] Unused access analyzers are enabled where the organization relies on Access Analyzer for unused roles, access keys, passwords, or unused permissions review.
+- [ ] Active findings are exported or summarized by analyzer, finding type, resource, principal, and age.
+- [ ] Archived findings have documented business justification and owner, not only broad archive rules.
+- [ ] Archive rules do not automatically hide public access or unapproved cross-account access.
+- [ ] Resolved findings are tied to policy changes, resource changes, or explicit access removal.
+
+**What to look for:**
+
+```
+AWS-AA-01: Access Analyzer exists, but active external-access findings are not reviewed
+AWS-AA-02: Archive rules are broad enough to suppress public or unapproved cross-account findings
+AWS-AA-03: Unused access analyzer is absent where unused role/key/permission review is expected
+AWS-AA-04: Archived findings lack owner, approval, or business justification
+AWS-AA-05: Resolved findings are not tied to a policy or resource change that removed the access
+```
+
+Do not mark CIS 1.20 as fully effective based only on an `aws_accessanalyzer_analyzer`
+resource when finding review, archive rules, and unused-access coverage are not
+available.
+
+---
+
 ### Step 7: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
@@ -163,6 +195,12 @@ Produce the final report using the structure defined in the Output Format sectio
 1. **[Critical]** CIS X.Y -- <action item>
 2. **[High]** CIS X.Y -- <action item>
 3. ...
+
+### IAM Access Analyzer Findings
+
+| Analyzer | Scope | Finding Type | Active | Archived | Resolved | Oldest Active Finding | Notes |
+|----------|-------|--------------|--------|----------|----------|-----------------------|-------|
+| <name> | <account/org> | <external/internal/unused> | <N> | <N> | <N> | <age> | <archive-rule or remediation notes> |
 
 ### Summary
 - Critical findings: <N>

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -146,6 +146,20 @@ aws_accessanalyzer_analyzer
 type = "ACCOUNT"
 ```
 
+**Finding review evidence:**
+
+```
+aws accessanalyzer list-analyzers
+aws accessanalyzer list-findings --analyzer-arn <arn> --filter '{"status":{"eq":["ACTIVE"]}}'
+aws accessanalyzer list-archive-rules --analyzer-name <name>
+```
+
+Verify analyzer scope (`ACCOUNT` vs. `ORGANIZATION`), analyzer type, active
+finding counts, archived finding justification, and unused-access analyzer
+coverage where unused role/key/permission review is expected. A configured
+analyzer resource without active finding review or archive-rule governance is
+only partial evidence for this control.
+
 ### CIS 1.21 -- Ensure IAM users are managed centrally via identity federation or AWS Organizations for multi-account environments
 
 Check for SSO/Identity Center configuration:


### PR DESCRIPTION
## Summary

Adds IAM Access Analyzer finding-review gates to AWS posture review.

Closes #1663.

## What changed

- Added `Step 6b: IAM Access Analyzer Finding Review`.
- Added gates for analyzer scope, unused access analyzer coverage, active finding review, archive-rule governance, and resolved-finding evidence.
- Added `AWS-AA-01` through `AWS-AA-05`.
- Added an `IAM Access Analyzer Findings` output table.
- Added CIS 1.20 checklist commands for analyzer, active finding, and archive-rule evidence.

## Why

CIS 1.20 checks that IAM Access Analyzer is enabled, but an analyzer resource alone does not prove that findings are reviewed or remediated. AWS Access Analyzer can generate external, internal, and unused access findings, and archive rules can automatically hide findings. The skill now asks for evidence that the analyzer is operationally governed.

## Validation

- `git diff --check`
- Confirmed the diff is scoped to `skills/cloud/aws-review/SKILL.md` and `skills/cloud/aws-review/benchmark-checklist.md`.
- Verified required markers are present: `AWS-AA-01`, `IAM Access Analyzer Finding Review`, `IAM Access Analyzer Findings`, and `list-archive-rules`.

## References

- https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-findings.html
- https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-archive-rules.html
