### PR TITLE
Add Azure Defender exemption governance gates

### DIFF
--- a/skills/cloud/azure-review/SKILL.md
+++ b/skills/cloud/azure-review/SKILL.md
@@ -88,6 +88,39 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, Bic
 
 ---
 
+### Step 10b: Defender for Cloud Exemption Governance
+
+Defender for Cloud recommendations can be exempted through Defender for Cloud or
+Azure Policy. Exemptions may be appropriate for accepted risk or already
+mitigated resources, but they can also hide unresolved CIS failures and reduce
+secure-score visibility. When Defender for Cloud or Azure Policy exports are
+available, review exemptions as part of the posture assessment.
+
+**What to verify:**
+
+- [ ] Recommendation exemptions are exported for the subscription or management group scope under review.
+- [ ] Each exemption has an owner, justification, category, expiry date, and linked risk acceptance or compensating control.
+- [ ] Exemptions are scoped narrowly to specific resources, resource groups, or subscriptions rather than broad management groups unless justified.
+- [ ] Expired exemptions are removed or renewed through an approval workflow.
+- [ ] Exemptions for high-impact CIS or regulatory recommendations have compensating evidence.
+- [ ] Defender recommendation health is reviewed both before and after applying exemptions.
+
+**What to look for:**
+
+```
+AZ-DEF-EXEMPT-01: Defender recommendation exemptions exist without owner or justification
+AZ-DEF-EXEMPT-02: Exemption scope is broader than the affected resource set
+AZ-DEF-EXEMPT-03: Expired exemptions still suppress recommendations
+AZ-DEF-EXEMPT-04: High-risk recommendations are exempted without compensating-control evidence
+AZ-DEF-EXEMPT-05: Assessment reports use post-exemption compliance only and omit raw recommendation state
+```
+
+Treat unmanaged Defender for Cloud exemptions as a **Medium** governance finding,
+or **High** when they suppress critical/high CIS, regulatory, or internet-exposed
+resource recommendations.
+
+---
+
 
 ---
 
@@ -159,6 +192,12 @@ Produce the final report using the structure defined in the Output Format sectio
 1. **[Critical]** CIS X.Y.Z -- <action item>
 2. **[High]** CIS X.Y.Z -- <action item>
 3. ...
+
+### Defender for Cloud Exemptions
+
+| Scope | Recommendation | Exempted Resources | Owner | Expiry | Justification | Compensating Evidence |
+|-------|----------------|--------------------|-------|--------|---------------|-----------------------|
+| <subscription/resource> | <recommendation> | <count/list> | <owner> | <date/none> | <reason> | <evidence> |
 
 ### Summary
 - Critical findings: <N>

--- a/skills/cloud/azure-review/benchmark-checklist.md
+++ b/skills/cloud/azure-review/benchmark-checklist.md
@@ -182,6 +182,20 @@ resource "azurerm_security_center_contact" {
 }
 ```
 
+### Defender for Cloud Recommendation Exemptions
+
+Review exemptions that suppress Defender for Cloud recommendations:
+
+```
+az policy exemption list --scope <subscription-or-management-group-scope>
+az graph query -q "securityresources | where type =~ 'microsoft.security/assessments'"
+```
+
+Verify each exemption has a narrow scope, owner, justification, expiry date, and
+compensating-control evidence. Do not rely only on post-exemption secure-score or
+compliance percentages when raw Defender recommendations still show unhealthy
+resources.
+
 ---
 
 ## Section 3 -- Storage Accounts


### PR DESCRIPTION
## Summary

Adds Defender for Cloud recommendation exemption governance gates to Azure posture review.

Closes #1665.

## What changed

- Added `Step 10b: Defender for Cloud Exemption Governance`.
- Added checks for exemption owner, justification, category, expiry, scope, compensating evidence, and raw recommendation health.
- Added `AZ-DEF-EXEMPT-01` through `AZ-DEF-EXEMPT-05`.
- Added a `Defender for Cloud Exemptions` output table.
- Added checklist commands for Azure Policy exemptions and Defender assessment state.

## Why

Defender for Cloud recommendation exemptions can be valid, but broad or expired exemptions can suppress unresolved CIS or regulatory findings. Azure reviews should collect exemption evidence rather than relying only on post-exemption secure-score or compliance state.

## Validation

- `git diff --check`
- Confirmed the diff is scoped to `skills/cloud/azure-review/SKILL.md` and `skills/cloud/azure-review/benchmark-checklist.md`.
- Verified required markers are present: `AZ-DEF-EXEMPT-01`, `Defender for Cloud Exemption`, `Defender for Cloud Exemptions`, and `policy exemption list`.

## Reference

- https://learn.microsoft.com/en-us/azure/defender-for-cloud/review-exemptions
