### PR TITLE
Add container image provenance evidence gates

### DIFF
--- a/skills/cloud/container-security/SKILL.md
+++ b/skills/cloud/container-security/SKILL.md
@@ -58,10 +58,13 @@ NIST SP 800-190 identifies five risk categories: image risks, registry risks, or
 
 - Access to Dockerfiles and container build configurations
 - Kubernetes manifests (YAML), Helm charts, or Kustomize overlays
+- Rendered production manifests or release artifacts that show the image reference
+  actually deployed
 - RBAC configuration files (Roles, ClusterRoles, RoleBindings)
 - NetworkPolicy definitions
 - Pod Security Standard configurations or OPA/Gatekeeper policies
-- Container registry configurations (if available)
+- Container registry configurations, signature verification output, SBOMs, and
+  admission policy configuration (if available)
 
 ---
 
@@ -107,7 +110,43 @@ Classify findings by type: Dockerfiles, Kubernetes manifests, Helm charts, Kusto
 
 ---
 
-### Step 2 through Step 6: CIS Benchmark and NIST SP 800-190 Evaluation
+### Step 2: Verify Image Provenance and Admission Evidence Chain
+
+For production workloads, verify that the deployed image is the same artifact
+that was built, scanned, signed, attested, and admitted by policy. Do not rely
+only on Dockerfile templates, Helm defaults, image tags, or CI claims.
+
+**Evidence chain to require:**
+
+- [ ] Rendered manifest or live workload records the production image reference.
+- [ ] Image reference resolves to an immutable digest, or tag exceptions include
+      owner, justification, expiry, and the resolved digest at deployment time.
+- [ ] Build provenance links the digest to a source commit, CI run, builder, and
+      artifact registry location.
+- [ ] Signature or attestation verification is performed against the deployed
+      digest and trusted signer identity, not only a mutable tag.
+- [ ] SBOM or vulnerability scan evidence is tied to the same deployed digest.
+- [ ] Admission policy is in enforce mode for production namespaces, or the
+      exception has compensating controls and expiry.
+- [ ] Helm, Kustomize, and environment-specific values do not override a pinned
+      or verified image reference with a mutable tag.
+
+**Finding IDs:**
+
+```
+CONT-PROV-01: Deployed image uses a mutable tag without resolved digest evidence or exception lifecycle
+CONT-PROV-02: Signature or attestation evidence does not match the deployed digest
+CONT-PROV-03: SBOM or vulnerability scan evidence cannot be linked to the deployed digest
+CONT-PROV-04: Admission policy is audit-only or not scoped to production namespaces
+CONT-PROV-05: Signer identity, issuer, or certificate SAN is not constrained to trusted build workflows
+CONT-PROV-06: Helm, Kustomize, or environment values override a pinned image with a mutable tag
+CONT-PROV-07: Production image exception lacks owner, justification, expiry, or compensating controls
+CONT-PROV-08: Registry lifecycle or retention policy can remove evidence needed to verify deployed images
+```
+
+---
+
+### Step 3 through Step 7: CIS Benchmark and NIST SP 800-190 Evaluation
 
 Evaluate all container and Kubernetes configurations against CIS Docker Benchmark v1.6.0, CIS Kubernetes Benchmark v1.9.0, and NIST SP 800-190 countermeasures. This covers Dockerfile security, Pod Security Standards, RBAC, Network Policies, Secrets Management, Control Plane configuration, and Container Runtime Hardening.
 
@@ -115,7 +154,7 @@ For detailed CIS benchmark checklist items, NIST SP 800-190 countermeasure table
 
 ---
 
-### Step 7: Compile Assessment Report
+### Step 8: Compile Assessment Report
 
 
 Produce the final report using the structure defined in the Output Format section.
@@ -157,6 +196,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | Domain | Framework | Critical | High | Medium | Low | Pass |
 |--------|-----------|----------|------|--------|-----|------|
 | Dockerfile Security | CIS Docker 4.x | X | X | X | X | X |
+| Image Provenance | NIST 800-190 | X | X | X | X | X |
 | Pod Security | CIS K8s 5.2.x | X | X | X | X | X |
 | RBAC | CIS K8s 5.1.x | X | X | X | X | X |
 | Network Policies | CIS K8s 5.3.x | X | X | X | X | X |
@@ -178,6 +218,12 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Evidence:** <specific configuration>
 - **Remediation:** <fix with code example>
 
+### Image Provenance Evidence Matrix
+
+| Workload | Namespace | Rendered Image | Resolved Digest | Build/CI Evidence | Signature/Attestation | SBOM/Scan Digest | Admission Mode | Exception |
+|----------|-----------|----------------|-----------------|-------------------|-----------------------|------------------|----------------|-----------|
+| deploy/api | production | registry.example.com/app/api@sha256:... | sha256:... | commit + CI run | cosign pass, trusted identity | sha256:... | enforce | none |
+
 ### Pod Security Standards Compliance Matrix
 
 | Workload | Namespace | PSS Level | Violations |
@@ -193,6 +239,7 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ### Summary
 - Dockerfiles reviewed: <N>
+- Production image references reviewed: <N>
 - Kubernetes workloads reviewed: <N>
 - Overall Pod Security Standard level: <Privileged / Baseline / Restricted>
 - Critical findings: <N>
@@ -257,6 +304,7 @@ Produce the final report using the structure defined in the Output Format sectio
 5. **`readOnlyRootFilesystem` breaks many applications.** When recommending this control, also recommend adding writable `emptyDir` volume mounts for directories the application needs to write to (e.g., `/tmp`, `/var/cache`).
 6. **Network policies are additive, not subtractive.** A default-deny policy must be explicitly created. Without it, all pod-to-pod traffic is allowed regardless of other NetworkPolicy resources.
 7. **Distroless images have no shell.** While this is excellent for security, note that debugging requires ephemeral containers (`kubectl debug`). Flag this as a consideration, not a problem.
+8. **`imagePullPolicy: Always` is not provenance.** It changes pull behavior but does not prove the image was built from the reviewed commit, signed by a trusted identity, scanned, or admitted in enforce mode.
 
 ---
 
@@ -284,9 +332,11 @@ Produce the final report using the structure defined in the Output Format sectio
 - Kubernetes Pod Security Standards: https://kubernetes.io/docs/concepts/security/pod-security-standards/
 - Kubernetes Pod Security Admission: https://kubernetes.io/docs/concepts/security/pod-security-admission/
 - Kubernetes Network Policies: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+- Kubernetes Dynamic Admission Control: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/
 - Kubernetes RBAC: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 - Docker Security Best Practices: https://docs.docker.com/develop/security-best-practices/
 - Dockerfile Best Practices: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
+- Sigstore Cosign Verification: https://docs.sigstore.dev/cosign/verifying/verify/
 - NSA/CISA Kubernetes Hardening Guide: https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF
 
 ---

--- a/skills/cloud/container-security/cis-benchmarks.md
+++ b/skills/cloud/container-security/cis-benchmarks.md
@@ -596,6 +596,70 @@ Evaluate container runtime configurations against NIST SP 800-190 countermeasure
 | **CM-4:** Use immutable tags or digests | `image: nginx@sha256:...` preferred over `image: nginx:1.25` |
 | **CM-5:** Remove unnecessary packages | No curl, wget, netcat, or shells in production images |
 
+#### Image Provenance and Admission Evidence Chain
+
+Reviewers must tie image security evidence to the artifact that is actually
+deployed. A signed tag, a scanned build output, or a Helm template default is
+not sufficient unless it matches the rendered production image digest.
+
+**Evidence to collect:**
+
+| Evidence | Required proof |
+|----------|----------------|
+| Rendered workload image | `kubectl get`, rendered Helm output, Kustomize build output, or release manifest showing the production image reference |
+| Resolved digest | Registry digest or workload status proving the exact `sha256` digest deployed |
+| Build provenance | Source commit, CI run, builder identity, and registry artifact for the digest |
+| Signature or attestation | Cosign/Notary/admission result for the deployed digest and trusted signer identity |
+| SBOM or scan | SBOM, vulnerability scan, or attestation whose subject digest equals the deployed digest |
+| Admission enforcement | Kyverno, Gatekeeper, admission webhook, or registry policy in enforce mode for production |
+| Exception lifecycle | Owner, justification, expiry, compensating controls, and resolved digest for any tag or policy exception |
+
+**Failure patterns:**
+
+```yaml
+# FAIL: Signed tag evidence does not prove the deployed digest.
+review_evidence:
+  signed_image: registry.example.com/app/api:1.4.2
+  signed_digest: sha256:aaa...
+runtime:
+  resolved_digest: sha256:bbb...
+```
+
+```yaml
+# FAIL: Production policy only audits unsigned images.
+kind: ClusterPolicy
+metadata:
+  name: verify-image-signature
+spec:
+  validationFailureAction: Audit
+```
+
+```yaml
+# FAIL: Environment values replace a pinned image with a mutable tag.
+image:
+  repository: registry.example.com/app/api
+  tag: latest
+```
+
+```text
+# FAIL: SBOM subject does not match workload digest.
+Workload digest: sha256:bbb...
+SBOM subject:    sha256:aaa...
+```
+
+**Finding IDs:**
+
+| ID | Finding |
+|----|---------|
+| CONT-PROV-01 | Deployed image uses a mutable tag without resolved digest evidence or exception lifecycle |
+| CONT-PROV-02 | Signature or attestation evidence does not match the deployed digest |
+| CONT-PROV-03 | SBOM or vulnerability scan evidence cannot be linked to the deployed digest |
+| CONT-PROV-04 | Admission policy is audit-only or not scoped to production namespaces |
+| CONT-PROV-05 | Signer identity, issuer, or certificate SAN is not constrained to trusted build workflows |
+| CONT-PROV-06 | Helm, Kustomize, or environment values override a pinned image with a mutable tag |
+| CONT-PROV-07 | Production image exception lacks owner, justification, expiry, or compensating controls |
+| CONT-PROV-08 | Registry lifecycle or retention policy can remove evidence needed to verify deployed images |
+
 ### NIST 800-190: Orchestrator Countermeasures
 
 | Countermeasure | What to Check |


### PR DESCRIPTION
## Pull Request Checklist

- [x] Skill follows the format specification in CONTRIBUTING.md
- [x] At least one real framework is cited with correct control IDs
- [x] All framework references verified against primary sources (not blogs or AI output)
- [x] Prompt Injection Safety Notice section included
- [x] `injection-hardened: true` set in frontmatter
- [x] `allowed-tools` scoped to minimum necessary permissions
- [x] Tested with at least one AI coding agent (which one: Codex)
- [x] No prohibited patterns per SECURITY.md
- [x] `index.yaml` updated with new skill entry (if adding a skill; not applicable, existing skill only)

## What This PR Does

Addresses #1659.

This improves `skills/cloud/container-security` by adding image provenance and admission evidence gates for production workloads. The update requires reviewers to verify that the deployed image is the same artifact that was built, scanned, signed, attested, and admitted by policy.

Summary:

- Adds a dedicated image provenance/admission evidence-chain step to `SKILL.md`.
- Adds `CONT-PROV-*` finding IDs for mutable tags, signature/SBOM digest mismatches, audit-only admission, weak signer identity constraints, Helm/Kustomize override drift, stale exceptions, and registry evidence retention gaps.
- Extends the output report with an image provenance evidence matrix.
- Adds detailed checklist guidance and failure examples in `cis-benchmarks.md`.
- Adds the `imagePullPolicy: Always` provenance pitfall.

## Framework References

- NIST SP 800-190 image and registry risk countermeasures
- CIS Docker Benchmark v1.6.0 Section 4 container image controls
- Kubernetes admission control documentation
- Sigstore Cosign verification documentation

## Testing

- `git diff --check`: passed; only existing Windows line-ending warnings were reported.
- PowerShell equivalent of `lint-skills.yml` frontmatter check: passed for all `skills/` and `roles/` `SKILL.md` files.
- PowerShell equivalent of `validate-index.yml`: all files listed by `index.yaml` exist.
- PowerShell equivalent of `injection-scan.yml`: no prompt injection patterns detected.
- Markdown fence-balance check: passed for edited files.
- Targeted issue coverage check: confirmed image provenance/admission chain, rendered workload evidence, immutable digest handling, build provenance, trusted signer identity, SBOM/scan digest linkage, enforce-mode admission, Helm/Kustomize override drift, all `CONT-PROV-*` IDs, evidence matrix, and `imagePullPolicy: Always` pitfall are present.
- Official reference availability checked with HTTP 200 for NIST SP 800-190, Sigstore Cosign verification, and Kubernetes dynamic admission control pages.