### PR TITLE
Add CIS AWS benchmark version preflight to aws-review

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Each skill is a directory with `SKILL.md` as the entrypoint, following the [Agen
 
 | Skill | File | Frameworks |
 |-------|------|------------|
-| AWS Security Review | `skills/cloud/aws-review.md` | CIS AWS Benchmark v3.0 |
+| AWS Security Review | `skills/cloud/aws-review.md` | CIS AWS Benchmark v3.0, AWS Security Hub CSPM version-aware evidence |
 | Azure Security Review | `skills/cloud/azure-review.md` | CIS Azure Benchmark v2.1 |
 | GCP Security Review | `skills/cloud/gcp-review.md` | CIS GCP Benchmark v2.0 |
 | IaC Security | `skills/cloud/iac-security.md` | OWASP IaC Security, SLSA v1.0 |

--- a/index.yaml
+++ b/index.yaml
@@ -145,7 +145,7 @@ skills:
     role: [cloud-security-engineer, security-engineer]
     phase: [assess, operate]
     activity: [audit, review]
-    frameworks: [CIS-AWS-v3.0.0]
+    frameworks: [CIS-AWS-v3.0.0, AWS-Security-Hub-CSPM]
     difficulty: intermediate
     time_estimate: "60-90min"
     file: skills/cloud/aws-review/SKILL.md

--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -1,19 +1,18 @@
 ---
 name: aws-review
 description: >
-  Performs an AWS security posture review against the CIS Amazon Web Services
-  Foundations Benchmark v3.0.0. Auto-invoked when reviewing AWS infrastructure,
-  IAM policies, S3 configurations, CloudTrail settings, VPC security groups, or
-  RDS encryption. Walks through all five benchmark sections, evaluates each
-  recommendation, and produces a prioritized findings report with remediation
-  guidance mapped to specific CIS control IDs.
+  Performs a version-aware AWS security posture review against the CIS Amazon
+  Web Services Foundations Benchmark. Auto-invoked when reviewing AWS
+  infrastructure, IAM policies, S3 configurations, CloudTrail settings, VPC
+  security groups, or RDS encryption. Records the selected benchmark version,
+  evidence source, and control support status before scoring findings.
 tags: [cloud, aws, cis-benchmark]
 role: [cloud-security-engineer, security-engineer]
 phase: [assess, operate]
-frameworks: [CIS-AWS-v3.0.0]
+frameworks: [CIS-AWS-v3.0.0, AWS-Security-Hub-CSPM]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -25,9 +24,9 @@ argument-hint: "[target-file-or-directory]"
 
 ## Overview
 
-This skill performs a structured security assessment of AWS environments against the **CIS Amazon Web Services Foundations Benchmark v3.0.0**. The benchmark is organized into five sections covering identity management, storage, logging, monitoring, and networking. Each recommendation is evaluated by inspecting infrastructure-as-code definitions (Terraform, CloudFormation, CDK), AWS CLI output, or configuration files available in the repository.
+This skill performs a structured, version-aware security assessment of AWS environments against the **CIS Amazon Web Services Foundations Benchmark**. Current posture reviews should identify the requested benchmark version first, then evaluate each recommendation by inspecting infrastructure-as-code definitions (Terraform, CloudFormation, CDK), AWS Security Hub CSPM evidence, AWS CLI output, or configuration files available in the repository.
 
-The CIS AWS Foundations Benchmark v3.0.0 contains 62 recommendations across five domains. This skill evaluates each applicable control against the codebase and produces a findings report with CIS recommendation IDs, severity ratings, and actionable remediation steps.
+The skill preserves the existing CIS AWS v3.0.0 checklist as a legacy baseline, but it must not present v3.0.0 section counts or fixed denominators as current CIS AWS v5.0.0 coverage. When v5.0.0 evidence is requested, the report records the benchmark source, Security Hub standard version or ARN when available, and whether each item is current, legacy, removed, unsupported by Security Hub CSPM, manual, or not evaluable from the supplied evidence.
 
 ---
 
@@ -39,13 +38,14 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 - Assessing an existing AWS environment's security posture against CIS benchmarks
 - Preparing for a CIS benchmark audit or compliance assessment
 - Evaluating IAM policies, S3 bucket configurations, CloudTrail settings, VPC security groups, or RDS encryption configurations
+- Reconciling Security Hub CSPM CIS AWS v5.0.0 findings with legacy v3.0.0 IaC checks
 - Onboarding a new AWS account into a security program
 
 ---
 
 ## Context
 
-The CIS Amazon Web Services Foundations Benchmark v3.0.0 is a consensus-driven security configuration guide developed by the Center for Internet Security. It provides prescriptive guidance for configuring AWS accounts to a hardened baseline. Organizations use it as the foundation for AWS security assessments, compliance programs (PCI DSS, HIPAA, SOC 2), and continuous monitoring.
+The CIS Amazon Web Services Foundations Benchmark is a consensus-driven security configuration guide developed by the Center for Internet Security. It provides prescriptive guidance for configuring AWS accounts to a hardened baseline. Organizations use it as the foundation for AWS security assessments, compliance programs (PCI DSS, HIPAA, SOC 2), and continuous monitoring. AWS Security Hub CSPM supports multiple CIS AWS Foundations Benchmark versions, including v5.0.0 and v3.0.0, so assessment output must identify which version and evidence source it used.
 
 ### Prerequisites
 
@@ -55,12 +55,28 @@ The CIS Amazon Web Services Foundations Benchmark v3.0.0 is a consensus-driven s
 - S3 bucket policies and ACL configurations
 - VPC, security group, and NACL definitions
 - CloudTrail and CloudWatch configuration files
+- Security Hub CSPM standard version or ARN when Security Hub evidence is used
+- Requested CIS AWS benchmark version, or an explicit statement that the review should use the current supported version
 
 ---
 
 ## Process
 
-### Step 1: Discovery -- Locate AWS Configuration Files
+### Step 1: Benchmark Version Preflight
+
+Before evaluating controls, record the benchmark scope:
+
+- Requested benchmark version: `v5.0.0`, `v3.0.0`, or `legacy-v3-compatible`
+- Benchmark source and source date or retrieval date
+- Security Hub CSPM standard ARN/version, if Security Hub findings are part of the evidence
+- Whether this is a current posture report or an explicit legacy baseline
+- Control status categories to use: `current`, `legacy`, `removed`, `unsupported`, `manual`, and `not evaluable`
+
+Default to CIS AWS Foundations Benchmark v5.0.0 for current posture reports when no legacy version is requested. Use v3.0.0 only when the user explicitly asks for legacy coverage or when the available evidence is v3.0.0-specific. If the exact v5.0.0 control mapping is not present in the supplied evidence, mark affected controls as `manual` or `not evaluable` rather than reusing v3.0.0 identifiers as current v5.0.0 results.
+
+---
+
+### Step 2: Discovery -- Locate AWS Configuration Files
 
 Use Glob to locate all AWS-related infrastructure definitions.
 
@@ -91,15 +107,15 @@ Record all discovered files. If no AWS configurations are found, report that fin
 
 ---
 
-### Step 2 through Step 6: CIS Benchmark Evaluation (Sections 1-5)
+### Step 3 through Step 7: CIS Benchmark Evaluation
 
-Evaluate all AWS configurations against CIS AWS v3.0.0 Sections 1 through 5, covering Identity and Access Management, Storage, Logging, Monitoring, and Networking.
+Evaluate all AWS configurations against the selected CIS AWS benchmark version. For explicit v3.0.0 or legacy-compatible reviews, use the Sections 1 through 5 checklist covering Identity and Access Management, Storage, Logging, Monitoring, and Networking. For current v5.0.0 reviews, use Security Hub CSPM v5.0.0 evidence or a verified v5.0.0 control mapping before assigning current CIS control IDs.
 
-For detailed CIS benchmark checklist items with specific Terraform patterns, grep patterns, and configuration examples for all five sections, see [benchmark-checklist.md](benchmark-checklist.md) in this skill directory.
+For detailed legacy v3.0.0 checklist items, plus version preflight rules and control support categories, see [benchmark-checklist.md](benchmark-checklist.md) in this skill directory.
 
 ---
 
-### Step 7: Compile Assessment Report
+### Step 8: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
 
@@ -125,33 +141,41 @@ Produce the final report using the structure defined in the Output Format sectio
 ### Environment
 - Account/Repository: <identifier>
 - Date: <assessment date>
-- Framework: CIS Amazon Web Services Foundations Benchmark v3.0.0
+- Framework: CIS Amazon Web Services Foundations Benchmark <selected version>
+- Benchmark source: <CIS / AWS Security Hub CSPM / supplied evidence>
+- Security Hub standard: <standard ARN/version or "not provided">
+- Legacy baseline: yes/no
 - Files reviewed: <list of IaC files>
 
 ### Executive Summary
-- Total CIS recommendations evaluated: <N>/62
+- Total CIS recommendations evaluated: <N>/<selected benchmark denominator or "source-specific">
 - Passed: <N>
 - Failed: <N>
 - Not Applicable: <N>
 - Not Evaluable (insufficient data): <N>
+- Current controls: <N>
+- Legacy controls: <N>
+- Removed or unsupported controls: <N>
+- Manual-only controls: <N>
 - Overall compliance: <percentage>
 
 ### Section Scores
 
-| Section | Description | Passed | Failed | N/A | Compliance |
-|---------|-------------|--------|--------|-----|------------|
-| 1 | Identity and Access Management | X/22 | Y | Z | nn% |
-| 2 | Storage | X/10 | Y | Z | nn% |
-| 3 | Logging | X/11 | Y | Z | nn% |
-| 4 | Monitoring | X/16 | Y | Z | nn% |
-| 5 | Networking | X/6 | Y | Z | nn% |
+| Section or Control Family | Description | Passed | Failed | N/A | Not Evaluable | Denominator Source | Compliance |
+|---------------------------|-------------|--------|--------|-----|---------------|--------------------|------------|
+| <selected section/family> | <selected benchmark domain> | X | Y | Z | W | <v5.0.0 mapping / Security Hub CSPM / legacy v3.0.0> | nn% |
+
+For explicit CIS AWS v3.0.0 legacy reports, use the legacy Sections 1-5 checklist as a source-specific baseline and state the denominator source. For current v5.0.0 reports, derive section or control-family denominators from verified v5.0.0 mapping or Security Hub CSPM evidence.
 
 ### Detailed Findings
 
-#### [CIS X.Y] <Recommendation Title>
+#### [CIS X.Y or SecurityHub.Control] <Recommendation Title>
 - **Status:** Pass / Fail / Not Evaluable
+- **Control support status:** Current / Legacy / Removed / Unsupported / Manual / Not Evaluable
 - **Severity:** Critical / High / Medium / Low
 - **CIS Profile:** Level 1 / Level 2
+- **Benchmark version:** <version>
+- **Evidence source:** <IaC / AWS CLI export / Security Hub CSPM / manual>
 - **File:** <path to relevant config>
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
@@ -175,15 +199,31 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Framework Reference
 
-### CIS AWS Foundations Benchmark v3.0.0 -- Section Map
+### Supported Benchmark Modes
 
-| Section | Domain | Recommendation Count | Key Focus Areas |
-|---------|--------|---------------------|-----------------|
-| 1 | Identity and Access Management | 22 | Root account security, MFA, password policy, access keys, IAM policies, Access Analyzer, identity federation |
-| 2 | Storage | 10 | S3 bucket security (public access, encryption, TLS), EBS encryption, RDS encryption and access, EFS encryption |
-| 3 | Logging | 11 | CloudTrail (multi-region, validation, encryption), AWS Config, S3 access logging, VPC flow logs, object-level logging |
-| 4 | Monitoring | 16 | CloudWatch metric filters and alarms for 15 critical event types, Security Hub enablement |
-| 5 | Networking | 6 | NACL restrictions, security group hardening, default SG lockdown, VPC peering routes, IMDSv2 enforcement |
+| Mode | Use When | Scoring Rule | Notes |
+|------|----------|--------------|-------|
+| CIS AWS v5.0.0 current | The user asks for current CIS AWS coverage or Security Hub CSPM v5 evidence is present | Use verified v5.0.0 mapping or Security Hub CSPM v5.0.0 control evidence | Do not reuse v3.0.0 denominators as v5.0.0 coverage |
+| CIS AWS v3.0.0 legacy | The user asks for v3.0.0 or only v3.0.0 evidence is available | Use the legacy Sections 1-5 checklist below | Mark report as `Legacy baseline: yes` |
+| Mixed evidence | Multiple Security Hub standards or IaC-only evidence are present | Report each finding with benchmark version and evidence source | Mark unsupported, removed, manual, and not-evaluable controls separately |
+
+### CIS AWS Foundations Benchmark v3.0.0 -- Legacy Section Map
+
+| Section | Domain | Denominator Source | Key Focus Areas |
+|---------|--------|--------------------|-----------------|
+| 1 | Identity and Access Management | Legacy checklist items in `benchmark-checklist.md` | Root account security, MFA, password policy, access keys, IAM policies, Access Analyzer, identity federation |
+| 2 | Storage | Legacy checklist items in `benchmark-checklist.md` | S3 bucket security (public access, encryption, TLS), EBS encryption, RDS encryption and access, EFS encryption |
+| 3 | Logging | Legacy checklist items in `benchmark-checklist.md` | CloudTrail (multi-region, validation, encryption), AWS Config, S3 access logging, VPC flow logs, object-level logging |
+| 4 | Monitoring | Legacy checklist items in `benchmark-checklist.md` | CloudWatch metric filters and alarms for critical event types, Security Hub enablement |
+| 5 | Networking | Legacy checklist items in `benchmark-checklist.md` | NACL restrictions, security group hardening, default SG lockdown, VPC peering routes, IMDSv2 enforcement |
+
+### Security Hub CSPM Standard ARN Pattern
+
+When Security Hub evidence is supplied, record the enabled CIS standard ARN. The v5.0.0 form is:
+
+```
+arn:aws:securityhub:<region>::standards/cis-aws-foundations-benchmark/v/5.0.0
+```
 
 ### CIS Profile Levels
 
@@ -200,6 +240,8 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
 5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
 6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
+7. **Treating a v3.0.0 report as current v5.0.0 coverage.** Always record the requested benchmark version and evidence source before scoring. Any fixed-count v3.0.0 score is a legacy baseline unless current v5.0.0 mapping is verified.
+8. **Collapsing removed, unsupported, manual, and not-evaluable controls.** These have different meanings. Removed or unsupported controls should not reduce current compliance, while manual and not-evaluable controls should stay visible as evidence gaps.
 
 ---
 
@@ -219,7 +261,9 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## References
 
-- CIS Amazon Web Services Foundations Benchmark v3.0.0: https://www.cisecurity.org/benchmark/amazon_web_services
+- CIS Amazon Web Services Foundations Benchmark: https://www.cisecurity.org/benchmark/amazon_web_services
+- AWS Security Hub CSPM CIS AWS Foundations Benchmark: https://docs.aws.amazon.com/securityhub/latest/userguide/cis-aws-foundations-benchmark.html
+- AWS Security Hub CSPM CIS AWS Foundations Benchmark v5.0 support announcement: https://aws.amazon.com/about-aws/whats-new/2025/10/aws-security-hub-cspm-cis-foundations-benchmark-v5/
 - AWS Security Best Practices: https://docs.aws.amazon.com/security/
 - AWS IAM Best Practices: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 - AWS CloudTrail Documentation: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/
@@ -231,4 +275,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
-- **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 (62 recommendations).
+- **1.1.0** -- Adds benchmark version preflight, Security Hub CSPM standard tracking, and control support status fields so v3.0.0 legacy evidence is not reported as current v5.0.0 coverage.
+- **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 as a legacy checklist baseline.

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -1,12 +1,69 @@
-# CIS AWS Foundations Benchmark v3.0.0 -- Detailed Checklist
+# CIS AWS Foundations Benchmark -- Detailed Checklist
 
-This file contains the detailed CIS benchmark checklist items for the AWS Security Posture Review skill. See [SKILL.md](SKILL.md) for the main skill definition, process overview, and output format.
+This file contains benchmark version preflight rules and the detailed legacy CIS AWS v3.0.0 checklist items for the AWS Security Posture Review skill. See [SKILL.md](SKILL.md) for the main skill definition, process overview, and output format.
+
+---
+
+## Benchmark Version Preflight
+
+Run this preflight before using any section checklist. The goal is to prevent a legacy v3.0.0 checklist from being reported as current CIS AWS v5.0.0 coverage.
+
+### Required report fields
+
+Record these fields in the final assessment:
+
+| Field | Required Value |
+|-------|----------------|
+| `benchmark_version` | `CIS AWS Foundations Benchmark v5.0.0`, `v3.0.0`, or the exact requested version |
+| `benchmark_source` | CIS benchmark, AWS Security Hub CSPM, supplied evidence export, or manual evidence |
+| `benchmark_source_date` | Publication date if known, otherwise retrieval date |
+| `security_hub_standard_arn_or_version` | Standard ARN/version when Security Hub evidence is present |
+| `legacy_baseline` | `true` only for explicit v3.0.0 or legacy-compatible reviews |
+| `control_denominator_source` | Selected benchmark mapping, Security Hub controls, or `source-specific` |
+
+### Security Hub standard detection
+
+Look for Security Hub standard identifiers in IaC, exported findings, or documentation:
+
+```
+standards/cis-aws-foundations-benchmark/v/5.0.0
+standards/cis-aws-foundations-benchmark/v/3.0.0
+aws_securityhub_standards_subscription
+SecurityHubStandardArn
+StandardsSubscriptionArn
+GetEnabledStandards
+```
+
+If the enabled or requested standard is `v/5.0.0`, treat the review as a current v5.0.0 report. If only `v/3.0.0` evidence exists, mark the report as a legacy baseline unless the user supplies a verified v5.0.0 control mapping.
+
+### Control support status categories
+
+Use one of these support statuses for every finding:
+
+| Support Status | Meaning |
+|----------------|---------|
+| `current` | The control is verified against the selected benchmark version or Security Hub standard |
+| `legacy` | The control belongs to v3.0.0 or another explicitly requested legacy baseline |
+| `removed` | The requirement was removed from the selected current benchmark |
+| `unsupported` | Security Hub CSPM does not support this requirement for the selected standard |
+| `manual` | The requirement exists but needs human or account-level evidence not present in the repository |
+| `not evaluable` | Supplied artifacts are insufficient to determine pass/fail |
+
+Do not convert a removed, unsupported, manual, or not-evaluable item into a failed current control. Keep these counts separate from pass/fail compliance scoring.
+
+### Version-specific scoring rules
+
+- For v5.0.0 current reports, use verified v5.0.0 control evidence or Security Hub CSPM v5.0.0 findings before assigning current control IDs.
+- For v3.0.0 legacy reports, use the Sections 1-5 checklist below and mark `legacy_baseline: true`.
+- For mixed Security Hub standards, report each finding with its own benchmark version and evidence source.
+- If exact v5.0.0 mapping is unavailable, mark affected items `manual` or `not evaluable` instead of copying v3.0.0 identifiers into a current v5.0.0 report.
+- If a fixed-count legacy v3.0.0 score is included for comparison, label it as legacy, state the denominator source, and do not use it as the current v5.0.0 denominator.
 
 ---
 
 ## Section 1 -- Identity and Access Management
 
-Evaluate IAM configurations against CIS AWS v3.0.0 Section 1 recommendations.
+Evaluate IAM configurations against CIS AWS v3.0.0 Section 1 recommendations when the review is explicitly legacy v3.0.0 or v3-compatible. For current v5.0.0 reports, verify the current control mapping first and record `current` or `manual` support status before scoring.
 
 ### CIS 1.1 -- Maintain current contact details
 

--- a/skills/cloud/aws-review/tests/cis-benchmark-version-preflight.md
+++ b/skills/cloud/aws-review/tests/cis-benchmark-version-preflight.md
@@ -1,0 +1,73 @@
+# CIS Benchmark Version Preflight Test Cases
+
+These fixtures exercise the version-aware reporting guardrails in `aws-review`.
+
+## Current v5.0.0 Security Hub Evidence
+
+### Input
+
+Minimal ASFF-like Security Hub finding with CIS AWS v5.0.0 standard metadata:
+
+```json
+{
+  "Findings": [
+    {
+      "AwsAccountId": "111122223333",
+      "ProductFields": {
+        "StandardsArn": "arn:aws:securityhub:us-east-1::standards/cis-aws-foundations-benchmark/v/5.0.0",
+        "StandardsSubscriptionArn": "arn:aws:securityhub:us-east-1:111122223333:subscription/cis-aws-foundations-benchmark/v/5.0.0"
+      },
+      "Compliance": {
+        "Status": "FAILED",
+        "SecurityControlId": "CloudTrail.1",
+        "AssociatedStandards": [
+          {
+            "StandardsId": "standards/cis-aws-foundations-benchmark/v/5.0.0"
+          }
+        ]
+      },
+      "Resources": [{ "Id": "arn:aws:cloudtrail:us-east-1:111122223333:trail/org" }]
+    }
+  ]
+}
+```
+
+### Expected Handling
+
+- `benchmark_version`: `CIS AWS Foundations Benchmark v5.0.0`
+- `security_hub_standard_arn_or_version`: `arn:aws:securityhub:us-east-1::standards/cis-aws-foundations-benchmark/v/5.0.0`
+- `legacy_baseline`: `false`
+- `control_support_status`: `current`
+- Do not report `Total CIS recommendations evaluated: <N>/62` as the current v5.0.0 denominator.
+
+## Legacy v3.0.0 IaC-Only Evidence
+
+### Input
+
+```hcl
+resource "aws_securityhub_standards_subscription" "cis_v3" {
+  standards_arn = "arn:aws:securityhub:us-east-1::standards/cis-aws-foundations-benchmark/v/3.0.0"
+}
+```
+
+### Expected Handling
+
+- `benchmark_version`: `CIS AWS Foundations Benchmark v3.0.0`
+- `security_hub_standard_arn_or_version`: `arn:aws:securityhub:us-east-1::standards/cis-aws-foundations-benchmark/v/3.0.0`
+- `legacy_baseline`: `true`
+- v3.0.0 section counts may be used only as legacy scoring.
+
+## Missing Version Evidence
+
+### Input
+
+```text
+Framework: CIS Amazon Web Services Foundations Benchmark
+Total CIS recommendations evaluated: 62/62
+```
+
+### Expected Handling
+
+- Request or infer the benchmark version before scoring.
+- If no current mapping is present, mark the denominator source as `source-specific`.
+- Keep current, legacy, removed, unsupported, manual, and not-evaluable counts separate.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** aws-review
**Skill path:** `skills/cloud/aws-review/`

### What Was Wrong
The aws-review skill was fixed to CIS AWS Foundations Benchmark v3.0.0 in several places. That made current posture reports easy to overstate because the output format used v3.0.0 assumptions such as fixed section denominators and did not require benchmark version, Security Hub standard, or support-status evidence before scoring.

Addresses #213 as a scoped preflight/output improvement. This PR does not attempt a full CIS AWS v5.0.0 control-map rewrite.

### What This PR Fixes
- Adds a benchmark version preflight before control evaluation.
- Records benchmark version, source, Security Hub standard ARN/version, legacy-baseline status, and denominator source.
- Adds control support statuses for current, legacy, removed, unsupported, manual, and not evaluable controls.
- Changes section scoring to use selected benchmark/control-family denominator sources instead of hard-coded v3 section counts.
- Marks the existing v3.0.0 section map as a legacy baseline.
- Updates README and index metadata so aws-review is no longer described as v3-only while avoiding a top-level claim of complete v5 control-map coverage.
- Adds a focused ASFF-like test fixture for v5.0.0 Security Hub evidence, v3.0.0 legacy evidence, and missing-version evidence.

### Evidence

**Before (skill could overstate current coverage):**
```text
Framework: CIS Amazon Web Services Foundations Benchmark v3.0.0
Total CIS recommendations evaluated: <N>/62
Section Scores: X/22, X/10, X/11, X/16, X/6
```

**After (now version-aware before scoring):**
```text
Framework: CIS Amazon Web Services Foundations Benchmark <selected version>
Benchmark source: <CIS / AWS Security Hub CSPM / supplied evidence>
Security Hub standard: <standard ARN/version or "not provided">
Legacy baseline: yes/no
Total CIS recommendations evaluated: <N>/<selected benchmark denominator or "source-specific">
Control support status: Current / Legacy / Removed / Unsupported / Manual / Not Evaluable
```

Reference sources used:
- AWS Security Hub CSPM CIS AWS Foundations Benchmark docs: https://docs.aws.amazon.com/securityhub/latest/userguide/cis-aws-foundations-benchmark.html
- AWS Security Hub CSPM CIS AWS Foundations Benchmark v5.0 announcement: https://aws.amazon.com/about-aws/whats-new/2025/10/aws-security-hub-cspm-cis-foundations-benchmark-v5/

### Test Cases Added/Updated
- [x] Added test cases: `skills/cloud/aws-review/tests/cis-benchmark-version-preflight.md`
- [ ] Added vulnerable test cases (`tests/vulnerable/`) - N/A for this reporting/preflight guardrail
- [ ] Added benign test cases (`tests/benign/`) - N/A for this reporting/preflight guardrail
- [x] Relevant static checks run locally

Validation run:
```bash
git diff --check
# required frontmatter check for changed aws-review SKILL.md
# prompt-injection scan logic from injection-scan.yml
# indexed-file existence check equivalent to validate-index.yml
```

Note: upstream GitHub Actions runs are currently waiting for maintainer approval for this fork PR (`action_required`) before jobs are created.

### Bounty Tier
- [ ] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** To be provided privately after acceptance
