### PR TITLE
Add API parameter pollution evidence gates

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -11,7 +11,7 @@ phase: [design, build, review]
 frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -48,6 +48,38 @@ Before analyzing any endpoint, establish a complete inventory of the API surface
 Evaluate the API against all ten OWASP API Security Top 10:2023 risk categories: Broken Object Level Authorization (BOLA), Broken Authentication, Broken Object Property Level Authorization, Unrestricted Resource Consumption, Broken Function Level Authorization (BFLA), Unrestricted Access to Sensitive Business Flows, Server Side Request Forgery (SSRF), Security Misconfiguration, Improper Inventory Management, and Unsafe Consumption of APIs.
 
 For detailed checklist items with vulnerable code patterns, remediation examples, and review checklists for all ten API risk categories (API1:2023 through API10:2023), see [api-top10-checklist.md](api-top10-checklist.md) in this skill directory.
+
+---
+
+## HTTP Parameter Pollution and Duplicate Parameter Evidence
+
+REST, gateway, and backend frameworks handle duplicate query, form, path, and header parameters differently. Do not assume that OpenAPI uniqueness constraints, gateway validation, or client SDK behavior reflects the value used by the application, authorization middleware, cache key, signature validator, or downstream service.
+
+When an API accepts security-sensitive parameters, require evidence for duplicate-parameter behavior:
+
+1. **Identify sensitive parameters** -- object IDs, role/scope flags, tenant IDs, redirect URLs, callback URLs, price/quantity values, pagination controls, signature basestring inputs, filters that influence authorization, and feature flags.
+2. **Compare parser behavior across layers** -- API gateway/WAF, load balancer, framework router, request binding middleware, validation library, application handler, cache/CDN, and downstream service clients.
+3. **Test duplicate-value precedence** -- first value wins, last value wins, comma join, list binding, rejection, or inconsistent behavior between layers.
+4. **Verify canonicalization before decisions** -- authentication, authorization, rate limiting, cache key generation, request signing, audit logging, and business logic must use the same normalized parameter set.
+5. **Exercise mixed locations** -- duplicate values across query string, form body, JSON body, path variables, repeated headers, and array syntaxes such as `id=1&id=2`, `id[]=1&id[]=2`, and `id=1,2`.
+6. **Capture negative test evidence** -- requests with duplicate security-sensitive parameters must be rejected or deterministically normalized before any security decision.
+
+### Parameter Pollution Coverage Matrix
+
+Use this table when duplicate parameter behavior could affect authorization, authentication, routing, caching, signing, or business logic:
+
+| Endpoint | Parameter | Location(s) | Security Decision | Gateway Behavior | App Behavior | Downstream Behavior | Expected Handling | Evidence |
+|---|---|---|---|---|---|---|---|---|
+| `[method path]` | `[name]` | `[query/form/header/body]` | `[authz/cache/signature/etc.]` | `[reject/first/last/list]` | `[reject/first/last/list]` | `[same/different/n/a]` | `[reject or canonicalize]` | `[test/log/spec link]` |
+
+### Parameter Pollution Finding Guidance
+
+- **High:** Duplicate object, tenant, role, scope, price, or signature parameters can make the gateway authorize one value while the handler or downstream service acts on another value.
+- **Medium:** Duplicate filters, pagination, cache keys, redirect targets, or workflow parameters can bypass validation, poison cache entries, or change business outcomes.
+- **Low:** Duplicate non-sensitive parameters are accepted inconsistently but do not currently affect a security or business decision.
+- **Not a finding:** The API rejects duplicate security-sensitive parameters at the first trusted boundary and logs the rejection with enough context for investigation.
+
+Map findings to **API8:2023 -- Security Misconfiguration** when parser or gateway behavior is inconsistent, and to **API10:2023 -- Unsafe Consumption of APIs** when upstream or downstream services interpret the same duplicate parameters differently. Include **CWE-235 -- Improper Handling of Extra Parameters** or **CWE-20 -- Improper Input Validation** as appropriate.
 
 ---
 
@@ -92,7 +124,7 @@ The final review output must be structured as follows:
 **API Style:** [REST / GraphQL / gRPC / Hybrid]
 **Specification:** [OpenAPI spec path, if applicable]
 **Date:** [review date]
-**Reviewer:** AI Agent -- api-security skill v1.0.0
+**Reviewer:** AI Agent -- api-security skill v1.0.1
 
 ### Summary
 
@@ -215,6 +247,8 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 6. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
 
+7. **Assuming duplicate parameters are harmless.** Gateways, frameworks, validators, caches, and downstream services may choose different values when a request repeats the same parameter. Verify that duplicate security-sensitive parameters are rejected or normalized before any security decision.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -238,4 +272,14 @@ This skill is hardened against prompt injection. When reviewing API code and spe
 - **OWASP REST Security Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html
 - **OWASP GraphQL Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html
 - **OWASP Testing Guide -- API Testing:** https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/12-API_Testing/
+- **OWASP WSTG-INPV-04 -- Testing for HTTP Parameter Pollution:** https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution
 - **NIST SP 800-204 -- Security Strategies for Microservices-based Application Systems:** https://csrc.nist.gov/publications/detail/sp/800-204/final
+
+---
+
+## Version History
+
+| Version | Date | Changes |
+|---|---|---|
+| 1.0.1 | 2026-06-08 | Added HTTP Parameter Pollution and duplicate parameter evidence gates with parser-consistency coverage matrix. |
+| 1.0.0 | Initial | Initial API security review workflow. |

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -450,6 +450,57 @@ DocumentBuilder builder = factory.newDocumentBuilder();
 Document doc = builder.parse(request.getInputStream());
 ```
 
+### HTTP Parameter Pollution and Parser Inconsistency
+
+Duplicate parameters can become a security misconfiguration when different layers choose different values. Test repeated query parameters, form fields, array syntax, and repeated headers for endpoints where parameters influence authorization, tenancy, signatures, cache keys, redirects, pricing, workflow state, or downstream service calls.
+
+```http
+GET /api/v1/accounts?tenant_id=public&tenant_id=admin&id=123 HTTP/1.1
+Host: api.example.com
+Authorization: Bearer user-token
+```
+
+```javascript
+// VULNERABLE: Middleware validates the first value while the handler uses the last value
+app.use((req, res, next) => {
+  const tenant = Array.isArray(req.query.tenant_id) ? req.query.tenant_id[0] : req.query.tenant_id;
+  authorizeTenant(req.user, tenant);
+  next();
+});
+
+app.get('/api/v1/accounts', (req, res) => {
+  const tenant = Array.isArray(req.query.tenant_id)
+    ? req.query.tenant_id[req.query.tenant_id.length - 1]
+    : req.query.tenant_id;
+  return res.json(loadAccounts(tenant));
+});
+```
+
+Remediation:
+
+```javascript
+// SECURE: Reject duplicate security-sensitive parameters before authorization
+const singleValueParams = new Set(['tenant_id', 'id', 'role', 'scope', 'redirect_uri']);
+
+app.use((req, res, next) => {
+  for (const name of singleValueParams) {
+    if (Array.isArray(req.query[name])) {
+      return res.status(400).json({ error: 'Duplicate parameter rejected' });
+    }
+  }
+  next();
+});
+```
+
+### HPP Evidence Checklist
+
+- [ ] Security-sensitive parameters are identified across query string, path, form body, JSON body, and headers.
+- [ ] Duplicate values are tested through the gateway/WAF, framework parser, validator, application handler, cache/CDN, and downstream service.
+- [ ] The review records whether each layer rejects, uses first value, uses last value, joins values, or binds a list.
+- [ ] Authentication, authorization, rate limiting, cache keys, request signing, audit logging, and business logic use the same canonical parameter set.
+- [ ] Duplicate object ID, tenant, role, scope, price, redirect, callback, and signature parameters are rejected or normalized before any security decision.
+- [ ] Negative tests and access logs prove duplicate parameter attempts are blocked or deterministically handled.
+
 ### Remediation Guidance
 
 - Configure CORS with an explicit allowlist of permitted origins. Never use `*` with `credentials: true`.
@@ -462,6 +513,7 @@ Document doc = builder.parse(request.getInputStream());
 - Disable XML External Entity processing: set `factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)`.
 - Enforce TLS 1.2+ with strong cipher suites. Disable TLS 1.0 and 1.1.
 - Automate configuration scanning in CI/CD to detect drift from security baselines.
+- Reject duplicate security-sensitive parameters at the first trusted boundary, or canonicalize them once and pass the normalized representation to every downstream decision point.
 
 ### Review Checklist
 
@@ -472,6 +524,7 @@ Document doc = builder.parse(request.getInputStream());
 - [ ] TLS 1.2+ is enforced with strong cipher suites.
 - [ ] XML parsers disable external entity processing and DTD loading.
 - [ ] Default credentials are changed or removed on all infrastructure components.
+- [ ] Duplicate security-sensitive parameters are rejected or consistently canonicalized across gateway, application, cache, and downstream layers.
 
 ---
 


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill
- `api-security`
- Files changed:
  - `skills/appsec/api-security/SKILL.md`
  - `skills/appsec/api-security/api-top10-checklist.md`

### What Was Wrong
The API security skill did not require reviewers to test HTTP Parameter Pollution (HPP) or duplicate-parameter parser behavior across gateways, frameworks, validators, caches, signing logic, authorization middleware, and downstream services. That can miss cases where one layer validates or authorizes one parameter value while another layer acts on a different value.

### What This PR Fixes
- Bumps `api-security` to version `1.0.1`.
- Adds `HTTP Parameter Pollution and Duplicate Parameter Evidence` to the main workflow.
- Adds parser-consistency checks for gateway/WAF, load balancer, framework router, request binding middleware, validation libraries, application handlers, cache/CDN, and downstream services.
- Adds a `Parameter Pollution Coverage Matrix` for endpoint-level evidence.
- Adds severity/finding guidance mapped to API8/API10 plus CWE-235/CWE-20.
- Adds detailed HPP vulnerable/secure examples and an evidence checklist to `api-top10-checklist.md`.
- Adds OWASP WSTG-INPV-04 as a reference and a version history entry.

### Test Cases / Validation
- `git diff --check` passed.
- Markdown code fence balance passed:
  - `SKILL.md` fences: 8, balanced.
  - `api-top10-checklist.md` fences: 58, balanced.
- Required marker checks passed for:
  - `version: "1.0.1"`
  - `HTTP Parameter Pollution and Duplicate Parameter Evidence`
  - `Parameter Pollution Coverage Matrix`
  - `CWE-235`
  - `WSTG-INPV-04`
  - duplicate security-sensitive parameter rejection guidance.

### Bounty Tier
Moderate improver bounty requested: $100.

Closes #1715