### PR TITLE
Add Azure App Service publishing auth gates

### DIFF
--- a/skills/cloud/azure-review/SKILL.md
+++ b/skills/cloud/azure-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-Azure-v2.1.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -88,6 +88,31 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, Bic
 
 ---
 
+### App Service Deployment-Plane Basic Authentication Evidence
+
+For every App Service, Function App, and deployment slot in scope, verify the deployment plane separately from the application runtime. Disabling FTP traffic or enabling App Service Authentication on the app does not prove that basic publishing credentials are disabled for SCM/Kudu, WebDeploy, Local Git, ZipDeploy, or FTP publishing endpoints.
+
+Require evidence for:
+
+1. **SCM/Kudu basic auth policy** -- `Microsoft.Web/sites/basicPublishingCredentialsPolicies/scm` exists with `properties.allow = false`, or the equivalent AzureRM field disables WebDeploy/SCM publishing basic auth.
+2. **FTP publishing basic auth policy** -- `Microsoft.Web/sites/basicPublishingCredentialsPolicies/ftp` exists with `properties.allow = false`, or the equivalent AzureRM field disables FTP publishing basic auth.
+3. **Slots and Function Apps** -- the same policies are evaluated for deployment slots and function apps, not only production web apps.
+4. **Deployment method replacement** -- CI/CD uses Entra ID/OIDC, managed identity, service principal federation, or another non-basic deployment path before disabling publishing credentials.
+5. **Credential exposure and rotation** -- publish profiles, Local Git credentials, WebDeploy credentials, and stored pipeline secrets are rotated or invalidated after disabling basic auth.
+6. **Policy coverage** -- Azure Policy, Defender for Cloud recommendations, or configuration exports prove the setting is enforced across subscriptions and resource groups.
+
+Use this output table when App Service resources exist:
+
+| App/Slot | Resource Type | SCM Basic Auth | FTP Basic Auth | Deployment Method | Publish Profile Exposure | Policy Evidence | Status |
+|---|---|---|---|---|---|---|---|
+| `[name]` | `[web/function/slot]` | `[disabled/enabled/unknown]` | `[disabled/enabled/unknown]` | `[OIDC/managed identity/SP/basic]` | `[none/rotated/exposed/unknown]` | `[policy/export/file]` | `[pass/fail/not evaluable]` |
+
+Severity guidance:
+
+- **High:** SCM/Kudu or WebDeploy basic auth remains enabled on production or internet-exposed apps, especially when publish profiles or deployment credentials are stored in CI/CD secrets.
+- **Medium:** FTP publishing basic auth remains enabled, slots are not evaluated, or deployment credentials were not rotated after policy changes.
+- **Low:** Evidence is missing for policy enforcement in non-production subscriptions where runtime access is otherwise restricted.
+- **Not Evaluable:** App Service resources are present but the review lacks basic publishing credential policy exports or IaC definitions.
 
 ---
 
@@ -183,7 +208,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | 6 | Networking | NSG rules (RDP, SSH, UDP, HTTP), flow log retention, traffic analytics |
 | 7 | Virtual Machines | Azure Bastion, managed disks, disk encryption with CMK, approved extensions, endpoint protection |
 | 8 | Key Vault | Key/secret expiration, soft delete, purge protection, RBAC authorization, private endpoints |
-| 9 | App Service | Authentication, HTTPS redirect, TLS version, client certificates, Entra ID registration, HTTP/2, FTP disabled |
+| 9 | App Service | Authentication, HTTPS redirect, TLS version, client certificates, Entra ID registration, HTTP/2, FTP disabled, SCM/FTP basic publishing credentials disabled |
 
 ### CIS Profile Levels
 
@@ -200,6 +225,7 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **NSG rules using service tags.** A rule with `source_address_prefix = "Internet"` is equivalent to `0.0.0.0/0`. Both must be flagged for CIS 6.1 and 6.2.
 5. **Key Vault purge protection is irreversible.** CIS 8.5 requires `purge_protection_enabled = true`. Note this cannot be disabled once enabled -- flag this for awareness during remediation.
 6. **App Service TLS version on both Linux and Windows.** Check `azurerm_linux_web_app` and `azurerm_windows_web_app` resources separately.
+7. **Confusing runtime authentication with deployment-plane authentication.** App Service Authentication protects the hosted application. It does not prove that SCM/Kudu, WebDeploy, Local Git, ZipDeploy, or FTP basic publishing credentials are disabled.
 
 ---
 
@@ -225,10 +251,13 @@ Produce the final report using the structure defined in the Output Format sectio
 - Azure Storage Security: https://learn.microsoft.com/en-us/azure/storage/common/storage-security-guide
 - Azure Key Vault Best Practices: https://learn.microsoft.com/en-us/azure/key-vault/general/best-practices
 - Azure App Service Security: https://learn.microsoft.com/en-us/azure/app-service/overview-security
+- Disable Basic Authentication for Azure App Service Deployment: https://learn.microsoft.com/en-us/azure/app-service/configure-basic-auth-disable
+- Microsoft.Web/sites/basicPublishingCredentialsPolicies Resource: https://learn.microsoft.com/en-us/azure/templates/microsoft.web/sites/basicpublishingcredentialspolicies
 - Terraform AzureRM Provider Documentation: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
 
 ---
 
 ## Changelog
 
+- **1.0.1** -- Added App Service deployment-plane basic publishing credential evidence gates for SCM/Kudu and FTP.
 - **1.0.0** -- Initial release. Full coverage of CIS Microsoft Azure Foundations Benchmark v2.1.0 sections 1 through 9.

--- a/skills/cloud/azure-review/benchmark-checklist.md
+++ b/skills/cloud/azure-review/benchmark-checklist.md
@@ -704,3 +704,69 @@ resource "azurerm_linux_web_app" {
   }
 }
 ```
+
+### Additional App Service Gate -- Disable SCM and FTP Basic Publishing Credentials
+
+FTP disabled is not enough by itself. Review the App Service deployment plane and verify that basic publishing credentials are disabled for both SCM/Kudu/WebDeploy and FTP publishing. Apply the same check to Linux web apps, Windows web apps, Function Apps, and deployment slots.
+
+AzureRM examples:
+
+```hcl
+resource "azurerm_linux_web_app" "example" {
+  ftp_publish_basic_authentication_enabled       = false
+  webdeploy_publish_basic_authentication_enabled = false
+}
+
+resource "azurerm_windows_web_app" "example" {
+  ftp_publish_basic_authentication_enabled       = false
+  webdeploy_publish_basic_authentication_enabled = false
+}
+```
+
+ARM/Bicep/AzAPI evidence should show both `ftp` and `scm` child policies with `allow = false`:
+
+```bicep
+resource scmPolicy 'Microsoft.Web/sites/basicPublishingCredentialsPolicies@2024-04-01' = {
+  parent: webApp
+  name: 'scm'
+  properties: {
+    allow: false
+  }
+}
+
+resource ftpPolicy 'Microsoft.Web/sites/basicPublishingCredentialsPolicies@2024-04-01' = {
+  parent: webApp
+  name: 'ftp'
+  properties: {
+    allow: false
+  }
+}
+```
+
+Live-environment evidence:
+
+```bash
+az resource show \
+  --resource-group <resource-group> \
+  --namespace Microsoft.Web \
+  --resource-type basicPublishingCredentialsPolicies \
+  --parent sites/<app-name> \
+  --name scm \
+  --query properties.allow
+
+az resource show \
+  --resource-group <resource-group> \
+  --namespace Microsoft.Web \
+  --resource-type basicPublishingCredentialsPolicies \
+  --parent sites/<app-name> \
+  --name ftp \
+  --query properties.allow
+```
+
+Review checklist:
+
+- [ ] Both SCM and FTP basic publishing credential policies are explicitly disabled.
+- [ ] Web apps, Function Apps, and deployment slots are all in scope.
+- [ ] CI/CD deployment uses Entra ID/OIDC, managed identity, or federated service principal authentication instead of publish-profile basic auth.
+- [ ] Publish profiles, Local Git credentials, WebDeploy credentials, and stored deployment secrets are rotated or invalidated after disabling basic auth.
+- [ ] Azure Policy, Defender for Cloud, or configuration exports prove the setting is enforced across subscriptions and resource groups.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill
- `azure-review`
- Files changed:
  - `skills/cloud/azure-review/SKILL.md`
  - `skills/cloud/azure-review/benchmark-checklist.md`

### What Was Wrong
The Azure review skill checked App Service runtime controls such as authentication, HTTPS, TLS, client certificates, HTTP/2, and FTP state, but it did not require evidence that deployment-plane basic publishing credentials are disabled for SCM/Kudu/WebDeploy and FTP publishing. Runtime authentication does not protect publish profiles, Local Git, ZipDeploy, WebDeploy, or Kudu/SCM basic-auth deployment endpoints.

### What This PR Fixes
- Bumps `azure-review` to version `1.0.1`.
- Adds `App Service Deployment-Plane Basic Authentication Evidence` to the main workflow.
- Requires SCM/Kudu and FTP basic publishing credential policies to be disabled.
- Adds coverage for web apps, Function Apps, and deployment slots.
- Requires non-basic deployment replacement evidence, such as Entra ID/OIDC, managed identity, or federated service principal deployment.
- Requires publish-profile and stored deployment credential rotation/invalidation evidence.
- Adds an App Service output matrix for SCM/FTP basic auth, deployment method, publish profile exposure, policy evidence, and status.
- Adds AzureRM and ARM/Bicep/AzAPI examples to the benchmark checklist.
- Adds Microsoft references for disabling App Service deployment basic authentication and `basicPublishingCredentialsPolicies`.

### Test Cases / Validation
- `git diff --check` passed.
- Markdown code fence balance passed:
  - `SKILL.md` fences: 4, balanced.
  - `benchmark-checklist.md` fences: 98, balanced.
- Required marker checks passed for:
  - `version: "1.0.1"`
  - `App Service Deployment-Plane Basic Authentication Evidence`
  - `basicPublishingCredentialsPolicies/scm`
  - `basicPublishingCredentialsPolicies/ftp`
  - `SCM Basic Auth`
  - `ftp_publish_basic_authentication_enabled`
  - `webdeploy_publish_basic_authentication_enabled`
  - `configure-basic-auth-disable`

### Bounty Tier
Moderate improver bounty requested: $100.

Closes #1717