### PR TITLE
Add App Service publishing basic auth evidence gates

### DIFF
--- a/skills/cloud/azure-review/SKILL.md
+++ b/skills/cloud/azure-review/SKILL.md
@@ -7,13 +7,13 @@ description: >
   access policies. Walks through all nine benchmark sections, evaluates each
   recommendation, and produces a prioritized findings report with remediation
   guidance mapped to specific CIS control IDs.
-tags: [cloud, azure, cis-benchmark]
+tags: [cloud, azure, cis-benchmark, app-service]
 role: [cloud-security-engineer, security-engineer]
 phase: [assess, operate]
 frameworks: [CIS-Azure-v2.1.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -82,9 +82,22 @@ Record all discovered files. If no Azure configurations are found, report that f
 
 ### Step 2 through Step 10: CIS Benchmark Evaluation (Sections 1-9)
 
-Evaluate all Azure configurations against CIS Azure v2.1.0 Sections 1 through 9, covering Identity and Access Management, Microsoft Defender for Cloud, Storage Accounts, Database Services, Logging and Monitoring, Networking, Virtual Machines, Key Vault, and App Service.
+Evaluate all Azure configurations against CIS Azure v2.1.0 Sections 1 through 9, covering Identity and Access Management, Microsoft Defender for Cloud, Storage Accounts, Database Services, Logging and Monitoring, Networking, Virtual Machines, Key Vault, and App Service. For App Service, include both runtime controls and deployment-plane publishing controls.
 
 For detailed CIS benchmark checklist items with specific Terraform patterns, Bicep examples, and configuration checks for all nine sections, see [benchmark-checklist.md](benchmark-checklist.md) in this skill directory.
+#### App Service Deployment-Plane Basic Authentication Gate
+
+For every Azure App Service Web App, Function App, and deployment slot in scope, verify that deployment publishing endpoints do not allow basic authentication:
+
+- `Microsoft.Web/sites/basicPublishingCredentialsPolicies/scm` has `properties.allow = false` for SCM/Kudu, WebDeploy, Local Git, and ZipDeploy publishing.
+- `Microsoft.Web/sites/basicPublishingCredentialsPolicies/ftp` has `properties.allow = false` for FTP/FTPS publishing.
+- Terraform AzureRM fields such as `ftp_publish_basic_authentication_enabled = false` and `webdeploy_publish_basic_authentication_enabled = false` are present where supported.
+- Deployment slots have equivalent `Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies/{scm,ftp}` coverage.
+- CI/CD uses Entra ID, OIDC federation, managed identity, or a federated service principal instead of publish-profile basic authentication.
+- Publish profiles, user-level deployment credentials, and stored pipeline secrets are rotated or invalidated after disabling basic auth.
+- Azure Policy, Resource Graph, ARM export, Terraform plan, or CLI evidence proves coverage across subscriptions, resource groups, apps, functions, and slots.
+
+Treat missing SCM or FTP publishing policy evidence as not evaluable or failed rather than assuming runtime authentication, HTTPS-only, TLS, or `ftps_state = "Disabled"` protects the deployment plane.
 
 ---
 
@@ -142,6 +155,11 @@ Produce the final report using the structure defined in the Output Format sectio
 | 8 | Key Vault | X | Y | Z | nn% |
 | 9 | App Service | X | Y | Z | nn% |
 
+
+### App Service Deployment Publishing Evidence
+| App/Slot | SCM Basic Auth | FTP Basic Auth | Deployment Method | Publish Profile Exposure | Credential Rotation | Policy/Export Evidence | Status |
+|----------|----------------|----------------|-------------------|--------------------------|--------------------|------------------------|--------|
+| <app-or-slot> | Disabled / Enabled / Unknown | Disabled / Enabled / Unknown | OIDC / Managed Identity / Publish Profile / Unknown | None / Stored / Unknown | Rotated / Pending / N/A | <policy, ARG, ARM, Terraform, or CLI evidence> | Pass / Fail / Not Evaluable |
 ### Detailed Findings
 
 #### [CIS X.Y.Z] <Recommendation Title>
@@ -183,7 +201,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | 6 | Networking | NSG rules (RDP, SSH, UDP, HTTP), flow log retention, traffic analytics |
 | 7 | Virtual Machines | Azure Bastion, managed disks, disk encryption with CMK, approved extensions, endpoint protection |
 | 8 | Key Vault | Key/secret expiration, soft delete, purge protection, RBAC authorization, private endpoints |
-| 9 | App Service | Authentication, HTTPS redirect, TLS version, client certificates, Entra ID registration, HTTP/2, FTP disabled |
+| 9 | App Service | Authentication, HTTPS redirect, TLS version, client certificates, Entra ID registration, HTTP/2, FTP disabled, SCM/FTP publishing basic auth disabled |
 
 ### CIS Profile Levels
 
@@ -224,11 +242,11 @@ Produce the final report using the structure defined in the Output Format sectio
 - Microsoft Entra ID Security: https://learn.microsoft.com/en-us/entra/identity/
 - Azure Storage Security: https://learn.microsoft.com/en-us/azure/storage/common/storage-security-guide
 - Azure Key Vault Best Practices: https://learn.microsoft.com/en-us/azure/key-vault/general/best-practices
-- Azure App Service Security: https://learn.microsoft.com/en-us/azure/app-service/overview-security
+- Azure App Service Security: https://learn.microsoft.com/en-us/azure/app-service/overview-security`n- Disable basic authentication for Azure App Service deployments: https://learn.microsoft.com/en-us/azure/app-service/configure-basic-auth-disable`n- Microsoft.Web sites/basicPublishingCredentialsPolicies ARM/Bicep reference: https://learn.microsoft.com/en-us/azure/templates/microsoft.web/sites/basicpublishingcredentialspolicies`n- Microsoft.Web sites/slots/basicPublishingCredentialsPolicies ARM/Bicep reference: https://learn.microsoft.com/en-us/azure/templates/microsoft.web/sites/slots/basicpublishingcredentialspolicies
 - Terraform AzureRM Provider Documentation: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
 
 ---
 
 ## Changelog
 
-- **1.0.0** -- Initial release. Full coverage of CIS Microsoft Azure Foundations Benchmark v2.1.0 sections 1 through 9.
+- **1.1.0** -- Added App Service SCM/FTP publishing basic authentication evidence gates.`n- **1.0.0** -- Initial release. Full coverage of CIS Microsoft Azure Foundations Benchmark v2.1.0 sections 1 through 9.

--- a/skills/cloud/azure-review/benchmark-checklist.md
+++ b/skills/cloud/azure-review/benchmark-checklist.md
@@ -695,6 +695,92 @@ resource "azurerm_linux_web_app" {
 }
 ```
 
+
+### CIS 9.X -- Ensure App Service deployment publishing basic authentication is Disabled
+
+Azure App Service has a separate deployment plane for SCM/Kudu, WebDeploy, Local Git, ZipDeploy, and FTP/FTPS publishing. Runtime controls such as App Service Authentication, HTTPS-only, TLS version, client certificates, and `ftps_state = "Disabled"` do not prove that publish-profile basic authentication is disabled.
+
+**Terraform AzureRM evidence:**
+
+```hcl
+resource "azurerm_linux_web_app" "app" {
+  name                = "example-app"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  service_plan_id     = azurerm_service_plan.plan.id
+
+  https_only = true
+
+  ftp_publish_basic_authentication_enabled       = false
+  webdeploy_publish_basic_authentication_enabled = false
+
+  site_config {
+    ftps_state = "Disabled"
+  }
+}
+```
+
+Apply the same evidence requirement to `azurerm_windows_web_app`, `azurerm_linux_function_app`, `azurerm_windows_function_app`, and deployment slot resources where used.
+
+**ARM/Bicep evidence for SCM and FTP policies:**
+
+```bicep
+resource webApp 'Microsoft.Web/sites@2023-12-01' existing = {
+  name: appName
+}
+
+resource scmBasicAuth 'Microsoft.Web/sites/basicPublishingCredentialsPolicies@2023-12-01' = {
+  parent: webApp
+  name: 'scm'
+  properties: {
+    allow: false
+  }
+}
+
+resource ftpBasicAuth 'Microsoft.Web/sites/basicPublishingCredentialsPolicies@2023-12-01' = {
+  parent: webApp
+  name: 'ftp'
+  properties: {
+    allow: false
+  }
+}
+```
+
+**Deployment slot evidence:**
+
+```bicep
+resource slot 'Microsoft.Web/sites/slots@2023-12-01' existing = {
+  parent: webApp
+  name: slotName
+}
+
+resource slotScmBasicAuth 'Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies@2023-12-01' = {
+  parent: slot
+  name: 'scm'
+  properties: {
+    allow: false
+  }
+}
+
+resource slotFtpBasicAuth 'Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies@2023-12-01' = {
+  parent: slot
+  name: 'ftp'
+  properties: {
+    allow: false
+  }
+}
+```
+
+**Review checklist:**
+
+- Confirm both `scm` and `ftp` `basicPublishingCredentialsPolicies` exist with `properties.allow = false` for every Web App and Function App.
+- Confirm deployment slots have equivalent `sites/slots/basicPublishingCredentialsPolicies/{scm,ftp}` resources or exported evidence.
+- Confirm Terraform AzureRM sets `ftp_publish_basic_authentication_enabled = false` and `webdeploy_publish_basic_authentication_enabled = false` where those fields are available.
+- Confirm CI/CD uses Entra ID, OIDC federation, managed identity, or federated service principal deployment instead of publish-profile basic auth.
+- Confirm stored publish profiles, deployment passwords, and pipeline secrets were rotated or invalidated after disabling basic authentication.
+- Confirm Azure Policy, Azure Resource Graph, CLI export, ARM export, or Terraform plan evidence covers all subscriptions and resource groups in scope.
+- Do not mark the control as pass based only on `ftps_state = "Disabled"`; that setting blocks FTP traffic but does not prove SCM/WebDeploy basic publishing credentials are disabled.
+
 ### CIS 9.10 -- Ensure FTP deployments are Disabled
 
 ```hcl


### PR DESCRIPTION
## Summary
- Add an App Service deployment-plane basic authentication evidence gate for SCM/Kudu/WebDeploy/Local Git/ZipDeploy and FTP publishing endpoints.
- Extend output guidance with SCM/FTP basic auth status, deployment method, publish-profile exposure, credential rotation, and policy/export evidence.
- Add Terraform AzureRM and ARM/Bicep examples for disabling SCM and FTP basic publishing credentials, including deployment slots.
- Bump `azure-review` to version `1.1.0` and add Microsoft references for App Service deployment basic authentication policies.

Closes #1717

## Validation
- Reviewed the generated Markdown changes through the GitHub API compare output.
- Confirmed the updated skill includes `version: "1.1.0"`, the App Service deployment-plane basic authentication gate, and the output evidence table.
- Confirmed the checklist includes AzureRM fields, ARM/Bicep `basicPublishingCredentialsPolicies`, slot policy examples, and coverage checks.
- Did not clone the repository, install dependencies, or run project code.