### PR TITLE
Add GCP IAM Conditions evidence gates

### DIFF
--- a/skills/cloud/gcp-review/SKILL.md
+++ b/skills/cloud/gcp-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-GCP-v2.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -85,6 +85,35 @@ Record all discovered files. If no GCP configurations are found, report that fin
 Evaluate all GCP configurations against CIS GCP v2.0.0 Sections 1 through 7, covering Identity and Access Management, Logging and Monitoring, Networking, Virtual Machines, Storage, Cloud SQL, and BigQuery.
 
 For detailed CIS benchmark checklist items with specific Terraform patterns, grep patterns, and configuration examples for all seven sections, see [benchmark-checklist.md](benchmark-checklist.md) in this skill directory.
+
+---
+
+### IAM Conditions and Time-Bound Access Evidence
+
+When reviewing IAM bindings, verify whether privileged, temporary, emergency, contractor, partner, or environment-scoped access is constrained with IAM Conditions or an equivalent just-in-time mechanism. A binding that is described as "temporary" or "limited" is not sufficient evidence unless the policy itself enforces the condition.
+
+Require evidence for:
+
+1. **Condition expression** -- role bindings that should be temporary or scoped include a `condition` with explicit CEL expression, title, and description.
+2. **Time-bound access** -- temporary access uses `request.time < timestamp("...")` or an equivalent expiry expression, not only a ticket due date or manual reminder.
+3. **Resource and tag scoping** -- environment, folder, project, bucket, dataset, or service-specific access uses `resource.name`, `resource.type`, resource tags, or Access Context attributes where supported.
+4. **Unsupported binding detection** -- reviewers do not credit conditions on legacy basic roles (`roles/owner`, `roles/editor`, `roles/viewer`) or public principals (`allUsers`, `allAuthenticatedUsers`), because Google Cloud IAM Conditions do not apply to those grants.
+5. **Break-glass governance** -- emergency access has expiry, approver, ticket, activation reason, monitoring, and post-use review evidence.
+6. **Drift and expiry monitoring** -- IAM policies are exported or monitored so expired, missing, or weakened conditions are detected.
+
+Use this output table when IAM bindings are in scope:
+
+| Scope | Principal | Role | Condition | Expiry / Scope Expression | Unsupported Basic/Public Grant? | Evidence | Status |
+|---|---|---|---|---|---|---|---|
+| `[org/folder/project/resource]` | `[member]` | `[role]` | `[title or none]` | `[request.time/resource/tag expression]` | `[yes/no]` | `[policy export/file]` | `[pass/fail/not evaluable]` |
+
+Severity guidance:
+
+- **High:** privileged or production access is described as temporary or scoped but has no enforceable IAM Condition or JIT control.
+- **High:** basic roles or public principals are granted where a reviewer claims conditional access reduces risk; these grants cannot rely on IAM Conditions.
+- **Medium:** non-production, contractor, partner, or emergency access lacks expiry, resource scope, or post-use review evidence.
+- **Low:** conditions exist but have unclear titles/descriptions, weak monitoring, or missing expiry-review evidence.
+- **Not Evaluable:** IAM policy exports are unavailable, or the review cannot determine whether bindings include conditions.
 
 ---
 
@@ -171,7 +200,7 @@ Produce the final report using the structure defined in the Output Format sectio
 
 | Section | Domain | Key Focus Areas |
 |---------|--------|-----------------|
-| 1 | Identity and Access Management | Corporate credentials, MFA, service account keys, admin privileges, SA role assignments, KMS key access, API key restrictions, Essential Contacts |
+| 1 | Identity and Access Management | Corporate credentials, MFA, service account keys, admin privileges, conditional IAM bindings, SA role assignments, KMS key access, API key restrictions, Essential Contacts |
 | 2 | Logging and Monitoring | Cloud Audit Logs (admin/data read/write), log sinks, bucket lock retention, metric filters and alerts (8 categories), DNS logging, Cloud Asset Inventory |
 | 3 | Networking | Default network removal, legacy networks, DNSSEC, firewall rules (SSH/RDP from internet), VPC flow logs, SSL policies, IAP-only access |
 | 4 | Virtual Machines | Default service accounts, access scopes, project SSH key blocking, OS Login, serial port, IP forwarding, CMEK disks, Shielded VM, public IPs, Confidential Computing |
@@ -194,6 +223,7 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Cloud SQL authorized_networks vs. private IP.** CIS 6.5 flags `0.0.0.0/0` in authorized networks, but CIS 6.6 goes further and recommends disabling public IP entirely in favor of private networking.
 5. **BigQuery dataset-level vs. table-level CMEK.** CIS 7.2 checks table-level encryption, while CIS 7.3 checks the dataset default. Both should be evaluated independently.
 6. **Default compute service account identification.** The default SA follows the pattern `PROJECT_NUMBER-compute@developer.gserviceaccount.com`. Grep for this pattern, not just the string "default."
+7. **Assuming all IAM grants can be conditional.** IAM Conditions do not apply to legacy basic roles or public principals. Do not downgrade `roles/owner`, `roles/editor`, `roles/viewer`, `allUsers`, or `allAuthenticatedUsers` grants based on a claimed condition.
 
 ---
 
@@ -216,6 +246,8 @@ Produce the final report using the structure defined in the Output Format sectio
 - CIS Google Cloud Platform Foundation Benchmark v2.0.0: https://www.cisecurity.org/benchmark/google_cloud_computing_platform
 - Google Cloud Security Best Practices: https://cloud.google.com/security/best-practices
 - Google Cloud IAM Documentation: https://cloud.google.com/iam/docs
+- Google Cloud IAM Conditions Overview: https://cloud.google.com/iam/docs/conditions-overview
+- Google Cloud Temporary Access with IAM Conditions: https://cloud.google.com/iam/docs/configuring-temporary-access
 - Google Cloud Audit Logs: https://cloud.google.com/logging/docs/audit
 - Google Cloud VPC Documentation: https://cloud.google.com/vpc/docs
 - Google Cloud SQL Security: https://cloud.google.com/sql/docs/mysql/configure-ssl-instance
@@ -225,4 +257,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Added IAM Conditions and time-bound access evidence gates for scoped, temporary, and break-glass IAM bindings.
 - **1.0.0** -- Initial release. Full coverage of CIS Google Cloud Platform Foundation Benchmark v2.0.0 sections 1 through 7.

--- a/skills/cloud/gcp-review/benchmark-checklist.md
+++ b/skills/cloud/gcp-review/benchmark-checklist.md
@@ -80,6 +80,71 @@ Check for key rotation mechanisms or expiration policies on service account keys
 
 Verify that no user has both `iam.serviceAccountUser` and `iam.serviceAccountAdmin` simultaneously.
 
+### Additional IAM Gate -- Conditional and Time-Bound Role Bindings
+
+For privileged, temporary, emergency, contractor, partner, or environment-scoped access, verify that the IAM policy enforces the claimed boundary with IAM Conditions or an equivalent JIT access mechanism. Ticket due dates, calendar reminders, or comments are not enforceable access controls.
+
+Terraform examples:
+
+```hcl
+# PASS: temporary project-level admin support access expires automatically
+resource "google_project_iam_member" "temporary_support" {
+  project = var.project_id
+  role    = "roles/compute.admin"
+  member  = "group:support@example.com"
+
+  condition {
+    title       = "expires_2026_06_30"
+    description = "Temporary support access approved in CHG-1234"
+    expression  = "request.time < timestamp(\"2026-06-30T23:59:59Z\")"
+  }
+}
+```
+
+```hcl
+# FAIL: described as temporary, but no enforced condition
+resource "google_project_iam_member" "temporary_support" {
+  project = var.project_id
+  role    = "roles/compute.admin"
+  member  = "group:support@example.com"
+}
+```
+
+```hcl
+# FAIL: IAM Conditions do not make legacy basic roles or public grants safe
+resource "google_project_iam_member" "owner_grant" {
+  project = var.project_id
+  role    = "roles/owner"
+  member  = "user:admin@example.com"
+}
+
+resource "google_storage_bucket_iam_member" "public_reader" {
+  bucket = google_storage_bucket.example.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}
+```
+
+Live-environment evidence:
+
+```bash
+gcloud projects get-iam-policy <project-id> \
+  --format=json
+
+gcloud organizations get-iam-policy <org-id> \
+  --format=json
+```
+
+Review checklist:
+
+- [ ] Privileged, emergency, partner, contractor, and temporary grants include an enforceable `condition` or are managed by a JIT system.
+- [ ] Time-limited access uses `request.time < timestamp("...")` or equivalent expiry logic.
+- [ ] Environment or resource-scoped access uses resource attributes, tags, Access Context attributes, or service-specific scopes where supported.
+- [ ] Legacy basic roles (`roles/owner`, `roles/editor`, `roles/viewer`) are not credited as conditionally constrained.
+- [ ] Public principals (`allUsers`, `allAuthenticatedUsers`) are not credited as conditionally constrained.
+- [ ] Break-glass grants include expiry, approver, ticket, activation reason, monitoring, and post-use review evidence.
+- [ ] IAM policy exports or SCC/Cloud Asset Inventory monitoring detect missing, expired, or weakened conditions.
+
 ### CIS 1.9 -- Ensure that Cloud KMS Cryptokeys Are Not Anonymously or Publicly Accessible
 
 **Grep patterns:**


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill
- `gcp-review`
- Files changed:
  - `skills/cloud/gcp-review/SKILL.md`
  - `skills/cloud/gcp-review/benchmark-checklist.md`

### What Was Wrong
The GCP review skill covered IAM service account keys, admin privileges, service account role assignments, KMS access, API keys, and public grants, but it did not require evidence that temporary, scoped, emergency, contractor, or partner access is actually enforced with IAM Conditions or a JIT mechanism. Reviewers could accept comments, ticket due dates, or manual reminders as proof of temporary access even when the IAM binding itself was permanent.

It also did not warn that IAM Conditions do not apply to legacy basic roles or public principals, which can lead to false risk reduction claims for `roles/owner`, `roles/editor`, `roles/viewer`, `allUsers`, or `allAuthenticatedUsers` grants.

### What This PR Fixes
- Bumps `gcp-review` to version `1.0.1`.
- Adds `IAM Conditions and Time-Bound Access Evidence` to the main workflow.
- Requires conditional bindings to include explicit CEL expression, title, and description.
- Requires temporary access to have enforceable `request.time < timestamp(...)` expiry.
- Requires scoped access to use resource attributes, tags, Access Context attributes, or service-specific scope where supported.
- Adds unsupported binding detection for legacy basic roles and public principals.
- Adds break-glass governance and drift/expiry monitoring evidence requirements.
- Adds an IAM Conditions output matrix.
- Adds Terraform and live `gcloud ... get-iam-policy` examples to the benchmark checklist.
- Adds Google Cloud IAM Conditions and temporary access references.

### Test Cases / Validation
- `git diff --check` passed.
- Markdown code fence balance passed:
  - `SKILL.md` fences: 4, balanced.
  - `benchmark-checklist.md` fences: 106, balanced.
- Required marker checks passed for:
  - `version: "1.0.1"`
  - `IAM Conditions and Time-Bound Access Evidence`
  - `request.time < timestamp`
  - `Unsupported Basic/Public Grant`
  - `roles/owner`
  - `allAuthenticatedUsers`
  - `configuring-temporary-access`
  - `Conditional and Time-Bound Role Bindings`

### Bounty Tier
Moderate improver bounty requested: $100.

Closes #1727