### PR TITLE
Add GCP IAM Conditions evidence gates

### DIFF
--- a/skills/cloud/gcp-review/SKILL.md
+++ b/skills/cloud/gcp-review/SKILL.md
@@ -7,13 +7,13 @@ description: >
   Walks through all seven benchmark sections, evaluates each recommendation,
   and produces a prioritized findings report with remediation guidance mapped
   to specific CIS control IDs.
-tags: [cloud, gcp, cis-benchmark]
+tags: [cloud, gcp, cis-benchmark, iam-conditions]
 role: [cloud-security-engineer, security-engineer]
 phase: [assess, operate]
 frameworks: [CIS-GCP-v2.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -82,9 +82,22 @@ Record all discovered files. If no GCP configurations are found, report that fin
 
 ### Step 2 through Step 8: CIS Benchmark Evaluation (Sections 1-7)
 
-Evaluate all GCP configurations against CIS GCP v2.0.0 Sections 1 through 7, covering Identity and Access Management, Logging and Monitoring, Networking, Virtual Machines, Storage, Cloud SQL, and BigQuery.
+Evaluate all GCP configurations against CIS GCP v2.0.0 Sections 1 through 7, covering Identity and Access Management, Logging and Monitoring, Networking, Virtual Machines, Storage, Cloud SQL, and BigQuery. For IAM, include permanent grants and conditional/time-bound access evidence.
 
 For detailed CIS benchmark checklist items with specific Terraform patterns, grep patterns, and configuration examples for all seven sections, see [benchmark-checklist.md](benchmark-checklist.md) in this skill directory.
+#### IAM Conditions and Time-Bound Access Gate
+
+For temporary, scoped, emergency, contractor, partner, or break-glass access, verify that risk reduction is enforced by the IAM policy or a documented JIT mechanism, not only by comments, tickets, calendar reminders, or manual offboarding tasks:
+
+- Conditional IAM bindings include a `condition` object with `title`, `description`, and a CEL `expression`.
+- Temporary access uses an enforceable expiry such as `request.time < timestamp("YYYY-MM-DDTHH:MM:SSZ")`.
+- Scoped access uses supported resource attributes, resource tags, Access Context attributes, or service-specific attributes where available.
+- Legacy basic roles (`roles/owner`, `roles/editor`, `roles/viewer`) are not credited as conditionally constrained because IAM Conditions do not apply to basic role grants.
+- Public principals (`allUsers`, `allAuthenticatedUsers`) are not credited as conditionally constrained because IAM Conditions do not apply to public grants.
+- Break-glass access evidence includes expiry, approver, ticket or incident ID, activation reason, monitoring, and post-use review.
+- IAM policy exports, Cloud Asset Inventory, Security Command Center, log metrics, or monitoring detect missing, expired, or weakened conditions.
+
+Treat missing condition expressions, unsupported basic/public grants, or expired conditions that remain bound as failed or not evaluable rather than accepting narrative evidence alone.
 
 ---
 
@@ -138,6 +151,11 @@ Produce the final report using the structure defined in the Output Format sectio
 | 6 | Cloud SQL | X | Y | Z | nn% |
 | 7 | BigQuery | X | Y | Z | nn% |
 
+
+### IAM Conditions and Temporary Access Evidence
+| Principal | Role | Resource Scope | Condition Title | Expiry / Scope Expression | Basic/Public Grant Unsupported? | Evidence Source | Review Status |
+|-----------|------|----------------|-----------------|---------------------------|----------------------------------|-----------------|---------------|
+| <principal> | <role> | <project/folder/org/resource> | <title or none> | <CEL expression, JIT grant, or none> | Yes / No / N/A | <Terraform, gcloud export, CAI, log, ticket> | Pass / Fail / Not Evaluable |
 ### Detailed Findings
 
 #### [CIS X.Y] <Recommendation Title>
@@ -171,7 +189,7 @@ Produce the final report using the structure defined in the Output Format sectio
 
 | Section | Domain | Key Focus Areas |
 |---------|--------|-----------------|
-| 1 | Identity and Access Management | Corporate credentials, MFA, service account keys, admin privileges, SA role assignments, KMS key access, API key restrictions, Essential Contacts |
+| 1 | Identity and Access Management | Corporate credentials, MFA, service account keys, admin privileges, SA role assignments, IAM Conditions/time-bound access, KMS key access, API key restrictions, Essential Contacts |
 | 2 | Logging and Monitoring | Cloud Audit Logs (admin/data read/write), log sinks, bucket lock retention, metric filters and alerts (8 categories), DNS logging, Cloud Asset Inventory |
 | 3 | Networking | Default network removal, legacy networks, DNSSEC, firewall rules (SSH/RDP from internet), VPC flow logs, SSL policies, IAP-only access |
 | 4 | Virtual Machines | Default service accounts, access scopes, project SSH key blocking, OS Login, serial port, IP forwarding, CMEK disks, Shielded VM, public IPs, Confidential Computing |
@@ -215,7 +233,7 @@ Produce the final report using the structure defined in the Output Format sectio
 
 - CIS Google Cloud Platform Foundation Benchmark v2.0.0: https://www.cisecurity.org/benchmark/google_cloud_computing_platform
 - Google Cloud Security Best Practices: https://cloud.google.com/security/best-practices
-- Google Cloud IAM Documentation: https://cloud.google.com/iam/docs
+- Google Cloud IAM Documentation: https://cloud.google.com/iam/docs`n- IAM Conditions overview: https://cloud.google.com/iam/docs/conditions-overview`n- Configure temporary access with IAM Conditions: https://cloud.google.com/iam/docs/configuring-temporary-access`n- IAM Conditions attribute reference: https://cloud.google.com/iam/docs/conditions-attribute-reference
 - Google Cloud Audit Logs: https://cloud.google.com/logging/docs/audit
 - Google Cloud VPC Documentation: https://cloud.google.com/vpc/docs
 - Google Cloud SQL Security: https://cloud.google.com/sql/docs/mysql/configure-ssl-instance
@@ -225,4 +243,4 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
-- **1.0.0** -- Initial release. Full coverage of CIS Google Cloud Platform Foundation Benchmark v2.0.0 sections 1 through 7.
+- **1.1.0** -- Added IAM Conditions and time-bound access evidence gates.`n- **1.0.0** -- Initial release. Full coverage of CIS Google Cloud Platform Foundation Benchmark v2.0.0 sections 1 through 7.

--- a/skills/cloud/gcp-review/benchmark-checklist.md
+++ b/skills/cloud/gcp-review/benchmark-checklist.md
@@ -76,6 +76,93 @@ These roles should be granted at the service account level, not project level.
 
 Check for key rotation mechanisms or expiration policies on service account keys.
 
+
+### CIS 1.X -- Ensure temporary and scoped access uses IAM Conditions or JIT enforcement
+
+Temporary, emergency, contractor, partner, and scoped access should be enforced in the IAM binding or a documented just-in-time access system. A ticket due date, comment, manual reminder, or spreadsheet owner is not sufficient evidence that access expires or stays scoped.
+
+**Terraform conditional binding evidence:**
+
+```hcl
+resource "google_project_iam_member" "temporary_incident_access" {
+  project = var.project_id
+  role    = "roles/logging.viewer"
+  member  = "user:incident.responder@example.com"
+
+  condition {
+    title       = "temporary_incident_access"
+    description = "Expires after INC-1234 remediation window"
+    expression  = "request.time < timestamp(\"2026-07-01T00:00:00Z\")"
+  }
+}
+```
+
+**Terraform scoped resource/tag evidence:**
+
+```hcl
+resource "google_project_iam_member" "tag_scoped_access" {
+  project = var.project_id
+  role    = "roles/compute.viewer"
+  member  = "group:contractors@example.com"
+
+  condition {
+    title       = "contractor_prod_read_scope"
+    description = "Limit contractor reads to approved tagged resources"
+    expression  = "resource.matchTag(\"123456789012/environment\", \"approved-review\")"
+  }
+}
+```
+
+**gcloud policy export evidence:**
+
+```sh
+gcloud projects get-iam-policy PROJECT_ID --format=json
+```
+
+Expected conditional binding shape:
+
+```json
+{
+  "role": "roles/logging.viewer",
+  "members": ["user:incident.responder@example.com"],
+  "condition": {
+    "title": "temporary_incident_access",
+    "description": "Expires after INC-1234 remediation window",
+    "expression": "request.time < timestamp(\"2026-07-01T00:00:00Z\")"
+  }
+}
+```
+
+**Unsupported grant checks:**
+
+```hcl
+# FAIL: IAM Conditions cannot constrain legacy basic roles.
+resource "google_project_iam_member" "temporary_owner" {
+  project = var.project_id
+  role    = "roles/owner"
+  member  = "user:contractor@example.com"
+}
+
+# FAIL: IAM Conditions cannot constrain public principals.
+resource "google_project_iam_member" "public_viewer" {
+  project = var.project_id
+  role    = "roles/storage.objectViewer"
+  member  = "allUsers"
+}
+```
+
+**Review checklist:**
+
+- Confirm every temporary, emergency, contractor, partner, and break-glass grant has a condition expression or JIT control that actually enforces expiry or scope.
+- Confirm conditional bindings include `title`, useful `description`, and a CEL `expression`.
+- Confirm temporary access includes `request.time < timestamp(...)` with a future UTC timestamp tied to the approved access window.
+- Confirm scoped access uses supported resource attributes, resource tags, Access Context attributes, or service-specific attributes; do not infer scope from naming alone.
+- Confirm `roles/owner`, `roles/editor`, and `roles/viewer` grants are treated as unsupported for IAM Conditions rather than marked as conditionally constrained.
+- Confirm `allUsers` and `allAuthenticatedUsers` grants are treated as unsupported for IAM Conditions rather than marked as conditionally constrained.
+- Confirm break-glass evidence includes approver, ticket or incident ID, activation reason, expiry, monitoring, and post-use review.
+- Confirm IAM policy exports, Cloud Asset Inventory, Security Command Center, log metrics, or monitoring detect missing, expired, removed, or weakened conditions.
+- Flag expired conditions that remain present with no cleanup workflow as weak evidence even if access is no longer effective.
+
 ### CIS 1.8 -- Ensure that Separation of Duties is Enforced While Assigning Service Account Related Roles to Users
 
 Verify that no user has both `iam.serviceAccountUser` and `iam.serviceAccountAdmin` simultaneously.


### PR DESCRIPTION
## Summary
- Add IAM Conditions and time-bound access evidence gates to the GCP review workflow.
- Extend output guidance with principal, role, resource scope, condition title, expiry/scope expression, unsupported basic/public grant status, evidence, and review status.
- Add Terraform conditional binding examples, `gcloud projects get-iam-policy` export evidence, and unsupported basic/public grant checks to the benchmark checklist.
- Bump `gcp-review` to version `1.1.0` and add Google IAM Conditions references.

Closes #1727

## Validation
- Reviewed the generated Markdown changes through the GitHub API compare output.
- Confirmed the updated skill includes `version: "1.1.0"`, the IAM Conditions evidence gate, and the output evidence table.
- Confirmed the checklist includes Terraform condition examples, `gcloud ... get-iam-policy`, and unsupported basic/public grant checks.
- Did not clone the repository, install dependencies, or run project code.