### PR TITLE
Add SOC 2 emergency change evidence gates

### DIFF
--- a/skills/compliance/soc2-gap/SKILL.md
+++ b/skills/compliance/soc2-gap/SKILL.md
@@ -6,13 +6,13 @@ description: >
   or security program maturity. Walks through all Common Criteria (CC1-CC9) plus
   selected additional criteria, identifies gaps, and produces a remediation
   roadmap with evidence requirements and 90-day action plan.
-tags: [compliance, soc2, audit]
+tags: [compliance, soc2, audit, change-management]
 role: [vciso, security-engineer]
 phase: [assess, operate]
 frameworks: [AICPA-TSC, NIST-CSF-2.0]
 difficulty: intermediate
 time_estimate: "60-120min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -318,7 +318,7 @@ Prioritize remediation by audit readiness impact. Items that would result in exa
 - [ ] Implement formal access provisioning and deprovisioning procedures (CC6.1, CC6.2, CC6.3, CC6.5)
 - [ ] Conduct initial quarterly access review (CC6.1)
 - [ ] Deploy centralized logging and SIEM or log aggregation (CC7.1, CC7.2)
-- [ ] Implement change management controls in CI/CD pipeline (CC8.1)
+- [ ] Implement change management controls in CI/CD pipeline (CC8.1)`n- [ ] Collect emergency-change rollback, abort criteria, segregation-of-duties, retroactive approval SLA, and post-implementation review evidence for sampled emergency changes (CC8.1)
 - [ ] Document and publish incident response plan (CC7.3, CC7.4)
 - [ ] Initiate vendor inventory and begin collecting vendor SOC 2 reports (CC9.2)
 - [ ] Conduct initial risk assessment (CC3.2)
@@ -368,7 +368,13 @@ When performing a SOC 2 gap analysis, produce the following deliverables:
 5. **Evidence Checklist**: Customized evidence requirements based on in-scope criteria, marking items as Exists / Partial / Missing.
 6. **90-Day Remediation Roadmap**: Prioritized action items with owners, deadlines, and dependencies.
 7. **Overall Readiness Assessment**: Go/no-go recommendation for engaging a SOC 2 auditor.
+7. **Emergency Change Evidence Matrix**: For any emergency production changes in the audit period, include sampled CC8.1 evidence with rollback, abort criteria, segregation-of-duties, approval SLA, validation, and post-implementation review status.
 
+
+### Emergency Change Evidence Matrix (CC8.1)
+| Change ID | Emergency Reason | Incident/Risk Link | Approval Evidence | SoD Evidence | Validation Evidence | Rollback / Abort Evidence | Post-Implementation Review | Finding ID / Status |
+|---|---|---|---|---|---|---|---|---|
+| [CHG-ID] | [reason] | [incident/vuln/outage/customer impact] | [pre/retro approval + SLA] | [requester/approver/deployer/verifier] | [CI/smoke/health evidence] | [specific rollback + abort criteria] | [reviewer/date/follow-up] | [Pass or SOC2-CC8-EMERG-*] |
 ## Prompt Injection Safety Notice
 
 This skill processes user-supplied content including compliance documentation, policies, and configuration files. The agent must adhere to the following safety constraints:
@@ -384,7 +390,7 @@ This skill processes user-supplied content including compliance documentation, p
 ## Cross-References
 
 - **NIST CSF 2.0 Mapping**: CC1-CC2 maps to Govern (GV), CC3 to Identify (ID), CC5-CC6 to Protect (PR), CC7 to Detect (DE) and Respond (RS), CC7.5 to Recover (RC).
-- **ISO 27001:2022**: CC6 maps to Annex A.8 (Technology Controls), CC8 maps to Annex A.8.32 (Change Management), CC9.2 maps to Annex A.5.19-5.22 (Supplier Relationships).
+- **ISO 27001:2022**: CC6 maps to Annex A.8 (Technology Controls), CC8 maps to Annex A.8.32 (Change Management), CC9.2 maps to Annex A.5.19-5.22 (Supplier Relationships).`n- **ITIL Change Enablement**: Emergency changes should retain authorization, implementation, rollback, and post-implementation review evidence even when the workflow is expedited.
 - **CIS Controls v8**: CC6.1 maps to CIS Control 6 (Access Control Management), CC6.8 maps to CIS Control 10 (Malware Defenses), CC7.1 maps to CIS Control 7 (Continuous Vulnerability Management).
 
 ## Limitations
@@ -393,3 +399,10 @@ This skill processes user-supplied content including compliance documentation, p
 - The gap analysis is based on information available in the codebase and documentation. It cannot assess controls that exist only in human processes without documentation.
 - Scoring is subjective and should be validated by the organization's security leadership and, ideally, a qualified auditor.
 - This analysis uses the 2017 AICPA Trust Services Criteria (with 2022 updates). Verify with your auditor that these criteria are current for your engagement.
+
+---
+
+## Changelog
+
+- **1.0.1** -- Added CC8.1 emergency-change rollback, segregation-of-duties, retroactive approval, and post-implementation review evidence gates.
+- **1.0.0** -- Initial SOC 2 Type II readiness gap analysis workflow.

--- a/skills/compliance/soc2-gap/SKILL.md
+++ b/skills/compliance/soc2-gap/SKILL.md
@@ -357,6 +357,32 @@ Prioritize remediation by audit readiness impact. Items that would result in exa
 
 ---
 
+### CC8.1 Emergency Change Evidence Gate
+
+Emergency changes are expedited changes, not evidence-free changes. When emergency production changes occurred during the SOC 2 review period, require auditor-verifiable evidence that each change was authorized, validated, recoverable, and reviewed after implementation.
+
+For every sampled emergency change, collect:
+
+- change identifier linking ticket, incident, PR, deployment run, and production audit log;
+- emergency reason tied to incident, outage, vulnerability, customer impact, or risk record;
+- approval evidence, including retroactive approval due/completed timestamps when pre-approval was not possible;
+- requester, approver, deployer, and verifier identities, plus compensating review if segregation of duties collapsed;
+- CI result, smoke test, health check, monitoring, or other validation evidence;
+- change-specific rollback plan, abort criteria, rollback owner, and previous known-good version or configuration;
+- post-implementation review with reviewer, completion timestamp, outcome, and follow-up control actions.
+
+Do not score CC8.1 as audit-ready based on chat-only approval, generic rollback runbooks, closed deployment tickets, or emergency labels without the evidence fields above.
+
+Use these finding IDs for emergency-change gaps:
+
+| Finding ID | Condition |
+|---|---|
+| SOC2-CC8-EMERG-01 | Emergency production change lacks a formal ticket or traceable change identifier. |
+| SOC2-CC8-EMERG-02 | Emergency reason is missing or not tied to incident, vulnerability, outage, customer-impact, or risk evidence. |
+| SOC2-CC8-EMERG-03 | Approval is missing, undocumented, or outside the policy-defined retroactive approval SLA. |
+| SOC2-CC8-EMERG-04 | Requester, approver, deployer, and verifier are the same person without compensating review. |
+| SOC2-CC8-EMERG-05 | Change-specific rollback plan, abort criteria, or rollback owner is missing. |
+| SOC2-CC8-EMERG-06 | Post-implementation review is missing, unsigned, late, or lacks follow-up control actions. |
 ## Output Format
 
 When performing a SOC 2 gap analysis, produce the following deliverables:
@@ -368,7 +394,7 @@ When performing a SOC 2 gap analysis, produce the following deliverables:
 5. **Evidence Checklist**: Customized evidence requirements based on in-scope criteria, marking items as Exists / Partial / Missing.
 6. **90-Day Remediation Roadmap**: Prioritized action items with owners, deadlines, and dependencies.
 7. **Overall Readiness Assessment**: Go/no-go recommendation for engaging a SOC 2 auditor.
-7. **Emergency Change Evidence Matrix**: For any emergency production changes in the audit period, include sampled CC8.1 evidence with rollback, abort criteria, segregation-of-duties, approval SLA, validation, and post-implementation review status.
+8. **Emergency Change Evidence Matrix**: For any emergency production changes in the audit period, include sampled CC8.1 evidence with rollback, abort criteria, segregation-of-duties, approval SLA, validation, and post-implementation review status.
 
 
 ### Emergency Change Evidence Matrix (CC8.1)

--- a/skills/compliance/soc2-gap/tsc-criteria.md
+++ b/skills/compliance/soc2-gap/tsc-criteria.md
@@ -290,7 +290,7 @@ This file contains the detailed Trust Services Criteria evaluation questions, ev
   - Is there a formal change management process?
   - Are changes tested before deployment to production?
   - Is there segregation of duties between development, testing, and deployment?
-  - Are emergency change procedures defined?
+  - Are emergency change procedures defined?`n  - Do emergency changes retain ticket, incident reason, approval SLA, segregation-of-duties, validation, rollback, abort, and post-implementation review evidence?
 - Evidence to look for:
   - Change management policy
   - CI/CD pipeline configurations showing approval gates, automated testing, and deployment controls
@@ -551,7 +551,7 @@ After scoring, calculate:
 | CC7.3 | Incident response plan; severity classification matrix; triage procedures |
 | CC7.4 | Tabletop exercise records; IR team roster; communication templates; post-incident review records |
 | CC7.5 | DR plan; BC plan; backup configs; backup restoration test records |
-| CC8.1 | Change management policy; CI/CD pipeline configs with approval gates; PR review records; CAB minutes; segregation of duties evidence |
+| CC8.1 | Change management policy; CI/CD pipeline configs with approval gates; PR review records; CAB minutes; emergency-change tickets; rollback plans; abort criteria; smoke-test/health-check evidence; post-implementation review sign-offs; segregation of duties evidence |
 | CC9.1 | Risk treatment plans; business impact analysis; risk acceptance sign-off records |
 | CC9.2 | Vendor management policy; vendor risk assessments; vendor SOC 2 review records; vendor inventory; DPAs/BAAs |
 | A1.1 | Capacity monitoring dashboards; auto-scaling configs; capacity planning documentation |

--- a/skills/compliance/soc2-gap/tsc-criteria.md
+++ b/skills/compliance/soc2-gap/tsc-criteria.md
@@ -434,6 +434,17 @@ Based on the scope determined in Step 1, evaluate the following additional crite
 
 ---
 
+### CC8.1 Emergency Change Sampling Checklist
+
+When emergency production changes occurred during the audit period, sample them separately from standard changes. Record each sampled emergency change in this matrix:
+
+| Change ID | Emergency Reason | Approval SLA Met | Requester | Approver | Deployer | Verifier | Validation Evidence | Rollback / Abort Evidence | Post-Implementation Review | Result |
+|---|---|---|---|---|---|---|---|---|---|---|
+| [CHG-ID] | [incident/vulnerability/outage] | [Yes/No/N/A] | [name/team] | [name/team] | [name/team] | [name/team] | [CI/smoke/health] | [specific rollback + threshold] | [reviewer/date/actions] | [Pass/Finding ID] |
+
+**Benign evidence example:** an emergency patch linked to an exploited vulnerability, with separated requester/approver/deployer/verifier, retroactive approval completed inside policy SLA, successful CI and smoke test, change-specific rollback/abort criteria, and completed post-implementation review.
+
+**Vulnerable evidence example:** a hotfix ticket where the same person requested, approved, deployed, and verified the change, approval is missing, rollback and abort criteria are null, and no post-implementation review exists.
 ## Gap Scoring Matrix
 
 Score each criterion using the following maturity scale:


### PR DESCRIPTION
## Summary
- Add a CC8.1 emergency-change evidence gate to the SOC 2 gap workflow.
- Add emergency-change finding IDs for missing ticket, reason, approval SLA, SoD, rollback/abort, and post-implementation review evidence.
- Extend the output schema with an emergency change evidence matrix.
- Extend the TSC criteria checklist with emergency-change sampling fields and benign/vulnerable examples.

Closes #1706

## Validation
- Reviewed the generated Markdown changes through the GitHub API compare output.
- Confirmed the updated skill includes `version: "1.0.1"`, the CC8.1 emergency change gate, output matrix, `SOC2-CC8-EMERG-*` finding IDs, and emergency-change sampling examples.
- Did not clone the repository, install dependencies, or run project code.