### PR TITLE
Add AWS public snapshot sharing gates

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-AWS-v3.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -53,6 +53,8 @@ The CIS Amazon Web Services Foundations Benchmark v3.0.0 is a consensus-driven s
 - AWS CLI output or configuration exports (if reviewing a live environment)
 - IAM policy documents (JSON)
 - S3 bucket policies and ACL configurations
+- RDS DB snapshot attributes, EBS snapshot permissions, and AMI launch permissions, if available
+- EBS snapshot block public access state for each in-scope Region, if available
 - VPC, security group, and NACL definitions
 - CloudTrail and CloudWatch configuration files
 
@@ -76,6 +78,10 @@ Use Glob to locate all AWS-related infrastructure definitions.
 **/terraform/**/*.tf
 **/iam-policies/**/*.json
 **/policies/**/*.json
+**/rds-snapshots/**/*.json
+**/ec2-snapshots/**/*.json
+**/amis/**/*.json
+**/aws-cli-exports/**/*.json
 ```
 
 Also locate supporting configuration:
@@ -99,6 +105,32 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
+### Step 6.5: Public Snapshot and AMI Sharing Evidence
+
+After evaluating storage controls, review backup and image artifacts that can expose data even when the live resource is private.
+
+Require evidence for:
+
+- **RDS DB snapshot restore attributes:** identify manual DB snapshots whose `restore` attribute includes `all` or unapproved account IDs.
+- **EBS snapshot create-volume permissions:** identify snapshots whose `createVolumePermission` includes `Group=all` or unapproved account IDs.
+- **AMI launch permissions:** identify AMIs whose `launchPermission` includes `Group=all`, then trace referenced block-device snapshots where possible.
+- **EBS block public access state:** record `get-snapshot-block-public-access-state` for each in-scope Region and distinguish `block-all-sharing`, `block-new-sharing`, and unblocked states.
+- **Coverage denominator:** list accounts and Regions reviewed, plus Not Evaluable reason codes for missing live inventory, missing snapshot attributes, unsupported export format, or out-of-scope backup accounts.
+
+Do not treat a private RDS instance, encrypted EBS volume, or encrypted live database as proof that snapshots and images are private. Snapshot sharing, AMI launch permissions, and account-level public-access blocks are separate evidence paths.
+
+Severity calibration:
+
+| Evidence Pattern | Severity |
+|------------------|----------|
+| Public RDS/EBS snapshot or public AMI containing sensitive production-derived data with no effective block-public-access mitigation | Critical |
+| Public RDS/EBS snapshot or public AMI where data sensitivity is unknown or production-derived | High |
+| Private cross-account snapshot sharing lacks approved account list, ticket, expiration, or periodic review evidence | Medium |
+| EBS block public access exists but Region coverage, existing public snapshot inventory, or AMI launch-permission evidence is incomplete | Low |
+| No public snapshots/AMIs found and snapshot public-access controls are evidenced across all in-scope Regions | Informational |
+
+---
+
 ### Step 7: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
@@ -109,8 +141,8 @@ Produce the final report using the structure defined in the Output Format sectio
 
 | Severity | Definition | Examples |
 |----------|-----------|----------|
-| **Critical** | Immediate risk of data breach or account compromise | Public S3 buckets with sensitive data, `*:*` admin policies on users, security groups open to 0.0.0.0/0 on admin ports |
-| **High** | Significant security gap that materially weakens posture | Missing CloudTrail, no MFA enforcement, unencrypted RDS, IMDSv1 enabled |
+| **Critical** | Immediate risk of data breach or account compromise | Public S3 buckets with sensitive data, public production DB snapshots, `*:*` admin policies on users, security groups open to 0.0.0.0/0 on admin ports |
+| **High** | Significant security gap that materially weakens posture | Missing CloudTrail, no MFA enforcement, public AMI backed by sensitive snapshots, unencrypted RDS, IMDSv1 enabled |
 | **Medium** | Control gap that should be addressed in normal cycle | Missing log metric filters, password policy below requirements, no VPC flow logs |
 | **Low** | Hardening recommendation or defense-in-depth measure | Missing Macie classification, no hardware MFA on root (when virtual MFA exists), missing access analyzer in non-primary regions |
 | **Informational** | Best practice observation, no direct security impact | Naming conventions, tag hygiene, documentation gaps |
@@ -135,6 +167,7 @@ Produce the final report using the structure defined in the Output Format sectio
 - Not Applicable: <N>
 - Not Evaluable (insufficient data): <N>
 - Overall compliance: <percentage>
+- Supplemental public snapshot/AMI exposure findings: <N>
 
 ### Section Scores
 
@@ -158,6 +191,20 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Evidence:** <specific configuration or code snippet>
 - **Remediation:** <specific fix with code example>
 
+#### [AWS-SNAPSHOT-EXPOSURE] <Snapshot or AMI Sharing Finding>
+- **Status:** Pass / Fail / Not Evaluable
+- **Severity:** Critical / High / Medium / Low / Informational
+- **Artifact Type:** RDS DB snapshot / EBS snapshot / AMI
+- **Account / Region:** <account-id> / <region>
+- **Artifact ID:** <snapshot-id or ami-id>
+- **Public Attribute:** `restore=all` / `createVolumePermission=Group=all` / `launchPermission=Group=all` / none
+- **Explicit Shared Accounts:** <approved accounts / unapproved accounts / not available>
+- **EBS Block Public Access State:** <block-all-sharing / block-new-sharing / unblocked / not applicable / not available>
+- **Data Sensitivity:** <production / regulated / unknown / non-sensitive>
+- **Evidence Source:** <CLI export, AWS Config, Security Hub, Terraform, manual evidence>
+- **Description:** <what was found and why it matters>
+- **Remediation:** <remove public sharing, copy encrypted snapshot, enable block-all-sharing, restrict AMI launch permission, document approved private sharing>
+
 ### Prioritized Remediation Plan
 
 1. **[Critical]** CIS X.Y -- <action item>
@@ -180,7 +227,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | Section | Domain | Recommendation Count | Key Focus Areas |
 |---------|--------|---------------------|-----------------|
 | 1 | Identity and Access Management | 22 | Root account security, MFA, password policy, access keys, IAM policies, Access Analyzer, identity federation |
-| 2 | Storage | 10 | S3 bucket security (public access, encryption, TLS), EBS encryption, RDS encryption and access, EFS encryption |
+| 2 | Storage | 10 | S3 bucket security (public access, encryption, TLS), EBS encryption, RDS encryption and access, EFS encryption, supplemental snapshot/AMI sharing evidence |
 | 3 | Logging | 11 | CloudTrail (multi-region, validation, encryption), AWS Config, S3 access logging, VPC flow logs, object-level logging |
 | 4 | Monitoring | 16 | CloudWatch metric filters and alarms for 15 critical event types, Security Hub enablement |
 | 5 | Networking | 6 | NACL restrictions, security group hardening, default SG lockdown, VPC peering routes, IMDSv2 enforcement |
@@ -200,6 +247,8 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
 5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
 6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
+7. **Equating private live resources with private backups.** A private RDS instance or encrypted EBS volume does not prove manual DB snapshots, EBS snapshots, or AMIs are private. Always check snapshot attributes and AMI launch permissions separately.
+8. **Treating EBS block public access as global.** EBS snapshot block public access is Regional and mode-dependent. `block-new-sharing` prevents new public sharing but does not provide the same evidence as `block-all-sharing` for already-public snapshots.
 
 ---
 
@@ -225,10 +274,15 @@ Produce the final report using the structure defined in the Output Format sectio
 - AWS CloudTrail Documentation: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/
 - AWS Security Hub: https://docs.aws.amazon.com/securityhub/latest/userguide/
 - AWS VPC Security: https://docs.aws.amazon.com/vpc/latest/userguide/security.html
+- AWS EBS Block Public Access for snapshots: https://docs.aws.amazon.com/ebs/latest/userguide/block-public-access-snapshots-enable.html
+- AWS EBS snapshot sharing: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-modifying-snapshot-permissions.html
+- AWS RDS snapshot sharing: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ShareSnapshot.html
+- AWS RDS public snapshots: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ShareSnapshot.Public.html
 - Terraform AWS Provider Documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 
 ---
 
 ## Changelog
 
+- **1.0.1** -- Added public RDS/EBS snapshot and AMI launch-permission evidence gates with EBS block-public-access calibration.
 - **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 (62 recommendations).

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -260,6 +260,76 @@ aws_efs_file_system
 encrypted = true
 ```
 
+### Supplemental -- Public Snapshot and AMI Sharing Gates
+
+These gates are not a separate CIS Foundations recommendation count. Use them to prevent storage exposure false negatives where live resources are private but copied backup or image artifacts are public.
+
+#### RDS DB snapshot public restore permissions
+
+Review manual DB snapshot attributes, especially production-derived and regulated-data snapshots.
+
+```bash
+aws rds describe-db-snapshots \
+  --snapshot-type manual \
+  --include-public \
+  --include-shared
+
+aws rds describe-db-snapshot-attributes \
+  --db-snapshot-identifier <snapshot-id>
+```
+
+Fail when the `restore` attribute contains `all`, unless the report proves the artifact is intentionally public, non-sensitive, and approved. Record explicit account IDs separately from public sharing.
+
+#### EBS snapshot public create-volume permissions
+
+Review snapshot permissions and account-level block public access state for every in-scope Region.
+
+```bash
+aws ec2 describe-snapshot-attribute \
+  --snapshot-id <snapshot-id> \
+  --attribute createVolumePermission
+
+aws ec2 get-snapshot-block-public-access-state \
+  --region <region>
+```
+
+Fail when `createVolumePermission` includes `Group=all`. Calibrate severity with the Regional block public access mode:
+
+| Block Public Access State | Interpretation |
+|---------------------------|----------------|
+| `block-all-sharing` | Strongest evidence that public EBS snapshot access is blocked in that Region |
+| `block-new-sharing` | Blocks new public sharing but requires inventory of existing public snapshots |
+| Unblocked / not configured | No account-level guardrail against public snapshot sharing |
+| Not available | Mark Not Evaluable for that Region unless another authoritative control covers it |
+
+#### AMI public launch permissions
+
+Review owned AMIs and trace block device mappings to snapshots where possible.
+
+```bash
+aws ec2 describe-images --owners self
+
+aws ec2 describe-image-attribute \
+  --image-id <ami-id> \
+  --attribute launchPermission
+```
+
+Fail when `launchPermission` includes `Group=all` for AMIs that are production-derived, contain sensitive software/data, or reference snapshots with unknown sharing posture. Do not treat AMI launch permission as the same evidence path as direct EBS snapshot `createVolumePermission`; record both when available.
+
+#### Evidence fields to capture
+
+For each evaluated artifact, record:
+
+- Artifact type: RDS DB snapshot, EBS snapshot, or AMI
+- Account and Region
+- Snapshot or AMI ID
+- Public attribute observed: `restore=all`, `createVolumePermission=Group=all`, `launchPermission=Group=all`, or none
+- Explicit shared account IDs and approval status
+- EBS block public access mode for the Region, when relevant
+- Data sensitivity or derivation from production
+- Evidence source and timestamp
+- Not Evaluable reason if live AWS inventory or snapshot attributes are unavailable
+
 ---
 
 ## Section 3 -- Logging


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

Closes #1737

### Skill Modified
**Skill name:** `aws-review`  
**Skill path:** `skills/cloud/aws-review/`

### What Was Wrong
The AWS review skill checks live storage controls such as S3 public access blocks, EBS/RDS encryption, and RDS instance public accessibility, but it did not require evidence for public backup or image artifacts. That can miss exposure where a private live database, encrypted EBS volume, or private instance still has a public manual RDS snapshot, public EBS snapshot, or public AMI launch permission.

### What This PR Fixes
- Adds a supplemental `Public Snapshot and AMI Sharing Evidence` step to `aws-review`.
- Requires review evidence for RDS snapshot `restore` attributes, EBS snapshot `createVolumePermission`, AMI `launchPermission`, and per-Region EBS block public access state.
- Adds severity calibration for public production-derived snapshots/AMIs, private cross-account sharing gaps, and incomplete Region coverage.
- Extends the output template with `AWS-SNAPSHOT-EXPOSURE` fields for artifact type, account/Region, artifact ID, public attribute, explicit shared accounts, block public access state, data sensitivity, evidence source, and remediation.
- Adds benchmark checklist commands and evidence fields for RDS, EBS, and AMI sharing review.
- Adds common pitfalls explaining why private live resources do not prove private snapshots and why EBS block public access is Regional and mode-dependent.

### Test Cases / Validation
- `git diff --check` passed.
- Markdown fence balance checked:
  - `skills/cloud/aws-review/SKILL.md`: 6 fences, balanced.
  - `skills/cloud/aws-review/benchmark-checklist.md`: 66 fences, balanced.
- Marker validation passed for:
  - `version: "1.0.1"`
  - `Public Snapshot and AMI Sharing Evidence`
  - `AWS-SNAPSHOT-EXPOSURE`
  - `createVolumePermission`
  - `launchPermission`
  - `block-all-sharing`
  - `restore=all`
- Duplicate search immediately before submission found only issue #1737 and no open PRs for `public snapshot AMI sharing aws-review`.

### Bounty Tier Requested
Moderate Improver ($100). This adds a new evidence path and false-negative reduction for an existing cloud review skill without changing runtime code.

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** GitHub Sponsors. PayPal or crypto details can be provided privately after maintainer acceptance.
