### PR TITLE
Add GCP image snapshot sharing gates

### DIFF
--- a/skills/cloud/gcp-review/SKILL.md
+++ b/skills/cloud/gcp-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-GCP-v2.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -54,6 +54,7 @@ The CIS Google Cloud Platform Foundation Benchmark v2.0.0 is a consensus-driven 
 - IAM policy bindings and org policy definitions
 - VPC and firewall rule definitions
 - Cloud Audit Logs configuration
+- Compute custom image and snapshot IAM policies, if available
 
 ---
 
@@ -74,6 +75,9 @@ Use Glob to locate all GCP-related infrastructure definitions.
 **/org-policies/**/*.json
 **/org-policies/**/*.yaml
 **/iam/**/*.json
+**/compute-images/**/*.json
+**/compute-snapshots/**/*.json
+**/asset-inventory/**/*.json
 ```
 
 Record all discovered files. If no GCP configurations are found, report that finding and halt.
@@ -85,6 +89,31 @@ Record all discovered files. If no GCP configurations are found, report that fin
 Evaluate all GCP configurations against CIS GCP v2.0.0 Sections 1 through 7, covering Identity and Access Management, Logging and Monitoring, Networking, Virtual Machines, Storage, Cloud SQL, and BigQuery.
 
 For detailed CIS benchmark checklist items with specific Terraform patterns, grep patterns, and configuration examples for all seven sections, see [benchmark-checklist.md](benchmark-checklist.md) in this skill directory.
+
+---
+
+### Step 8.5: Custom Image and Snapshot Sharing Evidence
+
+After reviewing VM configuration and disk encryption, verify Compute Engine custom image and snapshot IAM policies. Images and snapshots can expose production-derived disk data even when instances are private and disks use CMEK.
+
+Require evidence for:
+
+- **Custom image IAM policy:** record image-level bindings, especially `roles/compute.imageUser` grants to `allAuthenticatedUsers`, external domains, broad groups, or unapproved projects.
+- **Snapshot IAM policy:** record snapshot-level bindings and any external principals with restore/use permissions.
+- **Project-level discoverability:** identify project-level `roles/viewer` or similar bindings that make shared image catalogs visible to external users when paired with image use permissions.
+- **Approved sharing inventory:** capture owner, business justification, approved principals, expiration/review date, data sanitization, and sensitivity classification for cross-project or cross-organization sharing.
+- **Coverage denominator:** list image projects, snapshots, asset inventory scopes, and projects reviewed. Mark Not Evaluable when image/snapshot inventory or IAM policy exports are unavailable.
+
+Do not treat private VMs, no external IPs, or CMEK-encrypted disks as proof that images and snapshots are private. Compute image IAM, snapshot IAM, and project-level discoverability are separate evidence paths.
+
+Severity calibration:
+
+| Evidence Pattern | Severity |
+|------------------|----------|
+| Production-derived or sensitive custom image/snapshot shared with `allAuthenticatedUsers` or unapproved external principals | High |
+| Image/snapshot shared with named external groups but missing owner, approval, review date, or data sanitization evidence | Medium |
+| Image/snapshot inventory, project Viewer discoverability, or IAM policy export is incomplete | Low |
+| Image/snapshot IAM restricted to approved principals with review cadence and sensitivity evidence | Informational |
 
 ---
 
@@ -100,7 +129,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | Severity | Definition | Examples |
 |----------|-----------|----------|
 | **Critical** | Immediate risk of data breach or unauthorized access | Public GCS buckets, firewall rules allowing 0.0.0.0/0 on SSH/RDP, Cloud SQL with public IP and no SSL, user-managed SA keys with admin roles |
-| **High** | Significant security gap that materially weakens posture | Default service accounts with broad scopes, missing Cloud Audit Logs, no VPC flow logs, instances with public IPs |
+| **High** | Significant security gap that materially weakens posture | Default service accounts with broad scopes, public custom images or snapshots, missing Cloud Audit Logs, no VPC flow logs, instances with public IPs |
 | **Medium** | Control gap that should be addressed in normal cycle | Missing log metric filters, DNSSEC not enabled, Shielded VM not enabled, uniform bucket access not set |
 | **Low** | Hardening recommendation or defense-in-depth measure | OS Login not enabled, serial port access not explicitly disabled, BigQuery tables without CMEK |
 | **Informational** | Best practice observation, no direct security impact | Default network still exists (non-production), naming conventions, documentation gaps |
@@ -125,6 +154,7 @@ Produce the final report using the structure defined in the Output Format sectio
 - Not Applicable: <N>
 - Not Evaluable (insufficient data): <N>
 - Overall compliance: <percentage>
+- Supplemental image/snapshot sharing findings: <N>
 
 ### Section Scores
 
@@ -150,6 +180,21 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Evidence:** <specific configuration or code snippet>
 - **Remediation:** <specific fix with code example>
 
+#### [GCP-IMAGE-SNAPSHOT-SHARING] <Image or Snapshot Sharing Finding>
+- **Status:** Pass / Fail / Not Evaluable
+- **Severity:** High / Medium / Low / Informational
+- **Artifact Type:** Custom image / Snapshot
+- **Project:** <project-id>
+- **Artifact ID:** <image-name or snapshot-name>
+- **IAM Role:** <roles/compute.imageUser or other role>
+- **Shared Principals:** <allAuthenticatedUsers / external group / approved principals / not available>
+- **Project Viewer Discoverability:** <present / absent / not applicable / not available>
+- **Data Sensitivity:** <production / regulated / unknown / sanitized / non-sensitive>
+- **Owner / Approval / Review Date:** <evidence or not available>
+- **Evidence Source:** <gcloud export, Cloud Asset Inventory, Terraform, manual evidence>
+- **Description:** <what was found and why it matters>
+- **Remediation:** <remove public binding, restrict to approved group/project, add IAM Condition, sanitize image, document review/expiration>
+
 ### Prioritized Remediation Plan
 
 1. **[Critical]** CIS X.Y -- <action item>
@@ -174,7 +219,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | 1 | Identity and Access Management | Corporate credentials, MFA, service account keys, admin privileges, SA role assignments, KMS key access, API key restrictions, Essential Contacts |
 | 2 | Logging and Monitoring | Cloud Audit Logs (admin/data read/write), log sinks, bucket lock retention, metric filters and alerts (8 categories), DNS logging, Cloud Asset Inventory |
 | 3 | Networking | Default network removal, legacy networks, DNSSEC, firewall rules (SSH/RDP from internet), VPC flow logs, SSL policies, IAP-only access |
-| 4 | Virtual Machines | Default service accounts, access scopes, project SSH key blocking, OS Login, serial port, IP forwarding, CMEK disks, Shielded VM, public IPs, Confidential Computing |
+| 4 | Virtual Machines | Default service accounts, access scopes, project SSH key blocking, OS Login, serial port, IP forwarding, CMEK disks, custom image/snapshot sharing, Shielded VM, public IPs, Confidential Computing |
 | 5 | Storage | Public bucket access, uniform bucket-level access |
 | 6 | Cloud SQL | MySQL/PostgreSQL/SQL Server database flags, SSL enforcement, authorized networks, public IP, automated backups |
 | 7 | BigQuery | Public dataset access, CMEK encryption for tables and datasets |
@@ -194,6 +239,8 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Cloud SQL authorized_networks vs. private IP.** CIS 6.5 flags `0.0.0.0/0` in authorized networks, but CIS 6.6 goes further and recommends disabling public IP entirely in favor of private networking.
 5. **BigQuery dataset-level vs. table-level CMEK.** CIS 7.2 checks table-level encryption, while CIS 7.3 checks the dataset default. Both should be evaluated independently.
 6. **Default compute service account identification.** The default SA follows the pattern `PROJECT_NUMBER-compute@developer.gserviceaccount.com`. Grep for this pattern, not just the string "default."
+7. **Missing image and snapshot IAM policies.** A private VM and CMEK disk do not prove that the custom image or snapshot is private. Check image and snapshot IAM policies separately.
+8. **Looking only for `allUsers`.** Custom images cannot grant `allUsers`, but can be shared with `allAuthenticatedUsers`; flag that member explicitly for image sharing.
 
 ---
 
@@ -219,10 +266,15 @@ Produce the final report using the structure defined in the Output Format sectio
 - Google Cloud Audit Logs: https://cloud.google.com/logging/docs/audit
 - Google Cloud VPC Documentation: https://cloud.google.com/vpc/docs
 - Google Cloud SQL Security: https://cloud.google.com/sql/docs/mysql/configure-ssl-instance
+- Manage access to custom images: https://docs.cloud.google.com/compute/docs/images/managing-access-custom-images
+- About disk snapshots: https://docs.cloud.google.com/compute/docs/disks/snapshots
+- gcloud compute snapshots IAM policy: https://docs.cloud.google.com/sdk/gcloud/reference/compute/snapshots/set-iam-policy
+- Compute snapshots REST resource: https://docs.cloud.google.com/compute/docs/reference/rest/v1/snapshots
 - Terraform Google Provider Documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs
 
 ---
 
 ## Changelog
 
+- **1.0.1** -- Added custom image and snapshot IAM sharing evidence gates with `allAuthenticatedUsers`, project Viewer discoverability, and sensitivity calibration.
 - **1.0.0** -- Initial release. Full coverage of CIS Google Cloud Platform Foundation Benchmark v2.0.0 sections 1 through 7.

--- a/skills/cloud/gcp-review/benchmark-checklist.md
+++ b/skills/cloud/gcp-review/benchmark-checklist.md
@@ -497,6 +497,88 @@ resource "google_compute_disk" {
 }
 ```
 
+### Supplemental -- Custom Image and Snapshot IAM Sharing Gates
+
+These checks supplement VM disk and image review because custom images and snapshots can expose disk-derived data even when instances are private and disks are encrypted.
+
+#### Custom image IAM policy
+
+Review image-level IAM policies for public or unapproved sharing:
+
+```bash
+gcloud compute images list --project <image-project>
+
+gcloud compute images get-iam-policy <image-name> \
+  --project <image-project>
+```
+
+Terraform patterns to inspect:
+
+```hcl
+resource "google_compute_image_iam_binding" "public_image" {
+  project = var.image_project
+  image   = google_compute_image.hardened_app.name
+  role    = "roles/compute.imageUser"
+  members = ["allAuthenticatedUsers"] # FAIL for sensitive or production-derived images
+}
+
+resource "google_compute_image_iam_member" "external_group" {
+  image  = google_compute_image.hardened_app.name
+  role   = "roles/compute.imageUser"
+  member = "group:contractors@example.com"
+}
+```
+
+Fail when production-derived or sensitive custom images grant `roles/compute.imageUser` to `allAuthenticatedUsers` or unapproved external principals. Google Cloud custom images cannot grant `allUsers`; do not treat absence of `allUsers` as proof that the image is not public to authenticated users.
+
+#### Snapshot IAM policy
+
+Review snapshot-level IAM policies and sharing approvals:
+
+```bash
+gcloud compute snapshots list --project <snapshot-project>
+
+gcloud compute snapshots get-iam-policy <snapshot-name> \
+  --project <snapshot-project>
+```
+
+Terraform patterns to inspect:
+
+```hcl
+resource "google_compute_snapshot_iam_binding" "snapshot_share" {
+  project  = var.snapshot_project
+  snapshot = google_compute_snapshot.prod_disk.name
+  role     = "roles/compute.storageAdmin"
+  members  = ["group:partner-ops@example.com"]
+}
+```
+
+Fail when snapshot IAM grants broad storage, image, or snapshot use to external principals without owner, approval, expiration/review, and data sensitivity evidence.
+
+#### Project-level discoverability
+
+Users may need project-level Viewer to see shared images in the console. Capture this separately from image-level `compute.imageUser`.
+
+```bash
+gcloud projects get-iam-policy <image-project> \
+  --flatten='bindings[].members' \
+  --filter='bindings.role:roles/viewer AND bindings.members:<principal>'
+```
+
+Record whether project-level Viewer or equivalent read roles are granted to the same external principals that can use images.
+
+#### Cloud Asset Inventory coverage
+
+For organization or folder reviews, use Asset Inventory exports to avoid sampling only one project:
+
+```bash
+gcloud asset search-all-iam-policies \
+  --scope=organizations/<org-id> \
+  --query='policy:roles/compute.imageUser OR policy:allAuthenticatedUsers'
+```
+
+Required report fields: artifact type, project, image/snapshot ID, IAM role, shared principals, project Viewer discoverability, data sensitivity, owner/approval, review date, evidence source, and Not Evaluable reason when inventory is unavailable.
+
 ### CIS 4.8 -- Ensure Compute Instances Are Launched with Shielded VM Enabled
 
 ```hcl


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

Closes #1746

### Skill Modified
**Skill name:** `gcp-review`  
**Skill path:** `skills/cloud/gcp-review/`

### What Was Wrong
The GCP review skill checks VM posture, public IPs, default service accounts, access scopes, Shielded VM, and disk CMEK, but it did not require evidence for Compute Engine custom image or snapshot IAM policies. A private VM with encrypted disks can still expose disk-derived data through a public custom image or broadly shared snapshot.

### What This PR Fixes
- Adds a supplemental `Custom Image and Snapshot Sharing Evidence` step to `gcp-review`.
- Requires custom image IAM evidence for `roles/compute.imageUser`, including `allAuthenticatedUsers` and unapproved external principals.
- Requires snapshot IAM evidence and approval/sensitivity review for external sharing.
- Adds project-level Viewer discoverability review because shared images can be surfaced through the image project when Viewer is granted.
- Extends the output template with `GCP-IMAGE-SNAPSHOT-SHARING` fields for artifact type, project, artifact ID, IAM role, shared principals, project Viewer discoverability, sensitivity, owner/approval/review date, evidence source, and remediation.
- Adds Section 4 checklist commands for `gcloud compute images get-iam-policy`, `gcloud compute snapshots get-iam-policy`, project IAM Viewer checks, and Cloud Asset Inventory searches.
- Adds pitfalls clarifying that private VMs/CMEK disks do not prove private images/snapshots and that custom images can be shared with `allAuthenticatedUsers` even though `allUsers` is not allowed.

### Test Cases / Validation
- `git diff --check` passed.
- Markdown fence balance checked:
  - `skills/cloud/gcp-review/SKILL.md`: 4 fences, balanced.
  - `skills/cloud/gcp-review/benchmark-checklist.md`: 110 fences, balanced.
- Marker validation passed for:
  - `version: "1.0.1"`
  - `Custom Image and Snapshot Sharing Evidence`
  - `GCP-IMAGE-SNAPSHOT-SHARING`
  - `roles/compute.imageUser`
  - `allAuthenticatedUsers`
  - `gcloud compute images get-iam-policy`
  - `gcloud compute snapshots get-iam-policy`
  - `Project Viewer Discoverability`
- Duplicate search immediately before submission found only issue #1746 and no open PRs for `gcp-review custom image snapshot IAM sharing evidence gates`.

### Bounty Tier Requested
Moderate Improver ($100). This adds a new Compute Engine artifact evidence path and false-negative reduction to an existing cloud review skill without changing runtime code.

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** GitHub Sponsors. PayPal or crypto details can be provided privately after maintainer acceptance.
