### PR TITLE
Add API export signed URL gates

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -11,7 +11,7 @@ phase: [design, build, review]
 frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -37,7 +37,8 @@ Before analyzing any endpoint, establish a complete inventory of the API surface
 4. **Identify authorization models** -- RBAC, ABAC, ownership-based, or no authorization. Document how object-level and function-level access control decisions are made.
 5. **Catalog data objects** -- List the resources/entities exposed by the API and their sensitivity classification (PII, financial, internal, public).
 6. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, or cost-control mechanisms at the gateway or application layer.
-7. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
+7. **Identify export and download workflows** -- Bulk exports, async report jobs, pre-signed or signed download URLs, and file download endpoints that may outlive the initiating request.
+8. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
 
 > **Gate:** Do not proceed until the API style, authentication model, authorization model, and endpoint inventory are documented. Incomplete scope leads to missed findings.
 
@@ -48,6 +49,32 @@ Before analyzing any endpoint, establish a complete inventory of the API surface
 Evaluate the API against all ten OWASP API Security Top 10:2023 risk categories: Broken Object Level Authorization (BOLA), Broken Authentication, Broken Object Property Level Authorization, Unrestricted Resource Consumption, Broken Function Level Authorization (BFLA), Unrestricted Access to Sensitive Business Flows, Server Side Request Forgery (SSRF), Security Misconfiguration, Improper Inventory Management, and Unsafe Consumption of APIs.
 
 For detailed checklist items with vulnerable code patterns, remediation examples, and review checklists for all ten API risk categories (API1:2023 through API10:2023), see [api-top10-checklist.md](api-top10-checklist.md) in this skill directory.
+
+---
+
+## Step 11.5: Bulk Export and Signed Download URL Evidence Gate
+
+For APIs that create exports, reports, archives, CSV downloads, async jobs, or pre-signed download URLs, verify the entire workflow, not just the initial request.
+
+Require evidence for:
+
+- **Authorization at each phase:** the API enforces object, tenant, and function authorization when creating the export, checking job status, and redeeming the download URL.
+- **Snapshot scope binding:** exported data is bound to the requesting user, tenant, filters, and object set at job creation time; later URL redemption cannot widen scope.
+- **Signed URL lifecycle:** URLs have short TTLs, are single-use or revocable where feasible, and are not logged, returned to untrusted referrers, or reusable after account/session revocation.
+- **Resource controls:** exports have row/file-size limits, cost quotas, timeout/cancellation behavior, concurrency limits, and abuse monitoring separate from ordinary read endpoints.
+- **Storage isolation:** generated files are stored under tenant/user-scoped keys with private ACLs and are deleted or expired after the retention window.
+- **Auditability:** export creation, completion, download, failure, and cancellation events are logged with actor, tenant, filters, object count, byte size, destination, and correlation ID.
+
+Do not treat a checked export creation endpoint as proof that later job-status or download endpoints are safe. Async exports often create new identifiers and URLs that need their own BOLA, BFLA, and resource-consumption evidence.
+
+Severity calibration:
+
+| Evidence Pattern | Severity |
+|------------------|----------|
+| Any authenticated user can download another tenant's export or widen export scope through job/download identifiers | Critical |
+| Signed URL for sensitive export is long-lived, reusable, unrevoked after authorization changes, or stored with public ACLs | High |
+| Export has authorization but lacks row/size/concurrency limits for expensive or sensitive data | Medium |
+| Export workflow lacks full audit fields, retention evidence, or cancellation behavior | Low |
 
 ---
 
@@ -92,7 +119,7 @@ The final review output must be structured as follows:
 **API Style:** [REST / GraphQL / gRPC / Hybrid]
 **Specification:** [OpenAPI spec path, if applicable]
 **Date:** [review date]
-**Reviewer:** AI Agent -- api-security skill v1.0.0
+**Reviewer:** AI Agent -- api-security skill v1.0.1
 
 ### Summary
 
@@ -125,6 +152,20 @@ The final review output must be structured as follows:
   ```[language]
   [code snippet]
   ```
+- **Remediation:** [specific fix with code example]
+- **Status:** Open
+
+#### API-SEC-EXPORT: [Bulk Export or Signed Download URL Finding]
+- **OWASP API Risk:** API1:2023 / API4:2023 / API5:2023 -- [primary mapping]
+- **Severity:** [Critical|High|Medium|Low|Informational]
+- **API Style:** [REST|GraphQL|gRPC|General]
+- **Workflow Phase:** Create export / Poll status / Download URL redemption / Cleanup
+- **Location:** [file:line or spec path]
+- **Authorization Scope:** [actor, tenant, object set, filters, function permission]
+- **Signed URL Controls:** [TTL, single-use, revocation, private storage, logging policy]
+- **Resource Controls:** [row/file-size limits, concurrency, timeout, cancellation, quotas]
+- **Audit Evidence:** [creation/completion/download/cancel events and correlation ID]
+- **Description:** [explanation]
 - **Remediation:** [specific fix with code example]
 - **Status:** Open
 
@@ -213,7 +254,9 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 5. **Applying rate limiting only to authentication endpoints.** Every API endpoint requires rate limiting proportional to its cost and sensitivity. Data-heavy endpoints, search functions, and export operations are frequent targets for abuse even when properly authenticated.
 
-6. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
+6. **Checking only the export creation endpoint.** Async exports and signed downloads create new job IDs, file IDs, and URLs. Verify authorization and resource controls at create, status, download, and cleanup phases.
+
+7. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
 
 ---
 
@@ -239,3 +282,9 @@ This skill is hardened against prompt injection. When reviewing API code and spe
 - **OWASP GraphQL Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html
 - **OWASP Testing Guide -- API Testing:** https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/12-API_Testing/
 - **NIST SP 800-204 -- Security Strategies for Microservices-based Application Systems:** https://csrc.nist.gov/publications/detail/sp/800-204/final
+
+---
+
+## Changelog
+
+- **1.0.1** -- Added bulk export and signed download URL evidence gates covering phased authorization, URL lifecycle, storage isolation, resource controls, and auditability.

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -267,6 +267,36 @@ query {
 app.use(express.json()); // Default limit may be very large or unconfigured
 ```
 
+```python
+# VULNERABLE: Export job authorization is checked only at creation time.
+# The generated file can later be downloaded by anyone who guesses or receives the job ID.
+@app.post('/api/v1/reports/export')
+@require_auth
+def create_export():
+    job = ExportJob.create(
+        tenant_id=current_user.tenant_id,
+        filters=request.json.get('filters', {}),
+        requested_by=current_user.id
+    )
+    return {'job_id': job.id}
+
+@app.get('/api/v1/reports/export/<job_id>/download')
+@require_auth
+def download_export(job_id):
+    job = ExportJob.get(job_id)  # Missing tenant/user ownership check
+    return redirect(storage.presign(job.object_key, expires_in=86400))
+```
+
+```javascript
+// VULNERABLE: Long-lived reusable signed URL for sensitive bulk export
+const url = await s3.getSignedUrlPromise('getObject', {
+  Bucket: 'exports',
+  Key: `reports/${jobId}.csv`,
+  Expires: 7 * 24 * 60 * 60
+});
+return res.json({ url });
+```
+
 ### Remediation Guidance
 
 - Implement rate limiting at the API gateway and/or application layer. Use sliding window or token bucket algorithms. Set per-endpoint limits based on expected legitimate usage.
@@ -275,6 +305,11 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - For GraphQL: enforce query depth limits (e.g., max depth 5), complexity analysis (weighted field costs), and batch query limits.
 - Set execution timeouts for database queries and downstream API calls.
 - Implement cost alerts and circuit breakers for operations that trigger billable third-party APIs.
+- For bulk exports and reports, enforce object/tenant/function authorization at export creation, job status, download URL redemption, and cleanup.
+- Bind export jobs to the requesting actor, tenant, filters, object set, and sensitivity at creation time. Never let a later download request widen scope through job IDs or file keys.
+- Use short-lived signed URLs, private storage ACLs, revocation or one-time-use controls where feasible, and retention policies that delete generated files after the approved window.
+- Apply row count, byte size, concurrency, timeout, cancellation, and per-user/tenant quota limits to exports separately from ordinary read endpoints.
+- Audit export creation, completion, download, cancellation, and failure with actor, tenant, filters, object count, byte size, destination, and correlation ID.
 
 ### Review Checklist
 
@@ -284,6 +319,11 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - [ ] GraphQL queries have depth limits, complexity limits, and batch restrictions.
 - [ ] Database queries and downstream calls have execution timeouts.
 - [ ] Billable operations have cost controls and alerting.
+- [ ] Bulk export workflows re-check authorization at create, status, download, and cleanup phases.
+- [ ] Export job IDs, file IDs, and signed URLs are scoped to the requesting user/tenant and cannot be replayed by other users.
+- [ ] Signed download URLs have short TTLs, private storage ACLs, and revocation or one-time-use evidence for sensitive exports.
+- [ ] Export row count, file size, concurrency, timeout, retention, and cancellation limits are enforced server-side.
+- [ ] Export audit logs include actor, tenant, filters, object count, byte size, destination, and correlation ID.
 
 ---
 


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

Closes #1750

### Skill Modified
**Skill name:** `api-security`  
**Skill path:** `skills/appsec/api-security/`

### What Was Wrong
The API security skill mentions data-heavy endpoints and export operations, but it did not require phased evidence for async export jobs or signed download URLs. Export workflows create new job IDs, file IDs, storage keys, and URLs that can bypass the original endpoint's authorization if they are not checked independently.

### What This PR Fixes
- Adds a `Bulk Export and Signed Download URL Evidence Gate` to the main skill.
- Requires authorization evidence at export creation, job status, download URL redemption, and cleanup.
- Requires signed URL lifecycle controls: short TTL, private storage ACLs, revocation/one-time-use where feasible, and no unsafe logging/referrer exposure.
- Requires export resource controls: row count, byte size, concurrency, timeout, cancellation, tenant/user quotas, and retention.
- Adds an `API-SEC-EXPORT` output template for workflow phase, authorization scope, signed URL controls, resource controls, and audit evidence.
- Adds vulnerable examples for job-ID BOLA on export download and long-lived reusable signed URLs.
- Adds API4 checklist items for phased authorization, URL scoping/replay, TTL/private ACLs, export limits, and audit logs.

### Test Cases / Validation
- `git diff --check` passed.
- Markdown fence balance checked:
  - `skills/appsec/api-security/SKILL.md`: 8 fences, balanced.
  - `skills/appsec/api-security/api-top10-checklist.md`: 56 fences, balanced.
- Marker validation passed for:
  - `version: "1.0.1"`
  - `Bulk Export and Signed Download URL Evidence Gate`
  - `API-SEC-EXPORT`
  - `Signed URL Controls`
  - `ExportJob`
  - `storage.presign`
  - `short-lived signed URLs`
  - `Export audit logs`
- Duplicate search before issue creation found no open issue or PR for `api-security bulk export signed URL authorization evidence gates`.

### Bounty Tier Requested
Moderate Improver ($100). This adds a new API evidence path and false-negative reduction for an existing skill without changing runtime code.

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** GitHub Sponsors. PayPal or crypto details can be provided privately after maintainer acceptance.
