### PR TITLE
Add ISO 27001 internal audit evidence gates

### DIFF
--- a/skills/compliance/iso27001-gap/SKILL.md
+++ b/skills/compliance/iso27001-gap/SKILL.md
@@ -335,6 +335,23 @@ Assess internal audit program against requirements:
 - Corrective actions taken without undue delay
 - Nonconformities and corrective actions tracked to closure
 
+Require an internal-audit program evidence table before marking Clause 9.2 ready:
+
+| Audit Area | Criteria | Scope | Risk/Prior Finding Link | Sample Population | Sample Method | Auditor | Independence Evidence | Result | Management Reported | Corrective Action Link |
+|------------|----------|-------|-------------------------|-------------------|---------------|---------|-----------------------|--------|---------------------|------------------------|
+| [process/control] | [ISO clause/control IDs] | [systems/sites/period] | [risk register / prior audit / process criticality] | [records/users/vendors/tickets] | [judgmental/statistical/100%/rationale] | [name/role] | [no self-audit / conflict check / external or peer reviewer] | [conforming/nonconforming] | [date/audience/evidence] | [CAPA ID or N/A] |
+
+Raise a finding when any of these are missing:
+
+- **ISO-AUDIT-01:** audit program has no risk-based prioritization or prior-finding linkage.
+- **ISO-AUDIT-02:** audit criteria and scope are not defined per audit engagement.
+- **ISO-AUDIT-03:** auditor independence is asserted but not evidenced.
+- **ISO-AUDIT-04:** sampling method, sample population, or sample rationale is missing.
+- **ISO-AUDIT-05:** audit results are not reported to relevant management with retained evidence.
+- **ISO-AUDIT-06:** corrective actions lack owner, due date, root cause, implementation evidence, or effectiveness verification.
+
+For small organizations where one person owns security, risk, and compliance, do not require a large audit department. Require a documented independence strategy such as peer review, external reviewer, board-level review, or a conflict-of-interest declaration with compensating review.
+
 ---
 
 ### Step 7: Management Review Readiness (Clause 9.3)
@@ -412,6 +429,16 @@ Classify each finding using the following severity levels:
 
 ## Risk Assessment Findings
 [Summary of risk methodology review, gaps in risk register, treatment plan status]
+
+## Internal Audit Program Evidence
+| Audit Area | Criteria | Scope | Risk/Prior Finding Link | Sample Method | Auditor | Independence Evidence | Result | Management Reported | Corrective Action Link |
+|---|---|---|---|---|---|---|---|---|---|
+| [process/control] | [ISO clause/control IDs] | [systems/sites/period] | [risk/prior finding/process criticality] | [population/count/method/rationale] | [name/role] | [evidence] | [result] | [date/audience/evidence] | [CAPA ID or N/A] |
+
+## Corrective Action Closure
+| Finding | Root Cause | Owner | Due Date | Action Taken | Effectiveness Evidence | Closure Date | Status |
+|---|---|---|---|---|---|---|---|
+| [finding ID] | [root cause] | [owner] | [date] | [implemented action] | [retest/review/sample] | [date] | [open/closed/overdue] |
 
 ## Prioritized Remediation Roadmap
 
@@ -512,6 +539,10 @@ Each control in ISO 27002:2022 is tagged with five attributes:
 4. **Neglecting the 11 new controls introduced in the 2022 revision.** Organizations transitioning from 2013 often miss that controls like A.5.7 (Threat intelligence), A.5.23 (Cloud services security), A.8.9 (Configuration management), A.8.11 (Data masking), A.8.12 (Data leakage prevention), and A.8.16 (Monitoring activities) require explicit consideration in the SoA even if determined not applicable.
 
 5. **Scope exclusions without adequate justification.** Excluding organizational units, locations, or controls from ISMS scope requires documented justification demonstrating the exclusion does not affect the organization's ability or responsibility to provide information security. Auditors will challenge poorly justified exclusions.
+
+6. **Treating an audit calendar as an audit program.** A quarterly schedule and summary slide do not prove Clause 9.2 readiness. The program needs criteria, scope, risk/prior-finding linkage, sampling rationale, auditor independence evidence, management reporting, and retained workpapers.
+
+7. **Closing corrective actions without effectiveness evidence.** Clause 10.2 corrective action closure should include root cause, owner, due date, implementation evidence, and verification that the fix worked. A ticket marked "done" is not enough for audit readiness.
 
 ---
 


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** iso27001-gap
**Skill path:** `skills/compliance/iso27001-gap/`

### What Was Wrong
The skill listed ISO 27001:2022 Clause 9.2 internal-audit requirements, but the output and readiness checks did not force evidence for audit-program design quality. A recurring audit calendar plus a summary slide could be treated as mostly ready even when there was no risk-based coverage, sampling rationale, auditor independence evidence, management reporting, or corrective-action closure proof.

Specific gaps from #1633:

- Audit programs were not required to link scope/frequency to process importance, prior audit results, or risk register entries.
- Audit engagements did not require sample population, sample method, sample count/rationale, or audit criteria.
- Auditor objectivity and impartiality could be asserted without conflict evidence or compensating review.
- Corrective actions could be marked closed without root cause, owner, due date, action evidence, or effectiveness verification.

### What This PR Fixes
Refs #1633.

This PR updates `SKILL.md` to add:

- A Clause 9.2 internal-audit program evidence table.
- Required fields for audit criteria, scope, risk/prior-finding linkage, sample population, sample method, auditor, independence evidence, management reporting, and corrective-action linkage.
- Explicit finding checks `ISO-AUDIT-01` through `ISO-AUDIT-06`.
- Small-organization calibration for peer review, external review, board-level review, or conflict-of-interest declarations when one person owns multiple ISMS roles.
- Output sections for `Internal Audit Program Evidence` and `Corrective Action Closure`.
- Common pitfalls for treating an audit calendar as an audit program and closing corrective actions without effectiveness evidence.

### Evidence
**Before (skill misses this / false positive on this):**
```text
Internal audit plan:
- Q1: review access control policy
- Q2: review supplier contracts
- Q3: review incident response procedure
- Q4: review backup procedure

Auditor:
- CISO performs all audits

Evidence retained:
- Calendar invite and final summary slide
```
This could look scheduled and partially complete while still missing Clause 9.2 and Clause 10.2 evidence.

**After (now correctly handled):**
```text
The report must capture audit objective/criteria, scope, ISO clause/control mapping,
risk/prior-finding linkage, sample population and method, auditor independence,
management reporting, corrective-action linkage, and closure/effectiveness evidence.

If the CISO audits their own ISMS operation without independence evidence, or if a
corrective action is closed without root cause and effectiveness verification, the
skill now raises an explicit finding.
```

### Test Cases Added/Updated
- [x] Added inline evidence gates, finding IDs, and output table requirements in `SKILL.md`.
- [x] Existing documentation structure still validates.
- [ ] Did not add a separate `tests/` directory because this skill currently uses a single Markdown guidance file.

### Validation
- `git diff --check` -> no whitespace errors; Windows Git emitted only the existing LF/CRLF warning.
- Marker grep confirmed `Internal Audit Program Evidence`, `Corrective Action Closure`, `ISO-AUDIT-01` through `ISO-AUDIT-06`, `Sample Population`, `Independence Evidence`, `conflict-of-interest`, and `effectiveness evidence` are present.
- Markdown fence balance check -> `fence_count=10` and even.
- Frontmatter smoke check confirmed `name`, `version`, `allowed-tools`, and `injection-hardened` remain present.
- `git diff --stat` -> one file changed, 31 insertions.

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Crypto; details can be provided privately after maintainer acceptance.
