### PR TITLE
Add NIST CSF profile confidence gates

### DIFF
--- a/skills/compliance/nist-csf-assessment/SKILL.md
+++ b/skills/compliance/nist-csf-assessment/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [NIST-CSF-2.0]
 difficulty: intermediate
 time_estimate: "90-180min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -398,6 +398,16 @@ Use the NIST CSF 2.0 Reference Tool for comprehensive mappings.
 
 ---
 
+### Profile Evidence Confidence
+
+Tie current and target profile scores to evidence source, scope, confidence, and validation needs.
+
+| Function / Category | Subcategory | Score | Evidence Source | Owner | Evidence Date | Coverage | Confidence | Validation Needed | Result |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `[function/category]` | `[subcategory]` | `[score]` | `[evidence_source]` | `[owner]` | `[evidence_date]` | `[coverage]` | `[confidence]` | `[validation_needed]` | `High / Medium / Low / Unknown` |
+
+Mark `Unknown` when the evidence is missing, stale, or cannot be tied to the scoped system under review. Mark `Fail` when the evidence proves the control is absent, bypassable, or materially incomplete.
+
 ## Findings Classification
 
 | Classification | Definition | Organizational Impact |
@@ -500,6 +510,12 @@ Use the NIST CSF 2.0 Reference Tool for comprehensive mappings.
 
 ---
 
+### Profile Evidence Confidence
+
+| Function / Category | Subcategory | Score | Evidence Source | Owner | Evidence Date | Coverage | Confidence | Validation Needed | Result |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `[function/category]` | `[subcategory]` | `[score]` | `[evidence_source]` | `[owner]` | `[evidence_date]` | `[coverage]` | `[confidence]` | `[validation_needed]` | `High / Medium / Low / Unknown` |
+
 ## Framework Reference
 
 ### NIST CSF 2.0 Complete Function/Category Structure
@@ -577,6 +593,8 @@ Tier 4 — Adaptive
 4. **Failing to develop actionable organizational profiles.** The current and target profiles are the primary outputs of a CSF assessment. Many organizations conduct the assessment but do not formalize profiles into living documents that drive investment decisions, resource allocation, and progress tracking. Without profiles, the assessment becomes a one-time exercise rather than a continuous improvement tool.
 
 ---
+
+- Treating interview statements or stale artifacts as equal to current implementation evidence when scoring NIST CSF profiles.
 
 ## Prompt Injection Safety Notice
 


### PR DESCRIPTION
## Summary
- Add the evidence gate requested by #1800.
- Add a focused output table so reviewers capture audit-ready proof consistently.
- Add a pitfall warning for the main unsupported-evidence failure mode.

Closes #1800

## Validation
- Reviewed generated Markdown changes through the GitHub API.
- Confirmed the patch is scoped only to $(@{Issue=1800; Slug=nist-profile-confidence; Path=skills/compliance/nist-csf-assessment/SKILL.md; Title=Add NIST CSF profile confidence gates; Gate=Profile Evidence Confidence; Why=Tie current and target profile scores to evidence source, scope, confidence, and validation needs.; Cols=System.Object[]; Status=High / Medium / Low / Unknown; Pit=Treating interview statements or stale artifacts as equal to current implementation evidence when scoring NIST CSF profiles.}.Path).
- Did not clone the repository, install dependencies, or run project code.