### PR TITLE
Add cve-triage temporal exposure evidence gates

### DIFF
--- a/skills/vuln-management/cve-triage/SKILL.md
+++ b/skills/vuln-management/cve-triage/SKILL.md
@@ -49,6 +49,8 @@ Before starting, collect or confirm:
 - [ ] **CVE ID(s):** The specific CVE identifier(s) to triage (e.g., CVE-2024-3094)
 - [ ] **Affected software/version:** Product name, version, and component (e.g., OpenSSL 3.0.2, xz-utils 5.6.0)
 - [ ] **Deployment context:** Where is this software running? (Internet-facing, internal, air-gapped)
+- [ ] **Runtime exposure evidence:** Was the vulnerable artifact actually running, and during what first/last observed time window? (image digest, host package inventory, serverless layer, AMI/launch template, pod/job/CronJob)
+- [ ] **Remediation closure evidence:** What proves the vulnerable runtime was replaced and re-scanned? (fixed artifact digest, redeploy record, scanner clean result, residual stale asset list)
 - [ ] **Business criticality:** What business function does the affected system support? (Revenue-generating, customer-facing, internal tooling, development)
 - [ ] **Compensating controls:** Are there existing mitigations in place? (WAF, network segmentation, EDR, disabled feature)
 - [ ] **Compliance requirements:** Any regulatory mandates affecting patch timelines? (CISA BOD 22-01 for federal, PCI DSS, HIPAA)
@@ -67,7 +69,8 @@ Extract the CVE identifier and collect all available context about the vulnerabi
 2. Identify the affected software, version, and component
 3. Determine the vulnerability type (RCE, privilege escalation, information disclosure, DoS, etc.)
 4. Note the disclosure date and whether a patch/fix is available
-5. If the user provided scan output, extract the CVE ID, affected asset, and scanner-assigned severity
+5. If the user provided scan output, extract the CVE ID, affected asset, scanner-assigned severity, scanner observation time, and asset identifier
+6. For container, serverless, VM image, or package findings, record the vulnerable artifact identifier that was actually running (image digest, package build, layer version, AMI, launch template, or host inventory timestamp)
 
 **Framework mapping:** NVD (National Vulnerability Database) for CVE metadata
 
@@ -80,6 +83,8 @@ CVE Context Summary:
 - Disclosure Date:     [YYYY-MM-DD]
 - Patch Available:     [Yes (vX.Y.Z+) | No | Workaround Only]
 - Known Aliases:       [Common names, e.g., "Log4Shell", "Heartbleed"]
+- Scanner Source:      [Tool and scan timestamp]
+- Runtime Artifact:    [Image digest, package build, AMI/layer, host inventory, or unknown]
 ```
 
 ### Step 2: CVSS 4.0 Assessment
@@ -269,7 +274,38 @@ SSVC 2.1 Decision:
 - Rationale:           [1-2 sentences explaining the decision path]
 ```
 
-### Step 6: SLA Assignment and Remediation Recommendation
+### Step 6: Temporal Exposure and Closure Evidence
+
+Before assigning final remediation status, determine whether the vulnerable artifact was present at runtime and whether remediation has been verified after redeployment.
+
+**Why this matters:** A scanner can report a stale tag, dependency, or package version after the vulnerable workload has been replaced, or it can show a clean dashboard while stale pods, suspended jobs, autoscaling launch templates, or serverless layers still reference the vulnerable artifact. Do not treat source patching or a single clean scan as closure without runtime evidence.
+
+Collect and compare:
+
+- **First vulnerable runtime observation:** Earliest known time the vulnerable artifact was running in the environment
+- **Last vulnerable runtime observation:** Latest known time the vulnerable artifact was still running
+- **Exposure interval:** Whether the asset was internet-facing, reachable by the relevant threat actor, or protected by compensating controls during that window
+- **Fixed artifact evidence:** Fixed version and immutable identifier, such as container digest, package build, AMI ID, serverless layer version, or deployed commit
+- **Redeployment proof:** Deployment, rollout, restart, inventory, or configuration evidence showing vulnerable runtime replacement
+- **Scanner re-detection:** Follow-up scan timestamp and result, including whether the scanner still detects the CVE
+- **Residual stale assets:** Old pods, canary workloads, job templates, suspended CronJobs, autoscaling launch templates, snapshots, or images that still reference the vulnerable artifact
+
+Do not close a CVE as mitigated if runtime replacement evidence is missing, the scanner has not re-run after redeployment, or residual stale assets remain without documented exception ownership and expiry.
+
+```
+Temporal Exposure and Closure Evidence:
+- First Vulnerable Runtime Seen: [YYYY-MM-DD HH:MM UTC or Unknown]
+- Last Vulnerable Runtime Seen:  [YYYY-MM-DD HH:MM UTC or Unknown]
+- Exposure During Window:        [Internet-facing | Internal reachable | Isolated | Not deployed | Unknown]
+- Vulnerable Artifact ID:        [Digest/package build/AMI/layer/host inventory ID]
+- Fixed Artifact ID:             [Digest/package build/AMI/layer/host inventory ID]
+- Redeployment Evidence:         [Rollout/deploy/inventory record or Missing]
+- Scanner Re-detection:          [Clean | Still detected | Not re-run | Not available]
+- Residual Stale Assets:         [None | List assets and owner/expiry | Unknown]
+- Closure Status:                [Open | Mitigated pending re-scan | Closed with evidence | Accepted risk]
+```
+
+### Step 7: SLA Assignment and Remediation Recommendation
 
 Combine all assessment data to assign a remediation SLA and produce a final recommendation.
 
@@ -293,6 +329,7 @@ The following conditions override the standard SLA and escalate to the next tier
 - **Ransomware association** (KEV "Known Ransomware Use" = Known) -- escalates to Immediate
 - **Compliance deadline** (PCI DSS, HIPAA, BOD 22-01) -- SLA must not exceed compliance-mandated timeframe
 - **Chained vulnerability** -- if this CVE is part of a known exploit chain, escalate one tier
+- **Runtime still vulnerable** -- if stale pods, launch templates, serverless layers, or hosts still run the vulnerable artifact, do not reduce urgency based on source patch status or a planned deployment
 
 #### De-escalation Factors
 
@@ -302,6 +339,8 @@ The following conditions may justify a longer SLA (document the justification):
 - Affected component is disabled or not deployed in your environment
 - Network segmentation prevents attacker access to the vulnerable system
 - VEX (Vulnerability Exploitability eXchange) status is "not_affected" or "fixed"
+- Vulnerable artifact was never running during the relevant exposure window and runtime inventory confirms no residual stale assets
+- Follow-up scanner re-detection is clean after redeployment and the fixed artifact digest or package build is recorded
 
 ---
 
@@ -328,6 +367,8 @@ recommended SLA tier. Lead with the most critical fact.]
 | Affected Software | [Product vX.Y.Z] |
 | Affected Component | [Component] |
 | Patch Available | [Yes/No/Workaround] |
+| Scanner Source | [Tool and scan timestamp] |
+| Runtime Artifact | [Digest/package build/AMI/layer/host inventory ID] |
 
 ### CVSS 4.0 Assessment
 | Metric Group | Score | Severity |
@@ -361,6 +402,19 @@ recommended SLA tier. Lead with the most critical fact.]
 | Technical Impact | [Partial/Total] |
 | Mission Prevalence | [Minimal/Support/Essential] |
 | **Decision** | **[Defer/Scheduled/Out-of-Cycle/Immediate]** |
+
+### Temporal Exposure and Closure Evidence
+| Evidence Field | Value |
+|---|---|
+| First Vulnerable Runtime Seen | [YYYY-MM-DD HH:MM UTC or Unknown] |
+| Last Vulnerable Runtime Seen | [YYYY-MM-DD HH:MM UTC or Unknown] |
+| Exposure During Window | [Internet-facing/Internal/Isolated/Not deployed/Unknown] |
+| Vulnerable Artifact ID | [Digest/package build/AMI/layer/host inventory ID] |
+| Fixed Artifact ID | [Digest/package build/AMI/layer/host inventory ID] |
+| Redeployment Evidence | [Rollout/deploy/inventory record or Missing] |
+| Scanner Re-detection | [Clean/Still detected/Not re-run/Not available] |
+| Residual Stale Assets | [None/List assets and owner/expiry/Unknown] |
+| Closure Status | [Open/Mitigated pending re-scan/Closed with evidence/Accepted risk] |
 
 ### Remediation Recommendation
 - **SLA Tier:** [Immediate (24h) / Out-of-Cycle (72h) / Scheduled (30d) / Defer (90d)]


### PR DESCRIPTION
/claim #1909

## Summary
- add temporal exposure collection to cve-triage context gathering
- add closure gates for fixed artifact IDs, redeployment proof, scanner re-detection, and residual stale assets
- update the report template with runtime exposure and closure evidence fields

## Validation
- Documentation-only change; reviewed the targeted Markdown diff.