### PR TITLE
Improve agentic tool-output taint gates

### DIFF
--- a/skills/ai-security/agentic-top-10/SKILL.md
+++ b/skills/ai-security/agentic-top-10/SKILL.md
@@ -138,6 +138,21 @@ The 2024 Anthropic research paper on tool use showed that Claude, when given a c
 - MITRE ATLAS: AML.T0040 — ML Model Inference API Access
 - NIST AI RMF: MEASURE 2.6 (robustness testing), MANAGE 2.2 (risk response)
 
+**Tool-Output Taint and Delegated Capability Evidence Gate:**
+
+Tool outputs that re-enter the agent context must carry provenance and taint metadata. A downstream planner or delegated worker must not treat tool output, browser content, retrieval results, queue messages, or another agent's summary as system instructions or as authority to invoke broader tools.
+
+| Evidence Field | What to Verify | Fails When |
+|----------------|----------------|------------|
+| **Output source label** | Tool result includes tool name, instance identity, origin URL/resource, and retrieval timestamp | The agent cannot distinguish user input, tool output, and system instructions |
+| **Taint propagation** | Untrusted output remains marked untrusted through summarization, memory writes, delegation, and retries | Summaries or worker handoffs strip taint labels |
+| **Instruction boundary** | Tool output is parsed as data and cannot redefine role, policy, or tool permissions | Tool output text can trigger new instructions or override policy |
+| **Delegated capability check** | Delegated task includes requested tool, scope, risk tier, and parent authorization proof | A lower-privilege agent can ask a higher-privilege worker to run tools it cannot use |
+| **Recipient allowlist** | Worker agent validates sender identity and permitted request types before execution | Any agent or queue message can dispatch privileged work |
+| **Audit linkage** | The original user request, tool output, delegation envelope, approval artifact, and final tool call share a trace ID | Reviewers cannot reconstruct why a delegated action occurred |
+
+**Classification guidance:** Mark as **High** when untrusted tool output can trigger delegated privileged tool calls without taint labels, authorization proof, or recipient validation. Mark as **Critical** if the delegated path can write code, deploy, transfer funds, exfiltrate sensitive data, or modify permissions. Suppress the finding only when taint labels survive handoffs and the receiving agent enforces sender, scope, approval, and tool allowlists before execution.
+
 ---
 
 ### AG03 — Privilege Escalation
@@ -514,6 +529,12 @@ Structure the final report as follows:
 | AG01 | [rating] | [one-line summary] | [priority] |
 | ... | ... | ... | ... |
 
+## Tool-Output Taint and Delegation Evidence
+
+| Flow | Output Source | Taint Preserved | Delegated Tool | Authorization Proof | Recipient Validation | Trace ID |
+|---|---|---|---|---|---|---|
+| [flow name] | [tool/resource] | [yes/no/partial] | [tool name] | [policy/approval ID] | [sender + scope check] | [trace ID] |
+
 ## Recommendations
 1. [Highest priority recommendation]
 2. [Second priority recommendation]
@@ -585,6 +606,10 @@ Persistent agent memory is a high-value target because it persists across sessio
 ### 5. Assuming Tool Calls Are Safe Because the Tool Is Legitimate
 
 A tool functioning correctly is not the same as a tool being used correctly. The agent controls what parameters it passes, what sequence it calls tools in, and how it interprets results. A legitimate database query tool becomes an exfiltration vector when the agent is manipulated into querying sensitive tables and sending the results to an external webhook. Secure the tool invocation, not just the tool implementation.
+
+### 6. Dropping Taint During Agent Handoffs
+
+Tool output may be summarized, stored in memory, then delegated to another worker. If the handoff removes source labels, taint state, or authorization context, the receiving worker cannot tell whether it is executing a trusted plan or untrusted content. Preserve provenance and require delegated capability checks at every boundary.
 
 ---
 

--- a/skills/ai-security/agentic-top-10/tests/benign/tainted-tool-output-delegation-blocked.md
+++ b/skills/ai-security/agentic-top-10/tests/benign/tainted-tool-output-delegation-blocked.md
@@ -1,0 +1,45 @@
+# Benign Fixture: Tainted Tool Output Blocks Delegated Capability
+
+## Scenario
+
+A planner agent reads an external runbook and asks a worker to prepare a remediation draft. The system preserves taint metadata and blocks a requested privileged tool because the source is untrusted and no approval artifact exists.
+
+## Evidence
+
+```yaml
+flow: external-runbook-to-remediation-draft
+trace_id: trace-9012
+planner_agent:
+  tools:
+    - browser.read
+    - queue.publish
+  source:
+    type: external_web
+    url: https://runbooks.example.invalid/db-maintenance
+    taint: untrusted
+  summary_output:
+    taint: untrusted
+    content_type: source_summary
+delegation_message:
+  sender: planner-agent
+  recipient: remediation-worker
+  requested_tool: pull_request.create
+  requested_scope: draft-only
+  parent_authorization: policy-agentic-draft-remediation
+  risk_tier: medium
+  original_source_taint: untrusted
+worker_agent:
+  validates_sender: true
+  validates_requested_tool_scope: true
+  requires_approval_artifact_for_privileged_tools: true
+  blocked_tools:
+    - deploy.production
+    - secrets.read
+  action_taken: create_draft_summary
+```
+
+## Expected Assessment
+
+- Do not flag delegated capability bypass because taint and authorization context survive the handoff.
+- Mark the flow as controlled when the worker enforces sender identity, requested scope, tool allowlist, and approval requirements.
+- Record remaining residual risk as low or medium depending on draft review controls.

--- a/skills/ai-security/agentic-top-10/tests/vulnerable/tool-output-taint-stripped-delegated-deploy.md
+++ b/skills/ai-security/agentic-top-10/tests/vulnerable/tool-output-taint-stripped-delegated-deploy.md
@@ -1,0 +1,42 @@
+# Vulnerable Fixture: Tool Output Taint Stripped Before Delegated Deploy
+
+## Scenario
+
+A research agent browses an external issue page. The page contains attacker-controlled text that asks the system to deploy a hotfix. The research agent summarizes the page and delegates a deployment task to an executor agent, but the summary strips the untrusted-source label and the executor accepts the task as trusted internal work.
+
+## Evidence
+
+```yaml
+flow: external-issue-to-deploy
+trace_id: trace-7844
+research_agent:
+  tools:
+    - browser.read
+    - queue.publish
+  source:
+    type: external_web
+    url: https://issues.example.invalid/INC-441
+    taint: untrusted
+  summary_output:
+    taint: none
+    content_type: task_summary
+delegation_message:
+  sender: research-agent
+  recipient: deploy-executor
+  requested_tool: deploy.production
+  parent_authorization: null
+  risk_tier: high
+  original_source_taint: omitted
+executor_agent:
+  validates_sender: false
+  validates_requested_tool_scope: false
+  requires_approval_artifact: false
+  action_taken: deploy.production
+```
+
+## Expected Assessment
+
+- Flag a **Critical** finding because untrusted tool output can cause a delegated production deployment.
+- Identify AG02, AG03, AG05, and AG08 overlap: tool misuse, privilege escalation, trust-boundary violation, and HITL bypass.
+- Require taint propagation from browser output through summary and queue message.
+- Require delegated capability checks for sender identity, requested tool, risk tier, approval artifact, and trace ID before execution.


### PR DESCRIPTION
## Summary
- add a tool-output taint and delegated capability evidence gate to agentic-top-10
- require source labels, taint propagation, instruction boundaries, delegated capability checks, recipient allowlists, and traceable audit linkage
- add vulnerable and benign fixtures covering taint-stripped delegated deployment versus blocked scoped delegation

## Validation
- `git diff --check origin/main...HEAD`
- Markdown fence balance check
- Added-line ASCII check
- Content marker check for tool-output taint, delegated capability, taint propagation, instruction boundary, recipient allowlist, trace ID, and authorization proof
- `git merge-tree --write-tree origin/main HEAD`

Closes #1581

Bounty request: Improver Moderate / USD 100 if accepted.