### PR TITLE
Improve log redaction provenance gates

### DIFF
--- a/skills/secops/log-analysis/SKILL.md
+++ b/skills/secops/log-analysis/SKILL.md
@@ -317,6 +317,22 @@ Step 5: Build timeline
   -> Identify gaps in visibility (log sources not available)
 ```
 
+### Step 8: Log Redaction and Sensitive-Field Provenance
+
+When analyzing logs that contain credentials, tokens, PII, payment data, internal identifiers, or regulated fields, verify both the redaction result and the provenance of the fields being redacted. A value that appears redacted in one view may still exist in raw storage, enrichment fields, forwarded copies, or downstream exports.
+
+| Evidence Field | What to Verify | Fails When |
+|----------------|----------------|------------|
+| **Sensitive field inventory** | Field names, source parser, data class, owner, and downstream destinations are documented | Analysts rely on ad hoc string matching or do not know which fields may contain sensitive values |
+| **Parser and enrichment provenance** | The pipeline records whether sensitive fields came from raw events, parsed fields, enrichment, lookup tables, or joins | Enriched user, token, or URL fields bypass redaction because they were not in the original raw event |
+| **Redaction stage** | Redaction happens before broad indexing, forwarding, exports, tickets, and AI-assisted summaries | Raw sensitive values are stored or copied before masking |
+| **Raw-to-redacted linkage** | A stable event ID or hash links redacted analyst views to the original event without exposing the value | Investigators cannot prove what was redacted or correlate safely |
+| **Role-based access** | Only approved break-glass roles can view raw sensitive values, with audit logging and expiry | All analysts or automation can query unredacted logs |
+| **Sample verification** | Positive and negative samples show credentials/PII are masked while security-relevant context remains | Masking removes needed context or misses nested/encoded fields |
+| **Export and case-note controls** | SIEM exports, tickets, chat summaries, and reports inherit redaction rules | Sensitive values reappear in downstream artifacts |
+
+**Classification guidance:** Mark as **High** when sensitive values are available in normal analyst views, exported tickets, or AI summaries without role-gated access. Escalate to **Critical** when live credentials, session tokens, payment data, or regulated health/identity data are exposed broadly or retained without rotation/notification handling. Suppress the finding only when raw access is role-gated, redaction occurs before broad storage/export, and sample evidence proves sensitive fields are masked without breaking the investigation.
+
 ---
 
 ## 4. Findings Classification
@@ -379,6 +395,11 @@ Produce log analysis findings in this structure:
 
 ### Visibility Gaps
 [Log sources that were not available but would have provided relevant data]
+
+### Redaction and Sensitive-Field Provenance
+| Field | Source / Parser | Data Class | Redaction Stage | Raw Access Control | Downstream Exports Checked | Status |
+|-------|-----------------|------------|-----------------|--------------------|----------------------------|--------|
+| [field name] | [raw/parser/enrichment] | [credential/PII/payment/etc.] | [pre-index/post-index/missing] | [role-gated/open/N/A] | [yes/no] | [pass/fail/partial] |
 
 ### Recommendations
 - [ ] [Action 1]
@@ -450,6 +471,10 @@ A single Event ID can have very different meanings depending on the context. Eve
 ### Pitfall 5: Not Establishing Baselines Before Looking for Anomalies
 
 Attempting to identify anomalous behavior without knowing what normal behavior looks like leads to both false positives (flagging normal activity as suspicious) and false negatives (missing truly anomalous activity that blends into an unfamiliar baseline). Invest in baseline establishment for high-value log sources before relying on anomaly-based analysis.
+
+### Pitfall 6: Redacting Only Raw Messages
+
+Many pipelines parse, enrich, normalize, and forward log fields before analysts see them. A token or email address can be masked in `_raw` while still present in `url.query`, `Authorization`, `user.email`, enrichment tables, case notes, or exported CSV files. Verify redaction at every storage and forwarding stage, not only in the rendered event text.
 
 ---
 

--- a/skills/secops/log-analysis/tests/benign/pre-index-redaction-with-hash-linkage.md
+++ b/skills/secops/log-analysis/tests/benign/pre-index-redaction-with-hash-linkage.md
@@ -1,0 +1,41 @@
+# Benign Fixture: Pre-Index Redaction With Hash Linkage
+
+## Scenario
+
+An authentication log pipeline redacts sensitive values before indexing while preserving enough provenance for investigation. Raw access is break-glass only and downstream exports inherit the same masking rules.
+
+## Evidence
+
+```yaml
+pipeline: auth-service-to-siem
+event_id: evt-8820
+redaction:
+  stage: pre-index
+  raw_authorization_header: tokenized
+  url_query_token: tokenized
+  user_email: masked
+  linkage_hash: sha256(event_id + field_name + secret_version)
+provenance:
+  parser_version: auth-parser-4.8.2
+  enrichment_sources:
+    - idp-directory
+    - geoip
+access_control:
+  analyst_view_raw_values: false
+  break_glass_role: security-privacy-approver
+  break_glass_expiry_hours: 4
+  break_glass_audit_log: enabled
+exports:
+  csv_export_inherits_redaction: true
+  ticket_sync_inherits_redaction: true
+sample_verification:
+  positive_token_sample_masked: true
+  negative_status_code_sample_preserved: true
+  nested_query_sample_masked: true
+```
+
+## Expected Assessment
+
+- Do not flag sensitive-field leakage when evidence shows pre-index redaction and controlled raw access.
+- Record redaction and provenance status as passing.
+- Preserve event IDs, hashes, timestamps, and ATT&CK context without exposing sensitive values.

--- a/skills/secops/log-analysis/tests/vulnerable/post-index-token-redaction-missing-export.md
+++ b/skills/secops/log-analysis/tests/vulnerable/post-index-token-redaction-missing-export.md
@@ -1,0 +1,41 @@
+# Vulnerable Fixture: Sensitive Token Redacted in Raw View but Exported
+
+## Scenario
+
+A SIEM masks bearer tokens in the rendered raw event view, but parsed URL query fields and ticket exports still contain the original token. Analysts can export the unredacted field without break-glass approval.
+
+## Evidence
+
+```yaml
+pipeline: web-proxy-to-siem
+event_id: evt-7781
+raw_event:
+  redaction_stage: rendered_view_only
+  displayed_authorization: "[REDACTED]"
+parsed_fields:
+  url.path: /oauth/callback
+  url.query.token:
+    data_class: live-session-token
+    redacted: false
+    source: parser
+  user.email:
+    data_class: pii
+    redacted: false
+    source: idp-enrichment
+storage:
+  broad_index_contains_raw_token: true
+  analyst_role_can_query_raw: true
+exports:
+  csv_export_contains_url_query_token: true
+  ticket_sync_contains_user_email: true
+sample_verification:
+  positive_token_sample_masked: false
+  nested_query_sample_masked: false
+```
+
+## Expected Assessment
+
+- Flag a **High** or **Critical** finding depending on whether the token is live and privileged.
+- Note that raw display masking is insufficient because parsed and exported fields preserve sensitive values.
+- Require pre-index redaction or tokenization, role-gated raw access, downstream export controls, and verification samples.
+- Do not reproduce the actual token value in the report.


### PR DESCRIPTION
## Summary
- add log redaction and sensitive-field provenance evidence gates
- require sensitive field inventory, parser/enrichment provenance, redaction stage, raw-to-redacted linkage, role-gated raw access, sample verification, and downstream export checks
- add vulnerable and benign fixtures covering post-index token leakage versus pre-index redaction with hash linkage

## Validation
- `git diff --check origin/main...HEAD`
- Markdown fence balance check
- Added-line ASCII check
- Content marker check for sensitive field, provenance, redaction stage, raw access, downstream exports, sample verification, and pre-index evidence
- `git merge-tree --write-tree origin/main HEAD`

Closes #1579

Bounty request: Improver Moderate / USD 100 if accepted.