### PR TITLE
Improve container debug privilege gates

### DIFF
--- a/skills/cloud/container-security/SKILL.md
+++ b/skills/cloud/container-security/SKILL.md
@@ -115,6 +115,30 @@ For detailed CIS benchmark checklist items, NIST SP 800-190 countermeasure table
 
 ---
 
+### Step 6.5: Debug Container and Ephemeral Privilege Evidence Gate
+
+When a workload or policy allows privileged, root, host namespace, hostPath, `kubectl exec`, or ephemeral debug container access, determine whether the privilege is persistent application runtime or a controlled break-glass/debug path.
+
+Record evidence for each debug or ephemeral privilege path:
+
+| Evidence | Required check | Failure signal |
+|----------|----------------|----------------|
+| Workload persistence | Privilege appears only in `ephemeralContainers`, temporary debug pods, or approved troubleshooting overlays | Privilege is present in a Deployment, StatefulSet, DaemonSet, or base Helm values |
+| Time bound | TTL, active deadline, cleanup job, or ticket expiry limits the debug container lifetime | No expiry, no cleanup proof, or reusable privileged debug workload |
+| Namespace and target scope | Debug access is limited to named namespaces, workloads, and service accounts | Cluster-wide debug rights or wildcard namespaces |
+| RBAC and admission control | `pods/ephemeralcontainers`, `pods/exec`, and privileged pod creation are restricted to approved break-glass roles | Ordinary app teams or CI service accounts can create privileged/debug containers |
+| Audit trail | Kubernetes audit logs, cloud audit logs, or admission controller logs record who created the debug session and why | No audit log for debug/exec/ephemeral-container use |
+| Runtime constraints | Capabilities, host namespaces, hostPath mounts, and `allowPrivilegeEscalation` are minimized for the debug purpose | Debug image gets broad host access unrelated to the incident or ticket |
+
+Classification guidance:
+
+- Keep Critical/High when privileged settings are persistent in application workloads, base Helm values, DaemonSets, or CI-created manifests.
+- Keep High when break-glass debug access is not RBAC-limited, not time-bound, not audited, or can target arbitrary namespaces.
+- Downgrade to Medium/Observation only when the debug container is ephemeral, scoped, time-bound, audited, and tied to a specific incident/change ticket.
+- Do not suppress findings solely because a manifest name contains `debug`, `temporary`, or `breakglass`; require the evidence above.
+
+---
+
 ### Step 7: Compile Assessment Report
 
 
@@ -184,6 +208,12 @@ Produce the final report using the structure defined in the Output Format sectio
 |----------|-----------|-----------|------------|
 | deploy/app | production | Baseline (not Restricted) | runAsRoot, no seccomp |
 | deploy/worker | production | Privileged | privileged: true |
+
+### Debug and Ephemeral Privilege Evidence
+
+| Workload/Role | Privilege Path | Scope | TTL/Expiry | Audit Evidence | RBAC Gate | Decision |
+|---------------|----------------|-------|------------|----------------|-----------|----------|
+| <namespace/workload> | <ephemeralContainers / pods/exec / debug pod / privileged container> | <namespace/workload/service-account> | <duration/ticket expiry> | <audit event/ticket> | <role/admission policy> | <persistent risk / controlled debug / not evidenced> |
 
 ### Prioritized Remediation Plan
 
@@ -257,6 +287,7 @@ Produce the final report using the structure defined in the Output Format sectio
 5. **`readOnlyRootFilesystem` breaks many applications.** When recommending this control, also recommend adding writable `emptyDir` volume mounts for directories the application needs to write to (e.g., `/tmp`, `/var/cache`).
 6. **Network policies are additive, not subtractive.** A default-deny policy must be explicitly created. Without it, all pod-to-pod traffic is allowed regardless of other NetworkPolicy resources.
 7. **Distroless images have no shell.** While this is excellent for security, note that debugging requires ephemeral containers (`kubectl debug`). Flag this as a consideration, not a problem.
+8. **Debug labels are not evidence.** A privileged container named `debug` or `breakglass` is still persistent risk unless manifests, RBAC, admission policy, TTL, cleanup, and audit logs prove it is a scoped ephemeral debug path.
 
 ---
 

--- a/skills/cloud/container-security/tests/benign/scoped-ephemeral-debug-container-audited.md
+++ b/skills/cloud/container-security/tests/benign/scoped-ephemeral-debug-container-audited.md
@@ -1,0 +1,41 @@
+# Benign Fixture: Scoped Ephemeral Debug Container With Audit Evidence
+
+## Scenario
+
+An SRE team uses `kubectl debug` for a production pod that runs a distroless image. The debug path is limited to one namespace and target workload, requires a break-glass role, expires after the incident window, and is recorded by Kubernetes audit logs.
+
+## Evidence
+
+```yaml
+debug_session:
+  target_namespace: payments-prod
+  target_workload: deploy/payment-api
+  incident_ticket: INC-4421
+  expires_at: "2026-06-08T12:30:00Z"
+  created_by: sre-oncall@example.com
+  type: ephemeralContainers
+  container:
+    name: debugger-inc-4421
+    image: registry.example.com/debug-tools:2026.06
+    securityContext:
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop: ["ALL"]
+  rbac:
+    role: sre-breakglass-debug
+    verbs: ["get", "patch"]
+    resources: ["pods", "pods/ephemeralcontainers"]
+    resourceNames: ["payment-api-7d9f6c8c6b-2r4mk"]
+  audit:
+    event_id: audit-20260608-4421
+    user: sre-oncall@example.com
+    verb: patch
+    resource: pods/ephemeralcontainers
+    namespace: payments-prod
+```
+
+## Expected Result
+
+The skill may downgrade this to Medium/Observation or mark it controlled debug evidence. The access is ephemeral, scoped to a named workload, time-bound, audited, and does not grant broad host namespace, hostPath, or privilege escalation access.

--- a/skills/cloud/container-security/tests/vulnerable/persistent-debug-daemonset-privileged-no-ttl.md
+++ b/skills/cloud/container-security/tests/vulnerable/persistent-debug-daemonset-privileged-no-ttl.md
@@ -1,0 +1,51 @@
+# Vulnerable Fixture: Persistent Debug DaemonSet Without TTL
+
+## Scenario
+
+A platform team keeps a privileged debug DaemonSet deployed in every worker namespace so engineers can troubleshoot node-level networking issues. The manifest name and labels say `debug`, but the workload is persistent, cluster-scoped, and not tied to an incident ticket.
+
+## Evidence
+
+```yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-debug-shell
+  namespace: production
+  labels:
+    purpose: debug
+spec:
+  template:
+    spec:
+      serviceAccountName: default
+      hostPID: true
+      hostNetwork: true
+      containers:
+        - name: shell
+          image: busybox:latest
+          command: ["sleep", "365d"]
+          securityContext:
+            privileged: true
+            allowPrivilegeEscalation: true
+          volumeMounts:
+            - name: host-root
+              mountPath: /host
+      volumes:
+        - name: host-root
+          hostPath:
+            path: /
+```
+
+```yaml
+evidence:
+  ttl_seconds_after_finished: null
+  cleanup_job: null
+  incident_ticket: null
+  audit_log_for_creation: null
+  rbac_scope: "default service account can manage pods in production"
+  admission_exception_expiry: null
+```
+
+## Expected Result
+
+The skill should keep this as Critical or High. The privilege is persistent, host-scoped, not time-bound, not audited, and not limited to an approved break-glass role. The `debug` label must not suppress the finding.


### PR DESCRIPTION
## Summary
- add an additive debug container and ephemeral privilege evidence gate inside the existing container-security workflow
- require workload persistence, TTL/expiry, namespace and target scope, RBAC/admission control, audit trail, and runtime-constraint evidence before downgrading privileged debug access
- add vulnerable and benign fixtures for a persistent privileged debug DaemonSet versus a scoped audited ephemeral debug container

## Validation
- `git diff --check origin/main...HEAD`
- Markdown fence balance check
- Added-line ASCII check
- Content marker check for debug container, ephemeral privilege, TTL, audit evidence, RBAC gate, host namespace, privileged, and break-glass evidence
- `git merge-tree --write-tree origin/main HEAD`

Closes #1574

Bounty request: Improver Moderate / USD 100 if accepted.