### PR TITLE
Improve OWASP session token storage gates

### DIFF
--- a/skills/appsec/owasp-top-10-web/SKILL.md
+++ b/skills/appsec/owasp-top-10-web/SKILL.md
@@ -452,6 +452,25 @@ rejectUnauthorized\s*:\s*false|verify\s*=\s*False|CERT_NONE|InsecureRequestWarni
 - Set absolute and idle session timeouts appropriate to the application's risk profile.
 - Never expose session tokens in URLs.
 
+**Cookie, Session Storage, and Browser Token Evidence Gate:**
+
+Before rating a session or browser-token issue, confirm how the token is stored, transmitted, rotated, and protected from front-end script access.
+
+| Evidence | Secure signal | Failure signal |
+|----------|---------------|----------------|
+| Cookie attributes | Session cookie uses `Secure`, `HttpOnly`, `SameSite=Lax` or `Strict`, finite expiry, and preferably `__Host-` prefix with `Path=/` and no `Domain` | Missing `Secure`/`HttpOnly`, `SameSite=None` without a cross-site need, broad `Domain`, or persistent cookie without justification |
+| Browser storage | `localStorage`, `sessionStorage`, and IndexedDB do not contain bearer/session/refresh tokens or PII | Auth token, refresh token, JWT, API key, or user PII stored in browser-readable storage |
+| URL exposure | Tokens are never accepted from query strings, fragments, redirect URLs, or Referer-leaking routes | `token`, `session`, `jwt`, or reset secrets read from `req.query`, URL fragments, or logged URLs |
+| Rotation and expiry | Session ID rotates after login, MFA, privilege change, and password reset; idle and absolute timeouts are enforced server-side | Session fixation, long-lived remember-me tokens, or no server-side invalidation |
+| Framework abstraction | Framework-managed sessions are verified through actual config, middleware order, and emitted `Set-Cookie` attributes | Assuming Passport, Django, Spring Security, Devise, or Express-session is safe without checking config/output |
+
+Classification guidance:
+
+- High: bearer/session/refresh tokens are stored in `localStorage`/IndexedDB, exposed in URLs, or readable by JavaScript in an XSS-reachable context.
+- Medium: cookie flags, rotation, or expiry are incomplete but the token remains server-side and not exposed to front-end scripts.
+- Low/Informational: framework-managed `__Host-` or `__Secure-` cookies have `Secure`, `HttpOnly`, appropriate `SameSite`, finite expiry, server-side rotation, and no browser-readable token copy.
+- Do not suppress a finding only because a variable is named `csrfToken`; verify it is a CSRF nonce, not an authentication bearer token.
+
 ---
 
 ### A08:2021 — Software and Data Integrity Failures
@@ -635,6 +654,7 @@ Present findings in this structure:
 - **Location:** [file:line or file:function]
 - **Description:** [Clear explanation of the vulnerability, including how it could be exploited]
 - **Evidence:** [Code snippet or configuration excerpt]
+- **Session/token evidence:** [Storage location, cookie flags, URL exposure, rotation/expiry, and framework config if A07/session-related]
 - **Remediation:** [Specific, actionable fix with code example where applicable]
 - **Verification:** [How to confirm the fix is effective]
 
@@ -686,6 +706,8 @@ Present findings in this structure:
 4. **Reporting deprecated algorithms without context.** MD5 used for non-security checksums (e.g., cache busting, ETags) is not a cryptographic failure. Only flag weak algorithms when they protect sensitive data, passwords, or integrity-critical operations. State the security impact clearly.
 
 5. **Ignoring transitive dependencies.** A project may have zero direct vulnerable dependencies but inherit critical CVEs through transitive dependencies. Always analyze the full dependency tree, not just top-level declarations.
+
+6. **Assuming all browser storage is equivalent.** A CSRF nonce in `sessionStorage` is not the same risk as a bearer token in `localStorage`. Record the exact token purpose, storage location, lifetime, JavaScript accessibility, and server-side validation before assigning severity.
 
 ## Prompt Injection Safety Notice
 

--- a/skills/appsec/owasp-top-10-web/tests/benign/host-prefixed-session-cookie-csrf-nonce.md
+++ b/skills/appsec/owasp-top-10-web/tests/benign/host-prefixed-session-cookie-csrf-nonce.md
@@ -1,0 +1,48 @@
+# Benign Fixture: Host-Prefixed Session Cookie With CSRF Nonce
+
+## Scenario
+
+A web application uses a framework-managed server-side session. The authentication token is only in an `HttpOnly` `__Host-` cookie, while `sessionStorage` holds a short-lived CSRF nonce that is independently validated server-side and rotated per form.
+
+## Evidence
+
+```http
+Set-Cookie: __Host-session=opaque-id; Path=/; Secure; HttpOnly; SameSite=Lax; Max-Age=1800
+```
+
+```javascript
+// src/csrf.js
+export function storeCsrfNonce(nonce) {
+  sessionStorage.setItem("csrf_nonce", nonce);
+}
+
+export function buildFormHeaders() {
+  return {
+    "X-CSRF-Nonce": sessionStorage.getItem("csrf_nonce")
+  };
+}
+```
+
+```yaml
+session_config:
+  server_side_store: redis
+  rotate_on_login: true
+  rotate_on_mfa: true
+  rotate_on_privilege_change: true
+  idle_timeout_minutes: 30
+  absolute_timeout_hours: 8
+  cookie:
+    prefix: "__Host-"
+    secure: true
+    http_only: true
+    same_site: Lax
+    path: /
+    domain: null
+csrf:
+  nonce_lifetime_minutes: 10
+  nonce_reuse_allowed: false
+```
+
+## Expected Result
+
+The skill should not report browser-token storage for the CSRF nonce alone. The authentication session is server-side, protected by `Secure` and `HttpOnly`, not exposed through URLs, rotates on important state changes, and has finite idle and absolute expiry.

--- a/skills/appsec/owasp-top-10-web/tests/vulnerable/localstorage-refresh-token-query-fallback.md
+++ b/skills/appsec/owasp-top-10-web/tests/vulnerable/localstorage-refresh-token-query-fallback.md
@@ -1,0 +1,33 @@
+# Vulnerable Fixture: Refresh Token in LocalStorage With Query Fallback
+
+## Scenario
+
+A single-page application stores a long-lived refresh token in `localStorage` and also accepts a `token` query parameter during OAuth callback handling. The session cookie exists, but it is not the only authentication material.
+
+## Evidence
+
+```javascript
+// src/auth/session.js
+export function persistAuth(authResponse) {
+  localStorage.setItem("access_token", authResponse.accessToken);
+  localStorage.setItem("refresh_token", authResponse.refreshToken);
+  localStorage.setItem("expires_at", String(Date.now() + 30 * 24 * 60 * 60 * 1000));
+}
+
+export function readTokenFromCallback(req) {
+  const token = req.query.token || req.body.token;
+  if (token) {
+    console.info("oauth callback token", req.originalUrl);
+    return token;
+  }
+  return null;
+}
+```
+
+```http
+Set-Cookie: sid=abc123; Path=/; SameSite=Lax
+```
+
+## Expected Result
+
+The skill should classify this as High. Bearer and refresh tokens are browser-readable, long-lived, and accepted from query strings that can leak through logs, browser history, and Referer headers. The presence of a session cookie without `HttpOnly` and without server-side rotation evidence does not suppress the finding.


### PR DESCRIPTION
## Summary
- add an additive cookie/session storage and browser token evidence gate under A07
- require cookie attributes, browser storage, URL exposure, rotation/expiry, and framework configuration evidence before assigning severity
- add vulnerable and benign fixtures for localStorage refresh-token/query fallback versus a host-prefixed HttpOnly session cookie with a CSRF nonce

## Validation
- `git diff --check origin/main...HEAD`
- Markdown fence balance check
- Added-line ASCII check
- Content marker check for cookie/session storage, browser token, localStorage, sessionStorage, __Host-, HttpOnly, SameSite, URL exposure, rotation/expiry, refresh_token, and csrf_nonce evidence
- `git merge-tree --write-tree origin/main HEAD`

Closes #1572

Bounty request: Improver Moderate / USD 100 if accepted.