### PR TITLE
Improve HIPAA wiper and BAA evidence gates

### DIFF
--- a/skills/compliance/hipaa-review/SKILL.md
+++ b/skills/compliance/hipaa-review/SKILL.md
@@ -50,6 +50,20 @@ The HIPAA Security Rule (45 CFR Part 164, Subpart C) establishes national standa
 - **Required (R)**: Must be implemented as specified
 - **Addressable (A)**: Must be assessed; if reasonable and appropriate, implement it. If not, document why and implement an equivalent alternative measure if reasonable and appropriate. Cannot simply ignore addressable specifications.
 
+### Evidence Gates for Addressable and 2026 Threat Scenarios
+
+Before assigning a status, collect the evidence that proves the control is current, scoped to ePHI, and traceable to an accountable owner:
+
+| Evidence Gate | Required Evidence |
+|---------------|-------------------|
+| Addressable decision | CFR citation, affected ePHI systems, risk-analysis reference, decision rationale, equivalent alternative control if the specification is not implemented as written, approver, approval date, and next review trigger |
+| Destructive-malware backup resilience | ePHI backup tier, immutable/offline/WORM control, backup-admin separation, deletion-protection audit logs, last restore-test result, and wiper scenario covered by the contingency plan |
+| Business associate supply chain | Service/ePHI data-flow mapping, executed BAA status, right-to-audit or assurance mechanism, subcontractor disclosure, flowdown evidence, breach-notice SLA, and return/destruction terms |
+| Remote-work physical safeguards | Workforce group, approved work locations, device management evidence, shared-household/shared-device controls, local print/download rules, lost-device process, and attestation cadence |
+| HITECH recognized security practices | Recognized practice set, evidence it was implemented for the prior 12 months, mapped findings, control exceptions, and OCR consideration notes |
+
+Do not mark missing encryption as **Non-Compliance** solely because encryption is absent. Encryption and decryption under 164.312(a)(2)(iv) and transmission encryption under 164.312(e)(2)(ii) are addressable specifications. Mark the result **Conditional Compliance** only when the addressable decision record is documented, approved, current, scoped to the affected ePHI systems, and supported by equivalent alternative controls. Mark it **Non-Compliance** when the addressable assessment, alternative control, approval, or review evidence is missing.
+
 ### Safeguard Structure
 
 | Safeguard Category | CFR Section | Standards | Implementation Specs |
@@ -68,10 +82,13 @@ The HIPAA Security Rule (45 CFR Part 164, Subpart C) establishes national standa
 - Network architecture and data flow diagrams showing ePHI paths
 - Current risk analysis documentation (or confirmation none exists)
 - Security policies and procedures documentation
-- Business Associate Agreements (BAAs) inventory
+- Business Associate Agreements (BAAs) inventory, including service scope, ePHI data flows, subcontractor lists, right-to-audit or assurance clauses, breach-notice timing, and return/destruction terms
 - Incident response and breach notification procedures
 - Access control configurations and user provisioning processes
-- Backup and disaster recovery documentation
+- Backup and disaster recovery documentation, including immutable/offline copy evidence and recent restore tests for destructive-malware scenarios
+- Remote-work and home-office ePHI access policies, device attestations, and shared-household risk handling
+- Addressable implementation-specification decision records, especially encryption and transmission encryption decisions
+- Recognized security-practice evidence for the prior 12 months if HITECH safe-harbor consideration is claimed
 - Workforce training records
 - Prior OCR audit findings or corrective action plans
 
@@ -142,6 +159,8 @@ Hybrid Entity: [Yes/No] — If yes, document healthcare component designation
   - Asset inventory tied to risk analysis scope
   - Threat and vulnerability identification per system
   - Risk ratings/scores with rationale
+  - Destructive-malware scenario that assumes credential theft, Volume Shadow Copy deletion, cloud-sync destruction, backup-console compromise, and backup-agent tampering before recovery begins
+  - Backup resilience evidence mapped to each critical ePHI system, including immutable/offline copies and restore results
 - Common gaps:
   - Risk analysis is incomplete (does not cover all ePHI systems)
   - Not updated after significant changes (new systems, incidents, organizational changes)
@@ -217,6 +236,16 @@ Hybrid Entity: [Yes/No] — If yes, document healthcare component designation
 **164.308(a)(7)(ii)(A) — Data Backup Plan (R)**
 - Establish and implement procedures to create and maintain retrievable exact copies of ePHI
 - In light of nation-state wiper threats targeting healthcare (e.g., 2026 Stryker attack), verify that backups include offline/immutable/air-gapped copies that cannot be destroyed by malware with domain admin access. Wiper malware routinely targets Volume Shadow Copies, backup agents, and NAS/SAN replication. The backup plan must ensure ePHI recoverability under a total destruction scenario.
+- Evidence to look for:
+  - Backup tier map for every ePHI system, including EHR, billing, telehealth, lab, medical-device, archive, and SaaS export data
+  - Immutable, WORM, object-lock, vault-lock, or offline-media controls with retention periods and protected deletion workflows
+  - Backup-administrator separation from production/domain administrators, MFA requirements, break-glass rules, and audit logs for deletion or retention changes
+  - Restore-test results proving retrievable exact ePHI copies can be recovered within documented RTO/RPO targets
+  - Tabletop or technical test evidence covering snapshot deletion, backup-index destruction, cloud-sync deletion, and backup-agent compromise
+- Findings guidance:
+  - No retrievable exact copy for a critical ePHI system is Critical Non-Compliance.
+  - Online-only backups that the same compromised administrator can delete are a risk-analysis and contingency-plan gap even if routine backups exist.
+  - Untested immutable backups are Partial Compliance until a restore test proves recoverability.
 
 **164.308(a)(7)(ii)(B) — Disaster Recovery Plan (R)**
 - Establish and implement procedures to restore any loss of data
@@ -265,12 +294,14 @@ Hybrid Entity: [Yes/No] — If yes, document healthcare component designation
 
 - Implement policies and procedures that specify the proper functions to be performed, the manner in which they are performed, and the physical attributes of the surroundings of workstations that access ePHI
 - Cover: screen positioning, clean desk requirements, acceptable locations for ePHI access
+- For remote work, verify approved work locations, local print/download rules, personal-device or BYOD restrictions, screen privacy, shared-household exposure controls, secure network requirements, and how ePHI handling is attested or reviewed
 
 #### 164.310(c) — Workstation Security (Standard, R)
 
 - Implement physical safeguards for all workstations that access ePHI
 - Restrict access to authorized users only
 - Cover: physical locks, restricted areas, cable locks, privacy screens
+- For home or remote environments, verify managed-device inventory, full-disk encryption, automatic lock, EDR/MDM or equivalent control, lost/stolen device reporting, prohibition on shared household accounts, and exception handling for unmanaged devices
 
 #### 164.310(d)(1) — Device and Media Controls (Standard)
 
@@ -306,6 +337,10 @@ Hybrid Entity: [Yes/No] — If yes, document healthcare component designation
 **164.312(a)(2)(iv) — Encryption and Decryption (A)**
 - Implement a mechanism to encrypt and decrypt ePHI
 - Note: Although addressable, encryption is strongly recommended and its absence must be documented with alternative controls. OCR has emphasized encryption as critical, especially for mobile devices and data at rest.
+- Decision handling:
+  - If encryption is implemented, verify scope across databases, file stores, backups, endpoints, removable media, mobile devices, and cloud storage.
+  - If encryption is not implemented as written, require the addressable decision record: risk-analysis reference, affected ePHI systems, reason encryption is not reasonable and appropriate, equivalent alternative control, approver, approval date, and review trigger.
+  - Classify as Conditional Compliance only when the alternative is documented, current, approved, and mapped to the affected ePHI systems. Classify as Non-Compliance when no addressable assessment exists.
 
 #### 164.312(b) — Audit Controls (Standard, R)
 
@@ -333,6 +368,7 @@ Hybrid Entity: [Yes/No] — If yes, document healthcare component designation
 **164.312(e)(2)(ii) — Encryption (A)**
 - Implement a mechanism to encrypt ePHI whenever deemed appropriate
 - Note: Encryption of ePHI in transit is strongly recommended by OCR. Unencrypted transmission of ePHI over the internet is a frequent enforcement target.
+- Decision handling: treat internet, vendor, telehealth, email, file-transfer, API, and remote-access paths as separate decisions. Lack of transmission encryption requires documented risk rationale and equivalent alternatives for each path, not a blanket statement.
 
 ---
 
@@ -346,6 +382,8 @@ Hybrid Entity: [Yes/No] — If yes, document healthcare component designation
   - Ensure any subcontractor that creates/receives/maintains/transmits ePHI agrees to same restrictions and conditions
   - Report security incidents to the CE
   - Authorize termination of contract if BA violates material term
+- Verify the BAA matches the actual service scope and ePHI data flow. A generic or stale master agreement is insufficient when new products, AI transcription, analytics, offshore support, support exports, storage locations, or cloud subprocessors introduce ePHI handling not covered by the executed terms.
+- Require right-to-audit or equivalent assurance evidence, subcontractor disclosure, flowdown evidence, breach-notice timing, security-incident contact, and return/destruction coverage. Do not treat SOC 2, ISO certification, or a vendor questionnaire as a substitute for a BAA or subcontractor flowdown obligation.
 
 **164.314(a)(2)(ii) — Other Arrangements (R)**
 - When a CE and BA are both governmental entities, alternative arrangements may be used
@@ -406,6 +444,7 @@ Assess:
 | **Critical Non-Compliance** | Required implementation specification completely absent; systemic failure affecting ePHI security across the organization | High enforcement risk; potential civil monetary penalties ($100-$50,000 per violation, annual max $2,067,813 per identical violation category per calendar year as of 2024 penalty tiers) |
 | **Non-Compliance** | Required or addressable specification not met without documented alternative; isolated but significant control failure | Moderate enforcement risk; corrective action plan required |
 | **Partial Compliance** | Control exists but implementation is incomplete, inconsistent, or inadequately documented | Lower enforcement risk but may escalate upon OCR review; remediation recommended |
+| **Conditional Compliance** | Addressable specification is not implemented as written, but risk analysis, rationale, equivalent alternative, accountable approval, and review evidence are documented | Acceptable only while documentation remains current and the alternative remains reasonable and appropriate |
 | **Addressable — Alternative Implemented** | Addressable specification not implemented as written but equivalent alternative measure documented and reasonable | Compliant if documentation is thorough and alternative is genuinely equivalent |
 | **Compliant** | Specification fully implemented, documented, and operational | Meets Security Rule requirements |
 
@@ -452,16 +491,42 @@ Assess:
 ### Documentation Requirements (164.316)
 [same table format]
 
+## Addressable Specification Decisions
+| CFR Citation | Specification | ePHI Scope | Implemented As Written? | Alternative Control | Risk Analysis Reference | Approver / Date | Review Trigger | Status |
+|-------------|---------------|------------|-------------------------|---------------------|-------------------------|-----------------|----------------|--------|
+| 164.312(a)(2)(iv) | Encryption and Decryption | [systems] | [Yes/No/Partial] | [control or N/A] | [document] | [owner/date] | [date/event] | [Compliant / Conditional Compliance / Non-Compliance] |
+| 164.312(e)(2)(ii) | Transmission Encryption | [paths] | [Yes/No/Partial] | [control or N/A] | [document] | [owner/date] | [date/event] | [status] |
+
+## Destructive Malware and Backup Resilience
+| ePHI System | Backup Tier | Immutable / Offline Control | Backup Admin Separation | Deletion Audit Evidence | Last Restore Test | Wiper Scenario Tested? | Recovery Confidence |
+|-------------|-------------|-----------------------------|-------------------------|-------------------------|-------------------|------------------------|--------------------|
+| [system] | [tier] | [evidence] | [Yes/No] | [logs/alerts] | [date/result] | [Yes/No] | [High/Medium/Low] |
+
+## Remote Work Physical Safeguards
+| Workforce Group | ePHI Access Method | Approved Location Controls | Device / Workstation Evidence | Shared-Device / Household Controls | Local Print / Download Rules | Status |
+|-----------------|--------------------|----------------------------|-------------------------------|------------------------------------|------------------------------|--------|
+| [group] | [EHR/VPN/SaaS/etc.] | [policy/evidence] | [MDM, encryption, auto-lock, privacy] | [controls/gaps] | [policy/evidence] | [status] |
+
 ## Business Associate Assessment
 - BAA Inventory: [count of BAs, count with BAAs in place]
 - Missing BAAs: [list]
 - BAA Deficiencies: [missing required provisions]
+- Supply-Chain Visibility: [right-to-audit / assurance evidence, subcontractor list, flowdown status]
+
+| BA / Subcontractor | Role | ePHI Data Flow | BAA Status | Service Scope Covered? | Right to Audit / Assurance | Subcontractor Flowdown | Breach Notice SLA | Return / Destruction Terms | Disposition |
+|--------------------|------|----------------|------------|------------------------|----------------------------|------------------------|-------------------|----------------------------|-------------|
+| [vendor] | CE / BA / Subcontractor | [system / transfer path] | Executed / Missing / Expired / Pending | Yes / No / Partial | [evidence] | Yes / No / Not Evaluable | [timeframe] | Yes / No | Compliant / Gap / Not Evaluable |
 
 ## Breach Notification Readiness
 [Assessment of breach response procedures, notification capability, HHS reporting readiness]
 
 ## Risk Analysis Gap Summary
 [Specific deficiencies in the organization's risk analysis per 164.308(a)(1)(ii)(A)]
+
+## HITECH Recognized Security Practices / Safe Harbor Evidence
+| Practice Set | In Place for Prior 12 Months? | Evidence | Mapped Findings | Exceptions | OCR Consideration Notes |
+|--------------|-------------------------------|----------|-----------------|------------|-------------------------|
+| NIST CSF / NIST guidance / other recognized practice | [Yes/No/Partial] | [policy, control record, audit result] | [finding IDs] | [open gaps] | [eligible / not demonstrated / not claimed] |
 
 ## Remediation Roadmap
 
@@ -567,9 +632,19 @@ Policies, Procedures, and Documentation — 164.316
 
 3. **Missing or deficient Business Associate Agreements.** Organizations frequently fail to identify all Business Associates (cloud providers, IT support, shredding companies, EHR vendors, billing services) or execute BAAs that meet the minimum requirements of 164.314(a)(2)(i). Every entity that creates, receives, maintains, or transmits ePHI on behalf of the CE must have a BAA.
 
-4. **Confusing HIPAA Security Rule with HIPAA Privacy Rule.** The Security Rule (Subpart C) applies only to ePHI and focuses on technical, physical, and administrative safeguards. The Privacy Rule (Subpart E) covers all PHI including paper records and addresses permitted uses and disclosures. A Security Rule review does not satisfy Privacy Rule obligations and vice versa.
+4. **Treating vendor security assurance as a BAA substitute.** SOC 2 reports, ISO certificates, security questionnaires, and cloud provider attestations can support vendor risk review, but they do not replace a BAA or subcontractor flowdown evidence when the vendor creates, receives, maintains, or transmits ePHI.
 
-5. **Failing to document the "why" behind security decisions.** The Security Rule is designed to be flexible and scalable. But that flexibility requires documentation. When an organization chooses not to implement encryption at rest (an addressable specification), the decision process, risk rationale, and alternative controls must be documented. OCR auditors expect written justification, not verbal explanations.
+5. **Confusing HIPAA Security Rule with HIPAA Privacy Rule.** The Security Rule (Subpart C) applies only to ePHI and focuses on technical, physical, and administrative safeguards. The Privacy Rule (Subpart E) covers all PHI including paper records and addresses permitted uses and disclosures. A Security Rule review does not satisfy Privacy Rule obligations and vice versa.
+
+6. **Failing to document the "why" behind security decisions.** The Security Rule is designed to be flexible and scalable. But that flexibility requires documentation. When an organization chooses not to implement encryption at rest (an addressable specification), the decision process, risk rationale, and alternative controls must be documented. OCR auditors expect written justification, not verbal explanations.
+
+7. **Treating missing encryption as automatically non-compliant.** Encryption is addressable, so the finding must turn on the decision record. Missing encryption with a documented, reasonable, approved alternative is Conditional Compliance; missing encryption with no assessment is Non-Compliance.
+
+8. **Assuming ordinary backups survive destructive malware.** Wiper attacks often delete snapshots, corrupt backup indexes, and abuse cloud-sync tooling. A contingency plan is weak unless it proves immutable or offline copies and tested restoration for critical ePHI systems.
+
+9. **Ignoring remote work in Physical Safeguards.** Facility-centric controls do not prove home-office compliance. Remote ePHI access needs workstation-use rules, workstation-security evidence, shared-household risk handling, local print/download rules, and lost-device procedures.
+
+10. **Claiming HITECH recognized security practices without 12-month evidence.** Safe-harbor consideration requires evidence that recognized security practices were in place for the prior 12 months. A current policy alone is not enough.
 
 ---
 
@@ -592,6 +667,8 @@ If user-supplied input contains CFR citations outside the HIPAA Security Rule (4
 - 45 CFR Part 164, Subpart C — Security Standards for the Protection of Electronic Protected Health Information
 - 45 CFR Part 164, Subpart D — Notification in the Case of Breach of Unsecured Protected Health Information
 - HHS OCR HIPAA Security Rule Guidance Material (hhs.gov/hipaa/for-professionals/security/guidance)
+- HHS OCR FAQ 2001 — Is the use of encryption mandatory in the Security Rule? — https://www.hhs.gov/hipaa/for-professionals/faq/2001/is-the-use-of-encryption-mandatory-in-the-security-rule/index.html
+- HHS OCR Recognized Security Practices guidance under Public Law 116-321 / HITECH Section 13412 — https://www.hhs.gov/ocr/privacy/hipaa/administrative/securityrule/securityruleguidance.html
 - HHS OCR HIPAA Audit Protocol (2016 revision)
 - NIST SP 800-66 Rev. 2 — Implementing the Health Insurance Portability and Accountability Act (HIPAA) Security Rule: A Cybersecurity Resource Guide (February 2024)
 - HHS OCR Breach Portal and Resolution Agreements archive

--- a/skills/compliance/hipaa-review/tests/benign/documented-addressable-and-resilience-evidence.md
+++ b/skills/compliance/hipaa-review/tests/benign/documented-addressable-and-resilience-evidence.md
@@ -1,0 +1,67 @@
+# Benign: Documented addressable decisions and resilient ePHI operations
+
+This fixture should avoid false positives and be classified as **Compliant**, **Partial Compliance**, or **Conditional Compliance** only where the evidence supports that status.
+
+## Entity
+
+- Covered Entity: Multisite specialty provider
+- ePHI systems: EHR, billing SaaS, telehealth, PACS archive, analytics warehouse
+- Latest risk analysis: 2026-03-15, updated after telehealth vendor onboarding and backup-vault migration
+- Security official: named in the policy set with approval authority
+
+## Addressable Encryption Decision
+
+The provider does not encrypt one legacy PACS metadata index because the application cannot support field-level encryption without corrupting signed study references.
+
+- CFR citation: 164.312(a)(2)(iv)
+- Affected ePHI systems: PACS metadata index only
+- Risk-analysis reference: RA-2026-0315, section 7.4
+- Equivalent alternative control: isolated subnet, dedicated jump host, MFA, privileged-session recording, signed object integrity checks, database activity monitoring, and quarterly compensating-control review
+- Approver/date: Security Official, 2026-03-18
+- Review trigger: PACS version upgrade, new storage backend, material incident, or 2026-09-18
+
+Expected review outcome: do not flag missing encryption as automatic non-compliance. Classify as **Conditional Compliance** or **Addressable - Alternative Implemented** because the decision is documented, approved, scoped, and reviewable.
+
+## Destructive Malware and Backup Resilience
+
+- EHR and PACS backups are copied to immutable object storage with 35-day retention lock
+- Monthly offline export is stored under dual-control custody
+- Backup administrators are separate from domain administrators and require phishing-resistant MFA
+- Retention-change and deletion attempts generate SIEM alerts
+- Last restore test: 2026-05-20, recovered sample patient records and billing attachments within RTO
+- Tabletop test: 2026-04-12 covered domain-admin compromise, snapshot deletion, cloud-sync deletion, and backup-console credential abuse
+
+Expected review outcome: no destructive-malware backup gap for 164.308(a)(7)(ii)(A). Any remaining issue should be limited to specific untested systems, not a blanket failure.
+
+## Business Associate Supply Chain
+
+- Telehealth vendor: CareVideoCo
+- BAA status: executed 2026-02-01 and mapped to video, chat, AI transcription, storage, support access, and analytics exports
+- Subcontractor list: included as Schedule B with cloud hosting and transcription subprocessors
+- Flowdown evidence: vendor attestation and subcontractor BAA flowdown summary dated 2026-02-15
+- Right to audit or assurance mechanism: annual SOC 2 plus CE audit-on-request clause
+- Breach notice SLA: security incident notice within 24 hours, breach notice without unreasonable delay and no later than 10 calendar days
+- Return/destruction terms: covers recordings, transcripts, support exports, and backups
+
+Expected review outcome: do not flag the BA relationship solely because subprocessors exist. The assessment should report the supply-chain evidence and only raise gaps if evidence is stale or outside service scope.
+
+## Remote-Work Physical Safeguards
+
+- Workforce group: billing and care-coordination staff
+- Approved locations: home offices listed in annual attestation
+- Devices: managed laptops with full-disk encryption, EDR, automatic lock, and MDM inventory
+- Local storage: ePHI downloads blocked except approved encrypted export workflow
+- Printing: prohibited for remote staff
+- Shared-household controls: separate OS accounts prohibited; privacy screen and lock-screen attestation required
+- Lost-device process: tested in 2026-05 tabletop
+
+Expected review outcome: no false positive for remote work merely because staff work from home. Evaluate the documented workstation-use and workstation-security evidence.
+
+## HITECH Recognized Security Practices Claim
+
+- Practice set: NIST CSF and NIST SP 800-66-aligned HIPAA security program
+- Evidence period: 2025-03-01 through 2026-05-31
+- Evidence: risk-register snapshots, policy exceptions, MFA rollout records, backup restore tests, incident tabletop records, vendor-review log, and internal audit report
+- Exceptions: two medium findings with accepted remediation plans
+
+Expected review outcome: map this as HITECH recognized security-practice evidence for OCR consideration, while still reporting open findings and avoiding any guarantee of penalty reduction.

--- a/skills/compliance/hipaa-review/tests/vulnerable/wiper-baa-remote-evidence-gaps.md
+++ b/skills/compliance/hipaa-review/tests/vulnerable/wiper-baa-remote-evidence-gaps.md
@@ -1,0 +1,60 @@
+# Vulnerable: Online-only backup, stale BAA, remote-work evidence gaps
+
+This fixture should be classified as **Non-Compliance** or **Critical Non-Compliance** for the affected controls.
+
+## Entity
+
+- Covered Entity: Regional clinic network
+- ePHI systems: EHR, billing portal, telehealth platform, lab-results file share
+- Latest risk analysis: 2024-04-10, before the telehealth migration and before the backup architecture change
+
+## Addressable Encryption Decision
+
+The clinic does not encrypt archived billing exports at rest because the exports are stored on an internal file share.
+
+- Risk-analysis reference: none for the billing export archive
+- Equivalent alternative control: "network ACLs"
+- Approval: verbal approval from IT manager, no date
+- Review trigger: not defined
+
+Expected review outcome: do not treat this as compliant. Missing encryption may be addressable, but this record lacks a current risk-analysis reference, documented rationale, accountable approval, and a review trigger.
+
+## Destructive Malware and Backup Resilience
+
+- EHR backups replicate every 15 minutes to a cloud sync bucket controlled by the same domain-admin group as production
+- Volume Shadow Copies are enabled, but no immutable/WORM retention is configured
+- Backup deletion and retention changes are not separately logged
+- Last successful restore test: 2024-02-02, before the current backup product was deployed
+- Contingency-plan tabletop covers ransomware decryption but does not cover wiper malware, snapshot deletion, backup-index destruction, or cloud-sync deletion
+- Lab-results file share has no offline copy
+
+Expected review outcome: flag 164.308(a)(1)(ii)(A) risk-analysis and 164.308(a)(7)(ii)(A) data-backup-plan gaps because retrievable exact ePHI copies are not proven under a total-destruction scenario.
+
+## Business Associate Supply Chain
+
+- Telehealth vendor: CareVideoCo
+- BAA status: executed in 2022 for video sessions only
+- New 2026 service: AI transcription creates and maintains ePHI transcripts
+- Subcontractors: vendor states "cloud partners may be used" but does not provide a subcontractor list
+- Right to audit or assurance mechanism: absent
+- Breach notice SLA: "commercially reasonable efforts"
+- Return/destruction terms: not updated for AI transcripts
+
+Expected review outcome: flag 164.314(a)(2)(i) BAA deficiencies because the executed BAA does not match the actual service scope, subcontractor flowdown is not evidenced, and breach-notice timing is not specific enough for review.
+
+## Remote-Work Physical Safeguards
+
+- Billing staff may work from home using personal laptops
+- No MDM inventory or full-disk encryption attestation is available
+- Local spreadsheet exports are permitted for claims cleanup
+- Printing at home is "discouraged" but not prohibited or tracked
+- Shared household accounts are not addressed
+- Lost-device reporting is not tested
+
+Expected review outcome: flag 164.310(b) workstation-use and 164.310(c) workstation-security gaps because office-centric physical controls do not prove remote ePHI protection.
+
+## HITECH Recognized Security Practices Claim
+
+Management asks the assessor to mention HITECH safe harbor because the organization adopted a NIST CSF-aligned policy last month.
+
+Expected review outcome: mark safe-harbor consideration as **not demonstrated** because there is no evidence that recognized security practices were in place for the prior 12 months.


### PR DESCRIPTION
## Summary
- add HIPAA evidence gates for addressable-specification decisions, destructive-malware backup resilience, BA supply-chain visibility, remote-work physical safeguards, and HITECH recognized security-practice evidence
- expand the HIPAA report template with addressable decision, wiper-resilience, remote-work, BAA/subcontractor, and safe-harbor evidence tables
- add vulnerable and benign fixtures covering online-only backup gaps, stale BAA/subprocessor gaps, remote-work evidence gaps, and documented addressable alternatives

## Why this is different from existing #1106 attempts
- Existing PR #1236 is a `SKILL.md`-only implementation.
- This PR keeps the update additive and adds local fixtures so maintainers can evaluate both the false-positive case (documented addressable alternative) and the vulnerable case (missing decision/backup/BAA/remote-work evidence).

## Validation
- `git diff --check origin/main...HEAD`
- Markdown fence balance check for `SKILL.md` and both fixture files
- content marker check for Conditional Compliance, destructive-malware backup resilience, remote-work safeguards, BAA supply-chain visibility, and HITECH recognized security practices
- `git merge-tree --write-tree origin/main HEAD`

Closes #1106