### PR TITLE
Improve forensics timestamp normalization gates

### DIFF
--- a/skills/incident-response/forensics-checklist/SKILL.md
+++ b/skills/incident-response/forensics-checklist/SKILL.md
@@ -99,6 +99,44 @@ CUSTODY LOG:
 - Compute and record cryptographic hashes (SHA-256 minimum) at collection time and verify at each transfer
 - Maintain a continuous, unbroken record from collection through final disposition
 
+### Step 1b: Record Time Source and Clock Skew
+
+Forensic timelines can be wrong even when hashes and chain of custody are sound. Endpoint clocks, SIEM ingestion timestamps, cloud provider event times, SaaS export times, and collector workstation clocks often disagree. Record a per-evidence time basis before correlation so original timestamps remain intact and any normalized timeline is clearly marked as a derived artifact.
+
+**Time source record:**
+
+```
+TIME SOURCE RECORD
+==================
+Evidence ID:             [EVD-NNNN]
+Source System/Service:   [hostname, cloud service, IdP, SIEM, SaaS tenant]
+Source Time Zone:        [UTC / local TZ / unknown]
+Source Clock Value:      [YYYY-MM-DD HH:MM:SS plus timezone]
+Collector Clock Value:   [YYYY-MM-DD HH:MM:SS UTC]
+Observed Clock Offset:   [+/- seconds or "unknown"]
+Time Sync Source:        [NTP, domain controller, cloud provider, manual, unknown]
+Timestamp Fields:        [event_time, ingestion_time, processing_time, export_time]
+Normalization Applied:   [none / offset noted only / derived UTC timeline copy]
+Confidence:              [high / medium / low, with reason]
+```
+
+**Evidence gates:**
+
+```
+FOR-TIME-01: Evidence source timezone or UTC offset is missing or inferred without support
+FOR-TIME-02: Collector clock was not recorded and synchronized before acquisition
+FOR-TIME-03: Event time is mixed with ingestion, processing, or export time in the timeline
+FOR-TIME-04: Original timestamps were modified instead of preserving a derived normalized copy
+FOR-TIME-05: Clock skew is ignored when correlating attacker or responder actions across systems
+FOR-TIME-06: Large or unknown clock skew is not reflected in confidence or sequence-of-events conclusions
+```
+
+**False-positive boundaries:**
+
+- Do not flag a source simply because it uses local time when the timezone, UTC offset, collector clock, and normalization method are documented.
+- Do not require direct host clock access for SaaS/cloud logs when provider documentation, export metadata, and API event-time semantics are recorded.
+- Do not treat SIEM ingestion time as wrong by default; mark it as ingestion time and keep it separate from the original event time.
+
 ### Step 2: Collect Evidence in Order of Volatility (RFC 3227)
 
 RFC 3227 Section 2.1 defines the order of volatility -- evidence sources ranked from most volatile (shortest lifespan) to least volatile. Collect in this order to minimize evidence loss.
@@ -394,6 +432,11 @@ the order of collection, and any evidence that could not be obtained.]
 |---|---|---|---|
 | EVD-0001 | [hash] | [hash] | [YES/NO] |
 
+### Timestamp Normalization
+| Evidence ID | Source Time Zone | Source Clock Value | Collector Clock Value | Clock Offset | Time Sync Source | Timestamp Fields Used | Normalization Applied | Confidence |
+|---|---|---|---|---|---|---|---|---|
+| EVD-0001 | [UTC/local/unknown] | [timestamp] | [timestamp] | [+/- seconds/unknown] | [NTP/cloud/DC/manual/unknown] | [event/ingestion/export] | [none/derived timeline] | [high/medium/low] |
+
 ### Evidence Gaps
 [List any evidence that could not be collected and the reason]
 
@@ -460,6 +503,10 @@ Applying traditional forensic methods to cloud environments without adaptation l
 ### Pitfall 5: Overwriting Evidence with Collection Activity
 
 Every action on a live system modifies it -- writing memory dump files to the evidence drive changes timestamps and consumes disk space, running commands updates shell history and modifies access times. Minimize evidence contamination by writing collection output to external media (USB, network share, S3 bucket), documenting every command executed on the system, and noting the expected impact of each collection action on the evidence state.
+
+### Pitfall 6: Normalizing Timestamps by Editing Original Evidence
+
+Do not rewrite source log files, disk metadata, SaaS exports, or cloud logs to "fix" time zones or clock skew. Preserve original timestamps exactly as collected and create a separate derived UTC timeline with the offset, method, and confidence documented. If skew is unknown, say so and avoid overconfident sequence-of-events conclusions.
 
 ---
 

--- a/skills/incident-response/forensics-checklist/tests/benign/derived-utc-timeline-with-skew-record.md
+++ b/skills/incident-response/forensics-checklist/tests/benign/derived-utc-timeline-with-skew-record.md
@@ -1,0 +1,32 @@
+# Benign: Derived UTC timeline with documented skew and timestamp semantics
+
+This fixture should avoid false positives when timestamp normalization is documented and original evidence remains unchanged.
+
+## Incident Context
+
+- Incident ID: IR-2026-0613
+- Systems: `web-02`, Entra ID audit export, SIEM export, collector workstation
+- Collector workstation clock: `2026-06-13T09:00:00Z`, synchronized to `time.cloudflare.com`, drift under 1 second
+- Original evidence files: stored read-only with SHA-256 hashes before analysis
+- Derived timeline: separate `timeline-normalized-utc.csv`
+
+## Time Source Records
+
+| Evidence ID | Source | Source Time Zone | Source Clock Value | Collector Clock Value | Observed Offset | Time Sync Source | Timestamp Fields | Normalization Applied | Confidence |
+|---|---|---|---|---|---|---|---|---|---|
+| EVD-0101 | `web-02` auth log | America/New_York UTC-04:00 | `2026-06-13 04:57:11 -0400` | `2026-06-13T09:00:00Z` | +37 seconds | domain controller NTP | `event_time` | derived UTC copy only | high |
+| EVD-0102 | Entra ID audit | UTC | provider event time from API | `2026-06-13T09:01:00Z` | provider-managed | cloud provider | `activityDateTime`, `export_time` | `activityDateTime` used; export time preserved separately | high |
+| EVD-0103 | SIEM export | UTC | provider event time from event payload | `2026-06-13T09:02:00Z` | ingestion lag 94 seconds | SIEM managed NTP | `event_time`, `ingestion_time`, `processing_time` | event time used for ordering; ingestion time retained | medium |
+
+## Timeline Handling
+
+- Original timestamps in all source files are unchanged.
+- The normalized timeline stores `normalized_utc`, `original_timestamp`, `source_timezone`, `clock_offset_seconds`, `timestamp_field_used`, and `confidence`.
+- Sequence-of-events conclusion states: "The web login likely preceded the process execution by 41-45 seconds after applying the documented +37 second source clock offset."
+- The report separately notes that SIEM ingestion lag is not used as the event order source.
+
+Expected outcome:
+
+- Do not flag local timezone usage because UTC offset, collector clock, and skew are documented.
+- Do not flag SIEM ingestion time because it is preserved but not used as event time.
+- Do not flag timestamp normalization because original evidence is unchanged and the UTC timeline is a derived artifact with confidence notes.

--- a/skills/incident-response/forensics-checklist/tests/vulnerable/ingestion-time-clock-skew-timeline.md
+++ b/skills/incident-response/forensics-checklist/tests/vulnerable/ingestion-time-clock-skew-timeline.md
@@ -1,0 +1,52 @@
+# Vulnerable: Timeline built from ingestion time and unknown clock skew
+
+This fixture should produce timestamp normalization findings.
+
+## Incident Context
+
+- Incident ID: IR-2026-0612
+- Systems: `web-01`, `idp.example.com`, SIEM export, collector workstation
+- Collector workstation clock: not recorded before acquisition
+- Timeline conclusion: "user logged in after web shell execution"
+
+## Evidence Sources
+
+### EVD-0001: web-01 auth log
+
+- Source timezone: local time, timezone not recorded
+- Source clock value at acquisition: not recorded
+- Time sync source: unknown
+- Event shown in report: `2026-06-12 02:15:03 login accepted`
+
+### EVD-0002: SIEM export
+
+- Timestamp field used in report: `ingestion_time`
+- Event time field available: `event_time`
+- Processing time field available: `processing_time`
+- Ingestion lag: unknown
+- Export timezone: UTC
+
+### EVD-0003: IdP SaaS audit export
+
+- Provider event time: UTC
+- Export time: `2026-06-12T03:00:00Z`
+- Report treats export time as user action time
+
+## Timeline Mistake
+
+The investigation report sorts:
+
+1. web shell process at `2026-06-12T02:13:00Z`
+2. SIEM `ingestion_time` for login at `2026-06-12T02:18:00Z`
+3. IdP export time at `2026-06-12T03:00:00Z`
+
+The report concludes that the login happened after web shell execution, but it does not record source timezone, source clock, collector clock, clock offset, ingestion lag, or the distinction between event time and export time.
+
+Expected findings:
+
+- `FOR-TIME-01` because `web-01` timezone and UTC offset are missing.
+- `FOR-TIME-02` because the collector clock was not recorded before acquisition.
+- `FOR-TIME-03` because ingestion/export time is mixed with event time.
+- `FOR-TIME-05` and `FOR-TIME-06` because unknown clock skew is ignored while making a sequence-of-events conclusion.
+
+Expected handling: preserve original timestamps, create a derived UTC timeline, and downgrade timeline confidence until clock skew and timestamp semantics are documented.


### PR DESCRIPTION
## Summary
- add a timestamp source and clock-skew evidence step to the forensics checklist
- add `FOR-TIME-*` gates for missing timezone/offset, unsynchronized collector clock, event-vs-ingestion/export time confusion, original timestamp mutation, and overconfident skew handling
- add vulnerable and benign fixtures covering a bad ingestion-time timeline and a derived UTC timeline with documented skew/field semantics

## Why this is different from existing #1661 attempt
- Existing PR #1662 is a `SKILL.md`-only implementation.
- This PR adds local vulnerable/benign fixtures so maintainers can evaluate both failure cases and the false-positive boundary for documented local time and SIEM ingestion timestamps.

## Validation
- `git diff --check origin/main...HEAD`
- Markdown fence balance check for `SKILL.md` and both fixture files
- ASCII check for touched files
- content marker check for `FOR-TIME-*`, timestamp normalization output, derived UTC timeline, ingestion_time, and collector clock evidence
- `git merge-tree --write-tree origin/main HEAD`

Closes #1661