### PR TITLE
Improve DAST recorded-flow state evidence

### DIFF
--- a/skills/devsecops/dast-config/SKILL.md
+++ b/skills/devsecops/dast-config/SKILL.md
@@ -331,6 +331,36 @@ env:
 
 ---
 
+#### 4.2 Recorded Flow Replay and State Evidence Gate
+
+Authenticated DAST often depends on browser recordings, HAR files, Postman collections, Selenium/Zest login scripts, and seed fixtures to reach protected states. Review those artifacts as executable scan configuration: stale state or shared fixtures can make a scan look successful while it is unauthenticated, in the wrong role, or testing data mutated by an earlier run.
+
+**Required evidence:**
+
+| Gate | Evidence to Capture | Fail / Not Evaluable Condition |
+|------|---------------------|--------------------------------|
+| Flow-to-build freshness | Recording commit/date, target build version, route coverage diff, and last successful replay timestamp | Recording predates the deployed build, changed routes are not re-recorded, or freshness cannot be proven |
+| Dynamic one-time values | Proof that CSRF tokens, OAuth state/nonce, PKCE verifiers, MFA/OTP codes, signed URLs, and reset links are regenerated during replay | Static HAR/Postman/browser recording reuses one-time or signed values |
+| Auth state fail-closed behavior | Post-login assertion, expected role, logged-out detector, and pipeline failure on setup mismatch | Scanner continues unauthenticated or in the wrong role after recorded setup fails |
+| Seed data isolation | Per-run tenant/user fixtures, disposable records, database snapshot restore, or cleanup job evidence | Active scan mutates shared staging data without reset or ownership proof |
+| State-changing request safety | Idempotency proof, safe test accounts, explicit exclusions, or rollback evidence for create/update/delete actions | Destructive or non-idempotent requests remain in active-scan scope without isolated data |
+| Multi-role separation | Separate users, cookies, bearer tokens, browser storage, and scanner contexts for each role | Admin/user/guest scans reuse the same session, token, or browser context |
+
+Use these finding IDs when reporting gaps:
+
+```text
+DAST-STATE-01: Recorded flow is stale for the deployed build or lacks route coverage validation
+DAST-STATE-02: Recording replays static CSRF, OAuth state, nonce, MFA/OTP, signed URL, reset-link, or PKCE values
+DAST-STATE-03: Scanner continues after login/setup fails or reaches the wrong authenticated role
+DAST-STATE-04: Active scan mutates shared seed data without disposable fixtures, tenant isolation, or restore evidence
+DAST-STATE-05: Multi-role scan reuses cookies, bearer tokens, local storage, or browser context across roles
+DAST-STATE-06: State-changing requests are neither idempotent nor explicitly excluded from active scanning
+```
+
+**Finding classification:** Scanner continuation after failed authentication is **Critical** when it causes protected surfaces to be missed. Static replay of one-time authentication/session material is **High**. Shared mutable seed data without reset is **High** for active scans. Missing flow freshness evidence is **Medium**.
+
+---
+
 ### Step 5: CI/CD DAST Integration
 
 #### 5.1 Pipeline Integration Patterns
@@ -518,7 +548,14 @@ DAST tools report findings per-URL, producing hundreds of duplicate alerts for t
 | Passive scanning in CI | Yes/No | <workflow file> |
 | Active scanning (staging) | Yes/No | <workflow file> |
 | API scanning | Yes/No | <OpenAPI/GraphQL import> |
+| Recorded flow/state safety | Yes/No | <flow freshness, dynamic tokens, auth assertion, seed isolation> |
 | Results deduplication | Yes/No | <dedup method> |
+
+### Recorded Flow and Seed Data Evidence
+
+| Artifact | Target Build | Token Handling | Auth State Assertion | Seed Data Strategy | Role Separation | Status |
+|----------|--------------|----------------|----------------------|-------------------|-----------------|--------|
+| <HAR/Postman/browser flow/fixture> | <version/date> | Dynamic/Static/Unknown | <assertion and fail-closed behavior> | Isolated/Restored/Shared | Separate/Reused/Unknown | Pass/Fail/Not Evaluable |
 
 ### Findings
 
@@ -583,6 +620,10 @@ DAST tools report findings per-URL, producing hundreds of duplicate alerts for t
 4. **Treating DAST findings as ground truth without validation.** DAST tools have significant false positive rates, especially for injection findings. Every high-severity DAST finding must be manually validated before filing a remediation ticket. Build validation into the triage workflow.
 
 5. **Running only scheduled weekly scans instead of integrating into CI.** Weekly scans create a feedback loop measured in days. Passive baseline scans in CI (on every PR) give developers immediate feedback on security header regressions and configuration issues, while weekly full scans provide comprehensive active testing coverage.
+
+6. **Trusting stale recorded flows.** A HAR, Postman collection, browser recording, or login script can replay old routes, expired state, or wrong-role sessions after the app changes. Require deployed-build freshness checks and fail-closed authenticated-state assertions.
+
+7. **Using shared seed data for active scans.** Active DAST can create, update, or delete records. Use disposable fixtures, isolated tenants, or snapshot restore evidence so scans do not contaminate staging data or hide authorization failures.
 
 ---
 

--- a/skills/devsecops/dast-config/tests/benign/fresh-flow-seeded-reset-evidence.md
+++ b/skills/devsecops/dast-config/tests/benign/fresh-flow-seeded-reset-evidence.md
@@ -1,0 +1,73 @@
+# Benign: Fresh Recorded Flow with Isolated Seed Reset Evidence
+
+## Review Target
+
+```yaml
+scan:
+  tool: zap
+  target_build: web-2026.06.08.4
+  active_scan: true
+  context: ephemeral-staging
+
+recorded_flows:
+  - name: checkout-browser-flow
+    type: playwright
+    recorded_at: 2026-06-08T05:40:12Z
+    recorded_against_build: web-2026.06.08.4
+    route_coverage_diff: no_removed_or_changed_routes
+    replay_before_scan: true
+    fail_on_replay_error: true
+    dynamic_values:
+      csrf_token: extracted_from_dom_per_request
+      oauth_state: generated_per_run
+      pkce_verifier: generated_per_run
+      signed_urls: generated_from_fixture_api
+
+auth_assertion:
+  logged_in_regex: "data-testid=\"customer-dashboard\""
+  logged_out_regex: "data-testid=\"login-form\""
+  expected_role: customer
+  fail_pipeline_on_mismatch: true
+
+seed_data:
+  tenant: dast-run-${RUN_ID}
+  records:
+    - id: cart-${RUN_ID}
+      owner: dast-customer-${RUN_ID}
+  create_before_scan: scripts/dast_seed_create.sh
+  restore_after_scan: snapshot_restore
+  cleanup_job: scripts/dast_seed_destroy.sh
+
+roles:
+  - name: customer
+    user: dast-customer-${RUN_ID}
+    cookie_jar: customer-context-${RUN_ID}
+    browser_storage: customer-storage-${RUN_ID}
+  - name: support-admin
+    user: dast-support-${RUN_ID}
+    cookie_jar: support-context-${RUN_ID}
+    browser_storage: support-storage-${RUN_ID}
+
+scope:
+  include:
+    - https://ephemeral-${RUN_ID}.example.test/.*
+  exclude:
+    - https://ephemeral-${RUN_ID}.example.test/logout.*
+    - https://ephemeral-${RUN_ID}.example.test/account/delete.*
+    - https://ephemeral-${RUN_ID}.example.test/admin/reset.*
+```
+
+## Expected Review Result
+
+| Gate | Status | Evidence |
+|------|--------|----------|
+| Flow-to-build freshness | Pass | Recording and scan target both reference `web-2026.06.08.4`, with route diff evidence. |
+| Dynamic one-time values | Pass | CSRF, OAuth state, PKCE, and signed URL values are regenerated or extracted during each replay. |
+| Auth state fail-closed behavior | Pass | Specific customer dashboard and login-form detectors are configured, and mismatch fails the pipeline. |
+| Seed data isolation | Pass | Per-run tenant, setup script, snapshot restore, and cleanup job are documented. |
+| State-changing request safety | Pass | Destructive account/admin routes are excluded and mutable checkout data is disposable. |
+| Multi-role separation | Pass | Customer and support-admin roles use distinct users, cookie jars, and browser storage. |
+
+## Reviewer Notes
+
+This setup provides enough evidence to treat the recorded authenticated flow as current and safe for active DAST. Findings should focus on scan results instead of discounting coverage for stale recordings or contaminated seed state.

--- a/skills/devsecops/dast-config/tests/vulnerable/stale-recorded-flow-seed-data-drift.md
+++ b/skills/devsecops/dast-config/tests/vulnerable/stale-recorded-flow-seed-data-drift.md
@@ -1,0 +1,69 @@
+# Vulnerable: Stale Recorded Flow and Shared Seed Data Drift
+
+## Review Target
+
+```yaml
+scan:
+  tool: zap
+  target_build: web-2026.06.08.4
+  active_scan: true
+  context: staging
+
+recorded_flows:
+  - name: checkout-har
+    type: har
+    recorded_at: 2026-05-17T10:21:33Z
+    recorded_against_build: web-2026.05.17.2
+    replay_before_scan: true
+    fail_on_replay_error: false
+    requests:
+      - method: POST
+        path: /oauth/callback
+        body:
+          state: static-state-from-har
+          code_verifier: static-pkce-verifier
+      - method: POST
+        path: /checkout
+        headers:
+          x-csrf-token: csrf-2026-05-17
+
+auth_assertion:
+  logged_in_regex: "200 OK"
+  expected_role: customer
+  logged_out_regex: null
+
+seed_data:
+  tenant: shared-staging
+  records:
+    - id: shared-cart-001
+      owner: qa-team
+  restore_after_scan: false
+  cleanup_job: none
+
+roles:
+  - name: customer
+    cookie_jar: shared-browser-profile
+  - name: support-admin
+    cookie_jar: shared-browser-profile
+
+scope:
+  include:
+    - https://staging.example.test/.*
+  exclude:
+    - https://staging.example.test/logout.*
+```
+
+## Expected Findings
+
+| ID | Severity | Evidence |
+|----|----------|----------|
+| DAST-STATE-01 | Medium | `checkout-har` predates `web-2026.06.08.4` and has no route coverage validation. |
+| DAST-STATE-02 | High | The HAR replays static OAuth `state`, PKCE verifier, and CSRF token values. |
+| DAST-STATE-03 | Critical | `fail_on_replay_error: false` lets the scanner continue after setup failure, and `logged_in_regex` only checks for a generic status string. |
+| DAST-STATE-04 | High | Active scan mutates `shared-staging` seed data without restore, cleanup, or tenant isolation. |
+| DAST-STATE-05 | High | Customer and support-admin scans reuse `shared-browser-profile`. |
+| DAST-STATE-06 | High | The checkout POST remains in active-scan scope without idempotency, rollback, or disposable fixtures. |
+
+## Reviewer Notes
+
+This scan can report authenticated coverage while testing stale state, shared data, and a collapsed role context. Require a fresh recorded flow, dynamic token regeneration, fail-closed auth assertions, isolated seed data, and separate browser/session contexts before treating the DAST result as valid.


### PR DESCRIPTION
## Summary

Closes #1655.

Adds a focused recorded-flow replay and state evidence gate to `dast-config` so authenticated DAST reviews evaluate HAR/Postman/browser flows, one-time token replay, fail-closed auth assertions, seed data isolation, state-changing request safety, and multi-role session separation.

## Changes

- Adds `DAST-STATE-01` through `DAST-STATE-06` findings for stale recordings, static one-time token replay, auth setup continuation, shared seed data mutation, role context reuse, and unsafe state-changing requests.
- Extends the output format with recorded flow/state safety and a dedicated evidence table.
- Adds vulnerable and benign fixtures covering stale HAR/seed drift versus fresh replay with dynamic token regeneration and isolated per-run seed reset evidence.

## Validation

- `git diff --check origin/main...HEAD`
- Markdown fence balance check for changed files
- ASCII check for changed files
- Content marker checks for the new evidence gate, finding IDs, and fixtures
- `git merge-tree --write-tree origin/main HEAD`