### PR TITLE
Improve SIEM production query equivalence evidence

### DIFF
--- a/skills/secops/siem-rules/SKILL.md
+++ b/skills/secops/siem-rules/SKILL.md
@@ -456,6 +456,33 @@ Suppression:         Enabled, 1 hour
 Entity mapping:      Account -> UserPrincipalName, IP -> IPAddress, Host -> Computer
 ```
 
+#### Production Query Equivalence and Dependency Freshness
+
+Before promoting a detection, prove that the query reviewed by an engineer is equivalent to the scheduled production rule. Sentinel parameters, Splunk macros, saved-search app context, lookup tables, watchlists, accelerated data models, summary indexes, runtime permissions, and suppression settings can all change alert behavior after review.
+
+**Required evidence:**
+
+| Gate | Evidence to Capture | Fail / Not Evaluable Condition |
+|------|---------------------|--------------------------------|
+| Expanded production query | Exported Sentinel analytics rule or Splunk saved search after macros, parameters, app context, inherited defaults, and deployment transforms are resolved | Reviewer approved source text only, or the expanded production query cannot be produced |
+| Lookup/watchlist freshness | Name, owner, last modified time, refresh cadence, deployment target, and change ticket for every lookup/watchlist | Allowlist, threat-intel data, or entity inventory is stale, manually edited outside change control, or missing from production |
+| Acceleration and summary freshness | Splunk CIM data-model acceleration state, summary range, latest build time, `tstats` lag, summary-index schedule, and last successful materialized-view run | Acceleration is disabled, lagging beyond the rule lookback, scoped to different indexes, or the summary job has no health evidence |
+| Runtime principal equivalence | Scheduled rule service account or managed identity, app/workspace context, and accessible indexes/tables compared with reviewer permissions | Reviewer tested with broader permissions than the scheduled production principal |
+| Suppression and incident settings | Event grouping mode, suppression duration, throttle key, alert threshold, incident creation setting, and entity mapping | Query returns distinct entities, but production settings collapse or suppress them without documented intent |
+
+Use these finding IDs when reporting production-equivalence gaps:
+
+```text
+SIEM-EQUIV-01: Reviewed query does not match the expanded production query or saved-search export
+SIEM-EQUIV-02: Lookup, watchlist, or allowlist freshness and deployment state are missing or stale
+SIEM-EQUIV-03: Data-model acceleration, summary index, or materialized-view freshness is missing or lagging
+SIEM-EQUIV-04: Scheduled rule principal has narrower index/table/app permissions than the reviewer
+SIEM-EQUIV-05: Suppression, grouping, throttling, threshold, or incident settings hide distinct entities
+SIEM-EQUIV-06: Production dependency evidence is unavailable, so the rule is incorrectly marked validated
+```
+
+Treat missing equivalence evidence as a deployment blocker for P1/P2 detections and as a required remediation item for lower-priority detections. Mark the gate Not Evaluable when the production artifact or dependency evidence is unavailable; do not silently count the rule as validated.
+
 ### Step 5: Detection Rule Lifecycle Management
 
 **Lifecycle stages:**
@@ -549,6 +576,16 @@ Produce SIEM rule deliverables in this structure:
 
 ### Validation
 - [How to test the rule produces a true positive]
+- [How the reviewed query matches the scheduled production query, including expanded macros, parameters, saved-search or analytics-rule export, lookup/watchlist versions, acceleration or summary freshness, runtime principal, and suppression/grouping settings]
+
+### Production Equivalence Evidence
+| Dependency | Production Value | Freshness / Scope | Owner | Evidence Source | Status |
+|------------|------------------|-------------------|-------|-----------------|--------|
+| Expanded query | [query hash/export ID] | [resolved timestamp] | [owner] | [saved search or rule export] | Pass/Fail/Not Evaluable |
+| Lookup/watchlist | [name/version] | [last modified/cadence] | [owner] | [deployment/change record] | Pass/Fail/Not Evaluable |
+| Acceleration/summary | [model/job/view] | [latest build/run/range] | [owner] | [health evidence] | Pass/Fail/Not Evaluable |
+| Runtime principal | [service account/context] | [indexes/tables/apps] | [owner] | [role export] | Pass/Fail/Not Evaluable |
+| Suppression/grouping | [settings] | [scope/key/duration] | [owner] | [rule export] | Pass/Fail/Not Evaluable |
 ```
 
 ---
@@ -631,6 +668,10 @@ Deploying a rule without confirming it fires on known-malicious activity is depl
 ### Pitfall 5: Failing to Suppress Duplicate Alerts
 
 A detection rule that fires every 5 minutes on the same ongoing activity (e.g., a brute force attack lasting 2 hours) floods the alert queue with duplicates. Configure alert suppression or deduplication to prevent the same incident from generating hundreds of identical alerts. Use suppression windows and entity-based grouping to consolidate related alerts.
+
+### Pitfall 6: Reviewing a Query That Is Not the Production Query
+
+An analyst console query can differ from the scheduled production rule because macros expand in another app context, lookups or watchlists are stale, accelerated summaries lag, runtime permissions are narrower, or suppression settings collapse distinct entities. Capture the expanded production artifact and dependency freshness before declaring a detection validated.
 
 ---
 

--- a/skills/secops/siem-rules/tests/benign/exported-production-equivalence-evidence.md
+++ b/skills/secops/siem-rules/tests/benign/exported-production-equivalence-evidence.md
@@ -1,0 +1,67 @@
+# Benign: Exported Production Equivalence Evidence
+
+## Review Target
+
+```yaml
+platform: microsoft_sentinel
+rule_name: Password Spray From Single Source
+attack_mapping: T1110.003
+reviewed_query_hash: sha256:5b1f7f22-reviewed
+production_rule_export:
+  artifact: sentinel-analytics-password-spray-2026-06-08.json
+  exported_at: 2026-06-08T20:15:00Z
+  query_hash: sha256:5b1f7f22-reviewed
+  query_frequency: 5m
+  query_period: 1h
+  event_grouping: trigger_alert_for_each_event
+  suppression:
+    enabled: true
+    duration: 30m
+    key:
+      - IPAddress
+      - TargetAccounts
+  entity_mapping:
+    Account: TargetAccounts
+    IP: IPAddress
+
+dependencies:
+  watchlists:
+    - name: corporate_nat_allowlist
+      owner: soc-detections
+      last_modified: 2026-06-08T18:00:00Z
+      refresh_cadence: daily
+      deployed_to_workspace: prod-sentinel
+      change_ticket: SEC-4821
+  materialized_views: []
+  splunk_data_model_acceleration: not_applicable
+
+runtime_principal:
+  reviewer_identity: soc-detection-reviewer
+  scheduled_identity: sentinel-analytics-managed-identity
+  workspace: prod-sentinel
+  tables:
+    - SigninLogs
+    - AADNonInteractiveUserSignInLogs
+  permission_diff: none
+
+validation:
+  true_positive_test: replayed_password_spray_fixture
+  fired_alert_id: alert-2026-06-08-pspray-001
+  lookup_version_checked: corporate_nat_allowlist@SEC-4821
+  production_export_attached: true
+```
+
+## Expected Review Result
+
+| Gate | Status | Evidence |
+|------|--------|----------|
+| Expanded production query | Pass | Production export hash matches the reviewed query hash. |
+| Lookup/watchlist freshness | Pass | Watchlist owner, daily cadence, same-day modification time, workspace deployment, and change ticket are documented. |
+| Acceleration and summary freshness | Pass | No acceleration or materialized view dependency exists for this Sentinel rule. |
+| Runtime principal equivalence | Pass | Scheduled identity has the same required Sentinel tables as the reviewer. |
+| Suppression and incident settings | Pass | Suppression is bounded to 30 minutes and keyed by IP plus target account set, preserving distinct entities. |
+| Production dependency evidence | Pass | Production export and dependency evidence are attached before validation. |
+
+## Reviewer Notes
+
+This rule has sufficient production-equivalence evidence. Further review can focus on detection logic quality, threshold tuning, and response workflow rather than deployment drift.

--- a/skills/secops/siem-rules/tests/vulnerable/production-query-equivalence-drift.md
+++ b/skills/secops/siem-rules/tests/vulnerable/production-query-equivalence-drift.md
@@ -1,0 +1,69 @@
+# Vulnerable: Production Query Equivalence Drift
+
+## Review Target
+
+```yaml
+platform: splunk
+rule_name: Suspicious PowerShell Encoded Command
+attack_mapping: T1059.001
+reviewed_query: |
+  index=endpoint sourcetype=XmlWinEventLog:Microsoft-Windows-Sysmon/Operational EventCode=1
+  | search CommandLine="*-enc*" OR CommandLine="*EncodedCommand*"
+  | lookup powershell_admin_allowlist user as User output allowed
+  | where isnull(allowed)
+  | table _time host User CommandLine
+
+production_saved_search:
+  app_context: search
+  exported_query_available: false
+  query: |
+    `edr_index` sourcetype=XmlWinEventLog:Microsoft-Windows-Sysmon/Operational EventCode=1
+    | tstats summariesonly=true count from datamodel=Endpoint.Processes
+      where Processes.process="*-enc*" by Processes.user Processes.dest Processes.process
+    | lookup powershell_admin_allowlist user as Processes.user output allowed
+    | where isnull(allowed)
+  macro_expansion:
+    edr_index: index=windows
+    reviewed_by_engineer: false
+  lookup:
+    name: powershell_admin_allowlist.csv
+    last_modified: 2026-03-01T00:00:00Z
+    owner: unknown
+    refresh_cadence: manual
+    deployed_to_prod: unknown
+  acceleration:
+    data_model: Endpoint.Processes
+    enabled: true
+    latest_build_time: 2026-06-08T18:52:00Z
+    rule_lookback: 2h
+    summary_range: 15m
+    lag: 3h
+  runtime_principal:
+    reviewer_role: sec_admin
+    scheduled_role: splunk_svc_detection
+    scheduled_indexes:
+      - windows
+    expected_indexes:
+      - endpoint
+      - windows
+  suppression:
+    enabled: true
+    duration: 24h
+    throttle_key: User
+    incident_grouping: group_all_events
+```
+
+## Expected Findings
+
+| ID | Severity | Evidence |
+|----|----------|----------|
+| SIEM-EQUIV-01 | High | No exported production query is available, and production uses macro plus `tstats` logic that differs from the reviewed raw event search. |
+| SIEM-EQUIV-02 | Medium | `powershell_admin_allowlist.csv` is manually refreshed, stale, and has unknown owner/deployment state. |
+| SIEM-EQUIV-03 | High | Data-model acceleration lag is 3 hours while the rule lookback is 2 hours, so recent events can be missed. |
+| SIEM-EQUIV-04 | High | The scheduled role only has `windows` while reviewer expectations include `endpoint` and `windows`. |
+| SIEM-EQUIV-05 | Medium | A 24-hour throttle on `User` plus grouped incidents can collapse distinct hosts and commands. |
+| SIEM-EQUIV-06 | Medium | Missing production export evidence was still treated as validated. |
+
+## Reviewer Notes
+
+This rule should not be promoted as validated. Require the expanded saved-search export, fresh lookup ownership and deployment evidence, acceleration health within the lookback window, service-account permission parity, and documented suppression intent.


### PR DESCRIPTION
## Summary

Closes #1652.

Adds a focused production query equivalence and dependency freshness gate to `siem-rules` so reviewers verify the scheduled production rule, not just an analyst-console query.

## Changes

- Adds `SIEM-EQUIV-01` through `SIEM-EQUIV-06` findings for expanded query drift, stale lookups/watchlists, acceleration or summary lag, runtime principal mismatch, suppression/grouping drift, and unavailable dependency evidence.
- Extends the validation output with a production equivalence evidence table.
- Adds vulnerable and benign fixtures covering Splunk saved-search drift versus Sentinel exported production-rule evidence.

## Validation

- `git diff --check origin/main...HEAD`
- Markdown fence balance check for changed files
- ASCII check for changed files
- Content marker checks for the new evidence gate, finding IDs, and fixtures
- `git merge-tree --write-tree origin/main HEAD`