### PR TITLE
Improve privileged MFA assurance evidence

### DIFF
--- a/skills/identity/privileged-access/SKILL.md
+++ b/skills/identity/privileged-access/SKILL.md
@@ -170,6 +170,45 @@ PAM-TOOL-10: PAM tool not integrated with IdP for identity verification
 
 ---
 
+### Step 2.5: Privileged MFA Assurance
+
+**Objective:** Verify that MFA on privileged access is strong enough for the administrative action and enforced at each sensitive PAM chokepoint, not only at initial sign-in.
+
+**NIST SP 800-53 Reference:** IA-2, IA-5, AC-6, AC-17
+**CIS Controls v8 Reference:** Control 6.5 -- Require MFA for Administrative Access
+
+Generic MFA presence is not enough for PAM assurance. SMS, voice, email OTP, unnumbered push, remembered devices, weak helpdesk reset, weak external-tenant trust, and unbound break-glass exceptions can satisfy a checkbox while leaving vault checkout, JIT activation, session launch, recovery, and vendor administration exposed.
+
+**Required evidence:**
+
+| Gate | Evidence to Capture | Fail / Not Evaluable Condition |
+|------|---------------------|--------------------------------|
+| Method strength by admin path | Required and observed authenticator for PAM console, vault checkout, JIT activation, session launch, vendor admin, recovery, and break-glass | High-risk paths permit SMS, voice, email OTP, or simple push without phishing-resistant MFA or approved compensating controls |
+| Step-up enforcement point | Policy logs showing MFA or step-up at login, credential checkout, JIT activation, privileged session launch, recovery, and break-glass use | MFA is checked only at IdP/PAM login and not at the sensitive action boundary |
+| Push fatigue resistance | Number matching, request context, rate limits, device binding, and fatigue/anomaly controls for any push method allowed on admin paths | Push approval can be blindly accepted or spammed without controls |
+| Authenticator and device binding | Hardware-backed or phishing-resistant factor ID, managed-device binding, certificate/PIV/FIDO2/WebAuthn evidence, or risk-accepted alternative | Privileged authenticators are portable, unbound, or indistinguishable from standard-user MFA |
+| Recovery and re-enrollment assurance | Helpdesk reset, lost-device, factor replacement, remembered-device, and emergency recovery workflow evidence | Recovery can downgrade privileged MFA or replace factors without approval and method-level audit |
+| External and vendor parity | MSP/vendor/delegated administrator MFA method, enforcement point, tenant trust, and audit evidence | External admin sessions rely only on weaker home-tenant claims or lack PAM step-up |
+| Break-glass exception control | Dual control, scoped permissions, immediate alerting, session recording, post-use rotation, and follow-up review | Break-glass accounts have no MFA or lack compensating controls and post-use rotation |
+| Method-level audit proof | IdP/PAM logs showing actual method, device/credential ID, challenge type, enforcement point, session, and outcome | Logs show only "MFA satisfied" without proving which factor protected the privileged action |
+
+Use these finding IDs when reporting gaps:
+
+```text
+PAM-MFA-01: Privileged path permits SMS, voice, email OTP, or simple push without phishing-resistant MFA or approved compensating controls
+PAM-MFA-02: MFA is enforced only at login, not at vault checkout, JIT activation, session launch, recovery, or break-glass use
+PAM-MFA-03: Push-based MFA lacks number matching, request context, rate limiting, device binding, or fatigue detection
+PAM-MFA-04: Recovery, re-enrollment, remembered-device, or helpdesk reset can downgrade privileged MFA assurance
+PAM-MFA-05: Vendor, MSP, delegated, or external administrator access lacks equivalent MFA strength and PAM step-up
+PAM-MFA-06: Break-glass MFA exception lacks dual control, immediate alerting, session recording, post-use rotation, or follow-up review
+PAM-MFA-07: Audit logs do not record the authenticator method, device, challenge, enforcement point, and session for privileged actions
+PAM-MFA-08: Phishing-resistant authenticators are available but not required for highest-risk privileged roles
+```
+
+**Finding classification:** No MFA on privileged access paths is **Critical**. Weak or bypassable MFA on administrative paths is **High**. Missing method-level audit evidence or incomplete privileged MFA rollout is **Medium**.
+
+---
+
 ### Step 3: Just-In-Time (JIT) Access Patterns
 
 **Objective:** Evaluate whether privileged access is time-bounded, approval-gated, and automatically revoked.
@@ -388,6 +427,7 @@ PAM-VAULT-12: No secrets scanning in code repositories to detect credential leak
 |---|---|---|
 | Credential Vaulting | [Not Present/Basic/Mature/Advanced] | [Target] |
 | Session Management | [Not Present/Basic/Mature/Advanced] | [Target] |
+| Privileged MFA Assurance | [Weak/Partial/Phishing-resistant/Adaptive] | [Target] |
 | JIT Access | [Not Present/Basic/Mature/Advanced] | [Target] |
 | Break-Glass | [Not Present/Basic/Mature/Advanced] | [Target] |
 | Analytics | [Not Present/Basic/Mature/Advanced] | [Target] |
@@ -401,6 +441,7 @@ PAM-VAULT-12: No secrets scanning in code repositories to detect credential leak
 ### Findings by Category
 - Privileged Account Inventory (Step 1): [count]
 - PAM Tool Assessment (Step 2): [count]
+- Privileged MFA Assurance (Step 2.5): [count]
 - JIT Access (Step 3): [count]
 - Break-Glass Procedures (Step 4): [count]
 - Session Recording (Step 5): [count]
@@ -417,6 +458,11 @@ PAM-VAULT-12: No secrets scanning in code repositories to detect credential leak
 
 ### Framework Compliance Mapping
 [Map each finding to NIST SP 800-53 AC-6 enhancements and CIS Controls v8]
+
+### Privileged MFA Assurance Evidence
+| Admin Path | Required Strength | Observed Method | Step-Up Point | Recovery/External/Break-Glass Control | Method-Level Audit | Status |
+|---|---|---|---|---|---|---|
+| [PAM login / vault checkout / JIT activation / session launch / vendor admin / recovery / break-glass] | [phishing-resistant / compensated / weak] | [FIDO2/WebAuthn / PIV / certificate / push / OTP / none] | [login / checkout / activation / launch / recovery / break-glass] | [approval, dual control, vendor parity, rotation, exception expiry] | [method, device, challenge, session, outcome] | [Pass/Fail/Not Evaluable] |
 ```
 
 ---
@@ -457,6 +503,7 @@ PAM-VAULT-12: No secrets scanning in code repositories to detect credential leak
 6. **Session recording without review** — recording sessions without monitoring or alerting provides forensic value but not prevention. Add real-time alerting.
 7. **Ignoring service account privilege** — PAM programs often focus on human admin accounts and neglect service accounts with equally powerful permissions.
 8. **No PAM HA/DR** — if the PAM tool is a single point of failure, its outage creates either a lockout or a break-glass event. Architect for resilience.
+9. **Equating any MFA with privileged MFA assurance** -- SMS, voice, email OTP, and simple push may satisfy a generic MFA checkbox while leaving vault checkout, JIT activation, recovery, vendor administration, and break-glass paths vulnerable. Require method-level evidence and step-up enforcement at the actual privileged action.
 
 ---
 

--- a/skills/identity/privileged-access/tests/benign/phishing-resistant-privileged-mfa-evidence.md
+++ b/skills/identity/privileged-access/tests/benign/phishing-resistant-privileged-mfa-evidence.md
@@ -1,0 +1,72 @@
+# Benign: Phishing-Resistant Privileged MFA Evidence
+
+## Review Target
+
+```yaml
+pam_platform: delinea
+idp: entra-id
+privileged_paths:
+  - path: pam_console_login
+    required_mfa: phishing_resistant
+    observed_method: fido2_security_key
+    method_audit: method=fido2 credential_id=cred-admin-01 device=managed-admin-laptop
+  - path: vault_checkout_domain_admin
+    required_mfa: step_up_fido2
+    observed_method: fido2_security_key
+    step_up_policy: checkout_policy_tier0
+  - path: jit_activation_global_admin
+    required_mfa: fido2_with_justification
+    observed_method: fido2_security_key
+    approval_ticket: CHG-8042
+  - path: privileged_session_launch
+    required_mfa: session_launch_step_up
+    observed_method: fido2_security_key
+    session_recording: enabled
+  - path: vendor_admin_access
+    required_mfa: pam_brokered_fido2
+    observed_method: fido2_security_key
+    tenant_trust_reviewed: true
+    vendor_contract: MSP-2026-17
+  - path: helpdesk_recovery
+    required_mfa: dual_approval_identity_proofing
+    can_replace_factor_without_manager_approval: false
+    post_recovery_privileged_hold: 24h
+  - path: break_glass_use
+    required_mfa: sealed_fido2_plus_dual_control
+    dual_control: true
+    immediate_alerting: true
+    session_recording: enabled
+    post_use_rotation: immediate
+    follow_up_review: BG-REVIEW-2026-06
+
+authenticator_binding:
+  fido2_available: true
+  required_for_tier0_admins: true
+  managed_device_binding: true
+  exception_expiry_days: 7
+
+logs:
+  idp_policy_result: "phishing-resistant MFA satisfied"
+  pam_checkout_event: "checkout step-up completed"
+  method_detail_present: true
+  device_credential_id_present: true
+  enforcement_point_present: true
+  session_id: pam-session-2026-06-08-001
+```
+
+## Expected Review Result
+
+| Gate | Status | Evidence |
+|------|--------|----------|
+| Method strength by admin path | Pass | PAM login, vault checkout, JIT activation, session launch, vendor access, and break-glass require FIDO2 or sealed FIDO2 with compensating controls. |
+| Step-up enforcement point | Pass | Checkout, activation, and session launch all require step-up at the sensitive action. |
+| Push fatigue resistance | Pass | Push is not used for Tier 0 privileged paths. |
+| Authenticator and device binding | Pass | FIDO2 credential IDs are tied to managed admin devices. |
+| Recovery and re-enrollment assurance | Pass | Factor replacement requires dual approval and imposes a privileged hold. |
+| External and vendor parity | Pass | Vendor admins use PAM-brokered FIDO2 and a reviewed contract. |
+| Break-glass exception control | Pass | Break-glass requires dual control, immediate alerting, session recording, immediate rotation, and follow-up review. |
+| Method-level audit proof | Pass | Logs include method, credential ID, device, enforcement point, and session ID. |
+
+## Reviewer Notes
+
+This setup provides sufficient evidence to mark privileged MFA assurance as passing. Continue monitoring exception expiry and quarterly break-glass test results.

--- a/skills/identity/privileged-access/tests/vulnerable/weak-privileged-mfa-bypass-paths.md
+++ b/skills/identity/privileged-access/tests/vulnerable/weak-privileged-mfa-bypass-paths.md
@@ -1,0 +1,68 @@
+# Vulnerable: Weak Privileged MFA and Bypass Paths
+
+## Review Target
+
+```yaml
+pam_platform: cyberark
+idp: entra-id
+privileged_paths:
+  - path: pam_console_login
+    required_mfa: any
+    observed_method: sms_otp
+    method_audit: "MFA satisfied"
+  - path: vault_checkout_domain_admin
+    required_mfa: none_after_login
+    observed_method: inherited_idp_session
+    step_up_policy: disabled
+  - path: jit_activation_global_admin
+    required_mfa: push
+    observed_method: simple_push
+    number_matching: false
+    request_context: false
+    push_rate_limit: none
+  - path: privileged_session_launch
+    required_mfa: none_after_checkout
+    observed_method: inherited_pam_session
+  - path: vendor_admin_access
+    required_mfa: external_tenant_claim
+    observed_method: unknown
+    tenant_trust_reviewed: false
+  - path: helpdesk_recovery
+    required_mfa: knowledge_based_verification
+    can_replace_factor_without_manager_approval: true
+  - path: break_glass_use
+    required_mfa: none
+    dual_control: false
+    immediate_alerting: false
+    session_recording: false
+    post_use_rotation: manual_next_quarter
+
+authenticator_binding:
+  fido2_available: true
+  required_for_tier0_admins: false
+  managed_device_binding: false
+
+logs:
+  idp_policy_result: "MFA required: satisfied"
+  pam_checkout_event: "credential checked out"
+  method_detail_present: false
+  device_credential_id_present: false
+  enforcement_point_present: false
+```
+
+## Expected Findings
+
+| ID | Severity | Evidence |
+|----|----------|----------|
+| PAM-MFA-01 | High | PAM console and JIT allow SMS/simple push while FIDO2 is available for Tier 0 admins. |
+| PAM-MFA-02 | High | Vault checkout and session launch inherit the initial login session with no step-up. |
+| PAM-MFA-03 | High | Push approval lacks number matching, request context, and rate limits. |
+| PAM-MFA-04 | High | Helpdesk recovery can replace privileged factors using knowledge-based verification without manager approval. |
+| PAM-MFA-05 | High | Vendor admin access relies on an unreviewed external tenant MFA claim. |
+| PAM-MFA-06 | Critical | Break-glass has no MFA, no dual control, no immediate alerting, no session recording, and delayed rotation. |
+| PAM-MFA-07 | Medium | Logs show only "MFA satisfied" and do not record authenticator method, device, challenge, or enforcement point. |
+| PAM-MFA-08 | Medium | Phishing-resistant FIDO2 is available but not required for highest-risk roles. |
+
+## Reviewer Notes
+
+This environment should not pass CIS 6.5 for privileged access. Require phishing-resistant or compensated MFA at each privileged chokepoint, hardened recovery, vendor parity, controlled break-glass, and method-level audit proof before marking privileged MFA assurance complete.


### PR DESCRIPTION
## Summary

Closes #1678.

Adds a focused privileged MFA assurance step to `privileged-access` so reviewers verify MFA strength and enforcement at PAM-specific chokepoints instead of accepting a generic MFA checkbox.

## Changes

- Adds `PAM-MFA-01` through `PAM-MFA-08` findings for weak factors, missing step-up, push fatigue, recovery downgrade, vendor admin gaps, break-glass exceptions, missing method-level audit logs, and incomplete phishing-resistant rollout.
- Extends the PAM scorecard, findings-by-category list, and report output with privileged MFA assurance evidence.
- Adds vulnerable and benign fixtures covering weak privileged MFA bypass paths versus phishing-resistant privileged MFA evidence.

## Validation

- `git diff --check origin/main...HEAD`
- Added-line ASCII check
- Markdown fence balance check for changed files
- Content marker checks for the new evidence gate, finding IDs, and fixtures
- `git merge-tree --write-tree origin/main HEAD`