### PR TITLE
Improve IR communication channel integrity evidence

### DIFF
--- a/skills/incident-response/ir-playbook/SKILL.md
+++ b/skills/incident-response/ir-playbook/SKILL.md
@@ -110,6 +110,36 @@ Verify that the foundational elements for incident response are in place. If gap
 | Regulatory notification requirements documented | [ ] | GDPR, HIPAA, state laws, SEC |
 | Evidence storage with chain-of-custody procedures | [ ] | |
 
+#### Step 1.1: Communication Channel Integrity Gate
+
+For SEV-1 and SEV-2 incidents, treat response communications as part of the control surface. Do not assume email, chat, ticketing, paging, endpoint-management, or normal collaboration systems are safe until the team has assessed adversary visibility and recorded a trusted coordination path.
+
+**Required evidence:**
+
+| Gate | Evidence to Capture | Fail / Not Evaluable Condition |
+|------|---------------------|--------------------------------|
+| Channel trust status | Trust status for corporate email, chat, ticketing, phone bridge, paging, endpoint-management, and IR-retainer portals | Channel is used for containment or notification decisions before attacker visibility is assessed |
+| Switch trigger and timestamp | Severity trigger, compromise indicator, incident commander approval, timestamp, and selected out-of-band channel | No documented reason or time for moving away from normal communications |
+| Participant verification | War-room roster, role, verification method, pre-established contact source, join/leave timestamps, and access revocation | Unknown participants or external responders join without trusted callback or identity verification |
+| Access control and need-to-know | Channel owner, invite controls, access changes, transcript/export permissions, and retention setting | War room remains open to broad groups, compromised users, or stale participants |
+| Decision and order preservation | Trusted record for containment orders, legal approvals, public/regulatory notices, and business shutdown decisions | High-impact actions are issued only in transient chat or untrusted channels |
+| Adversary visibility review | Review of mailbox rules, chat exports, IdP sessions, ticket watchers, admin audit logs, and endpoint-management access | The team does not check whether the attacker can monitor or alter the selected channel |
+| Return-to-normal criteria | Evidence required before resuming internal channels, approver, timestamp, and cleanup actions | Internal channels are resumed without proof that access, forwarding, sessions, and memberships are clean |
+
+Use these finding IDs when reporting gaps:
+
+```text
+IR-COMMS-01: SEV-1/SEV-2 response uses a channel the adversary can plausibly monitor without documented risk acceptance
+IR-COMMS-02: No timestamped trigger, approver, or selected out-of-band channel is recorded
+IR-COMMS-03: War-room, bridge, ticket, or retainer-portal participants are not verified through trusted contact records
+IR-COMMS-04: Containment orders, legal approvals, public notices, or regulator communications lack a trusted preservation record
+IR-COMMS-05: The team does not review attacker visibility into mailboxes, chat exports, IdP sessions, ticket queues, or endpoint-management tools
+IR-COMMS-06: War-room access control is not limited to need-to-know participants or stale access is not removed
+IR-COMMS-07: Internal communication resumes without documented return-to-normal criteria and cleanup evidence
+```
+
+**Finding classification:** Using attacker-visible communications for active containment or notification decisions is **High**, and **Critical** if it exposes regulated data or changes response outcome. Missing participant verification, approver traceability, access control, or return-to-normal evidence is **Medium**. Incomplete retention is **Low** unless it affects legal, regulatory, or containment decisions.
+
 ### Phase 2: Detection and Analysis (NIST) / Identification (SANS)
 
 #### Step 2.1: Incident Classification
@@ -412,6 +442,11 @@ and recommended immediate actions. Lead with the most critical fact.]
 |---|---|---|---|
 | [Executive / Legal / Regulator / Customer / Insurance] | [Yes / No / Pending] | [timestamp] | [Email / Phone / Portal] |
 
+### Communication Channel Integrity
+| Channel | Trust Status | Switch Trigger / Time | Participants Verified | Access Control | Preservation Record | Return-to-Normal Criteria | Status |
+|---|---|---|---|---|---|---|---|
+| [Email / Chat / Ticketing / Phone / IR portal / Endpoint management] | [Trusted / Suspect / Compromised / Out-of-band] | [trigger + timestamp + approver] | [roster and verification method] | [owner, access changes, retention/export controls] | [decision log / approval record / transcript ID] | [cleanup evidence and approver] | [Pass/Fail/Not Evaluable] |
+
 ### Escalation Decisions
 [Document any escalation triggers hit and actions taken]
 
@@ -455,6 +490,10 @@ Responders under pressure often prioritize containment speed over evidence prese
 ### Pitfall 2: Alerting the Attacker During Investigation
 
 Communicating about the incident over channels the attacker may be monitoring (corporate email, Slack, Teams) can tip off the adversary, prompting them to accelerate data exfiltration, deploy destructive payloads, or cover their tracks. For SEV-1 and SEV-2 incidents, use out-of-band communication channels (personal phones, dedicated secure messaging, physical meetings) until the attacker's access to communication systems has been assessed and ruled out.
+
+### Pitfall 2b: Switching Channels Without Preserving Authority
+
+Moving to a phone bridge or private chat can reduce attacker visibility but create a different failure mode: unverified participants, missing decision logs, and containment orders with no named approver. Record who joined, how they were verified, what channel was used, which decisions were made, where the record was preserved, and what evidence allowed normal channels to resume.
 
 ### Pitfall 3: Failing to Establish a Clear Incident Commander
 

--- a/skills/incident-response/ir-playbook/tests/benign/verified-out-of-band-channel-record.md
+++ b/skills/incident-response/ir-playbook/tests/benign/verified-out-of-band-channel-record.md
@@ -1,0 +1,89 @@
+# Benign: Verified Out-of-Band Channel Record
+
+## Review Target
+
+```yaml
+incident:
+  id: IR-2026-0608-014
+  severity: SEV-1
+  category: destructive_malware
+  attacker_access:
+    mailbox_admin: ruled_out_after_review
+    chat_admin: suspect_until_2026-06-08T10:20Z
+    ticket_queue_watchers: reviewed_clean
+    endpoint_management_admin: suspect
+
+communications:
+  normal_channels:
+    corporate_email:
+      trust_status: restricted
+      approved_use: executive_status_only_after_legal_approval
+      mailbox_rule_review: completed
+      session_review: completed
+    teams_war_room:
+      trust_status: disabled_for_containment
+      membership_export: teams-membership-IR-014.csv
+    ticketing:
+      trust_status: trusted_after_queue_watcher_review
+      approved_use: preservation_record_only
+  out_of_band:
+    activated: true
+    selected_channel: ir_retainer_portal_and_verified_phone_bridge
+    trigger: SEV-1 destructive malware plus suspect chat and endpoint-management admin access
+    trigger_time: 2026-06-08T09:18:00Z
+    approver: incident_commander
+    bridge_recording: bridge-rec-IR-014-0918
+    portal_case: portal-case-IR-014
+
+participants:
+  - name: incident_commander
+    role: IC
+    verification: pre-established_call_tree
+    joined: 2026-06-08T09:19:00Z
+    left: 2026-06-08T14:30:00Z
+  - name: legal_counsel
+    role: legal
+    verification: callback_to_retainer_contact
+    joined: 2026-06-08T09:23:00Z
+  - name: external_ir_lead
+    role: external_ir
+    verification: retainer_portal_identity
+    joined: 2026-06-08T09:25:00Z
+
+decision_records:
+  isolate_production_segment:
+    channel: verified_phone_bridge
+    named_approver: incident_commander
+    owner: network_lead
+    preserved_record: decision-log-IR-014#D3
+  regulatory_notification_hold:
+    channel: ir_retainer_portal
+    named_approver: legal_counsel
+    preserved_record: portal-case-IR-014#legal-2
+
+return_to_normal:
+  internal_channels_resumed: true
+  time: 2026-06-08T15:10:00Z
+  approver: incident_commander
+  cleanup_evidence:
+    mailbox_rules: clean-export-IR-014
+    sessions_revoked: idp-session-review-IR-014
+    chat_membership_review: teams-membership-clean-IR-014
+    endpoint_management_admin_review: mdm-admin-review-IR-014
+```
+
+## Expected Review Result
+
+| Gate | Status | Evidence |
+|------|--------|----------|
+| Channel trust status | Pass | Email, Teams, ticketing, phone bridge, portal, and endpoint-management trust states are documented. |
+| Switch trigger and timestamp | Pass | SEV-1 destructive malware and suspect channels triggered OOB at `2026-06-08T09:18:00Z` with IC approval. |
+| Participant verification | Pass | Participants were verified through call tree, retainer callback, or portal identity. |
+| Access control and need-to-know | Pass | Teams was disabled for containment and portal/bridge membership is scoped to response roles. |
+| Decision and order preservation | Pass | Containment and legal decisions have named approvers and preserved decision-log or portal records. |
+| Adversary visibility review | Pass | Mailbox rules, sessions, ticket watchers, chat membership, and endpoint-management admins were reviewed. |
+| Return-to-normal criteria | Pass | Internal channels resumed only after cleanup evidence and IC approval. |
+
+## Reviewer Notes
+
+This record supports communication channel integrity for a SEV-1 incident. Further review should focus on whether containment actions and forensic preservation were technically sufficient.

--- a/skills/incident-response/ir-playbook/tests/vulnerable/attacker-visible-war-room-decisions.md
+++ b/skills/incident-response/ir-playbook/tests/vulnerable/attacker-visible-war-room-decisions.md
@@ -1,0 +1,74 @@
+# Vulnerable: Attacker-Visible War Room Decisions
+
+## Review Target
+
+```yaml
+incident:
+  id: IR-2026-0608-001
+  severity: SEV-1
+  category: data_exfiltration
+  attacker_access:
+    mailbox_admin: suspected
+    chat_admin: confirmed
+    ticket_queue_watchers: unknown
+    endpoint_management_admin: suspected
+
+communications:
+  normal_channels:
+    corporate_email:
+      trust_status: not_assessed
+      used_for: legal_review_and_customer_notice_draft
+      mailbox_rule_review: not_done
+    teams_war_room:
+      trust_status: compromised
+      used_for: containment_orders
+      participants:
+        - incident-commander
+        - soc-team
+        - all-it-admins
+        - disabled-user-still-present
+      participant_verification: none
+      retention: 7_days
+    ticketing:
+      trust_status: unknown
+      used_for: credential_revocation_orders
+      queue_watchers_review: not_done
+  out_of_band:
+    activated: false
+    trigger_time: null
+    approver: null
+
+decision_records:
+  isolate_database_cluster:
+    channel: teams_war_room
+    named_approver: none
+    preserved_record: chat_scrollback_only
+  public_statement:
+    channel: corporate_email
+    named_approver: legal_counsel_unverified
+    preserved_record: draft_email
+
+return_to_normal:
+  internal_channels_resumed: true
+  cleanup_evidence:
+    mailbox_rules: not_checked
+    sessions_revoked: partial
+    chat_membership_review: not_done
+  approver: none
+```
+
+## Expected Findings
+
+| ID | Severity | Evidence |
+|----|----------|----------|
+| IR-COMMS-01 | High | SEV-1 containment and notification work continued in email and Teams while mailbox/chat compromise was suspected or confirmed. |
+| IR-COMMS-02 | Medium | No out-of-band activation trigger, timestamp, approver, or selected alternate channel is documented. |
+| IR-COMMS-03 | Medium | War-room participants include broad groups and a disabled user without trusted participant verification. |
+| IR-COMMS-04 | High | Database isolation and public statement decisions are preserved only in chat scrollback or draft email without trusted authority records. |
+| IR-COMMS-05 | High | The team did not review mailbox rules, ticket watchers, IdP sessions, or endpoint-management access before using those channels. |
+| IR-COMMS-06 | Medium | War-room access is not limited to need-to-know and stale participants were not removed. |
+| IR-COMMS-07 | Medium | Internal channels resumed without cleanup evidence or approver. |
+
+## Reviewer Notes
+
+This incident needs a trusted out-of-band channel, verified roster, named approvers for containment and public communication, preserved decision records, and explicit cleanup evidence before internal channels resume.


### PR DESCRIPTION
## Summary

Closes #1680.

Adds a focused communication channel integrity gate to `ir-playbook` so SEV-1/SEV-2 responders verify whether response channels are trusted, who is allowed in the war room, how decisions are preserved, and what evidence allows return to normal communications.

## Changes

- Adds `IR-COMMS-01` through `IR-COMMS-07` findings for attacker-visible communications, missing OOB switch evidence, unverified participants, missing preservation records, unreviewed adversary visibility, stale war-room access, and unsafe return to normal channels.
- Extends the incident response report output with a communication channel integrity table.
- Adds vulnerable and benign fixtures covering attacker-visible war-room decisions versus verified out-of-band coordination records.

## Validation

- `git diff --check origin/main...HEAD`
- Added-line ASCII check
- Markdown fence balance check for changed files
- Content marker checks for the new evidence gate, finding IDs, and fixtures
- `git merge-tree --write-tree origin/main HEAD`