### PR TITLE
Improve secure code review crypto agility evidence

### DIFF
--- a/skills/appsec/secure-code-review/SKILL.md
+++ b/skills/appsec/secure-code-review/SKILL.md
@@ -269,6 +269,38 @@ Remediation: Use `crypto.randomBytes(32).toString('hex')` (Node.js) or `crypto.g
 - [ ] Cryptographic keys are not hard-coded -- loaded from a key management system.
 - [ ] TLS certificates and configurations are not bypassed or weakened in code.
 
+### 5.4 Cryptographic Agility and Migration Readiness
+
+**Objective:** Verify that acceptable cryptography today can be migrated safely when algorithms, key sizes, libraries, or compliance requirements change.
+
+Point-in-time algorithm checks are not enough. Review whether ciphertexts, hashes, signatures, and tokens carry metadata that allows safe migration, whether legacy compatibility is time-bound, and whether migration code is tested before a forced rotation or deprecation event.
+
+**Required evidence:**
+
+| Gate | Evidence to Capture | Fail / Not Evaluable Condition |
+|------|---------------------|--------------------------------|
+| Artifact metadata | Algorithm ID, mode, key ID, key version, KDF parameters, token issuer, and format version on encrypted values, hashes, signatures, and tokens | Data format omits metadata needed to choose decrypt/verify/upgrade logic |
+| Central crypto policy | Versioned policy layer or wrapper defining approved algorithms, key sizes, modes, libraries, and deprecation dates | Algorithms, key IDs, or modes are scattered as hard-coded constants |
+| Migration path coverage | Tested re-encryption, re-signing, password-hash upgrade, token reissue, or certificate/key rotation path | Migration is manual, untested, or requires guessing legacy formats |
+| Legacy compatibility window | Expiry date, owner, telemetry threshold, and removal ticket for legacy decrypt/verify fallback | Legacy fallback has no end date or accepts retired algorithms indefinitely |
+| Fail-closed behavior | Tests for unknown algorithms, malformed envelopes, retired keys, downgrade attempts, and mixed-version data | Unknown or malformed crypto artifacts are accepted or silently downgraded |
+| Migration test fixtures | Old-format read, new-format write, mixed-version data, idempotent migration, rollback, and partial-failure tests | Only new-format happy path tests exist |
+| Legacy telemetry | Metrics showing count/percent of legacy artifacts, migration rate, failures, and fallback use before removal | Team cannot prove how much legacy data remains |
+
+Use these finding IDs when reporting gaps:
+
+```text
+SCR-CRYPTO-AGILITY-01: Crypto artifacts lack algorithm ID, key ID, version, or KDF metadata needed for migration
+SCR-CRYPTO-AGILITY-02: Crypto algorithms, modes, key IDs, or library choices are hard-coded outside a central policy layer
+SCR-CRYPTO-AGILITY-03: Re-encryption, re-signing, password-hash upgrade, token reissue, or key-rotation migration path is missing or untested
+SCR-CRYPTO-AGILITY-04: Legacy decrypt/verify fallback has no owner, expiration date, telemetry threshold, or removal ticket
+SCR-CRYPTO-AGILITY-05: Unknown algorithms, retired keys, malformed envelopes, or downgrade attempts do not fail closed
+SCR-CRYPTO-AGILITY-06: Migration fixtures do not cover old reads, new writes, mixed-version data, idempotency, rollback, and partial failures
+SCR-CRYPTO-AGILITY-07: Legacy artifact telemetry is missing, so fallback removal cannot be safely scheduled
+```
+
+**Finding classification:** Missing metadata that prevents safe decryption/verification migration for regulated or high-value data is **High**. Untested migration jobs, indefinite legacy fallback, or non-fail-closed downgrade behavior is **High**. Missing telemetry or incomplete fixture coverage is **Medium**.
+
 ---
 
 ## Step 6: Error Handling and Logging
@@ -477,6 +509,11 @@ The final review output must be structured as follows:
 | V2 Authentication | Yes/No | [count] | [result] |
 | V3 Session Management | Yes/No | [count] | [result] |
 | ... | ... | ... | ... |
+
+### Cryptographic Agility Evidence
+| Artifact Type | Metadata Present | Policy Source | Migration Path | Legacy Window | Fail-Closed Tests | Telemetry | Status |
+|---|---|---|---|---|---|---|---|
+| [ciphertext / password hash / signature / token / certificate] | [algorithm, key ID, version, KDF params] | [policy file/wrapper] | [job/test name] | [owner, expiry, removal ticket] | [unknown alg, retired key, malformed, downgrade] | [legacy count, fallback use] | [Pass/Fail/Not Evaluable] |
 ```
 
 ---
@@ -540,6 +577,8 @@ The final review output must be structured as follows:
 4. **Treating authentication as authorization.** Verifying that a user is logged in is not the same as verifying they are permitted to perform the requested action. Every endpoint must enforce both authentication and authorization, including ownership checks for resource-level access.
 
 5. **Overlooking secrets in non-obvious locations.** Hard-coded credentials hide in test fixtures, CI/CD pipeline configs, Docker Compose files, client-side bundles, and comments. Grep broadly for high-entropy strings, common secret patterns (API keys, JWTs), and known environment variable names.
+
+6. **Treating current crypto as migration-ready.** AES-GCM, Argon2id, Ed25519, or modern TLS settings can still be brittle if artifacts omit algorithm/key metadata, migration jobs are untested, legacy fallback never expires, or downgrade attempts do not fail closed. Review crypto agility before the next forced algorithm or key rotation.
 
 ---
 

--- a/skills/appsec/secure-code-review/tests/benign/versioned-crypto-migration-evidence.md
+++ b/skills/appsec/secure-code-review/tests/benign/versioned-crypto-migration-evidence.md
@@ -1,0 +1,88 @@
+# Benign: Versioned Crypto Migration Evidence
+
+## Review Target
+
+```yaml
+module: billing-crypto
+language: typescript
+artifacts:
+  encrypted_payment_token:
+    envelope_format: json
+    fields:
+      alg: AES-256-GCM
+      kid: kms-prod-payments-v4
+      version: 4
+      nonce: present
+      aad: tenant_id:artifact_type:version
+    legacy_supported:
+      - version: 3
+        alg: AES-256-CBC-HMAC
+        expiry: 2026-07-31
+        removal_ticket: SEC-4920
+  password_hash:
+    format: modular
+    examples:
+      - $argon2id$v=19$m=65536,t=3,p=2$...
+    upgrade_on_login: true
+    legacy_bcrypt_expiry: 2026-08-15
+  signed_webhook:
+    header: X-Signature
+    protected_header:
+      alg: hmac-sha256
+      kid: webhook-signing-v3
+      issued_at: present
+
+crypto_policy:
+  central_policy_file: src/security/cryptoPolicy.ts
+  owner: appsec-platform
+  approved_algorithms:
+    encryption: AES-256-GCM
+    password_hash: Argon2id
+    webhook_signature: HMAC-SHA256
+  deprecations:
+    AES-256-CBC-HMAC: 2026-07-31
+    bcrypt: 2026-08-15
+
+migration:
+  reencryption_job: scripts/reencrypt-payment-tokens.ts
+  token_reissue_job: scripts/reissue-webhook-signatures.ts
+  tests:
+    old_format_read: test_reads_v3_envelopes
+    new_format_write: test_writes_v4_envelopes
+    mixed_version_data: test_mixed_v3_v4_batch
+    idempotency: test_reencrypt_idempotent
+    partial_failure_resume: test_reencrypt_resume_from_checkpoint
+    rollback: test_policy_rollback_blocks_new_writes_only
+  legacy_fallback:
+    owner: appsec-platform
+    expiry_date: 2026-07-31
+    removal_ticket: SEC-4920
+    telemetry_threshold: legacy_v3_tokens == 0 for 14 days
+
+fail_closed_tests:
+  unknown_algorithm: test_rejects_unknown_alg
+  retired_key: test_rejects_retired_kid
+  malformed_envelope: test_rejects_missing_version
+  downgrade_attempt: test_rejects_v2_write_attempt
+
+telemetry:
+  legacy_ciphertexts_remaining: crypto_legacy_artifacts{type="payment-token",version="3"}
+  password_hash_upgrade_rate: password_hash_upgrade_total
+  webhook_fallback_count: webhook_signature_legacy_verify_total
+```
+
+## Expected Review Result
+
+| Gate | Status | Evidence |
+|------|--------|----------|
+| Artifact metadata | Pass | Envelopes, hashes, and signatures carry algorithm, key ID, version, and KDF metadata. |
+| Central crypto policy | Pass | `src/security/cryptoPolicy.ts` owns algorithms and deprecation dates. |
+| Migration path coverage | Pass | Re-encryption, token reissue, old-read, new-write, mixed-version, idempotency, resume, and rollback tests are documented. |
+| Legacy compatibility window | Pass | Legacy v3 and bcrypt support have owners, expiry dates, removal tickets, and telemetry thresholds. |
+| Fail-closed behavior | Pass | Unknown algorithms, retired keys, malformed envelopes, and downgrade attempts are rejected in tests. |
+| Migration test fixtures | Pass | Fixtures cover old reads, new writes, mixed data, idempotency, rollback, and partial failures. |
+| Legacy telemetry | Pass | Metrics track legacy ciphertexts, password upgrades, and webhook fallback use. |
+
+## Reviewer Notes
+
+This module has sufficient crypto agility evidence. Further review should focus on implementation correctness of the crypto wrapper and migration jobs.

--- a/skills/appsec/secure-code-review/tests/vulnerable/crypto-agility-migration-brittle.md
+++ b/skills/appsec/secure-code-review/tests/vulnerable/crypto-agility-migration-brittle.md
@@ -1,0 +1,78 @@
+# Vulnerable: Brittle Crypto Migration
+
+## Review Target
+
+```yaml
+module: billing-crypto
+language: typescript
+artifacts:
+  encrypted_payment_token:
+    storage_column: payment_tokens.ciphertext
+    envelope_format: raw_base64_ciphertext
+    algorithm_metadata: absent
+    key_id_metadata: absent
+    key_version_metadata: absent
+    current_algorithm: aes-256-gcm
+    legacy_algorithm: aes-128-cbc
+    decrypt_logic: try_current_then_try_legacy
+  password_hash:
+    format: hex_digest
+    algorithm_metadata: absent
+    current_algorithm: argon2id
+    legacy_algorithm: sha256
+    upgrade_on_login: false
+  signed_webhook:
+    header: X-Signature
+    key_id: absent
+    algorithm: hmac-sha256
+    fallback_accepts_sha1: true
+
+crypto_policy:
+  central_policy_file: none
+  hard_coded_constants:
+    - src/crypto/payment.ts:AES_MODE
+    - src/auth/passwords.ts:HASH_ALG
+    - src/webhooks/verify.ts:ALLOW_SHA1
+
+migration:
+  reencryption_job: scripts/reencrypt-payment-tokens.ts
+  tests:
+    old_format_read: missing
+    new_format_write: present
+    mixed_version_data: missing
+    idempotency: missing
+    partial_failure_resume: missing
+    rollback: missing
+  legacy_fallback:
+    owner: none
+    expiry_date: none
+    removal_ticket: none
+    telemetry_threshold: none
+
+fail_closed_tests:
+  unknown_algorithm: missing
+  retired_key: missing
+  malformed_envelope: missing
+  downgrade_attempt: missing
+
+telemetry:
+  legacy_ciphertexts_remaining: unknown
+  sha256_passwords_remaining: unknown
+  sha1_webhook_fallback_count: unknown
+```
+
+## Expected Findings
+
+| ID | Severity | Evidence |
+|----|----------|----------|
+| SCR-CRYPTO-AGILITY-01 | High | Payment tokens and password hashes lack algorithm, key ID, version, or KDF metadata. |
+| SCR-CRYPTO-AGILITY-02 | Medium | Crypto settings are scattered across hard-coded constants instead of a versioned policy layer. |
+| SCR-CRYPTO-AGILITY-03 | High | Re-encryption exists but lacks old-read, mixed-version, idempotency, rollback, and partial-failure tests. |
+| SCR-CRYPTO-AGILITY-04 | High | Legacy AES-CBC, SHA-256 password, and SHA-1 webhook fallback paths have no owner, expiry, or removal ticket. |
+| SCR-CRYPTO-AGILITY-05 | High | Unknown algorithms, retired keys, malformed envelopes, and downgrade attempts have no fail-closed tests. |
+| SCR-CRYPTO-AGILITY-06 | Medium | Migration fixtures cover only the new-format happy path. |
+| SCR-CRYPTO-AGILITY-07 | Medium | Legacy artifact and fallback-use telemetry is unknown. |
+
+## Reviewer Notes
+
+This module may use acceptable current primitives, but it is not migration-ready. Require versioned envelopes, central policy, complete migration fixtures, fail-closed behavior, and telemetry before accepting a crypto migration plan.


### PR DESCRIPTION
## Summary

Closes #1675.

Adds a focused cryptographic agility and migration readiness gate to `secure-code-review` so reviewers check whether acceptable crypto today can be safely migrated later.

## Changes

- Adds `SCR-CRYPTO-AGILITY-01` through `SCR-CRYPTO-AGILITY-07` findings for missing artifact metadata, scattered crypto constants, missing migration paths, indefinite legacy fallback, non-fail-closed behavior, incomplete migration fixtures, and missing legacy telemetry.
- Extends the report output with a cryptographic agility evidence table.
- Adds vulnerable and benign fixtures covering brittle crypto migration versus versioned crypto migration evidence.

## Validation

- `git diff --check origin/main...HEAD`
- Added-line ASCII check
- Markdown fence balance check for changed files
- Content marker checks for the new evidence gate, finding IDs, and fixtures
- `git merge-tree --write-tree origin/main HEAD`