### PR TITLE
Improve AWS Access Analyzer finding evidence

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -99,6 +99,37 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
+### Step 6b: IAM Access Analyzer Finding Review
+
+CIS 1.20 verifies that IAM Access Analyzer is enabled, but analyzer existence alone does not prove that exposed or unused access is reviewed. Treat analyzer findings, archive rules, and unused-access coverage as operational evidence.
+
+**Required evidence:**
+
+| Gate | Evidence to Capture | Fail / Not Evaluable Condition |
+|------|---------------------|--------------------------------|
+| Analyzer scope and regions | Analyzer name, ARN, region, type, `ACCOUNT` or `ORGANIZATION` scope, and intended trust boundary | Analyzer scope does not match the account/organization boundary or required regions are missing |
+| Active finding inventory | Active external/internal/unused findings by analyzer, resource, principal, finding type, severity, first observed date, and age | Active findings are not exported, aged findings lack owner, or only dashboard totals are provided |
+| Unused access analyzer coverage | Whether unused role, access key, password, and unused permission findings are enabled where the review relies on Access Analyzer | Unused access review is claimed but no unused-access analyzer evidence exists |
+| Archive-rule governance | Archive rule filters, owner, approver, business justification, expiry/review date, and affected finding examples | Broad archive rules hide public or unapproved cross-account access without narrow filters and approval |
+| Resolved finding proof | Policy/resource diff, access removal evidence, finding status transition, and validation timestamp | Findings are marked resolved without a linked policy/resource change that removed access |
+| Reporting separation | Raw active/archived/resolved counts shown separately from CIS 1.20 enablement pass/fail | CIS 1.20 is marked fully effective based only on `aws_accessanalyzer_analyzer` resources |
+
+Use these finding IDs when reporting gaps:
+
+```text
+AWS-AA-01: Access Analyzer exists, but active external, internal, or unused-access findings are not reviewed
+AWS-AA-02: Analyzer scope or region coverage does not match the intended account or organization trust boundary
+AWS-AA-03: Unused access analyzer coverage is missing where unused role, key, password, or permission review is expected
+AWS-AA-04: Archive rules are broad enough to suppress public or unapproved cross-account findings
+AWS-AA-05: Archived findings lack owner, approval, business justification, expiry, or review evidence
+AWS-AA-06: Resolved findings are not tied to policy/resource changes that actually removed access
+AWS-AA-07: Raw Access Analyzer finding counts are not reported separately from CIS 1.20 enablement status
+```
+
+**Finding classification:** Active public or unapproved cross-account findings hidden by archive rules are **High** or **Critical** depending on resource sensitivity. Missing active finding review, unused-access coverage, or resolved-finding proof is **Medium**. Missing reporting separation is **Low** unless it materially changes compliance status.
+
+---
+
 ### Step 7: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
@@ -163,6 +194,12 @@ Produce the final report using the structure defined in the Output Format sectio
 1. **[Critical]** CIS X.Y -- <action item>
 2. **[High]** CIS X.Y -- <action item>
 3. ...
+
+### IAM Access Analyzer Finding Review
+
+| Analyzer | Scope / Region | Finding Class | Active | Archived | Resolved | Oldest Active | Archive Rule Governance | Resolved Proof | Status |
+|----------|----------------|---------------|--------|----------|----------|---------------|-------------------------|----------------|--------|
+| <name> | <ACCOUNT/ORGANIZATION + region> | <external/internal/unused> | <N> | <N> | <N> | <age> | <owner, approval, expiry, narrow filters> | <policy/resource change> | <Pass/Fail/Not Evaluable> |
 
 ### Summary
 - Critical findings: <N>

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -146,6 +146,17 @@ aws_accessanalyzer_analyzer
 type = "ACCOUNT"
 ```
 
+**Finding-review evidence commands:**
+
+```bash
+aws accessanalyzer list-analyzers
+aws accessanalyzer list-findings --analyzer-arn <analyzer-arn> --filter '{"status":{"eq":["ACTIVE"]}}'
+aws accessanalyzer list-findings --analyzer-arn <analyzer-arn> --filter '{"status":{"eq":["ARCHIVED"]}}'
+aws accessanalyzer list-archive-rules --analyzer-name <analyzer-name>
+```
+
+Also capture analyzer scope (`ACCOUNT` versus `ORGANIZATION`), analyzer type, region coverage, unused-access analyzer coverage, active finding age, archive-rule owner/justification/expiry, and evidence that resolved findings map to policy or resource changes. Mark CIS 1.20 as partial evidence when an analyzer exists but finding review and archive-rule governance are missing.
+
 ### CIS 1.21 -- Ensure IAM users are managed centrally via identity federation or AWS Organizations for multi-account environments
 
 Check for SSO/Identity Center configuration:

--- a/skills/cloud/aws-review/tests/benign/access-analyzer-governed-findings.md
+++ b/skills/cloud/aws-review/tests/benign/access-analyzer-governed-findings.md
@@ -1,0 +1,85 @@
+# Benign: Governed Access Analyzer Finding Review
+
+## Review Target
+
+```yaml
+account: "123456789012"
+organization: o-example
+regions:
+  - us-east-1
+  - us-west-2
+
+analyzers:
+  - name: org-external-access-use1
+    region: us-east-1
+    scope: ORGANIZATION
+    intended_boundary: ORGANIZATION
+    type: EXTERNAL_ACCESS
+    active_findings:
+      - id: finding-vendor-readonly-bucket
+        resource: arn:aws:s3:::shared-vendor-drop
+        principal: arn:aws:iam::222222222222:role/vendor-reader
+        finding_type: external_access
+        first_observed: 2026-06-06
+        age_days: 2
+        owner: data-platform
+        ticket: SEC-5011
+    archived_findings:
+      - id: finding-approved-cloudtrail-delivery
+        resource: arn:aws:s3:::org-cloudtrail-logs
+        principal: cloudtrail.amazonaws.com
+        archive_rule: archive-aws-service-cloudtrail
+    archive_rules:
+      - name: archive-aws-service-cloudtrail
+        filter: principal.service == "cloudtrail.amazonaws.com" and resource.type == "AWS::S3::Bucket"
+        owner: cloud-security
+        approver: security-architecture
+        justification: AWS service delivery to centralized CloudTrail bucket
+        expiry: 2026-09-30
+        example_findings_reviewed: true
+  - name: org-external-access-usw2
+    region: us-west-2
+    scope: ORGANIZATION
+    intended_boundary: ORGANIZATION
+    type: EXTERNAL_ACCESS
+    active_findings: []
+    archived_findings: []
+    archive_rules: []
+
+unused_access:
+  expected: true
+  analyzer_enabled: true
+  coverage:
+    roles: true
+    access_keys: true
+    passwords: true
+    permissions: true
+  oldest_unused_finding_days: 9
+
+resolved_findings:
+  - id: finding-public-role-old
+    status: RESOLVED
+    linked_policy_change: iam-policy-pr-884
+    validation_timestamp: 2026-06-08T03:15:00Z
+
+reporting:
+  cis_1_20_status: Partial_with_operational_evidence
+  raw_active_count_reported: true
+  archived_count_reported: true
+  oldest_active_finding_reported: true
+```
+
+## Expected Review Result
+
+| Gate | Status | Evidence |
+|------|--------|----------|
+| Analyzer scope and regions | Pass | Organization-scoped analyzers exist in both required regions. |
+| Active finding inventory | Pass | Active finding has resource, principal, age, owner, and ticket. |
+| Unused access analyzer coverage | Pass | Roles, access keys, passwords, and permissions are covered. |
+| Archive-rule governance | Pass | Archive rule has narrow AWS service filter, owner, approver, justification, expiry, and example review. |
+| Resolved finding proof | Pass | Resolved finding links to policy PR and validation timestamp. |
+| Reporting separation | Pass | Raw active/archived counts and oldest active finding are reported separately from enablement. |
+
+## Reviewer Notes
+
+This evidence supports a mature Access Analyzer review. Continue tracking active finding SLA and archive-rule expiry review.

--- a/skills/cloud/aws-review/tests/vulnerable/access-analyzer-broad-archive-rules.md
+++ b/skills/cloud/aws-review/tests/vulnerable/access-analyzer-broad-archive-rules.md
@@ -1,0 +1,74 @@
+# Vulnerable: Access Analyzer Enabled but Findings Hidden
+
+## Review Target
+
+```yaml
+account: "123456789012"
+organization: o-example
+regions:
+  - us-east-1
+  - us-west-2
+
+analyzers:
+  - name: account-analyzer-use1
+    region: us-east-1
+    scope: ACCOUNT
+    intended_boundary: ORGANIZATION
+    type: EXTERNAL_ACCESS
+    active_findings:
+      - id: finding-public-s3-prod
+        resource: arn:aws:s3:::prod-customer-exports
+        principal: "*"
+        finding_type: external_access
+        first_observed: 2026-04-15
+        age_days: 54
+        owner: none
+    archived_findings:
+      - id: finding-cross-account-kms
+        resource: arn:aws:kms:us-east-1:123456789012:key/prod-data
+        principal: arn:aws:iam::999999999999:root
+        archive_rule: archive-approved-partners
+    archive_rules:
+      - name: archive-approved-partners
+        filter: principal.account != "123456789012"
+        owner: none
+        approver: none
+        justification: "known partners"
+        expiry: none
+        example_findings_reviewed: false
+  - name: missing-usw2
+    region: us-west-2
+    scope: none
+
+unused_access:
+  expected: true
+  analyzer_enabled: false
+  review_claim: "unused role and access key review handled by Access Analyzer"
+
+resolved_findings:
+  - id: finding-old-public-role
+    status: RESOLVED
+    linked_policy_change: none
+    validation_timestamp: none
+
+reporting:
+  cis_1_20_status: Pass
+  raw_active_count_reported: false
+  archived_count_reported: false
+```
+
+## Expected Findings
+
+| ID | Severity | Evidence |
+|----|----------|----------|
+| AWS-AA-01 | Medium | Active external-access findings exist but are not owned or reviewed. |
+| AWS-AA-02 | Medium | Analyzer is `ACCOUNT` scoped even though the intended trust boundary is the organization, and `us-west-2` has no analyzer evidence. |
+| AWS-AA-03 | Medium | Unused access review is claimed but unused-access analyzer coverage is disabled. |
+| AWS-AA-04 | High | Archive rule suppresses any external principal outside the account, broad enough to hide unapproved cross-account access. |
+| AWS-AA-05 | Medium | Archive rule and archived findings lack owner, approver, expiry, and example review evidence. |
+| AWS-AA-06 | Medium | Resolved finding has no linked policy/resource change or validation timestamp. |
+| AWS-AA-07 | Low | CIS 1.20 is marked Pass while raw active and archived counts are not reported. |
+
+## Reviewer Notes
+
+This environment should not treat Access Analyzer enablement as full CIS 1.20 effectiveness. Require organization/region scope evidence, active finding ownership, narrow archive rules, unused-access coverage, resolved-finding proof, and separate raw finding counts.


### PR DESCRIPTION
## Summary

Closes #1663.

Adds a focused IAM Access Analyzer finding-review gate to `aws-review` so CIS 1.20 evidence includes active findings, archive-rule governance, unused-access coverage, and resolved-finding proof rather than analyzer existence alone.

## Changes

- Adds `AWS-AA-01` through `AWS-AA-07` findings for missing active finding review, scope or region gaps, missing unused-access coverage, broad archive rules, unowned archived findings, unresolved proof gaps, and missing raw finding counts.
- Extends the AWS report output with an IAM Access Analyzer finding review table.
- Adds benchmark evidence commands for analyzers, active/archived findings, and archive rules.
- Adds vulnerable and benign fixtures covering broad archive-rule suppression versus governed finding review evidence.

## Validation

- `git diff --check origin/main...HEAD`
- Added-line ASCII check
- Markdown fence balance check for changed files
- Content marker checks for the new evidence gate, finding IDs, benchmark commands, and fixtures
- `git merge-tree --write-tree origin/main HEAD`