### PR TITLE
Improve Azure Defender exemption governance

### DIFF
--- a/skills/cloud/azure-review/SKILL.md
+++ b/skills/cloud/azure-review/SKILL.md
@@ -88,6 +88,31 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, Bic
 
 ---
 
+### Step 10b: Defender for Cloud Exemption Governance
+
+After evaluating Defender for Cloud enablement and CIS recommendation status, review Defender for Cloud and Azure Policy exemptions that change the visible recommendation state or secure-score impact. Treat exemptions as evidence that needs ownership and scope validation, not as automatic proof that the underlying risk is remediated.
+
+**Evidence to collect:**
+
+- Policy exemption inventory from each subscription, management group, and resource scope reviewed.
+- Defender for Cloud recommendation exports that include exempted and raw unhealthy assessment state.
+- Exemption category (`Mitigated` or `Waiver`), owner, approver, description, expiry, linked ticket, and compensating-control evidence.
+- Scope evidence showing whether the exemption targets a single resource/resource group, subscription, or management group.
+- Duplicate or conflicting exemption evidence for the same recommendation, policy assignment, or resource selector.
+
+**What to flag:**
+
+```
+AZ-DEF-EXEMPT-01: Defender recommendation exemption lacks owner, approver, description, expiry, or ticket evidence
+AZ-DEF-EXEMPT-02: Exemption scope is broader than the affected resource set or covers a management group without justification
+AZ-DEF-EXEMPT-03: Expired exemption still suppresses unhealthy Defender recommendations
+AZ-DEF-EXEMPT-04: High-impact CIS or regulatory recommendation is exempted without compensating-control evidence
+AZ-DEF-EXEMPT-05: Report relies on post-exemption secure-score/compliance only and omits raw unhealthy recommendation state
+AZ-DEF-EXEMPT-06: Duplicate or conflicting exemptions exist for the same recommendation, assignment, or resource selector
+```
+
+Rate unmanaged or stale exemptions as **Medium** by default. Escalate to **High** when an exemption suppresses internet exposure, privileged access, data protection, regulatory, or Critical/High Defender recommendations without time-bound risk acceptance and compensating evidence.
+
 
 ---
 
@@ -160,6 +185,12 @@ Produce the final report using the structure defined in the Output Format sectio
 2. **[High]** CIS X.Y.Z -- <action item>
 3. ...
 
+### Defender for Cloud Exemption Governance
+
+| Scope | Recommendation/Policy Assignment | Category | Owner/Approver | Expiry | Raw Status | Exempted Status | Risk Decision | Compensating Evidence |
+|-------|----------------------------------|----------|----------------|--------|------------|-----------------|---------------|-----------------------|
+| <scope> | <recommendation or policy assignment> | <Mitigated/Waiver> | <owner/approver> | <date/none> | <Healthy/Unhealthy> | <Exempt/NotApplicable> | <ticket/decision> | <link/summary> |
+
 ### Summary
 - Critical findings: <N>
 - High findings: <N>
@@ -200,6 +231,7 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **NSG rules using service tags.** A rule with `source_address_prefix = "Internet"` is equivalent to `0.0.0.0/0`. Both must be flagged for CIS 6.1 and 6.2.
 5. **Key Vault purge protection is irreversible.** CIS 8.5 requires `purge_protection_enabled = true`. Note this cannot be disabled once enabled -- flag this for awareness during remediation.
 6. **App Service TLS version on both Linux and Windows.** Check `azurerm_linux_web_app` and `azurerm_windows_web_app` resources separately.
+7. **Post-exemption compliance is not raw risk status.** Defender for Cloud exemptions can remove resources from unhealthy recommendation views or secure-score impact. Always report raw recommendation state separately from exempted status.
 
 ---
 
@@ -221,6 +253,9 @@ Produce the final report using the structure defined in the Output Format sectio
 
 - CIS Microsoft Azure Foundations Benchmark v2.1.0: https://www.cisecurity.org/benchmark/azure
 - Microsoft Defender for Cloud Documentation: https://learn.microsoft.com/en-us/azure/defender-for-cloud/
+- Microsoft Defender for Cloud Recommendation Exemptions: https://learn.microsoft.com/en-us/azure/defender-for-cloud/exempt-resource
+- Microsoft Defender for Cloud Exemption Review: https://learn.microsoft.com/en-us/azure/defender-for-cloud/review-exemptions
+- Azure Policy Exemption Structure: https://learn.microsoft.com/en-us/azure/governance/policy/concepts/exemption-structure
 - Microsoft Entra ID Security: https://learn.microsoft.com/en-us/entra/identity/
 - Azure Storage Security: https://learn.microsoft.com/en-us/azure/storage/common/storage-security-guide
 - Azure Key Vault Best Practices: https://learn.microsoft.com/en-us/azure/key-vault/general/best-practices

--- a/skills/cloud/azure-review/benchmark-checklist.md
+++ b/skills/cloud/azure-review/benchmark-checklist.md
@@ -182,6 +182,29 @@ resource "azurerm_security_center_contact" {
 }
 ```
 
+### Defender for Cloud Recommendation Exemptions
+
+Review exemptions that suppress Defender for Cloud or Azure Policy recommendations.
+
+```bash
+# List policy exemptions for each scope under review.
+az policy exemption list --scope <subscription-or-management-group-or-resource-scope>
+
+# Export exemption resources with owner, expiry, category, assignment, and selectors.
+az graph query -q "policyresources | where type =~ 'microsoft.authorization/policyexemptions' | project id, name, scope=properties.scope, assignment=properties.policyAssignmentId, category=properties.exemptionCategory, expiresOn=properties.expiresOn, displayName=properties.displayName, description=properties.description, metadata=properties.metadata, selectors=properties.resourceSelectors"
+
+# Export Defender assessment state, including exempted and unhealthy records.
+az graph query -q "securityresources | where type =~ 'microsoft.security/assessments' | project id, name, resourceGroup, subscriptionId, status=properties.status.code, cause=properties.status.cause, displayName=properties.displayName, metadata=properties.metadata"
+
+# Identify duplicate exemptions for the same policy assignment and selector set.
+az graph query -q "policyresources | where type =~ 'microsoft.authorization/policyexemptions' | extend assignment=tostring(properties.policyAssignmentId), selectors=tostring(properties.resourceSelectors) | summarize exemptions=make_set(id), count() by assignment, selectors | where count_ > 1"
+```
+
+Verify each exemption has a narrow scope, owner, approver, justification,
+expiry, linked risk ticket, and compensating-control evidence. Compare raw
+Defender recommendation state with post-exemption compliance or secure-score
+summaries so unresolved unhealthy resources are not hidden by exemptions.
+
 ---
 
 ## Section 3 -- Storage Accounts

--- a/skills/cloud/azure-review/tests/benign/narrow-owned-defender-exemptions.md
+++ b/skills/cloud/azure-review/tests/benign/narrow-owned-defender-exemptions.md
@@ -1,0 +1,90 @@
+# Benign: Narrow and Owned Defender Exemptions
+
+## Review Target
+
+```yaml
+environment:
+  tenant: contoso-prod
+  subscriptions:
+    - id: "00000000-0000-0000-0000-000000000001"
+      name: prod-shared
+
+defender_for_cloud:
+  mcsb_assigned: true
+  defender_plans_enabled:
+    servers: true
+    storage: true
+    containers: true
+  secure_score_report:
+    source: defender-portal-and-arg-export
+    includes_exempted_resources: true
+    raw_unhealthy_export_attached: true
+    post_exemption_summary_attached: true
+
+policy_exemptions:
+  - name: exempt-vendor-managed-vm-jit
+    scope: "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/prod-vendor"
+    policy_assignment_id: "/subscriptions/00000000-0000-0000-0000-000000000001/providers/Microsoft.Authorization/policyAssignments/mcsb"
+    recommendation: "Management ports of virtual machines should be protected with just-in-time network access control"
+    category: Waiver
+    expires_on: "2026-09-30"
+    owner: vendor-platform
+    approver: cloud-security
+    description: "Vendor-managed VM uses private bastion and is being migrated to JIT-capable image."
+    ticket: RISK-4821
+    compensating_control: "Private endpoint only, NSG source restricted to bastion subnet, weekly Defender review."
+    resource_selectors:
+      - kind: resourceLocation
+        in:
+          - eastus
+      - kind: resourceWithoutLocation
+        in:
+          - "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/prod-vendor/providers/Microsoft.Compute/virtualMachines/vendor01"
+    affected_resources:
+      - "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/prod-vendor/providers/Microsoft.Compute/virtualMachines/vendor01"
+    raw_status: Unhealthy
+    exempted_status: NotApplicable
+  - name: mitigated-storage-legacy-migration
+    scope: "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/legacy-storage"
+    policy_assignment_id: "/subscriptions/00000000-0000-0000-0000-000000000001/providers/Microsoft.Authorization/policyAssignments/mcsb"
+    recommendation: "Storage accounts should prevent public access"
+    category: Mitigated
+    expires_on: "2026-08-15"
+    owner: data-platform
+    approver: security-architecture
+    description: "Legacy static export account has public access disabled by policy exception after verified CDN migration."
+    ticket: SEC-6120
+    compensating_control: "Azure Policy denies new public containers; migration evidence attached."
+    resource_selectors:
+      - kind: resourceWithoutLocation
+        in:
+          - "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/legacy-storage/providers/Microsoft.Storage/storageAccounts/exportarchive"
+    affected_resources:
+      - "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/legacy-storage/providers/Microsoft.Storage/storageAccounts/exportarchive"
+    raw_status: HealthyWithEvidence
+    exempted_status: Healthy
+
+arg_exports:
+  policyresources_exported: true
+  securityresources_exempted_filter_exported: true
+  securityresources_raw_unhealthy_exported: true
+  duplicate_exemption_query:
+    duplicate_count: 0
+  review_date: "2026-06-08"
+```
+
+## Expected Review Result
+
+| Gate | Status | Evidence |
+|------|--------|----------|
+| Inventory coverage | Pass | Policy exemption and Defender assessment exports are both attached. |
+| Ownership | Pass | Each exemption has owner, approver, ticket, description, and expiry evidence. |
+| Scope | Pass | Exemptions are scoped to the affected resource group or explicit resource selectors. |
+| Expiry | Pass | Expiry dates are future-dated and tied to migration or risk review. |
+| Compensating evidence | Pass | Waiver and mitigated cases include concrete alternate controls or migration proof. |
+| Reporting separation | Pass | Raw unhealthy state and post-exemption status are reported separately. |
+| Duplicate review | Pass | Duplicate exemption query returns zero overlapping policy assignment/resource selector pairs. |
+
+## Reviewer Notes
+
+This evidence supports accepting the exemptions as governed risk decisions. Continue tracking expiry dates and revalidate Defender recommendation state after each exemption renewal or deletion.

--- a/skills/cloud/azure-review/tests/vulnerable/broad-expired-defender-exemptions.md
+++ b/skills/cloud/azure-review/tests/vulnerable/broad-expired-defender-exemptions.md
@@ -1,0 +1,94 @@
+# Vulnerable: Broad and Expired Defender Exemptions
+
+## Review Target
+
+```yaml
+environment:
+  tenant: contoso-prod
+  management_group: "/providers/Microsoft.Management/managementGroups/prod"
+  subscriptions:
+    - id: "00000000-0000-0000-0000-000000000001"
+      name: prod-shared
+
+defender_for_cloud:
+  mcsb_assigned: true
+  defender_plans_enabled:
+    servers: true
+    storage: true
+    containers: true
+  secure_score_report:
+    source: portal-summary
+    includes_exempted_resources: false
+    raw_unhealthy_export_attached: false
+
+policy_exemptions:
+  - name: exempt-management-ports-prod
+    scope: "/providers/Microsoft.Management/managementGroups/prod"
+    policy_assignment_id: "/providers/Microsoft.Management/managementGroups/prod/providers/Microsoft.Authorization/policyAssignments/mcsb"
+    recommendation: "Management ports of virtual machines should be protected with just-in-time network access control"
+    category: Waiver
+    expires_on: "2026-03-31"
+    owner: null
+    approver: null
+    description: "legacy systems"
+    ticket: null
+    compensating_control: null
+    resource_selectors: []
+    affected_resources:
+      - "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/prod-app/providers/Microsoft.Compute/virtualMachines/app01"
+      - "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/prod-db/providers/Microsoft.Compute/virtualMachines/db01"
+    raw_status: Unhealthy
+    exempted_status: NotApplicable
+  - name: exempt-storage-public-access
+    scope: "/subscriptions/00000000-0000-0000-0000-000000000001"
+    policy_assignment_id: "/subscriptions/00000000-0000-0000-0000-000000000001/providers/Microsoft.Authorization/policyAssignments/mcsb"
+    recommendation: "Storage accounts should prevent public access"
+    category: Mitigated
+    expires_on: null
+    owner: cloud-platform
+    approver: null
+    description: "covered elsewhere"
+    ticket: null
+    compensating_control: null
+    resource_selectors:
+      - kind: resourceType
+        in:
+          - "Microsoft.Storage/storageAccounts"
+    affected_resources: all-storage-accounts-in-subscription
+    raw_status: Unhealthy
+    exempted_status: NotApplicable
+  - name: duplicate-storage-public-access
+    scope: "/subscriptions/00000000-0000-0000-0000-000000000001"
+    policy_assignment_id: "/subscriptions/00000000-0000-0000-0000-000000000001/providers/Microsoft.Authorization/policyAssignments/mcsb"
+    recommendation: "Storage accounts should prevent public access"
+    category: Waiver
+    expires_on: "2026-12-31"
+    owner: application-team
+    approver: application-team
+    description: "same recommendation covered by another exemption"
+    ticket: APP-77
+    resource_selectors:
+      - kind: resourceType
+        in:
+          - "Microsoft.Storage/storageAccounts"
+
+arg_exports:
+  policyresources_exported: true
+  securityresources_exempted_filter_exported: true
+  securityresources_raw_unhealthy_exported: false
+```
+
+## Expected Findings
+
+| ID | Severity | Evidence |
+|----|----------|----------|
+| AZ-DEF-EXEMPT-01 | Medium | The management-port exemption has no owner, approver, ticket, or compensating evidence. |
+| AZ-DEF-EXEMPT-02 | High | The management-port exemption is scoped to the production management group while evidence lists only two affected VMs. |
+| AZ-DEF-EXEMPT-03 | High | The management-port exemption expired on 2026-03-31 but still reports `NotApplicable`. |
+| AZ-DEF-EXEMPT-04 | High | Internet-management-port and public-storage recommendations are exempted without compensating controls. |
+| AZ-DEF-EXEMPT-05 | Medium | The secure-score report omits raw unhealthy recommendation state. |
+| AZ-DEF-EXEMPT-06 | Medium | Two storage public-access exemptions overlap on the same policy assignment and resource selector. |
+
+## Reviewer Notes
+
+Do not mark this environment compliant from the post-exemption portal summary. Require raw Defender recommendation exports, remove or renew expired exemptions, narrow the management-group waiver, and attach owner-approved risk or compensating-control evidence before accepting the exemptions.


### PR DESCRIPTION
## Summary
- Adds Defender for Cloud / Azure Policy exemption governance to `azure-review`.
- Requires raw Defender recommendation state to be reported separately from post-exemption compliance.
- Adds Azure Resource Graph evidence queries plus duplicate exemption detection.
- Adds vulnerable and benign fixtures covering broad/expired exemptions and narrow owned exemptions.

## Issue
Fixes #1665

## Validation
- `git diff --check origin/main...HEAD`
- Markdown fence balance check
- Added-line ASCII check
- Content marker check for `AZ-DEF-EXEMPT-*` and fixture expectations
- `git merge-tree --write-tree origin/main HEAD`

## Bounty
Requested tier: Improver Moderate ($100) if accepted/merged.