### PR TITLE
Improve GCP SCC mute governance

### DIFF
--- a/skills/cloud/gcp-review/SKILL.md
+++ b/skills/cloud/gcp-review/SKILL.md
@@ -88,7 +88,34 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
-### Step 9: Compile Assessment Report
+### Step 9: Security Command Center Finding and Mute Governance
+
+When Security Command Center (SCC) exports are available, review raw active findings before relying on dashboard totals, saved views, or post-mute reports. Muting changes visibility and notification behavior; it does not prove that the underlying misconfiguration, vulnerability, or threat finding was remediated.
+
+**Evidence to collect:**
+
+- Active SCC finding export for the organization, folder, or project scope, including category, severity, state, mute state, resource name, event time, and finding class.
+- Static mute rule inventory with filter expression, owner, approver, justification, compensating control, linked ticket, and next review date.
+- Dynamic mute rule inventory with creation time, update time, automation owner, expiry or recertification cadence, and stale-rule cleanup evidence.
+- Bulk mute/audit-log history with requester, approver, affected categories/resources, change record, rollback plan, and follow-up tracking.
+- Raw active-finding counts reported separately from muted/default-dashboard counts and CIS pass/fail scoring.
+
+**What to flag:**
+
+```
+GCP-SCC-MUTE-01: SCC evidence starts from dashboard or post-mute totals instead of raw active findings
+GCP-SCC-MUTE-02: Static mute rule has a broad filter, missing owner, missing justification, or no review date
+GCP-SCC-MUTE-03: Dynamic mute rule has no expiry, recertification cadence, automation owner, or stale-rule cleanup evidence
+GCP-SCC-MUTE-04: High or Critical active muted finding lacks ticket, owner, remediation target, or accepted-risk approval
+GCP-SCC-MUTE-05: Bulk mute operation lacks change approval, affected-scope inventory, rollback plan, or follow-up tracking
+GCP-SCC-MUTE-06: Report counts muted SCC findings as remediated or CIS-passing without separate risk acceptance
+```
+
+Rate unmanaged SCC mute governance as **Medium** by default. Escalate to **High** when a mute suppresses High/Critical findings, internet exposure, public data access, privileged access, malware/threat findings, or production assets without time-bound approval and compensating evidence.
+
+---
+
+### Step 10: Compile Assessment Report
 
 
 Produce the final report using the structure defined in the Output Format section.
@@ -150,6 +177,12 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Evidence:** <specific configuration or code snippet>
 - **Remediation:** <specific fix with code example>
 
+### Security Command Center Finding and Mute Governance
+
+| Scope | Finding Category | Severity | Raw State | Mute State | Mute Rule | Owner/Approver | Review/Expiry | Decision | Required Action |
+|-------|------------------|----------|-----------|------------|-----------|----------------|---------------|----------|-----------------|
+| <org/folder/project/resource> | <category> | <severity> | <ACTIVE/INACTIVE> | <MUTED/UNMUTED> | <rule/name> | <owner/approver> | <date/none> | <remediate/risk/false-positive> | <action> |
+
 ### Prioritized Remediation Plan
 
 1. **[Critical]** CIS X.Y -- <action item>
@@ -194,6 +227,7 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Cloud SQL authorized_networks vs. private IP.** CIS 6.5 flags `0.0.0.0/0` in authorized networks, but CIS 6.6 goes further and recommends disabling public IP entirely in favor of private networking.
 5. **BigQuery dataset-level vs. table-level CMEK.** CIS 7.2 checks table-level encryption, while CIS 7.3 checks the dataset default. Both should be evaluated independently.
 6. **Default compute service account identification.** The default SA follows the pattern `PROJECT_NUMBER-compute@developer.gserviceaccount.com`. Grep for this pattern, not just the string "default."
+7. **Treating muted SCC findings as fixed.** Muted SCC findings can disappear from default views while still remaining active. Always compare raw active findings, mute-rule evidence, and remediation or risk-acceptance tracking.
 
 ---
 
@@ -219,6 +253,9 @@ Produce the final report using the structure defined in the Output Format sectio
 - Google Cloud Audit Logs: https://cloud.google.com/logging/docs/audit
 - Google Cloud VPC Documentation: https://cloud.google.com/vpc/docs
 - Google Cloud SQL Security: https://cloud.google.com/sql/docs/mysql/configure-ssl-instance
+- Security Command Center Findings: https://cloud.google.com/security-command-center/docs/how-to-api-list-findings
+- Security Command Center Mute Findings: https://cloud.google.com/security-command-center/docs/how-to-mute-findings
+- gcloud SCC Mute Configs: https://cloud.google.com/sdk/gcloud/reference/scc/muteconfigs/list
 - Terraform Google Provider Documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs
 
 ---

--- a/skills/cloud/gcp-review/benchmark-checklist.md
+++ b/skills/cloud/gcp-review/benchmark-checklist.md
@@ -293,6 +293,38 @@ resource "google_project_service" {
 }
 ```
 
+### Security Command Center Findings and Mute Rules
+
+These checks supplement CIS Section 2. Record the result separately from CIS
+pass/fail scoring because muted SCC findings can be hidden from default views
+while the underlying finding remains active.
+
+```bash
+# Export raw active findings before applying saved views, dashboard totals, or mute filters.
+gcloud scc findings list ORG_ID \
+  --location=global \
+  --filter='state="ACTIVE"' \
+  --field-mask='finding.category,finding.severity,finding.state,finding.mute,finding.event_time,finding.resource_name,finding.finding_class' \
+  --format=json
+
+# Inventory mute configurations and their filters.
+gcloud scc muteconfigs list \
+  --organization=ORG_ID \
+  --location=global \
+  --format=json
+
+# Review mute and bulk-mute activity in Cloud Audit Logs.
+gcloud logging read \
+  'protoPayload.serviceName="securitycenter.googleapis.com" AND (protoPayload.methodName:"Mute" OR protoPayload.methodName:"mute")' \
+  --freshness=90d \
+  --format=json
+```
+
+Flag raw active findings that disappear only because of mute rules, broad static
+mute filters across production projects or severity levels, dynamic mutes with
+no expiry or recertification, and bulk mute events without approval, rollback,
+or remediation tracking.
+
 ---
 
 ## Section 3 -- Networking

--- a/skills/cloud/gcp-review/tests/benign/governed-scc-mute-review.md
+++ b/skills/cloud/gcp-review/tests/benign/governed-scc-mute-review.md
@@ -1,0 +1,93 @@
+# Benign: Governed SCC Mute Review
+
+## Review Target
+
+```yaml
+environment:
+  organization: "123456789012"
+  projects:
+    - prod-payments
+    - prod-data
+
+scc_exports:
+  raw_active_findings_exported: true
+  dashboard_summary_used: true
+  muted_default_view_used: false
+  export_time: "2026-06-08T03:00:00Z"
+
+active_findings_sample:
+  - name: organizations/123456789012/sources/111/findings/test-bucket-lab
+    category: PUBLIC_BUCKET_ACL
+    severity: MEDIUM
+    state: ACTIVE
+    mute: MUTED
+    resource_name: //storage.googleapis.com/security-lab-public-fixture
+    finding_class: MISCONFIGURATION
+    owner: security-engineering
+    ticket: RISK-7112
+    remediation_target: "2026-06-30"
+    accepted_risk: "lab fixture with synthetic data only"
+  - name: organizations/123456789012/sources/111/findings/service-account-key-prod
+    category: SERVICE_ACCOUNT_KEY_NOT_ROTATED
+    severity: HIGH
+    state: ACTIVE
+    mute: UNMUTED
+    resource_name: //iam.googleapis.com/projects/prod-data/serviceAccounts/importer
+    finding_class: VULNERABILITY
+    owner: data-platform
+    ticket: SEC-8801
+    remediation_target: "2026-06-12"
+
+mute_configs:
+  - name: organizations/123456789012/muteConfigs/security-lab-fixture
+    type: STATIC
+    filter: 'resource.name="//storage.googleapis.com/security-lab-public-fixture" AND category="PUBLIC_BUCKET_ACL"'
+    owner: security-engineering
+    approver: cloud-security
+    justification: "Synthetic public bucket used by internal detector tests."
+    next_review_date: "2026-07-01"
+    compensating_control: "Org policy prevents public access outside the lab project."
+    ticket: RISK-7112
+  - name: organizations/123456789012/muteConfigs/ephemeral-scanner-findings
+    type: DYNAMIC
+    filter: 'category="VULNERABILITY_SCAN_INFO" AND resource.project_display_name="scanner-sandbox"'
+    owner: vulnerability-management
+    automation_owner: scc-mute-controller
+    expires_on: "2026-06-30"
+    recertification_days: 30
+    stale_rule_cleanup_job: "scc-mute-reaper"
+
+bulk_mute_events:
+  - event_time: "2026-06-01T12:05:00Z"
+    requester: vuln-management@example.com
+    approver: cloud-security@example.com
+    affected_categories:
+      - VULNERABILITY_SCAN_INFO
+    affected_resource_count: 12
+    change_ticket: CHG-9401
+    rollback_plan: "remove ephemeral-scanner-findings mute config if scanner labels drift"
+    follow_up_ticket: SEC-8791
+
+reporting:
+  cis_score: "88%"
+  scc_high_findings_reported: 1
+  muted_findings_count_reported: true
+  raw_active_count_reported: true
+  muted_count: 1
+  unmuted_high_count: 1
+```
+
+## Expected Review Result
+
+| Gate | Status | Evidence |
+|------|--------|----------|
+| Raw active baseline | Pass | Raw SCC active findings were exported before dashboard rollups. |
+| Static mute governance | Pass | Static rule is resource- and category-scoped with owner, approver, ticket, next review date, and compensating control. |
+| Dynamic mute governance | Pass | Dynamic rule has automation owner, expiry, 30-day recertification, and stale-rule cleanup job. |
+| Muted active tracking | Pass | Muted active finding has owner, ticket, remediation target, and accepted-risk context. |
+| Bulk mute controls | Pass | Bulk mute event has requester, approver, affected scope, change ticket, rollback plan, and follow-up ticket. |
+| Reporting separation | Pass | Raw active, muted, and unmuted high finding counts are reported separately from CIS score. |
+
+## Reviewer Notes
+
+This evidence supports accepting the SCC mute rules as governed exceptions. Keep the high unmuted service account key finding in the remediation plan and revalidate all mute rules at expiry or recertification.

--- a/skills/cloud/gcp-review/tests/vulnerable/broad-scc-mute-rules.md
+++ b/skills/cloud/gcp-review/tests/vulnerable/broad-scc-mute-rules.md
@@ -1,0 +1,90 @@
+# Vulnerable: Broad SCC Mute Rules Hide Active Findings
+
+## Review Target
+
+```yaml
+environment:
+  organization: "123456789012"
+  folders:
+    - name: prod
+      id: "456789012345"
+  projects:
+    - prod-payments
+    - prod-data
+
+scc_exports:
+  raw_active_findings_exported: false
+  dashboard_summary_used: true
+  muted_default_view_used: true
+
+active_findings_sample:
+  - name: organizations/123456789012/sources/111/findings/public-bucket-prod
+    category: PUBLIC_BUCKET_ACL
+    severity: HIGH
+    state: ACTIVE
+    mute: MUTED
+    resource_name: //storage.googleapis.com/prod-customer-exports
+    finding_class: MISCONFIGURATION
+    owner: null
+    ticket: null
+    remediation_target: null
+  - name: organizations/123456789012/sources/111/findings/open-ssh-prod
+    category: OPEN_FIREWALL
+    severity: HIGH
+    state: ACTIVE
+    mute: MUTED
+    resource_name: //compute.googleapis.com/projects/prod-payments/global/firewalls/allow-ssh
+    finding_class: THREAT
+    owner: null
+    ticket: null
+    remediation_target: null
+
+mute_configs:
+  - name: organizations/123456789012/muteConfigs/prod-noise
+    type: STATIC
+    filter: 'resource.project_display_name =~ "prod-.*"'
+    owner: null
+    approver: null
+    justification: "too noisy"
+    next_review_date: null
+    compensating_control: null
+  - name: organizations/123456789012/muteConfigs/temp-threat-noise
+    type: DYNAMIC
+    filter: 'severity="HIGH" OR severity="CRITICAL"'
+    owner: detection-team
+    automation_owner: null
+    expires_on: null
+    recertification_days: null
+
+bulk_mute_events:
+  - event_time: "2026-06-05T10:30:00Z"
+    requester: cloud-admin@example.com
+    approver: null
+    affected_categories:
+      - PUBLIC_BUCKET_ACL
+      - OPEN_FIREWALL
+    affected_resource_count: 418
+    change_ticket: null
+    rollback_plan: null
+
+reporting:
+  cis_score: "96%"
+  scc_high_findings_reported: 0
+  muted_findings_count_reported: false
+  raw_active_count_reported: false
+```
+
+## Expected Findings
+
+| ID | Severity | Evidence |
+|----|----------|----------|
+| GCP-SCC-MUTE-01 | Medium | Review evidence starts from dashboard and muted default view, not raw active findings. |
+| GCP-SCC-MUTE-02 | High | Static mute rule covers production projects with a broad regex and lacks owner, approver, review date, and compensating control. |
+| GCP-SCC-MUTE-03 | High | Dynamic rule mutes High/Critical findings without expiry, recertification, or automation owner. |
+| GCP-SCC-MUTE-04 | High | Muted public bucket and open firewall findings are active High findings with no owner, ticket, or remediation target. |
+| GCP-SCC-MUTE-05 | High | Bulk mute event affects 418 resources without approval, change ticket, or rollback plan. |
+| GCP-SCC-MUTE-06 | Medium | Report shows 0 high SCC findings and high CIS score without raw or muted finding counts. |
+
+## Reviewer Notes
+
+Do not accept the dashboard summary as proof of remediation. Require raw SCC active finding export, narrow mute filters, owner-approved risk decisions, remediation tracking, and bulk mute change evidence.


### PR DESCRIPTION
## Summary
- Adds Security Command Center active-finding and mute-rule governance to `gcp-review`.
- Requires raw active SCC findings to be reviewed separately from muted dashboards and CIS pass/fail scoring.
- Adds evidence commands for active findings, mute configs, and bulk mute audit events.
- Adds vulnerable and benign fixtures covering broad mute rules and governed mute review.

## Issue
Fixes #1667

## Validation
- `git diff --check origin/main...HEAD`
- Markdown fence balance check
- Added-line ASCII check
- Content marker check for `GCP-SCC-MUTE-*` and fixture expectations
- `git merge-tree --write-tree origin/main HEAD`

## Bounty
Requested tier: Improver Moderate ($100) if accepted/merged.