### PR TITLE
Improve RBAC role mining evidence

### DIFF
--- a/skills/identity/rbac-design/SKILL.md
+++ b/skills/identity/rbac-design/SKILL.md
@@ -305,6 +305,31 @@ RBAC-ABAC-08: Obligations (logging, notification) not enforced by PEP
 
 **Objective:** Derive optimal roles from existing access patterns and reduce role sprawl.
 
+#### Role Mining Dataset Quality Gate
+
+Before promoting mined clusters into target roles, validate that the mining dataset is fresh, complete, and normalized. Role mining should not encode stale access, emergency accounts, contractor exceptions, or inherited privilege creep into the new RBAC model.
+
+**Evidence to collect:**
+
+- Source systems, extraction date, observation window, and population denominators for users, groups, roles, permissions, and resources.
+- Coverage gaps for systems, account populations, resource types, direct assignments, cloud/IAM scopes, application RBAC, and SaaS exports.
+- Entitlement normalization proof for direct, inherited, nested-group, JIT, temporary, break-glass, and service-account assignments.
+- Account filtering or explicit separation for dormant, orphaned, contractor, test, emergency, service, and machine identities.
+- Permission-use evidence such as last-used timestamps, access logs, tickets, or documented unavailability.
+- Owner validation for candidate roles, outlier disposition, and direct-assignment remediation before role promotion.
+
+**What to flag:**
+
+```
+RBAC-MINE-07: Mining dataset lacks source coverage, extraction date, observation window, or population denominator
+RBAC-MINE-08: Direct, inherited, nested-group, JIT, temporary, or break-glass entitlements are not normalized before clustering
+RBAC-MINE-09: Dormant, orphaned, contractor, service, test, or emergency accounts are mixed into standard role mining
+RBAC-MINE-10: Permission-use or last-used evidence is absent for privileges promoted into candidate roles
+RBAC-MINE-11: Candidate role lacks business/resource-owner signoff, outlier disposition, or direct-assignment remediation evidence
+```
+
+Mark role-mining evidence **Not Evaluable** when the dataset window, entitlement expansion, filtering, or owner validation cannot be proven. Escalate to **High** when dirty mining data would preserve privileged access, SoD conflicts, production deployment rights, financial approvals, or sensitive-data access in a target role.
+
 #### Role Mining Process
 
 1. **Extract current assignments** — dump all user-permission mappings from IAM, IdP, applications
@@ -323,6 +348,11 @@ RBAC-MINE-03: Mined roles not reviewed by application/resource owners
 RBAC-MINE-04: Outlier permissions force creation of single-user roles (should use ABAC)
 RBAC-MINE-05: No periodic re-mining cadence to catch drift (recommended: annually)
 RBAC-MINE-06: Mining does not account for SoD constraints (mined roles may create conflicts)
+RBAC-MINE-07: Mining dataset lacks source coverage, extraction date, observation window, or population denominator
+RBAC-MINE-08: Direct, inherited, nested-group, JIT, temporary, or break-glass entitlements are not normalized before clustering
+RBAC-MINE-09: Dormant, orphaned, contractor, service, test, or emergency accounts are mixed into standard role mining
+RBAC-MINE-10: Permission-use or last-used evidence is absent for privileges promoted into candidate roles
+RBAC-MINE-11: Candidate role lacks business/resource-owner signoff, outlier disposition, or direct-assignment remediation evidence
 ```
 
 #### Role Rationalization Targets
@@ -392,6 +422,12 @@ RBAC-MINE-06: Mining does not account for SoD constraints (mined roles may creat
 ### Detailed Findings
 [Findings table]
 
+### Role Mining Dataset Quality
+
+| Source Systems | Extraction Date | Observation Window | Population Denominator | Coverage Gaps | Entitlement Normalization | Account Filtering | Permission-Use Evidence | Owner Validation | Outlier/Direct Assignment Disposition | Mining Confidence |
+|---|---|---|---|---|---|---|---|---|---|---|
+| [IdP/app/cloud/SaaS] | [date] | [window] | [users/groups/roles/permissions/resources] | [gaps] | [direct/inherited/nested/JIT/temp/break-glass] | [filters] | [last-used/logs/tickets/unavailable] | [owner/date/status] | [ABAC/exception/retire/role/remediate] | [High/Medium/Low/Not Evaluable] |
+
 ### Design Recommendations
 [Architecture diagram or pattern with framework justification]
 
@@ -436,6 +472,7 @@ RBAC-MINE-06: Mining does not account for SoD constraints (mined roles may creat
 5. **Ignoring permission boundaries** — roles define what you get; boundaries define maximum what you can get. Without boundaries, misconfigured roles grant unlimited access.
 6. **Role mining without business validation** — clustering users by access patterns may replicate existing privilege creep rather than correct it.
 7. **Choosing RBAC vs. ABAC as binary** — most environments need both. RBAC for structural, ABAC for contextual. Hybrid is the norm.
+8. **Trusting dirty role-mining data.** Stale users, unexpanded nested groups, emergency accounts, contractor access, and direct grants can turn privilege creep into "recommended" roles. Validate the dataset before clustering.
 
 ---
 

--- a/skills/identity/rbac-design/tests/benign/validated-role-mining-dataset.md
+++ b/skills/identity/rbac-design/tests/benign/validated-role-mining-dataset.md
@@ -1,0 +1,84 @@
+# Benign: Validated Role-Mining Dataset
+
+## Review Target
+
+```yaml
+role_mining:
+  source_systems:
+    - entra-id-groups
+    - okta-app-assignments
+    - finance-app-rbac
+    - aws-iam-identity-center
+  extraction_date: "2026-06-08"
+  observation_window:
+    start: "2026-03-01"
+    end: "2026-05-31"
+  population_denominator:
+    users: 398
+    groups: 112
+    roles: 46
+    permissions: 1834
+    resources: 271
+  coverage_gaps:
+    - "legacy expense app excluded; owner accepted separate migration review in RISK-9021"
+  entitlement_normalization:
+    direct_assignments: true
+    inherited_groups: true
+    nested_groups: true
+    jit_assignments: true
+    temporary_roles: true
+    break_glass_accounts: separated
+  account_filtering:
+    dormant_accounts_removed: true
+    orphaned_users_removed: true
+    service_accounts_separated: true
+    contractors_separated: true
+    test_users_removed: true
+    emergency_accounts_separated: true
+  permission_use_evidence:
+    last_used_available: true
+    access_logs_reviewed: true
+    ticket_history_reviewed: true
+    unavailable_reason: null
+  clustering:
+    overlap_threshold: "82%"
+    candidate_roles: 19
+    algorithm: jaccard-permission-overlap-plus-owner-review
+    rationale: "selected from elbow analysis and validated by resource owners"
+  candidate_roles:
+    - name: finance-invoice-reviewer
+      members: 31
+      permissions:
+        - invoice.read
+        - vendor.read
+        - payment.view
+      owner_signoff:
+        owner: finance-systems
+        date: "2026-06-07"
+        decision: approved
+      outlier_disposition:
+        payment.release: retired
+        vendor.create: ABAC_with_manager_approval
+      direct_assignment_remediation:
+        removed: 14
+        converted_to_role: 22
+        justified_exception: 2
+      sod_review:
+        payment_initiator_vs_approver: pass
+  confidence_claim: High
+```
+
+## Expected Review Result
+
+| Gate | Status | Evidence |
+|------|--------|----------|
+| Dataset freshness and coverage | Pass | Extraction date, 90-day window, population denominators, and one documented coverage gap are present. |
+| Entitlement normalization | Pass | Direct, inherited, nested, JIT, temporary, and break-glass assignments are expanded or separated. |
+| Account filtering | Pass | Dormant, orphaned, service, contractor, test, and emergency accounts are removed or separated. |
+| Permission-use evidence | Pass | Last-used, access-log, and ticket evidence are reviewed before role promotion. |
+| Owner validation | Pass | Finance owner approved the candidate role and SoD review passed. |
+| Outlier remediation | Pass | Excess permissions are retired, converted to ABAC, or tracked as justified exceptions. |
+
+## Reviewer Notes
+
+This dataset can support role-mining recommendations. Keep the legacy expense app gap and justified exceptions in the remediation roadmap, and schedule periodic re-mining to detect drift.

--- a/skills/identity/rbac-design/tests/vulnerable/dirty-role-mining-dataset.md
+++ b/skills/identity/rbac-design/tests/vulnerable/dirty-role-mining-dataset.md
@@ -1,0 +1,76 @@
+# Vulnerable: Dirty Role-Mining Dataset Promotes Privilege Creep
+
+## Review Target
+
+```yaml
+role_mining:
+  source_systems:
+    - idp-groups
+    - finance-app-rbac
+  extraction_date: null
+  observation_window: unknown
+  population_denominator:
+    users: 420
+    groups: null
+    roles: 38
+    permissions: 1800
+    resources: null
+  coverage_gaps:
+    - cloud-iam-direct-grants-not-exported
+    - nested-groups-not-expanded
+    - saas-admin-roles-missing
+  entitlement_normalization:
+    direct_assignments: false
+    inherited_groups: partial
+    nested_groups: false
+    jit_assignments: false
+    temporary_roles: false
+    break_glass_accounts: false
+  account_filtering:
+    dormant_accounts_removed: false
+    orphaned_users_removed: false
+    service_accounts_separated: false
+    contractors_separated: false
+    test_users_removed: false
+    emergency_accounts_separated: false
+  permission_use_evidence:
+    last_used_available: false
+    access_logs_reviewed: false
+    ticket_history_reviewed: false
+  clustering:
+    overlap_threshold: "80%"
+    candidate_roles: 38
+    algorithm: jaccard-permission-overlap
+    rationale: "default threshold"
+  candidate_roles:
+    - name: finance-power-user
+      members:
+        - alice
+        - bob
+        - contractor-temp-17
+        - breakglass-finance
+      permissions:
+        - invoice.read
+        - invoice.approve
+        - vendor.create
+        - payment.release
+      owner_signoff: missing
+      outlier_disposition: none
+      direct_assignment_remediation: none
+      sod_review: missing
+  confidence_claim: High
+```
+
+## Expected Findings
+
+| ID | Severity | Evidence |
+|----|----------|----------|
+| RBAC-MINE-07 | Medium | Dataset lacks extraction date, observation window, group/resource denominators, and full source coverage. |
+| RBAC-MINE-08 | High | Direct, nested-group, JIT, temporary, and break-glass entitlements are not normalized before clustering. |
+| RBAC-MINE-09 | High | Contractor and break-glass identities are mixed into a standard finance candidate role. |
+| RBAC-MINE-10 | Medium | Payment and vendor permissions are promoted without last-used, log, or ticket evidence. |
+| RBAC-MINE-11 | High | Finance candidate role lacks owner signoff, outlier disposition, direct-assignment remediation, and SoD review. |
+
+## Reviewer Notes
+
+Do not accept the claimed high confidence. Mark role mining as Not Evaluable until the dataset is re-extracted with dated coverage, expanded entitlements, filtered account populations, permission-use evidence, owner validation, and outlier remediation.


### PR DESCRIPTION
## Summary
- Adds a role-mining dataset quality gate to `rbac-design`.
- Requires source coverage, extraction date, observation window, entitlement normalization, account filtering, permission-use evidence, owner validation, and outlier remediation before mined roles are promoted.
- Adds vulnerable and benign fixtures for dirty versus validated role-mining datasets.

## Issue
Fixes #1699

## Validation
- `git diff --check origin/main...HEAD`
- Markdown fence balance check
- Added-line ASCII check
- Content marker check for `RBAC-MINE-*` and fixture expectations
- `git merge-tree --write-tree origin/main HEAD`

## Bounty
Requested tier: Improver Moderate ($100) if accepted/merged.