### PR TITLE
Improve access review non-human credential evidence

### DIFF
--- a/skills/identity/access-review/SKILL.md
+++ b/skills/identity/access-review/SKILL.md
@@ -12,7 +12,7 @@ phase: [operate]
 frameworks: [CIS-Controls-v8, NIST-SP-800-53-AC]
 difficulty: intermediate
 time_estimate: "45-90min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -35,6 +35,7 @@ Invoke this skill when:
 - Performing quarterly or semi-annual access certification campaigns
 - Auditing user entitlements for least privilege compliance
 - Investigating orphaned accounts (owner departed, no reassignment)
+- Reviewing API keys, PATs, OAuth grants, deploy keys, webhook secrets, bot accounts, or CI/CD tokens
 - Detecting role explosion (excessive number of roles with overlapping permissions)
 - Validating segregation of duties (SoD) controls
 - Preparing for SOC 2, ISO 27001, PCI DSS, or HIPAA audits that require evidence of access reviews
@@ -99,6 +100,7 @@ Access reviews are the operational heartbeat of identity governance. NIST SP 800
 
 Identify:
 
+- **Non-human credential sources** - API keys, PATs, OAuth grants, deploy keys, webhook secrets, CI/CD tokens, and bot credentials
 - **In-scope systems** — production environments, SaaS applications, infrastructure platforms, databases, internal tools
 - **In-scope identity types** — human users, service accounts, shared accounts, external/guest accounts
 - **Entitlement sources** — IdP group memberships, cloud IAM roles, application-level permissions, database grants
@@ -113,6 +115,7 @@ AR-SCOPE-03: Service accounts excluded from review population
 AR-SCOPE-04: SaaS applications not included in centralized review (shadow IT gap)
 AR-SCOPE-05: No single authoritative source for entitlements (CIS 6.7 — centralize access control)
 AR-SCOPE-06: Guest/external accounts not included in review scope
+AR-SCOPE-07: Non-human credentials excluded from the review population
 ```
 
 **Recommended cadences:**
@@ -122,6 +125,7 @@ AR-SCOPE-06: Guest/external accounts not included in review scope
 | Privileged / admin accounts | Quarterly (90 days) | AC-6(7), CIS 5.4 |
 | Standard user accounts | Semi-annually (180 days) | AC-2(j) |
 | Service accounts | Quarterly (90 days) | CIS 5.5 |
+| API keys / PATs / OAuth grants / deploy keys | Quarterly (90 days) | AC-2, AC-6 |
 | External / guest accounts | Quarterly (90 days) | AC-2 |
 | Break-glass / emergency accounts | Monthly (30 days) | AC-6(1) |
 
@@ -191,7 +195,64 @@ AR-ORPH-08: Test/temporary accounts promoted to production without lifecycle man
 
 ---
 
-### Step 4: Role Explosion Detection
+### Step 4: Non-Human Credential and API Access Review
+
+**Objective:** Treat non-human credentials as first-class review objects, not merely attributes of service accounts.
+
+**NIST SP 800-53 Reference:** AC-2 - Account Management; AC-6 - Least Privilege
+**CIS Controls v8 Reference:** Control 5.5 - Establish and Maintain an Inventory of Service Accounts; Control 6.1 - Establish an Access Granting Process; Control 6.2 - Establish an Access Revoking Process
+
+Human access certification is not enough when persistent credentials can authenticate automation, repositories, SaaS integrations, or third parties. Review both the account and each attached credential or grant.
+
+**Credential inventory fields:**
+
+| Field | Required Evidence |
+|---|---|
+| Credential identity | Credential ID, grant ID, key fingerprint, token name, or deploy-key ID without exposing the secret value |
+| Credential type | API key, PAT, OAuth grant, deploy key, webhook secret, CI/CD token, bot credential, or service-account key |
+| Owner and backup owner | Named accountable owner plus fallback owner, not only an unowned team alias |
+| System and business process | Application, SaaS tenant, cloud account, repository, pipeline, vendor, or automation purpose |
+| Exact scope | Resource, tenant, environment, action, IP, and time constraints where available |
+| Lifecycle evidence | Created date, last-used date, last-rotated date, expiry date, and planned retirement date |
+| Storage evidence | Approved secrets manager, KMS/HSM, protected CI variable, or documented exception |
+| Approval evidence | Access request, change ticket, app-consent record, contract/SOW, or risk acceptance for broad scopes |
+| Revocation path | Tested emergency revocation procedure and expected blast radius |
+
+**What to look for:**
+
+```
+AR-NHI-01: Credential inventory omits API keys, PATs, OAuth grants, deploy keys, webhook secrets, CI/CD tokens, or service-account keys
+AR-NHI-02: Non-human credential lacks named owner and backup owner
+AR-NHI-03: Credential scope is broader than the system, tenant, environment, or business process requires
+AR-NHI-04: Credential has no created, last-used, last-rotated, or expiry evidence
+AR-NHI-05: Unused credential remains active beyond policy threshold without documented exception
+AR-NHI-06: Human-owned PAT or deploy key powers production automation
+AR-NHI-07: Secret is stored outside approved secrets manager or copied from tickets, chat, wikis, CI logs, or local files
+AR-NHI-08: Emergency revocation path is missing, untested, or dependent on a single unavailable owner
+AR-NHI-09: Third-party OAuth/API integration remains active after project shutdown, vendor offboarding, or owner departure
+AR-NHI-10: Rotation evidence cannot be reconciled to the credential currently deployed in production
+```
+
+**Evidence quality for non-human credentials:**
+
+| Evidence Quality | Acceptable Signals | Review Decision |
+|---|---|---|
+| Reliable | Inventory covers credential type, owner, exact scope, last-used data, rotation/expiry, approved storage, and revocation runbook | Can certify if business need remains valid |
+| Weak | Owner exists but scope, storage, last-used, rotation, or revocation evidence is incomplete | Certify only with time-bound remediation |
+| Not evaluable | Secret value is known but ID, owner, system, or storage source cannot be proven | Treat as high-risk until rotated or revoked |
+
+**Severity guidance:**
+
+| Context | Severity | Rationale |
+|---|---|---|
+| Production credential with admin/write scope, no owner, no expiry, or human-owned automation | **Critical** | Immediate unauthorized change or persistence risk |
+| Broad OAuth/PAT/API credential with no rotation or storage evidence | **High** | Privilege persists outside normal lifecycle controls |
+| Stale third-party integration with unclear business owner | **Medium** | Offboarding and vendor-access risk |
+| Missing backup owner but current owner and rotation evidence exist | **Low** | Process resilience gap |
+
+---
+
+### Step 5: Role Explosion Detection
 
 **Objective:** Identify uncontrolled growth in role definitions that undermines RBAC governance.
 
@@ -222,7 +283,7 @@ AR-ROLE-08: Custom roles duplicating built-in/managed role permissions
 
 ---
 
-### Step 5: Segregation of Duties Analysis
+### Step 6: Segregation of Duties Analysis
 
 **Objective:** Detect SoD violations where a single identity holds conflicting entitlements.
 
@@ -266,7 +327,7 @@ AR-SOD-07: SoD conflicts in service accounts (single account spans multiple func
 
 ---
 
-### Step 6: Remediation Enforcement and Evidence Collection
+### Step 7: Remediation Enforcement and Evidence Collection
 
 **Objective:** Verify that review outcomes are enforced and evidence is retained for audit.
 
@@ -303,8 +364,8 @@ AR-ENF-08: No metrics or reporting on review completion rates and outcomes
 | Severity | Definition | Examples |
 |---|---|---|
 | **Critical** | Immediate unauthorized access risk or active SoD violation in financial/production systems | Terminated employee with active admin access; SoD conflict on payment systems |
-| **High** | Significant privilege excess or governance gap with exploitation potential | Orphaned service accounts with production access; no access review process exists |
-| **Medium** | Governance deficiency increasing risk over time | Rubber-stamped certifications; role explosion; reviews not on cadence |
+| **High** | Significant privilege excess or governance gap with exploitation potential | Orphaned service accounts with production access; broad unreviewed OAuth/PAT/API credentials; no access review process exists |
+| **Medium** | Governance deficiency increasing risk over time | Rubber-stamped certifications; missing non-human credential rotation evidence; role explosion; reviews not on cadence |
 | **Low** | Process improvement opportunity | Inconsistent role naming; documentation gaps; review SLA slightly exceeded |
 
 ---
@@ -333,7 +394,7 @@ AR-ENF-08: No metrics or reporting on review completion rates and outcomes
 - Systems reviewed: [list]
 - Identity provider(s): [list]
 - Review period: [start date] to [end date]
-- Population: [X human users, Y service accounts, Z total entitlements]
+- Population: [X human users, Y service accounts, Z total entitlements, N non-human credentials]
 
 ### Executive Summary
 [2-3 sentences: overall entitlement hygiene, critical gaps, top priority actions]
@@ -348,9 +409,16 @@ AR-ENF-08: No metrics or reporting on review completion rates and outcomes
 - Review Scope & Cadence (Step 1): [count]
 - Entitlement Certification (Step 2): [count]
 - Orphaned Accounts (Step 3): [count]
-- Role Explosion (Step 4): [count]
-- Segregation of Duties (Step 5): [count]
-- Enforcement & Evidence (Step 6): [count]
+- Non-Human Credentials (Step 4): [count]
+- Role Explosion (Step 5): [count]
+- Segregation of Duties (Step 6): [count]
+- Enforcement & Evidence (Step 7): [count]
+
+### Non-Human Credential Review
+
+| Identity / Credential | Type | Owner | System / Integration | Scope | Created | Last Used | Rotation / Expiry | Storage Evidence | Decision | Finding |
+|---|---|---|---|---|---|---|---|---|---|---|
+| svc-ci-deploy / ci-prod-deploy-token | CI/CD token | Platform Team | Production deploy pipeline | deploy:production | 2024-01-15 | 2026-03-01 | unknown / never expires | copied from ticket | Revoke/rotate | AR-NHI-04, AR-NHI-07 |
 
 ### Detailed Findings
 [Findings table]
@@ -397,10 +465,11 @@ See the mapping table in the Framework Quick Reference section above for sub-con
 1. **Rubber-stamp reviews** — Certifiers approve everything to clear their queue. Mitigate with approval rate monitoring and sampling audits.
 2. **Scope creep exclusion** — New SaaS apps and shadow IT systems get added without inclusion in access reviews. Require SaaS inventory integration.
 3. **Service account blind spot** — Service accounts often lack an owner and are skipped. Assign ownership at creation and include in every review cycle.
-4. **Revocation without enforcement** — Reviews produce revocation decisions but no one executes them. Automate enforcement or track with SLA-bound tickets.
-5. **Role explosion masking risk** — When roles proliferate, reviewers cannot meaningfully assess what permissions a role grants. Pair reviews with role rationalization.
-6. **SoD analysis done manually** — Manual SoD checks do not scale and miss cross-system conflicts. Implement conflict rules in IGA tooling.
-7. **Evidence not retained** — Reviews happen but evidence is not preserved for the audit window. Configure IGA tools to retain decisions and timestamps.
+4. **Credential-level blind spot** - A service account can have an owner while its PATs, OAuth grants, deploy keys, CI tokens, or webhook secrets are stale, human-owned, or stored outside approved secret management.
+5. **Revocation without enforcement** - Reviews produce revocation decisions but no one executes them. Automate enforcement or track with SLA-bound tickets.
+6. **Role explosion masking risk** - When roles proliferate, reviewers cannot meaningfully assess what permissions a role grants. Pair reviews with role rationalization.
+7. **SoD analysis done manually** - Manual SoD checks do not scale and miss cross-system conflicts. Implement conflict rules in IGA tooling.
+8. **Evidence not retained** - Reviews happen but evidence is not preserved for the audit window. Configure IGA tools to retain decisions and timestamps.
 
 ---
 
@@ -434,6 +503,7 @@ This skill processes identity and entitlement data that may contain adversarial 
 | `identity/iam-review.md` | Broader IAM security assessment covering authentication, service accounts, and zero trust alignment |
 | `identity/rbac-design.md` | Designing or refactoring roles when role explosion is detected |
 | `identity/privileged-access.md` | Deep dive on PAM controls when privileged account findings surface |
+| `devsecops/secrets-management.md` | Validate storage, rotation, and exposure controls for credential findings |
 | `identity/zero-trust-assessment.md` | When access review findings indicate need for continuous verification |
 | `compliance/soc2-gap.md` | Mapping access review findings to SOC 2 CC6.1-CC6.3 |
 
@@ -443,4 +513,5 @@ This skill processes identity and entitlement data that may contain adversarial 
 
 | Version | Date | Changes |
 |---|---|---|
+| 1.1.0 | 2026-06-08 | Added non-human credential and API access review gates covering API keys, PATs, OAuth grants, deploy keys, webhook secrets, CI/CD tokens, storage, scope, rotation, and revocation evidence. |
 | 1.0.0 | 2025-03-06 | Initial release |

--- a/skills/identity/access-review/tests/benign/governed-nonhuman-credential-review.md
+++ b/skills/identity/access-review/tests/benign/governed-nonhuman-credential-review.md
@@ -1,0 +1,113 @@
+# Benign: Governed Non-Human Credential Review
+
+## Review Target
+
+```yaml
+access_review:
+  campaign: Q2 production access certification
+  review_period: 2026-04-01 to 2026-06-30
+  identity_population:
+    human_users: 412
+    service_accounts: 37
+    nonhuman_credentials_in_population: true
+    nonhuman_credentials_reviewed: 94
+
+service_account:
+  id: svc-ci-deploy
+  owner: platform-release-owner@example.com
+  backup_owner: platform-release-backup@example.com
+  certification_decision: approved_with_evidence
+  systems:
+    - production deploy pipeline
+    - payments-api repository
+  entitlements:
+    - deploy:payments-production
+
+credentials:
+  - id: ci-prod-deploy-token-2026q2
+    type: ci_cd_token
+    owner: platform-release-owner@example.com
+    backup_owner: platform-release-backup@example.com
+    system: production deploy pipeline
+    business_process: approved release deployment
+    scope:
+      repositories:
+        - payments-api
+      environments:
+        - production
+      actions:
+        - deploy
+      ip_constraints:
+        - 203.0.113.10/32
+    created: 2026-04-01
+    last_used: 2026-06-06
+    last_rotated: 2026-04-01
+    expires: 2026-07-01
+    storage: vault://prod/platform/ci-prod-deploy-token-2026q2
+    approval_ticket: IAM-4621
+    emergency_revocation_runbook: RUNBOOK-DEPLOY-TOKEN-REVOKE
+    revocation_tested: 2026-05-12
+
+  - id: vendor-fulfillment-oauth-2026q2
+    type: oauth_grant
+    owner: vendor-access-owner@example.com
+    backup_owner: platform-release-backup@example.com
+    vendor_status: active_contract
+    contract_reference: SOW-2026-014
+    system: fulfillment integration
+    scopes:
+      - orders.read
+    tenant_constraint: tenant-prod-payments
+    created: 2026-04-04
+    last_used: 2026-06-05
+    last_rotated: 2026-04-04
+    expires: 2026-07-04
+    storage: saas_managed_secret_reference:fulfillment-prod-oauth
+    approval_ticket: IAM-4633
+    offboarding_control: vendor-access-quarterly-check
+
+  - id: payments-webhook-secret-2026q2
+    type: webhook_secret
+    owner: payments-ops-owner@example.com
+    backup_owner: platform-release-backup@example.com
+    endpoint: https://payments.example.test/webhooks/provider
+    event_types:
+      - payment.succeeded
+      - payment.failed
+    created: 2026-04-01
+    last_rotated: 2026-04-01
+    expires: 2026-07-01
+    storage: vault://prod/payments/provider-webhook-secret
+    signing_algorithm: hmac-sha256
+    emergency_revocation_runbook: RUNBOOK-WEBHOOK-SECRET-ROTATE
+    revocation_tested: 2026-05-20
+
+observed_review_evidence:
+  credential_level_rows:
+    - ci-prod-deploy-token-2026q2
+    - vendor-fulfillment-oauth-2026q2
+    - payments-webhook-secret-2026q2
+  no_human_pat_for_production_automation: true
+  stale_vendor_grants: 0
+  credentials_missing_expiry: 0
+  credentials_outside_approved_storage: 0
+  revocation_runbooks_tested: true
+```
+
+## Expected Review Result
+
+| Gate | Status | Evidence |
+|------|--------|----------|
+| Review population | Pass | Non-human credentials are included in the certification campaign. |
+| Owner and backup owner | Pass | Every credential has named primary and backup owners. |
+| Scope constraint | Pass | CI/CD token is limited to one repository, production deploy action, and approved runner IP. |
+| Lifecycle evidence | Pass | Credentials show created, last-used, last-rotated, and expiry dates. |
+| Secret storage | Pass | Secrets reference Vault or managed SaaS secret storage without exposing secret values. |
+| Approval evidence | Pass | Each credential has an IAM ticket, contract/SOW, or access approval. |
+| Revocation path | Pass | Runbooks exist and revocation tests were completed during the review period. |
+| Human-owned automation | Pass | Production automation does not depend on human PATs or deploy keys. |
+| Third-party offboarding | Pass | OAuth grant is tied to an active contract and quarterly offboarding control. |
+
+## Reviewer Notes
+
+This evidence supports certifying the non-human credential gate as controlled. Keep the quarterly review cadence, ensure expired credentials fail closed, and preserve credential-level rows without storing secret values in the report.

--- a/skills/identity/access-review/tests/vulnerable/stale-human-owned-automation-credentials.md
+++ b/skills/identity/access-review/tests/vulnerable/stale-human-owned-automation-credentials.md
@@ -1,0 +1,102 @@
+# Vulnerable: Stale Human-Owned Automation Credentials
+
+## Review Target
+
+```yaml
+access_review:
+  campaign: Q2 production access certification
+  review_period: 2026-04-01 to 2026-06-30
+  identity_population:
+    human_users: 412
+    service_accounts: 37
+    nonhuman_credentials_in_population: false
+
+service_account:
+  id: svc-ci-deploy
+  owner: Platform Team
+  backup_owner: null
+  certification_decision: approved
+  systems:
+    - production deploy pipeline
+    - payments-api repository
+  entitlements:
+    - deploy:production
+    - repo:write
+
+credentials:
+  - id: ci-prod-deploy-token
+    type: personal_access_token
+    human_owner: alice@example.com
+    owner_status: departed_contractor
+    system: production deploy pipeline
+    scope:
+      repo: "*"
+      environment: "*"
+      actions:
+        - repo:write
+        - workflow:admin
+        - deploy:production
+    created: 2024-01-15
+    last_used: 2026-05-29
+    last_rotated: unknown
+    expires: never
+    storage: CI variable copied from old incident ticket
+    approved_secret_manager_reference: null
+    approval_ticket: null
+    emergency_revocation_runbook: missing
+
+  - id: vendor-fulfillment-oauth
+    type: oauth_grant
+    owner: former_project_owner@example.com
+    owner_status: transferred_to_other_team
+    vendor_status: offboarded
+    project_status: shut_down
+    scopes:
+      - orders.read
+      - orders.write
+      - customers.read
+    tenant_constraint: none
+    created: 2023-08-02
+    last_used: 2025-11-18
+    last_rotated: never
+    expires: never
+    storage: SaaS native secret field, not inventoried
+    approval_ticket: closed-without-revocation
+
+  - id: payments-webhook-secret
+    type: webhook_secret
+    owner: Payments Ops
+    backup_owner: null
+    endpoint: https://payments.example.test/webhooks/provider
+    created: 2023-03-10
+    last_rotated: never
+    expires: never
+    storage: wiki page visible to engineering group
+    signing_algorithm: hmac-sha256
+    emergency_revocation_runbook: owner-dependent
+
+observed_review_evidence:
+  certifier_notes: "Service account has Platform Team owner; approved."
+  credential_level_rows: []
+  secret_storage_export: not_requested
+  rotation_evidence_export: not_requested
+  last_used_export: not_requested
+```
+
+## Expected Findings
+
+| ID | Severity | Evidence |
+|----|----------|----------|
+| AR-SCOPE-07 | High | API keys, PATs, OAuth grants, webhook secrets, and CI/CD tokens were excluded from the review population. |
+| AR-NHI-01 | High | Credential inventory is empty even though production automation uses PAT, OAuth, and webhook credentials. |
+| AR-NHI-02 | Medium | `svc-ci-deploy`, `ci-prod-deploy-token`, and `payments-webhook-secret` lack named backup owners. |
+| AR-NHI-03 | Critical | `ci-prod-deploy-token` has wildcard repository and environment scope with workflow admin and production deploy rights. |
+| AR-NHI-04 | Critical | Production credentials have unknown or never rotation evidence and no expiry. |
+| AR-NHI-06 | Critical | Production automation depends on a departed contractor's personal access token. |
+| AR-NHI-07 | High | Secrets are copied from an incident ticket or stored on a wiki instead of an approved secrets manager. |
+| AR-NHI-08 | High | Emergency revocation is missing or dependent on a single owner. |
+| AR-NHI-09 | Medium | Offboarded vendor OAuth grant remains active after project shutdown. |
+
+## Reviewer Notes
+
+Do not mark the service account as clean because a team owner approved it. Require credential-level review rows, rotation or revocation of the human-owned PAT, OAuth grant cleanup, migration to approved secret storage, and a tested emergency revocation path before certification.


### PR DESCRIPTION
Closes #1688.

## Summary
- add a non-human credential and API access review gate to `access-review`
- require credential-level owner, backup owner, scope, lifecycle, storage, approval, and emergency revocation evidence
- add vulnerable and benign fixtures for stale human-owned automation credentials versus governed credential review

## Validation
- `git diff --check origin/main...HEAD`
- Markdown fence balance check
- added-line ASCII check
- content marker check for `AR-NHI-*` findings and fixtures
- `git merge-tree --write-tree origin/main HEAD`

## Bounty
Requested tier: Improver Moderate, USD 100 if accepted.