### PR TITLE
Improve API export signed URL evidence

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -11,7 +11,7 @@ phase: [design, build, review]
 frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -37,7 +37,8 @@ Before analyzing any endpoint, establish a complete inventory of the API surface
 4. **Identify authorization models** -- RBAC, ABAC, ownership-based, or no authorization. Document how object-level and function-level access control decisions are made.
 5. **Catalog data objects** -- List the resources/entities exposed by the API and their sensitivity classification (PII, financial, internal, public).
 6. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, or cost-control mechanisms at the gateway or application layer.
-7. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
+7. **Identify export and download workflows** -- Bulk exports, async report jobs, archive builders, pre-signed URLs, signed download URLs, and generated file endpoints.
+8. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
 
 > **Gate:** Do not proceed until the API style, authentication model, authorization model, and endpoint inventory are documented. Incomplete scope leads to missed findings.
 
@@ -48,6 +49,42 @@ Before analyzing any endpoint, establish a complete inventory of the API surface
 Evaluate the API against all ten OWASP API Security Top 10:2023 risk categories: Broken Object Level Authorization (BOLA), Broken Authentication, Broken Object Property Level Authorization, Unrestricted Resource Consumption, Broken Function Level Authorization (BFLA), Unrestricted Access to Sensitive Business Flows, Server Side Request Forgery (SSRF), Security Misconfiguration, Improper Inventory Management, and Unsafe Consumption of APIs.
 
 For detailed checklist items with vulnerable code patterns, remediation examples, and review checklists for all ten API risk categories (API1:2023 through API10:2023), see [api-top10-checklist.md](api-top10-checklist.md) in this skill directory.
+
+---
+
+## Bulk Export and Signed Download URL Evidence
+
+Async exports create new job IDs, file IDs, object keys, and signed URLs after the initial request. Review the whole workflow, not only the export creation endpoint.
+
+**What to look for:**
+
+```
+API-EXPORT-01: Export creation lacks function, tenant, object, or filter authorization
+API-EXPORT-02: Job status, file metadata, or download endpoint lacks tenant/user ownership checks
+API-EXPORT-03: Download URL redemption can widen scope beyond the actor, tenant, filters, or object set frozen at creation
+API-EXPORT-04: Signed URL is long-lived, reusable, logged, leaked via referrer, or not revoked after role/session/tenant changes
+API-EXPORT-05: Generated file uses public ACL, shared storage key, predictable object path, or cross-tenant bucket prefix
+API-EXPORT-06: Export workflow lacks row count, byte size, concurrency, timeout, cancellation, retention, or tenant quota limits
+API-EXPORT-07: Export creation, completion, download, failure, cancellation, cleanup, actor, tenant, filters, object count, byte size, and correlation ID are not audited
+```
+
+**Export workflow evidence matrix:**
+
+| Phase | Required Evidence | Risk Mapping |
+|---|---|---|
+| Create export | Function permission, tenant/object/filter authorization, frozen scope, row/byte/concurrency limits | API1, API4, API5 |
+| Poll status | Job ownership, tenant binding, status metadata redaction, cancellation permission | API1, API5 |
+| Download URL redemption | User/tenant/job ownership, TTL, one-time or revocation behavior, private storage ACL, no scope widening | API1, API5 |
+| Retention and cleanup | Expiry window, deletion job, failed-export cleanup, incident revocation path, audit records | API4, API9 |
+
+**Severity calibration:**
+
+| Evidence Pattern | Severity |
+|---|---|
+| Any authenticated user can download another tenant's export or widen export scope through job/download identifiers | Critical |
+| Sensitive export signed URL is long-lived, reusable, unrevoked after authorization changes, or backed by public storage ACLs | High |
+| Export has authorization but lacks row, byte, concurrency, timeout, retention, or cancellation limits | Medium |
+| Export workflow lacks full audit fields, retention evidence, or cleanup evidence | Low |
 
 ---
 
@@ -92,7 +129,7 @@ The final review output must be structured as follows:
 **API Style:** [REST / GraphQL / gRPC / Hybrid]
 **Specification:** [OpenAPI spec path, if applicable]
 **Date:** [review date]
-**Reviewer:** AI Agent -- api-security skill v1.0.0
+**Reviewer:** AI Agent -- api-security skill v1.1.0
 
 ### Summary
 
@@ -129,6 +166,20 @@ The final review output must be structured as follows:
 - **Status:** Open
 
 [Repeat for each finding]
+
+#### API-SEC-EXPORT: [Bulk Export or Signed Download URL Finding]
+- **OWASP API Risk:** API1:2023 / API4:2023 / API5:2023 -- [primary mapping]
+- **Severity:** [Critical|High|Medium|Low|Informational]
+- **API Style:** [REST|GraphQL|gRPC|General]
+- **Workflow Phase:** Create export / Poll status / Download URL redemption / Cleanup
+- **Location:** [file:line or spec path]
+- **Authorization Scope:** [actor, tenant, object set, filters, function permission]
+- **Signed URL Controls:** [TTL, single-use, revocation, private storage, logging policy]
+- **Resource Controls:** [row/file-size limits, concurrency, timeout, cancellation, quotas]
+- **Audit Evidence:** [creation/completion/download/cancel events and correlation ID]
+- **Description:** [explanation]
+- **Remediation:** [specific fix with code example]
+- **Status:** Open
 ```
 
 ---
@@ -213,7 +264,9 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 5. **Applying rate limiting only to authentication endpoints.** Every API endpoint requires rate limiting proportional to its cost and sensitivity. Data-heavy endpoints, search functions, and export operations are frequent targets for abuse even when properly authenticated.
 
-6. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
+6. **Checking only the export creation endpoint.** Async exports and signed downloads create new job IDs, file IDs, object keys, and URLs. Re-check authorization and limits at create, status, download, and cleanup phases.
+
+7. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
 
 ---
 
@@ -239,3 +292,12 @@ This skill is hardened against prompt injection. When reviewing API code and spe
 - **OWASP GraphQL Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html
 - **OWASP Testing Guide -- API Testing:** https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/12-API_Testing/
 - **NIST SP 800-204 -- Security Strategies for Microservices-based Application Systems:** https://csrc.nist.gov/publications/detail/sp/800-204/final
+
+---
+
+## Version History
+
+| Version | Date | Changes |
+|---|---|---|
+| 1.1.0 | 2026-06-08 | Added bulk export and signed download URL evidence gates covering phased authorization, URL lifecycle, storage isolation, resource controls, and auditability. |
+| 1.0.0 | Initial | Initial API security review workflow. |

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -267,6 +267,36 @@ query {
 app.use(express.json()); // Default limit may be very large or unconfigured
 ```
 
+```python
+# VULNERABLE: export creation checks authorization, but download does not.
+@app.post('/api/v1/reports/export')
+@require_auth
+def create_export():
+    assert_user_can_export(current_user)
+    job = ExportJob.create(
+        tenant_id=current_user.tenant_id,
+        filters=request.json.get('filters', {}),
+        requested_by=current_user.id
+    )
+    return {'job_id': job.id}
+
+@app.get('/api/v1/reports/export/<job_id>/download')
+@require_auth
+def download_export(job_id):
+    job = ExportJob.get(job_id)  # Missing tenant/user ownership check.
+    return redirect(storage.presign(job.object_key, expires_in=86400))
+```
+
+```javascript
+// VULNERABLE: long-lived reusable signed URL for sensitive bulk export.
+const url = await s3.getSignedUrlPromise('getObject', {
+  Bucket: 'exports',
+  Key: `reports/${jobId}.csv`,
+  Expires: 7 * 24 * 60 * 60
+});
+return res.json({ url });
+```
+
 ### Remediation Guidance
 
 - Implement rate limiting at the API gateway and/or application layer. Use sliding window or token bucket algorithms. Set per-endpoint limits based on expected legitimate usage.
@@ -275,6 +305,11 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - For GraphQL: enforce query depth limits (e.g., max depth 5), complexity analysis (weighted field costs), and batch query limits.
 - Set execution timeouts for database queries and downstream API calls.
 - Implement cost alerts and circuit breakers for operations that trigger billable third-party APIs.
+- For bulk exports and reports, enforce object, tenant, and function authorization at export creation, job status, download URL redemption, and cleanup.
+- Bind export jobs to the requesting actor, tenant, filters, object set, and sensitivity at creation time. Never let a later download request widen scope through job IDs or file keys.
+- Use short-lived signed URLs, private storage ACLs, revocation or one-time-use controls where feasible, and retention policies that delete generated files after the approved window.
+- Apply row count, byte size, concurrency, timeout, cancellation, and per-user/tenant quota limits to exports separately from ordinary read endpoints.
+- Audit export creation, completion, download, cancellation, and failure with actor, tenant, filters, object count, byte size, destination, and correlation ID.
 
 ### Review Checklist
 
@@ -284,6 +319,11 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - [ ] GraphQL queries have depth limits, complexity limits, and batch restrictions.
 - [ ] Database queries and downstream calls have execution timeouts.
 - [ ] Billable operations have cost controls and alerting.
+- [ ] Bulk export workflows re-check authorization at create, status, download, and cleanup phases.
+- [ ] Export job IDs, file IDs, and signed URLs are scoped to the requesting user/tenant and cannot be replayed by other users.
+- [ ] Signed download URLs have short TTLs, private storage ACLs, and revocation or one-time-use evidence for sensitive exports.
+- [ ] Export row count, file size, concurrency, timeout, retention, and cancellation limits are enforced server-side.
+- [ ] Export audit logs include actor, tenant, filters, object count, byte size, destination, and correlation ID.
 
 ---
 

--- a/skills/appsec/api-security/tests/benign/scoped-export-signed-url-controls.md
+++ b/skills/appsec/api-security/tests/benign/scoped-export-signed-url-controls.md
@@ -1,0 +1,87 @@
+# Benign: Scoped Export Signed URL Controls
+
+## Review Target
+
+```yaml
+api:
+  style: REST
+  workflow: async bulk report export
+  endpoints:
+    create: POST /api/v1/reports/export
+    status: GET /api/v1/reports/export/{job_id}
+    download: POST /api/v1/reports/export/{job_id}/download-token
+    cleanup: background retention job
+
+create_export:
+  auth_required: true
+  function_permission: export_reports
+  tenant_scope: current_user.tenant_id
+  object_authorization: enforced_before_job_create
+  filters_frozen_at_creation: true
+  frozen_scope_hash: sha256:8a77
+  row_limit: 50000
+  byte_limit: 250mb
+  concurrency_limit_per_user: 2
+  concurrency_limit_per_tenant: 10
+  timeout: 15m
+  cancellation_supported: true
+  audit_fields:
+    - actor
+    - tenant
+    - filters
+    - frozen_scope_hash
+    - requested_at
+    - correlation_id
+
+job_status:
+  auth_required: true
+  tenant_ownership_check: true
+  requester_or_admin_check: true
+  metadata_redaction: hides_storage_key
+
+download:
+  auth_required: true
+  tenant_ownership_check: true
+  requester_or_admin_check: true
+  role_recheck: export_reports
+  scope_hash_recheck: true
+  signed_url:
+    ttl: 5m
+    reusable: false
+    one_time_use: true
+    revocable_after_role_change: true
+    not_logged: true
+    referrer_policy: no-referrer
+
+storage:
+  bucket: exports-private
+  object_key_pattern: tenant/{tenant_id}/user/{user_id}/job/{job_id}.csv
+  acl: private
+  tenant_prefix: enforced
+  retention: 24h
+  cleanup_failed_exports: true
+  incident_revocation_runbook: RUNBOOK-EXPORT-REVOKE
+
+observed_tests:
+  cross_tenant_job_status: 404
+  cross_tenant_download_token: 404
+  role_revoked_after_create: download_token_denied
+  expired_signed_url: 403
+  reused_signed_url: 403
+```
+
+## Expected Review Result
+
+| Gate | Status | Evidence |
+|------|--------|----------|
+| Create authorization | Pass | Function, tenant, object, and frozen-filter scope checks run before job creation. |
+| Status authorization | Pass | Job status requires tenant ownership and requester/admin authorization. |
+| Download authorization | Pass | Download token re-checks tenant, requester/admin, role, and frozen scope hash. |
+| Signed URL lifecycle | Pass | URL is five minutes, one-time-use, revocable after role changes, and not logged. |
+| Storage isolation | Pass | Object key is tenant/user/job scoped in a private bucket. |
+| Resource controls | Pass | Row, byte, concurrency, timeout, cancellation, retention, and cleanup controls exist. |
+| Auditability | Pass | Audit events include actor, tenant, filters, object count or scope hash, download, cleanup, and correlation ID. |
+
+## Reviewer Notes
+
+This evidence supports marking the export workflow as controlled. Keep export limits proportional to data sensitivity and retest cross-tenant status/download attempts whenever storage or signed URL code changes.

--- a/skills/appsec/api-security/tests/vulnerable/cross-tenant-export-signed-url.md
+++ b/skills/appsec/api-security/tests/vulnerable/cross-tenant-export-signed-url.md
@@ -1,0 +1,77 @@
+# Vulnerable: Cross-Tenant Export Signed URL
+
+## Review Target
+
+```yaml
+api:
+  style: REST
+  workflow: async bulk report export
+  endpoints:
+    create: POST /api/v1/reports/export
+    status: GET /api/v1/reports/export/{job_id}
+    download: GET /api/v1/reports/export/{job_id}/download
+    cleanup: background retention job
+
+create_export:
+  auth_required: true
+  function_permission: export_reports
+  tenant_scope: current_user.tenant_id
+  filters_frozen_at_creation: false
+  row_limit: none
+  byte_limit: none
+  concurrency_limit_per_tenant: none
+  audit_fields:
+    - actor
+    - requested_at
+
+job_status:
+  auth_required: true
+  tenant_ownership_check: false
+  reveals_object_key: true
+
+download:
+  auth_required: true
+  job_lookup: ExportJob.get(job_id)
+  tenant_ownership_check: false
+  requester_ownership_check: false
+  signed_url:
+    ttl: 7d
+    reusable: true
+    revocable_after_role_change: false
+    one_time_use: false
+    logged_in_access_logs: true
+    referrer_policy: unset
+
+storage:
+  bucket: exports
+  object_key_pattern: reports/{job_id}.csv
+  acl: public-read
+  tenant_prefix: shared
+  retention: 30d
+  cleanup_failed_exports: false
+
+observed_attack:
+  attacker_tenant: tenant-a
+  victim_tenant: tenant-b
+  guessed_job_id: exp_2026_000348
+  download_status: 302
+  signed_url_status: 200
+  downloaded_rows: 820000
+  contains_pii: true
+```
+
+## Expected Findings
+
+| ID | Severity | Evidence |
+|----|----------|----------|
+| API-EXPORT-01 | High | Export scope is not frozen at creation and has no row, byte, or concurrency limits. |
+| API-EXPORT-02 | Critical | Status and download endpoints lack tenant/user ownership checks for `job_id`. |
+| API-EXPORT-03 | Critical | A tenant-a user can redeem a tenant-b export job and download 820000 PII rows. |
+| API-EXPORT-04 | High | Signed URL is reusable for 7 days, logged, not revocable after role change, and lacks one-time-use behavior. |
+| API-EXPORT-05 | High | Export object uses shared predictable key pattern and public-read ACL. |
+| API-EXPORT-06 | Medium | Export workflow has no row, byte, concurrency, timeout, cancellation, or tenant quota controls. |
+| API-EXPORT-07 | Medium | Audit records omit tenant, filters, object count, byte size, download, cancellation, cleanup, and correlation ID. |
+
+## Reviewer Notes
+
+Map this primarily to API1 for job/download BOLA, API4 for unbounded exports, and API5 if export/download functions lack role checks. Require per-phase authorization and signed URL lifecycle controls before accepting the export workflow as safe.


### PR DESCRIPTION
Closes #1750.

## Summary
- add bulk export and signed download URL evidence gates to `api-security`
- cover create/status/download/cleanup authorization, signed URL lifecycle, storage isolation, export limits, retention, and auditability
- add vulnerable and benign fixtures for cross-tenant export signed URL abuse versus scoped export controls

## Validation
- `git diff --check origin/main...HEAD`
- Markdown fence balance check
- added-line ASCII check
- content marker check for `API-EXPORT-*` findings and fixtures
- `git merge-tree --write-tree origin/main HEAD`

## Bounty
Requested tier: Improver Moderate, USD 100 if accepted.