### PR TITLE
fix(#1915): add temporal role expiry and stale-attribute evidence gates for rbac-design

### DIFF
--- a/skills/identity/rbac-design/SKILL.md
+++ b/skills/identity/rbac-design/SKILL.md
@@ -12,7 +12,7 @@ phase: [design]
 frameworks: [NIST-RBAC, NIST-SP-800-162]
 difficulty: intermediate
 time_estimate: "45-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -426,6 +426,45 @@ RBAC-MINE-06: Mining does not account for SoD constraints (mined roles may creat
 | **Auditability** | All policy evaluations logged with input attributes and decision rationale |
 
 ---
+
+
+## Temporal Role Expiry and Stale-Attribute Gates
+
+### Gate 1: Role Expiry Enforcement
+
+Verify the system enforces temporary role expiration:
+
+```
+# Evidence items (at least 2 required)
+- Role assignment includes explicit expiry timestamp
+- System rejects or revokes access after expiry
+- Expired role triggers notification to role owner and approver
+- Re-activation requires fresh approval workflow
+```
+
+### Gate 2: Stale-Attribute Reconciliation
+
+Check for role bindings tied to inactive or outdated attributes:
+
+```
+# Evidence items (at least 2 required)
+- Role membership checked against active directory/HRIS status
+- Orphaned role bindings from terminated users detected
+- Group membership changes cascade to role assignments
+- Stale roles older than 90 days flagged for review
+```
+
+### Gate 3: Temporal Re-Approval Cadence
+
+Verify roles exceeding policy-defined duration require re-approval:
+
+```
+# Evidence items (at least 2 required)
+- Maximum role duration defined in policy (e.g., 90 days)
+- Roles approaching expiry trigger re-approval workflow
+- Re-approval requires manager + security sign-off
+- Expired roles logged for audit trail
+```
 
 ## Common Pitfalls
 

--- a/skills/identity/rbac-design/tests/benign/benign-temporal-reviewer-role.md
+++ b/skills/identity/rbac-design/tests/benign/benign-temporal-reviewer-role.md
@@ -1,0 +1,30 @@
+---
+name: benign-temporal-reviewer-role
+expected: pass
+---
+
+# Benign temporal role assignment
+
+## Role configuration
+
+```
+role=quarter-end-finance-reviewer
+assigned_until=2026-07-05
+approver=finance-controller
+reapproval_required=true
+attribute_source=HRIS
+project=fin-close-2026
+```
+
+## Evidence
+
+| Field | Value |
+|---|---|
+| Expiry timestamp | Explicit (2026-07-05) |
+| Enforced by system | Yes — API checks assigned_until before granting access |
+| Re-approval workflow | Quarterly recertification with manager approval |
+| Attribute source | HRIS — auto-revoked on termination |
+
+## Expected review result
+
+Pass the role expiry gates. The role has a defined scope, explicit expiry, enforcement mechanism, and re-approval cadence.

--- a/skills/identity/rbac-design/tests/vulnerable/vulnerable-stale-role-without-expiry.md
+++ b/skills/identity/rbac-design/tests/vulnerable/vulnerable-stale-role-without-expiry.md
@@ -1,0 +1,29 @@
+---
+name: vulnerable-stale-role-without-expiry
+expected: fail
+---
+
+# Vulnerable stale role assignment
+
+## Role configuration
+
+```
+role=legacy-db-admin
+assigned_until=none
+attribute_source=manual_group
+last_reviewed=2024-03-15
+user_status=terminated_2025-01-20
+```
+
+## Evidence
+
+| Field | Value |
+|---|---|
+| Expiry timestamp | None — permanent grant |
+| User status | Terminated (15+ months ago) |
+| Attribute source | Manual group — no HRIS sync |
+| Last reviewed | 2024-03-15 (27+ months ago) |
+
+## Expected review result
+
+Fail the review. The role has no expiry, was assigned to a terminated user, uses manual attribute source without HRIS reconciliation, and has not been reviewed in over 2 years.


### PR DESCRIPTION
Adds temporal role expiry enforcement, stale-attribute reconciliation, and temporal re-approval evidence gates for RBAC design review.

Closes #1915