### PR TITLE
fix(#1913): add schema-drift and data-model version evidence gates for siem-rules

### DIFF
--- a/skills/secops/siem-rules/SKILL.md
+++ b/skills/secops/siem-rules/SKILL.md
@@ -12,7 +12,7 @@ phase: [operate]
 frameworks: [MITRE-ATT&CK-v16]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -658,3 +658,41 @@ This skill processes user-supplied content that may include SIEM query drafts, l
 8. **MITRE ATT&CK Data Sources** -- https://attack.mitre.org/datasources/
 9. **Sentinel Entity Mapping** -- https://learn.microsoft.com/en-us/azure/sentinel/map-data-fields-to-entities
 10. **Splunk CIM (Common Information Model)** -- https://docs.splunk.com/Documentation/CIM/latest/User/Overview
+
+## Schema Drift and Data-Model Version Gates
+
+### Gate 1: Data-Model Version Alignment
+
+Verify the rule's expected field names match the current platform data model:
+
+```
+# Evidence items (at least 2 required)
+- Rule specifies target data-model version in metadata
+- Field names referenced in rule exist in current data model
+- Field type and format match the data-model definition
+- Deprecated field aliases mapped to current field names
+```
+
+### Gate 2: Schema-Drift Detection
+
+Check whether a rule still resolves correctly after a data-model update:
+
+```
+# Evidence items (at least 2 required)
+- Rule tested against current data-model version
+- Previous data-model mappings documented for regression
+- Schema change log reviewed for affected field paths
+- Rule has automated schema-compatibility test
+```
+
+### Gate 3: Fixture Coverage Verification
+
+Confirm unit test fixtures exercise mapped field paths end-to-end:
+
+```
+# Evidence items (at least 2 required)
+- Sample events include all mapped field paths
+- Fixtures cover both populated and null field states
+- Test output verifies field resolution through mapping layer
+- Negative test cases for missing or malformed fields
+```

--- a/skills/secops/siem-rules/tests/benign/benign-sigma-rule-with-mapped-field.md
+++ b/skills/secops/siem-rules/tests/benign/benign-sigma-rule-with-mapped-field.md
@@ -1,0 +1,29 @@
+---
+name: benign-sigma-rule-with-mapped-field
+expected: pass
+---
+
+# Benign SIEM rule with platform data-model mapping
+
+## Rule configuration
+
+```
+Sigma field: CommandLine
+Platform field: DeviceProcessEvents.ProcessCommandLine
+mapping_version: 2026-06
+last_sample_count: 18422
+unit_test_fixture: pass
+```
+
+## Evidence
+
+| Field | Value |
+|---|---|
+| Data-model version | 2026-06 (current) |
+| Field mapping verified | Yes — CommandLine maps to DeviceProcessEvents.ProcessCommandLine |
+| Schema compatibility test | Pass — all 18,422 samples resolve |
+| Negative test | Pass — null CommandLine returns expected no-match |
+
+## Expected review result
+
+Pass the schema-drift gates. The rule correctly references a mapped field, specifies the data-model version, and has verified fixture coverage.

--- a/skills/secops/siem-rules/tests/vulnerable/vulnerable-sigma-rule-stale-mapping.md
+++ b/skills/secops/siem-rules/tests/vulnerable/vulnerable-sigma-rule-stale-mapping.md
@@ -1,0 +1,29 @@
+---
+name: vulnerable-sigma-rule-stale-mapping
+expected: fail
+---
+
+# Vulnerable SIEM rule with stale data-model mapping
+
+## Rule configuration
+
+```
+Sigma field: EventID
+Platform field: WindowsEventLog.EventID
+mapping_version: 2024-03
+last_sample_count: 0
+unit_test_fixture: none
+```
+
+## Evidence
+
+| Field | Value |
+|---|---|
+| Data-model version | 2024-03 (stale — current is 2026-06) |
+| Field mapping | EventID deprecated in v2025-12, replaced by EventIdentifier |
+| Schema compatibility test | None — no test since migration |
+| Fixture coverage | None — no sample events |
+
+## Expected review result
+
+Fail the review. The rule references a deprecated field through a stale mapping version, has no fixture coverage, and would silently fail to match events under the current data model.


### PR DESCRIPTION
Adds data-model version alignment, schema-drift detection, and fixture coverage verification evidence gates for SIEM rule review.

Closes #1913