### PR TITLE
fix(#1912): add dangling-record and takeover evidence gates for dns-security

### DIFF
--- a/skills/network/dns-security/SKILL.md
+++ b/skills/network/dns-security/SKILL.md
@@ -13,7 +13,7 @@ phase: [operate]
 frameworks: [NIST-SP-800-81-Rev2, CIS-Controls-v8]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -373,6 +373,45 @@ abcdef0123456789.dnscat.example.com TXT
 | 3.12 | Segment Data Processing and Storage Based on Sensitivity | DNS resolver isolation per zone |
 
 ---
+
+
+## Dangling-Record and Takeover Evidence Gates
+
+### Gate 1: Vendor Reservation Verification
+
+Confirm the external provider still actively reserves the domain:
+
+```
+# Evidence items (at least 2 required)
+- External provider account shows active reservation
+- Provider API or status page confirms domain association
+- Support ticket or contract reference for domain reservation
+- Reservation expiry date documented and tracked
+```
+
+### Gate 2: Unclaimable Target Profile
+
+Document which endpoints and HTTP statuses are definitively unclaimable:
+
+```
+# Evidence items (at least 2 required)
+- Known unclaimable HTTP statuses documented (e.g., provider-specific 404 vs generic)
+- Provider documentation confirms domain cannot be claimed by third parties
+- Historical record: domain pointed to same provider >12 months without incident
+- Automatic verification: provider responds with definitive unclaimable marker
+```
+
+### Gate 3: Verification Freshness
+
+Assert the last dangling-record check is within policy-defined recency:
+
+```
+# Evidence items (at least 2 required)
+- Last DNS verification timestamp logged
+- Verification interval within policy limit (e.g., <7 days for external CNAMEs)
+- Automated re-verification scheduled on a recurring basis
+- Verification failure triggers alert for manual review
+```
 
 ## Common Pitfalls
 

--- a/skills/network/dns-security/tests/benign/benign-cname-with-vendor-reservation.md
+++ b/skills/network/dns-security/tests/benign/benign-cname-with-vendor-reservation.md
@@ -1,0 +1,28 @@
+---
+name: benign-cname-with-vendor-reservation
+expected: pass
+---
+
+# Benign CNAME record with confirmed vendor reservation
+
+## DNS record
+
+```
+CNAME docs.example.com -> vendor.example-host.com
+vendor_reservation: active
+http_status: 404 (custom domain not claimable)
+last_verified: 2026-06-08
+```
+
+## Evidence
+
+| Field | Value |
+|---|---|
+| Vendor reservation | Active — account confirms domain binding |
+| Claimable status | Not claimable — provider returns unclaimable 404 |
+| Verification freshness | 0 days — verified today |
+| Reservation history | Same provider since 2024 |
+
+## Expected review result
+
+Pass the dangling-record gates. The vendor reservation is active, the target is documented as unclaimable, and the verification is recent.

--- a/skills/network/dns-security/tests/vulnerable/vulnerable-dangling-cname-with-stale-check.md
+++ b/skills/network/dns-security/tests/vulnerable/vulnerable-dangling-cname-with-stale-check.md
@@ -1,0 +1,28 @@
+---
+name: vulnerable-dangling-cname-with-stale-check
+expected: fail
+---
+
+# Vulnerable dangling CNAME record with stale verification
+
+## DNS record
+
+```
+CNAME app.example.com -> old-cdn.example-cdn.com
+vendor_reservation: unknown
+http_status: 200 (generic landing page)
+last_verified: 2025-01-15
+```
+
+## Evidence
+
+| Field | Value |
+|---|---|
+| Vendor reservation | Unknown — no active account found for example-cdn.com |
+| Claimable status | Claimable — generic 200 response, domain registration expired |
+| Verification freshness | 18+ months — far exceeds typical policy limit |
+| Reservation history | CDN contract ended 2024-12 |
+
+## Expected review result
+
+Fail the review. The CNAME points to a domain whose registration has expired, the target returns a generic response, and no verification has been performed in over 18 months.


### PR DESCRIPTION
Adds vendor-reservation verification, unclaimable-target profiling, and verification freshness evidence gates for DNS security review.

Closes #1912