### PR TITLE
Improve container policy exception evidence

### DIFF
--- a/skills/cloud/container-security/SKILL.md
+++ b/skills/cloud/container-security/SKILL.md
@@ -13,7 +13,7 @@ phase: [build, deploy, operate]
 frameworks: [CIS-Docker-v1.6.0, CIS-Kubernetes-v1.9.0, NIST-SP-800-190]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -115,6 +115,35 @@ For detailed CIS benchmark checklist items, NIST SP 800-190 countermeasure table
 
 ---
 
+### Step 6b: Policy Exception Evidence Gate
+
+Pod Security Admission, OPA/Gatekeeper, Kyverno, admission webhooks, and Helm security defaults only prove control coverage when exceptions are narrow, owned, expiring, and monitored. Broad namespace exemptions, policy exclude blocks, non-expiring Helm overrides, or webhook bypass annotations can nullify the control while making the cluster look governed.
+
+For every exception, record:
+
+- **Exception mechanism:** namespace label, policy exclude block, webhook bypass, constraint exemption, Helm value override, annotation, admission controller flag, or CI/CD waiver.
+- **Exact scope:** namespace, workload, service account, image, chart, capability, host namespace, hostPath, hostPort, seccomp/AppArmor profile, RBAC verb, or registry path covered by the exception.
+- **Owner and approval:** named business/system owner, security approver, ticket, change request, or risk acceptance record.
+- **Expiration or review date:** expiry date, next review date, and automated reminder or enforcement behavior. Treat no-expiry exceptions as persistent risk.
+- **Compensating controls:** NetworkPolicy, runtime detection, read-only root filesystem, restricted RBAC, image signing, admission audit mode, monitoring, or other controls that reduce the exception risk.
+- **Enforcement evidence:** proof that non-exempt resources are still blocked or audited, and that exception matches are logged.
+
+**What to look for:**
+
+```
+CTR-EXCEPTION-01: Broad namespace or cluster-wide exception disables Pod Security, Gatekeeper, Kyverno, or admission webhook enforcement
+CTR-EXCEPTION-02: Exception lacks named owner, security approval, ticket, or risk acceptance record
+CTR-EXCEPTION-03: Exception has no expiration, review date, automated reminder, or removal plan
+CTR-EXCEPTION-04: Exception scope covers privileged, hostNetwork, hostPID, hostPath, hostPort, added capabilities, root user, or wildcard image patterns beyond the stated workload need
+CTR-EXCEPTION-05: Compensating controls are missing or do not address the exempted risk
+CTR-EXCEPTION-06: Policy engine does not prove non-exempt resources are still blocked or audited
+CTR-EXCEPTION-07: Exception hits are not logged, monitored, or reviewed for drift
+```
+
+Do not mark a policy domain as passing solely because a policy engine exists. Report broad, ownerless, unapproved, non-expiring, or unmonitored exceptions as findings.
+
+---
+
 ### Step 7: Compile Assessment Report
 
 
@@ -184,6 +213,12 @@ Produce the final report using the structure defined in the Output Format sectio
 |----------|-----------|-----------|------------|
 | deploy/app | production | Baseline (not Restricted) | runAsRoot, no seccomp |
 | deploy/worker | production | Privileged | privileged: true |
+
+### Policy Exception Evidence
+
+| Policy Engine / Control | Exception Mechanism | Scope | Owner / Approval | Expiration | Compensating Controls | Enforcement Evidence | Risk |
+|---|---|---|---|---|---|---|---|
+| [PSA/Gatekeeper/Kyverno/webhook] | [label/exclude/annotation/override] | [namespace/workload/image/SA] | [owner/ticket] | [date/none] | [controls] | [audit/block evidence] | [Low/Medium/High] |
 
 ### Prioritized Remediation Plan
 
@@ -257,6 +292,7 @@ Produce the final report using the structure defined in the Output Format sectio
 5. **`readOnlyRootFilesystem` breaks many applications.** When recommending this control, also recommend adding writable `emptyDir` volume mounts for directories the application needs to write to (e.g., `/tmp`, `/var/cache`).
 6. **Network policies are additive, not subtractive.** A default-deny policy must be explicitly created. Without it, all pod-to-pod traffic is allowed regardless of other NetworkPolicy resources.
 7. **Distroless images have no shell.** While this is excellent for security, note that debugging requires ephemeral containers (`kubectl debug`). Flag this as a consideration, not a problem.
+8. **Policy engines can be neutralized by exceptions.** Pod Security Admission, Gatekeeper, Kyverno, and custom webhooks only help when exceptions are narrow, owned, expiring, and monitored. Treat broad namespace exemptions or permanent exclude rules as findings, not as evidence of control coverage.
 
 ---
 
@@ -293,4 +329,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.1.0** -- Added policy exception evidence gates for Pod Security Admission, Gatekeeper, Kyverno, admission webhooks, Helm overrides, exception ownership, expiry, compensating controls, and enforcement evidence.
 - **1.0.0** -- Initial release. Full coverage of CIS Docker Benchmark v1.6.0 Section 4-5, CIS Kubernetes Benchmark v1.9.0 Sections 1-5, and NIST SP 800-190 countermeasures across all five risk categories.

--- a/skills/cloud/container-security/tests/benign/narrow-owned-policy-exception.md
+++ b/skills/cloud/container-security/tests/benign/narrow-owned-policy-exception.md
@@ -1,0 +1,109 @@
+# Benign: Narrow Owned Policy Exception
+
+## Review Target
+
+```yaml
+cluster:
+  admission_controls:
+    pod_security_admission: enabled
+    gatekeeper: enabled
+    kyverno: enabled
+  claimed_result: policy_enforced_with_exception_governance
+
+namespaces:
+  - name: payments-prod
+    labels:
+      pod-security.kubernetes.io/enforce: restricted
+      pod-security.kubernetes.io/audit: restricted
+      pod-security.kubernetes.io/warn: restricted
+
+gatekeeper:
+  constraints:
+    - name: disallow-hostpath
+      enforcementAction: deny
+      excludedNamespaces: []
+    - name: allow-debug-hostpath-temporary
+      enforcementAction: dryrun
+      match:
+        namespaces:
+          - payments-prod
+        kinds:
+          - apiGroups: [""]
+            kinds: ["Pod"]
+      parameters:
+        allowedWorkloads:
+          - payment-debug
+        allowedHostPaths:
+          - /var/log/payments
+      owner: platform-runtime-owner@example.com
+      approval_ticket: SEC-4421
+      security_approver: container-security-lead@example.com
+      expires: 2026-06-30
+
+kyverno:
+  policies:
+    - name: restrict-host-network
+      validationFailureAction: Enforce
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - payments-prod
+              names:
+                - payment-debug
+              annotations:
+                security.unitone.ai/exception-id: SEC-4421
+
+workloads:
+  - namespace: payments-prod
+    name: payment-debug
+    serviceAccount: payment-debug-sa
+    securityContext:
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      seccompProfile: RuntimeDefault
+    podSpec:
+      hostNetwork: false
+      hostPID: false
+      volumes:
+        - name: payment-logs
+          hostPath:
+            path: /var/log/payments
+            type: Directory
+    exception:
+      mechanism: named Kyverno exception + Gatekeeper dryrun constraint
+      scope: workload payment-debug hostPath /var/log/payments only
+      owner: platform-runtime-owner@example.com
+      approval: SEC-4421
+      expires: 2026-06-30
+      compensating_controls:
+        - dedicated service account with no cluster-admin
+        - namespace default-deny NetworkPolicy
+        - runtime detection rule ctr-hostpath-payments
+        - readOnlyRootFilesystem
+      review_reminder: jira-automation-2026-06-23
+
+enforcement_tests:
+  non_exempt_namespace_privileged_pod_blocked: true
+  non_exempt_hostpath_root_blocked: true
+  exception_workload_allowed_with_audit: true
+  exception_hits_logged: true
+  last_reviewed: 2026-06-01
+```
+
+## Expected Review Result
+
+| Gate | Status | Evidence |
+|------|--------|----------|
+| Exception mechanism | Pass | Exception is named and tied to a specific Kyverno/Gatekeeper control. |
+| Exact scope | Pass | Scope is one workload and one hostPath, not a namespace-wide privileged bypass. |
+| Owner and approval | Pass | Named owner, security approver, and ticket `SEC-4421` are present. |
+| Expiration | Pass | Exception expires on 2026-06-30 with reminder automation. |
+| Compensating controls | Pass | Dedicated SA, default-deny NetworkPolicy, runtime detection, and read-only root filesystem reduce risk. |
+| Enforcement evidence | Pass | Non-exempt privileged and root hostPath pods are blocked; exception hit is audited. |
+| Monitoring | Pass | Exception hits are logged and reviewed. |
+
+## Reviewer Notes
+
+This exception can be treated as governed and time-bound. Continue to report it as residual risk if it is renewed without fresh approval or if the hostPath scope expands.

--- a/skills/cloud/container-security/tests/vulnerable/broad-policy-exception.md
+++ b/skills/cloud/container-security/tests/vulnerable/broad-policy-exception.md
@@ -1,0 +1,92 @@
+# Vulnerable: Broad Policy Exception
+
+## Review Target
+
+```yaml
+cluster:
+  admission_controls:
+    pod_security_admission: enabled
+    gatekeeper: enabled
+    kyverno: enabled
+  claimed_result: policy_enforced
+
+namespaces:
+  - name: payments-prod
+    labels:
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: restricted
+      pod-security.kubernetes.io/warn: restricted
+    owner: unknown
+    approval_ticket: null
+    exception_expires: never
+
+gatekeeper:
+  constraints:
+    - name: disallow-hostpath
+      enforcementAction: deny
+      excludedNamespaces:
+        - payments-prod
+        - platform-*
+    - name: require-nonroot
+      enforcementAction: deny
+      excludedNamespaces:
+        - payments-prod
+  audit:
+    last_run: 2026-06-01T04:00:00Z
+    exception_hits_logged: false
+
+kyverno:
+  policies:
+    - name: restrict-host-network
+      validationFailureAction: Enforce
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - payments-prod
+              annotations:
+                security.unitone.ai/exception: "*"
+
+workloads:
+  - namespace: payments-prod
+    name: payment-debug
+    serviceAccount: default
+    securityContext:
+      runAsUser: 0
+      privileged: true
+      allowPrivilegeEscalation: true
+    podSpec:
+      hostNetwork: true
+      hostPID: true
+      volumes:
+        - name: host
+          hostPath:
+            path: /
+    exception:
+      mechanism: namespace PSA privileged + Gatekeeper exclude + Kyverno wildcard annotation
+      owner: null
+      approval: null
+      expires: never
+      compensating_controls: []
+
+enforcement_tests:
+  non_exempt_namespace_privileged_pod_blocked: unknown
+  exempt_namespace_privileged_pod_logged: false
+  exception_review_report: missing
+```
+
+## Expected Findings
+
+| ID | Severity | Evidence |
+|----|----------|----------|
+| CTR-EXCEPTION-01 | High | `payments-prod` is broadly exempt through privileged PSA labels, Gatekeeper namespace excludes, and Kyverno wildcard annotation matching. |
+| CTR-EXCEPTION-02 | Medium | Exception lacks named owner, security approval, ticket, or risk acceptance. |
+| CTR-EXCEPTION-03 | Medium | Exception never expires and has no review or removal plan. |
+| CTR-EXCEPTION-04 | High | Exception permits privileged, root, hostNetwork, hostPID, and hostPath `/` beyond a narrow workload need. |
+| CTR-EXCEPTION-05 | High | No compensating NetworkPolicy, runtime detection, read-only root filesystem, RBAC restriction, or monitoring is documented. |
+| CTR-EXCEPTION-06 | Medium | No evidence proves non-exempt privileged pods are still blocked or audited. |
+| CTR-EXCEPTION-07 | Medium | Exception hits are not logged, monitored, or reviewed for drift. |
+
+## Reviewer Notes
+
+Do not mark Pod Security, Gatekeeper, or Kyverno as passing because they are installed. The effective control is bypassed for a production namespace and should be reported until the exception is narrowed, owned, expiring, compensated, and monitored.


### PR DESCRIPTION
Closes #1794.

## Summary
- add policy exception evidence gates to `container-security`
- cover PSA, Gatekeeper, Kyverno, webhook, Helm override, owner, approval, expiry, compensating control, and enforcement evidence
- add vulnerable and benign fixtures for broad namespace/policy exceptions versus narrow owned exceptions

## Validation
- `git diff --check origin/main...HEAD`
- Markdown fence balance check
- added-line ASCII check
- content marker check for `CTR-EXCEPTION-*` findings and fixtures
- `git merge-tree --write-tree origin/main HEAD`

## Bounty
Requested tier: Improver Moderate, USD 100 if accepted.