### PR TITLE
fix(#1906): add policy-decision trace and stale posture evidence gates for zero-trust-assessment

### DIFF
--- a/skills/identity/zero-trust-assessment/SKILL.md
+++ b/skills/identity/zero-trust-assessment/SKILL.md
@@ -12,7 +12,7 @@ phase: [design, operate]
 frameworks: [NIST-SP-800-207, CISA-ZTMM-v2]
 difficulty: advanced
 time_estimate: "90-180min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -432,6 +432,45 @@ ZT-GOV-05: Regulatory zero trust mandates not tracked (OMB M-22-09 for federal)
 | **Optimal** | Adaptive, risk-based, continuous | Real-time posture assessment | Identity-aware microseg | Per-request authorization | Persistent protection |
 
 ---
+
+
+## Policy-Decision Trace and Stale Posture Gates
+
+### Gate 1: Policy-Decision Traceability
+
+Verify each ZTNA access decision has an audit trail back to the policy that granted it:
+
+```
+# Evidence items (at least 2 required)
+- Each access decision recorded with a unique policy decision ID
+- Audit log maps decision ID to specific policy version
+- Policy engine logs show which rules were evaluated for each decision
+- Decision ID is immutable and time-stamped
+```
+
+### Gate 2: Posture Freshness Gate
+
+Assert device posture checks are within policy-defined recency:
+
+```
+# Evidence items (at least 2 required)
+- Device last posture check timestamp recorded
+- Posture check recency within policy limit (e.g., <24h for high-risk apps)
+- Stale posture triggers step-up authentication or block
+- Posture check frequency adjusts based on risk level
+```
+
+### Gate 3: Subject-Device-Resource Binding
+
+Confirm the policy enforces all three dimensions:
+
+```
+# Evidence items (at least 2 required)
+- Policy binds specific subject identity to access
+- Policy requires verified device identity or attestation
+- Policy scopes access to specific resource or resource class
+- Binding is enforced at PEP, not just documented in policy
+```
 
 ## Common Pitfalls
 

--- a/skills/identity/zero-trust-assessment/tests/benign/benign-ztna-policy-with-traceable-decision.md
+++ b/skills/identity/zero-trust-assessment/tests/benign/benign-ztna-policy-with-traceable-decision.md
@@ -1,0 +1,31 @@
+---
+name: benign-ztna-policy-with-traceable-decision
+expected: pass
+---
+
+# Benign ZTNA policy with traceable decisions and fresh posture
+
+## Access decision
+
+```
+ZTNA allow finance-app
+subject=user:alice
+device=compliant
+device_posture_checked_at=2026-06-08T08:57Z
+policy_decision_id=pdp-44af
+resource=finance-app/invoices
+```
+
+## Evidence
+
+| Field | Value |
+|---|---|
+| Policy decision trace | Yes — pdp-44af maps to policy version 2.3.1 |
+| Posture freshness | 15 minutes ago — within 24h policy limit |
+| Subject binding | user:alice — specific identity |
+| Device binding | compliant device attestation |
+| Resource binding | finance-app/invoices — scoped resource path |
+
+## Expected review result
+
+Pass the policy-decision trace gates. The decision is traceable, posture is fresh, and all three binding dimensions are enforced.

--- a/skills/identity/zero-trust-assessment/tests/vulnerable/vulnerable-ztna-decision-without-trace.md
+++ b/skills/identity/zero-trust-assessment/tests/vulnerable/vulnerable-ztna-decision-without-trace.md
@@ -1,0 +1,31 @@
+---
+name: vulnerable-ztna-decision-without-trace
+expected: fail
+---
+
+# Vulnerable ZTNA access with missing policy trace and stale posture
+
+## Access decision
+
+```
+ZTNA allow admin-panel
+subject=any authenticated
+device=not checked
+device_posture_checked_at=2026-03-01T00:00Z
+policy_decision_id=none
+resource=admin-panel
+```
+
+## Evidence
+
+| Field | Value |
+|---|---|
+| Policy decision trace | None — no decision ID recorded |
+| Posture freshness | 3+ months stale — far exceeds typical 24h policy |
+| Subject binding | "any authenticated" — no specific identity scope |
+| Device binding | Not checked — any device accepted |
+| Resource binding | admin-panel — broad scope, no sub-resource restriction |
+
+## Expected review result
+
+Fail the review. No policy decision tracing, stale device posture (3+ months), no device verification, and overly broad subject/resource binding create critical ZT gaps.


### PR DESCRIPTION
Adds policy-decision traceability, posture freshness, and subject-device-resource binding evidence gates for ZTA assessment.

Closes #1906