### PR TITLE
fix(#1907): add legal-hold and evidence handoff gates for ir-playbook

### DIFF
--- a/skills/incident-response/ir-playbook/SKILL.md
+++ b/skills/incident-response/ir-playbook/SKILL.md
@@ -13,7 +13,7 @@ phase: [respond, recover]
 frameworks: [NIST-SP-800-61r2, SANS-IH]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.1"
+version: "1.0.2"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -497,3 +497,41 @@ This skill processes incident data that may include attacker-controlled content 
 11. **CISA Destructive Malware Guidance** -- https://www.cisa.gov/topics/cyber-threats-and-advisories
 12. **H-ISAC (Health Information Sharing and Analysis Center)** -- https://h-isac.org/
 13. **KrebsOnSecurity: Iran-backed wiper attack on Stryker medtech (2026)** -- https://krebsonsystems.com/2026/03/iran-backed-hackers-claim-wiper-attack-on-medtech-firm-stryker/
+
+## Legal-Hold and Evidence Handoff Gates
+
+### Gate 1: Legal-Hold Authorization
+
+Confirm legal hold was issued by authorized entity before evidence collection:
+
+```
+# Evidence items (at least 2 required)
+- Legal hold ticket references authorized requester (legal/compliance)
+- Hold issued before or simultaneously with first evidence collection
+- Hold scope matches the incident scope
+- Authorization timestamp precedes evidence acquisition timestamp
+```
+
+### Gate 2: Chain-of-Custody Hash Chain
+
+Verify cryptographic signatures link each custodian transfer:
+
+```
+# Evidence items (at least 2 required)
+- Each evidence transfer includes hash of previous custody record
+- Custodian signatures captured at each handoff
+- Hash chain verifiable from collection through final disposition
+- Any break in chain documented with incident report
+```
+
+### Gate 3: Recipient Acknowledgment
+
+Confirm external recipients have cryptographically signed for evidence receipt:
+
+```
+# Evidence items (at least 2 required)
+- Recipient digitally signed evidence receipt
+- Receipt includes timestamp, recipient identity, and hash of evidence
+- Delivery method logged (encrypted channel, courier receipt)
+- Unacknowledged deliveries trigger escalation
+```

--- a/skills/incident-response/ir-playbook/tests/benign/benign-legal-hold-with-custody-chain.md
+++ b/skills/incident-response/ir-playbook/tests/benign/benign-legal-hold-with-custody-chain.md
@@ -1,0 +1,28 @@
+---
+name: benign-legal-hold-with-custody-chain
+expected: pass
+---
+
+# Benign incident response with proper legal hold and custody chain
+
+## Incident evidence
+
+```
+containment_action: isolate host after memory capture
+legal_hold_ticket: LH-2026-184
+evidence_package: disk.img.sha256 + chain_of_custody.pdf
+external_ir_transfer: encrypted archive with recipient receipt
+```
+
+## Evidence
+
+| Field | Value |
+|---|---|
+| Legal hold authorization | LH-2026-184 — issued by legal@company.com at 2026-06-08T09:00Z |
+| Hold vs collection timing | Hold issued before evidence collection (09:00 vs 09:15) |
+| Custody hash chain | disk.img.sha256 → custodian sig → encrypted transfer → recipient sig |
+| Recipient acknowledgment | Signed receipt from external IR provider at 2026-06-08T11:30Z |
+
+## Expected review result
+
+Pass the legal-hold gates. Proper authorization, chain-of-custody, and recipient acknowledgment are all documented.

--- a/skills/incident-response/ir-playbook/tests/vulnerable/vulnerable-evidence-transfer-without-custody.md
+++ b/skills/incident-response/ir-playbook/tests/vulnerable/vulnerable-evidence-transfer-without-custody.md
@@ -1,0 +1,28 @@
+---
+name: vulnerable-evidence-transfer-without-custody
+expected: fail
+---
+
+# Vulnerable evidence transfer missing custody chain and authorization
+
+## Incident evidence
+
+```
+containment_action: quarantine server
+legal_hold_ticket: none
+evidence_package: disk_image.dd (no hash)
+external_ir_transfer: email attachment
+```
+
+## Evidence
+
+| Field | Value |
+|---|---|
+| Legal hold authorization | None — no hold ticket referenced |
+| Hold vs collection timing | No hold — evidence collected without legal authorization |
+| Custody hash chain | None — no hash, no signatures, no chain |
+| Recipient acknowledgment | None — emailed as attachment without receipt tracking |
+
+## Expected review result
+
+Fail the review. No legal hold authorization, no evidence hash or custody chain, and email-based transfer without recipient tracking create significant evidentiary risk.


### PR DESCRIPTION
Adds legal-hold authorization verification, chain-of-custody hash chain, and recipient acknowledgment evidence gates for incident response.

Closes #1907