### PR TITLE
Improve PAM break-glass drill evidence

### DIFF
--- a/skills/identity/privileged-access/SKILL.md
+++ b/skills/identity/privileged-access/SKILL.md
@@ -12,7 +12,7 @@ phase: [operate]
 frameworks: [CIS-Controls-v8, NIST-SP-800-53-AC-6]
 difficulty: intermediate
 time_estimate: "45-90min"
-version: "1.0.0"
+version: "1.1.0"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -259,6 +259,34 @@ PAM-BG-10: Break-glass procedure not included in disaster recovery plans
 | **Scoped permissions** | Break-glass accounts limited to recovery actions, not full admin | AC-6 |
 | **Time-bounded** | Break-glass sessions auto-terminate after defined maximum duration | AC-2(2) |
 
+#### Break-Glass Drill Evidence Gate
+
+Do not mark break-glass procedures as tested unless the review can cite recent drill or real-use evidence. A written runbook is not enough; reviewers need evidence that credentials work, access is detected, sessions terminate, and credentials are rotated or re-sealed after use.
+
+For each critical platform, collect:
+
+- **Drill date and scenario:** date of the most recent test, failure scenario tested, and whether it covered PAM outage, IdP outage, cloud-provider outage, or emergency operational recovery.
+- **Authorized participants and custody:** named roles involved in request, approval, custody release, session execution, monitoring, and post-use review. Confirm split custody or dual control where required.
+- **Access path validated:** account, vault object, sealed envelope, HSM-backed secret, emergency role, root account, alternate IdP path, or recovery workstation used during the drill.
+- **Scope, duration, and termination:** privileges granted, systems reached, maximum session duration, and evidence that access terminated or was revoked after the drill.
+- **Alerting, logging, and recording:** timestamped alert, SIEM event, PAM audit event, session recording, immutable log, or management notification proving break-glass use was detected and retained.
+- **Recovery objective:** whether the drill restored required administrative capability within the documented recovery time objective.
+- **Post-use rotation or re-sealing:** evidence that passwords, keys, recovery codes, or emergency role credentials were rotated, disabled, or re-sealed after use.
+- **Post-drill review:** issues found, owner, remediation due date, and whether prior drill findings were closed.
+
+**What to look for:**
+
+```
+PAM-BG-11: Break-glass runbook exists but no recent drill or real-use evidence is available
+PAM-BG-12: Drill did not validate custody, dual control, or authorized participant roles
+PAM-BG-13: Drill did not prove the emergency access path worked for the target platform
+PAM-BG-14: Break-glass access scope, duration, termination, or revocation evidence is missing
+PAM-BG-15: Break-glass use did not generate alerting, logging, session recording, or immutable audit evidence
+PAM-BG-16: Recovery objective was not measured or failed without tracked remediation
+PAM-BG-17: Credentials were not rotated, disabled, or re-sealed after drill or real use
+PAM-BG-18: Post-drill issues lack owner, due date, or closure evidence
+```
+
 ---
 
 ### Step 5: Session Recording and Monitoring
@@ -409,6 +437,12 @@ PAM-VAULT-12: No secrets scanning in code repositories to detect credential leak
 ### Detailed Findings
 [Findings table]
 
+### Break-Glass Drill Evidence
+
+| Platform | Last Drill Date | Scenario Tested | Participants / Custody | Access Path | Alert / Log Evidence | Session Terminated | Post-Use Rotation | Follow-Up Owner |
+|---|---|---|---|---|---|---|---|---|
+| [AWS/Azure/GCP/AD/etc.] | [YYYY-MM-DD or Not Tested] | [PAM outage / IdP outage / provider outage / recovery] | [roles] | [account/role/vault object] | [event ID/link/summary] | [Yes/No] | [Yes/No/N/A] | [owner/date] |
+
 ### Remediation Roadmap
 - Immediate (0-7 days): [critical findings — credential exposure, uncontrolled root access]
 - Short-term (8-30 days): [high findings — JIT deployment, session recording gaps]
@@ -457,6 +491,7 @@ PAM-VAULT-12: No secrets scanning in code repositories to detect credential leak
 6. **Session recording without review** — recording sessions without monitoring or alerting provides forensic value but not prevention. Add real-time alerting.
 7. **Ignoring service account privilege** — PAM programs often focus on human admin accounts and neglect service accounts with equally powerful permissions.
 8. **No PAM HA/DR** — if the PAM tool is a single point of failure, its outage creates either a lockout or a break-glass event. Architect for resilience.
+9. **Accepting procedure documents as drill evidence** - a written emergency access runbook does not prove credentials work, alerts fire, logs are retained, access terminates, or post-use rotation occurs. Require timestamped drill evidence.
 
 ---
 
@@ -502,4 +537,5 @@ that may contain adversarial content.
 
 | Version | Date | Changes |
 |---|---|---|
+| 1.1.0 | 2026-06-08 | Added break-glass drill evidence gates for scenario, custody, access path, duration, alerting, recovery objective, post-use rotation, and remediation evidence. |
 | 1.0.0 | 2025-03-06 | Initial release |

--- a/skills/identity/privileged-access/tests/benign/validated-break-glass-drill.md
+++ b/skills/identity/privileged-access/tests/benign/validated-break-glass-drill.md
@@ -1,0 +1,91 @@
+# Benign: Validated Break Glass Drill
+
+## Review Target
+
+```yaml
+pam_program:
+  tool: CyberArk + AWS IAM Identity Center
+  platforms:
+    - AWS production
+    - Active Directory
+  break_glass_policy:
+    runbook: PAM-RUNBOOK-BG-001
+    required_test_cadence: quarterly
+    split_custody_required: true
+    post_use_rotation_required: true
+
+break_glass_drill_evidence:
+  platform: AWS production
+  last_drill_date: 2026-05-15
+  scenario_tested: PAM outage + IdP outage during production incident
+  participants:
+    requester: incident-commander@example.com
+    approver: security-director@example.com
+    custody_release:
+      - vault-admin-a@example.com
+      - vault-admin-b@example.com
+    session_operator: cloud-platform-lead@example.com
+    monitoring_owner: soc-lead@example.com
+    post_use_reviewer: pam-control-owner@example.com
+  custody:
+    sealed_envelope_id: BG-AWS-ROOT
+    dual_control_verified: true
+    release_log: PAM-BG-2026-05-15-release
+  access_path:
+    emergency_account: aws-break-glass-admin
+    vault_object: cyberark://safe/aws-prod/break-glass-admin
+    validation_result: success
+    systems_reached:
+      - AWS Organizations
+      - IAM Identity Center emergency permission set
+  scope_duration_termination:
+    privileges_granted:
+      - IAM Identity Center administrator recovery
+      - CloudTrail validation read
+    max_duration: 60m
+    actual_start: 2026-05-15T09:10:00Z
+    actual_end: 2026-05-15T09:42:00Z
+    session_terminated_evidence: PAM-BG-2026-05-15-session-end
+    role_disabled_after_drill: true
+  alerting_logging_recording:
+    siem_event: SIEM-884201
+    pam_audit_event: CYBR-AUDIT-77201
+    cloudtrail_event: CT-2026-05-15-BG
+    session_recording: REC-PAM-884201
+    management_notification: SEC-NOTIFY-2026-05-15
+  recovery_objective:
+    rto: 30m
+    measured_result: 22m
+    status: met
+  post_use:
+    password_rotated: true
+    mfa_seed_resealed: true
+    recovery_codes_resealed: true
+    rotation_ticket: PAM-ROTATE-9912
+  post_drill_review:
+    review_document: PIR-PAM-BG-2026-05-15
+    issues_found:
+      - alert notification group missing deputy CISO
+    remediation_owner: soc-lead@example.com
+    due_date: 2026-05-30
+    closed_at: 2026-05-28
+
+claimed_result: break_glass_tested_with_evidence
+```
+
+## Expected Review Result
+
+| Gate | Status | Evidence |
+|------|--------|----------|
+| Drill date and scenario | Pass | Drill occurred 2026-05-15 and covered PAM plus IdP outage. |
+| Participants and custody | Pass | Request, approval, dual custody, operator, monitoring, and reviewer roles are named. |
+| Access path | Pass | CyberArk vault object and AWS break-glass admin path were validated successfully. |
+| Scope and termination | Pass | Privileges, start/end times, session termination, and role disable evidence are present. |
+| Alerting and logging | Pass | SIEM, PAM audit, CloudTrail, session recording, and management notification IDs are listed. |
+| Recovery objective | Pass | Recovery capability was restored in 22 minutes against a 30-minute RTO. |
+| Post-use rotation | Pass | Password, MFA seed, and recovery codes were rotated or re-sealed with ticket evidence. |
+| Post-drill review | Pass | Issue owner, due date, and closure evidence are documented. |
+
+## Reviewer Notes
+
+This evidence supports marking the AWS production break-glass drill as tested for the review period. Continue to test other critical platforms on the required cadence and verify prior drill findings stay closed.

--- a/skills/identity/privileged-access/tests/vulnerable/runbook-only-break-glass.md
+++ b/skills/identity/privileged-access/tests/vulnerable/runbook-only-break-glass.md
@@ -1,0 +1,78 @@
+# Vulnerable: Runbook-Only Break Glass
+
+## Review Target
+
+```yaml
+pam_program:
+  tool: CyberArk
+  platforms:
+    - AWS production
+    - Active Directory
+  break_glass_policy:
+    runbook: PAM-RUNBOOK-BG-001
+    required_test_cadence: quarterly
+    split_custody_required: true
+    post_use_rotation_required: true
+
+break_glass_drill_evidence:
+  platform: AWS production
+  last_drill_date: null
+  last_real_use: 2024-11-02
+  scenario_tested: null
+  participants:
+    requester: null
+    approver: null
+    custody_release: null
+    session_operator: null
+    monitoring_owner: null
+    post_use_reviewer: null
+  custody:
+    sealed_envelope_id: BG-AWS-ROOT
+    dual_control_verified: false
+    release_log: missing
+  access_path:
+    emergency_account: aws-root
+    vault_object: root-account-password
+    validation_result: not_tested
+  scope_duration_termination:
+    max_duration: 4h
+    actual_start: null
+    actual_end: null
+    session_terminated_evidence: missing
+  alerting_logging_recording:
+    siem_event: missing
+    pam_audit_event: missing
+    session_recording: missing
+    management_notification: missing
+  recovery_objective:
+    rto: 30m
+    measured_result: not_measured
+  post_use:
+    password_rotated: false
+    mfa_seed_resealed: false
+    recovery_codes_resealed: false
+  post_drill_review:
+    review_document: missing
+    issues_found: unknown
+    remediation_owner: null
+    due_date: null
+
+claimed_result: break_glass_tested
+```
+
+## Expected Findings
+
+| ID | Severity | Evidence |
+|----|----------|----------|
+| PAM-BG-11 | High | Break-glass runbook exists, but no recent drill or real-use evidence is available for AWS production. |
+| PAM-BG-12 | High | No participant, release log, or dual-control evidence proves authorized custody. |
+| PAM-BG-13 | High | Emergency root account and vault object were not validated during the review period. |
+| PAM-BG-14 | High | Scope, actual duration, and termination evidence are missing. |
+| PAM-BG-15 | High | No SIEM event, PAM audit event, session recording, or management notification proves detection. |
+| PAM-BG-16 | Medium | Recovery objective was not measured. |
+| PAM-BG-17 | High | Credentials and recovery material were not rotated or re-sealed after last real use. |
+| PAM-BG-18 | Medium | No post-drill review, issue owner, due date, or closure evidence exists. |
+
+## Reviewer Notes
+
+Do not accept the written runbook as drill evidence. Require a timestamped drill package or real-use package that proves custody, access, detection, termination, recovery objective, and post-use rotation.


### PR DESCRIPTION
Closes #1787.

## Summary
- add break-glass drill evidence gates to `privileged-access`
- require scenario, custody, access path, scope/duration/termination, alerting/logging/session evidence, recovery objective, post-use rotation, and post-drill review evidence
- add vulnerable and benign fixtures for runbook-only break glass versus validated drill evidence

## Validation
- `git diff --check origin/main...HEAD`
- Markdown fence balance check
- added-line ASCII check
- content marker check for `PAM-BG-*` findings and fixtures
- `git merge-tree --write-tree origin/main HEAD`

## Bounty
Requested tier: Improver Moderate, USD 100 if accepted.