### PR TITLE
fix(#1464): add AI-specific GOVERN metrics and NIST AI RMF alignment gates for nist-csf-assessment

### DIFF
--- a/skills/compliance/nist-csf-assessment/SKILL.md
+++ b/skills/compliance/nist-csf-assessment/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [NIST-CSF-2.0]
 difficulty: intermediate
 time_estimate: "90-180min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -565,6 +565,45 @@ Tier 4 — Adaptive
 ```
 
 ---
+
+
+## AI-Specific GOVERN Metrics and NIST AI RMF Alignment Gates
+
+### Gate 1: AI Governance Framework Coverage
+
+Confirm the assessment covers NIST AI RMF governance functions:
+
+```
+# Evidence items (at least 2 required)
+- AI RMF GOVERN function (GV) assessed for AI-specific systems
+- AI risk management policy documented and attributed to accountable owner
+- AI system inventory maintained with risk classification
+- AI governance board or equivalent oversight body established
+```
+
+### Gate 2: AI Risk Mapping to CSF
+
+Verify AI-specific risks are mapped to CSF 2.0 functions:
+
+```
+# Evidence items (at least 2 required)
+- AI model risks mapped to GOV/IDENTIFY/PROTECT/DETECT/RESPOND/RECOVER
+- AI-specific threat scenarios documented (adversarial ML, data poisoning, etc.)
+- AI model bias and fairness risks assessed
+- Third-party AI model supply chain risks evaluated
+```
+
+### Gate 3: Continuous AI Monitoring
+
+Confirm AI-specific monitoring and reporting is in place:
+
+```
+# Evidence items (at least 2 required)
+- AI model performance and drift monitoring implemented
+- AI incident reporting procedure documented
+- Automated AI model behavior logging in place
+- Regular AI risk assessment cadence established
+```
 
 ## Common Pitfalls
 

--- a/skills/compliance/nist-csf-assessment/tests/benign/benign-ai-governance-with-rmf-alignment.md
+++ b/skills/compliance/nist-csf-assessment/tests/benign/benign-ai-governance-with-rmf-alignment.md
@@ -1,0 +1,28 @@
+---
+name: benign-ai-governance-with-rmf-alignment
+expected: pass
+---
+
+# Benign NIST CSF assessment with AI RMF governance alignment
+
+## AI governance context
+
+```
+ai_governance_board: established
+ai_inventory: maintained (42 models)
+ai_rmf_assessment: completed Q2-2026
+ai_risk_owner: CISO + CAIO
+```
+
+## Evidence
+
+| Field | Value |
+|---|---|
+| AI RMF GOVERN | GV function assessed with accountable owner assigned |
+| Risk mapping | AI risks mapped to CSF 2.0 all 6 functions |
+| Model bias | Fairness assessment completed for all high-risk models |
+| Continuous monitoring | Weekly drift detection plus monthly AI risk review |
+
+## Expected review result
+
+Pass. AI governance board established, RMF alignment complete, risks mapped, and continuous monitoring in place.

--- a/skills/compliance/nist-csf-assessment/tests/vulnerable/vulnerable-ai-governance-gap.md
+++ b/skills/compliance/nist-csf-assessment/tests/vulnerable/vulnerable-ai-governance-gap.md
@@ -1,0 +1,28 @@
+---
+name: vulnerable-ai-governance-gap
+expected: fail
+---
+
+# Vulnerable CSF assessment missing AI RMF governance
+
+## AI governance context
+
+```
+ai_governance_board: none
+ai_inventory: partial (12 of estimated 40+ models)
+ai_rmf_assessment: not performed
+ai_risk_owner: none assigned
+```
+
+## Evidence
+
+| Field | Value |
+|---|---|
+| AI RMF GOVERN | Not assessed — no governance function coverage |
+| Risk mapping | AI risks not mapped to CSF (treated as generic IT risks) |
+| Model bias | No fairness or bias assessment performed |
+| Continuous monitoring | None — AI systems not included in monitoring scope |
+
+## Expected review result
+
+Fail. No AI governance board, no RMF alignment, no risk mapping, no bias assessment, and no monitoring.


### PR DESCRIPTION
Adds AI governance framework coverage, AI risk mapping to CSF, and continuous AI monitoring gates for nist-csf-assessment.

Closes #1464