### PR TITLE
Improve forensic immutable evidence storage checks

### DIFF
--- a/skills/incident-response/forensics-checklist/SKILL.md
+++ b/skills/incident-response/forensics-checklist/SKILL.md
@@ -99,6 +99,47 @@ CUSTODY LOG:
 - Compute and record cryptographic hashes (SHA-256 minimum) at collection time and verify at each transfer
 - Maintain a continuous, unbroken record from collection through final disposition
 
+### Step 1b: Verify Immutable Evidence Storage
+
+Before acquisition starts, confirm that the evidence destination prevents alteration, overwrite, early deletion, and unauthorized access. A valid hash proves that a later copy differs from the collected artifact, but it does not prove the original evidence could not be deleted, replaced, lifecycle-expired, or read by an unauthorized party.
+
+**Immutable storage control record:**
+
+```
+IMMUTABLE EVIDENCE STORAGE RECORD
+=================================
+Case/Incident ID:        [IR-YYYY-NNNN]
+Storage Location:        [bucket/share/drive/path]
+Evidence IDs Covered:    [EVD-NNNN list or case folder]
+Write Protection:        [WORM/Object Lock/immutable policy/write blocker/none]
+Retention / Legal Hold:  [retention period, legal hold status, expiry]
+Authorized Custodians:   [named users/groups and approval source]
+Deletion Protection:     [lifecycle/delete-marker/admin-delete controls reviewed]
+Audit Logging:           [read/write/delete/retention/access-policy log destination]
+Encryption / Key Custody:[KMS/HSM/offline key, key custodians, separation of duties]
+Verification Manifest:   [SHA-256 manifest path, signature, verification timestamps]
+Exception / Risk Owner:  [required if immutable storage is unavailable]
+```
+
+**Evidence gates:**
+
+```
+FOR-IMMUT-01: Evidence is stored on a mutable share, ticket attachment, SIEM export, or analyst workstation without write protection
+FOR-IMMUT-02: Retention period, legal hold, or evidence disposition date is missing or shorter than the incident preservation requirement
+FOR-IMMUT-03: Evidence custodian access is broad, shared, unapproved, or not separated from ordinary administrator access
+FOR-IMMUT-04: Lifecycle, cleanup, overwrite, delete-marker, or privileged-delete paths can remove evidence before retention expires
+FOR-IMMUT-05: Reads, writes, deletes, retention changes, and access-policy changes are not logged to a separately protected location
+FOR-IMMUT-06: Encryption status or key custody is unknown, or evidence keys are controlled by the same operators being investigated
+FOR-IMMUT-07: Hashes are recorded only at acquisition and not independently re-verified after upload, transfer, and before analysis
+FOR-IMMUT-08: Immutable storage is unavailable but the report omits compensating controls, residual risk, and a named risk owner
+```
+
+**False-positive boundaries:**
+
+- Do not require a specific vendor mechanism. Hardware write blockers, WORM media, S3 Object Lock, immutable blob policy, object retention, and offline sealed media can all satisfy the control when configuration evidence is captured.
+- Do not flag short-lived volatile evidence staging when the artifact is immediately transferred into immutable storage, hashed at each hop, and the staging window is documented.
+- Do not treat read access by legal counsel or approved forensic partners as excessive when access is named, time-bounded, logged, and covered by the custody record.
+
 ### Step 2: Collect Evidence in Order of Volatility (RFC 3227)
 
 RFC 3227 Section 2.1 defines the order of volatility -- evidence sources ranked from most volatile (shortest lifespan) to least volatile. Collect in this order to minimize evidence loss.
@@ -389,6 +430,11 @@ the order of collection, and any evidence that could not be obtained.]
 ### Chain of Custody
 [Include chain of custody form for each evidence item]
 
+### Immutable Evidence Storage
+| Storage Location | Evidence IDs Covered | Write Protection | Retention / Legal Hold | Authorized Custodians | Deletion Protection | Audit Logging | Encryption / Key Custody | Verification Manifest | Exception / Risk Owner |
+|---|---|---|---|---|---|---|---|---|---|
+| [bucket/share/drive/path] | [EVD list] | [mechanism/status] | [period/status] | [names/groups] | [controls reviewed] | [log destination] | [key owner/separation] | [path/signature/timestamps] | [N/A or owner] |
+
 ### Integrity Verification
 | Evidence ID | Acquisition Hash | Verification Hash | Match |
 |---|---|---|---|
@@ -460,6 +506,10 @@ Applying traditional forensic methods to cloud environments without adaptation l
 ### Pitfall 5: Overwriting Evidence with Collection Activity
 
 Every action on a live system modifies it -- writing memory dump files to the evidence drive changes timestamps and consumes disk space, running commands updates shell history and modifies access times. Minimize evidence contamination by writing collection output to external media (USB, network share, S3 bucket), documenting every command executed on the system, and noting the expected impact of each collection action on the evidence state.
+
+### Pitfall 6: Hashing Evidence Without Protecting Its Storage
+
+Hashes help detect alteration, but they do not stop deletion, overwrite, lifecycle cleanup, or unauthorized reads. Preserve evidence in write-protected or immutable storage, record retention and legal hold settings, limit custodian access, log storage control changes, and re-verify the manifest after upload, transfer, and before analysis.
 
 ---
 

--- a/skills/incident-response/forensics-checklist/tests/benign/immutable-evidence-vault-with-manifest.md
+++ b/skills/incident-response/forensics-checklist/tests/benign/immutable-evidence-vault-with-manifest.md
@@ -1,0 +1,50 @@
+# Benign: Immutable evidence vault with manifest re-verification
+
+This fixture should avoid immutable evidence storage findings because preservation, access, audit, key custody, and verification evidence are recorded.
+
+## Incident Context
+
+- Incident ID: IR-2026-0615
+- Matter: ransomware intrusion on `app-04` and `db-02`
+- Legal hold: `LH-2026-0615`, issued by counsel before collection
+- Evidence destination: dedicated cloud evidence vault plus sealed offline copy
+
+## Immutable Evidence Storage Record
+
+| Control | Evidence |
+|---|---|
+| Storage location | `s3://corp-forensics-evidence/IR-2026-0615/` and sealed drive `OFF-EVD-0615-A` |
+| Evidence IDs covered | `EVD-0301` through `EVD-0310` |
+| Write protection | S3 Object Lock compliance mode enabled on the bucket, default retention 7 years; offline drive sealed after write-once copy |
+| Retention / legal hold | Legal hold `LH-2026-0615` applied to case prefix; retention expiry `2033-06-15`; counsel approval required for release |
+| Authorized custodians | `forensics-custodian-primary`, `forensics-custodian-backup`, and `legal-discovery-readonly`; no ordinary domain admins |
+| Deletion protection | Lifecycle rules reviewed: no expiration or transition rule on `IR-2026-0615`; privileged delete blocked while retention is active |
+| Audit logging | Object read, write, delete, retention, legal hold, and bucket policy events sent to separate log account `security-audit-archive` |
+| Encryption / key custody | SSE-KMS with key `forensics-evidence-kms`; key admins are security governance, not investigated operations team |
+| Verification manifest | `manifest-IR-2026-0615.sha256` signed by `forensics-custodian-primary`; hashes verified after upload, after offline copy, and before analysis |
+| Exception / risk owner | N/A |
+
+## Verification Events
+
+| Time (UTC) | Action | Result |
+|---|---|---|
+| 2026-06-15T04:12:00Z | Acquisition hash computed for `EVD-0301` memory image | match recorded in custody log |
+| 2026-06-15T04:27:00Z | Upload completed to locked case prefix | object version ID and retention timestamp recorded |
+| 2026-06-15T04:31:00Z | Manifest re-verified from a separate custodian workstation | all hashes match |
+| 2026-06-15T05:10:00Z | Offline sealed copy created and verified | all hashes match; seal ID recorded |
+| 2026-06-16T09:00:00Z | Pre-analysis verification from vault download | all hashes match; analyst has read-only temporary access |
+
+## False-Positive Boundaries
+
+- Temporary local staging was used for 14 minutes during memory acquisition, but the staging path, hash, transfer time, and deletion of the temporary copy are documented.
+- Legal counsel has read-only access, but access is named, role-based, time-bounded, and fully logged.
+- The cloud bucket uses provider-managed object immutability rather than physical WORM media, which is acceptable because configuration and retention evidence are captured.
+
+Expected outcome:
+
+- Do not flag `FOR-IMMUT-01` because write protection and object retention are enabled before evidence upload.
+- Do not flag `FOR-IMMUT-02` because retention and legal hold match the preservation directive.
+- Do not flag `FOR-IMMUT-03` because custodian access is narrow and separated from investigated administrators.
+- Do not flag `FOR-IMMUT-04` or `FOR-IMMUT-05` because deletion paths and storage audit logs are reviewed and protected.
+- Do not flag `FOR-IMMUT-06` because encryption and key custody are documented.
+- Do not flag `FOR-IMMUT-07` because hashes are re-verified after upload, after offline copy, and before analysis.

--- a/skills/incident-response/forensics-checklist/tests/vulnerable/mutable-evidence-share-with-hashes.md
+++ b/skills/incident-response/forensics-checklist/tests/vulnerable/mutable-evidence-share-with-hashes.md
@@ -1,0 +1,44 @@
+# Vulnerable: Hashed evidence kept on a mutable incident share
+
+This fixture should produce immutable evidence storage findings even though the collection report contains SHA-256 hashes.
+
+## Incident Context
+
+- Incident ID: IR-2026-0614
+- Matter: suspected privileged insider data staging on `filesrv-07`
+- Evidence types: memory dump, disk image, firewall log export, SIEM search export
+- Legal hold: requested by counsel, but not mapped to storage controls
+
+## Evidence Storage Record
+
+| Evidence ID | Artifact | Storage Location | Hash Status | Retention / Hold | Access | Audit Logging |
+|---|---|---|---|---|---|---|
+| EVD-0201 | `filesrv-07-memory.raw` | `\\corp-share\IR\2026-0614\` | SHA-256 recorded at acquisition | none | `Domain Admins`, `SOC-Analysts`, `Helpdesk-L2` | share access logging disabled |
+| EVD-0202 | `filesrv-07-disk.E01` | same share | SHA-256 recorded at acquisition | inherited 30-day cleanup | same groups | share access logging disabled |
+| EVD-0203 | firewall export CSV | ticket attachment | SHA-256 pasted in ticket | ticket retention unknown | ticket project members | ticket audit only tracks comments |
+| EVD-0204 | SIEM export JSON | analyst laptop downloads folder | SHA-256 recorded before upload | none | local analyst account | no storage audit |
+
+## Storage Control Gaps
+
+- The network share allows overwrite and delete by all listed admin groups.
+- The cleanup job removes incident folders older than 30 days unless a separate exemption is created.
+- No S3 Object Lock, immutable blob policy, WORM media, offline sealed drive, or write blocker evidence is recorded.
+- There is no legal hold flag or retention setting on the share or ticket attachments.
+- The storage administrators include the same privileged operations team whose activity is under investigation.
+- Reads, writes, deletes, retention changes, and access-policy changes are not sent to a separately protected log location.
+- The KMS or file-encryption key owner is not recorded.
+- Hashes were not re-verified after upload to the share, after the ticket attachment was downloaded, or before analysis.
+- The report says "hashes prove preservation" and does not name a compensating control or risk owner.
+
+Expected findings:
+
+- `FOR-IMMUT-01` because the main evidence copy is on mutable share, ticket, and laptop storage.
+- `FOR-IMMUT-02` because retention and legal hold are absent or shorter than the investigation need.
+- `FOR-IMMUT-03` because custodian access is broad and includes operators in scope.
+- `FOR-IMMUT-04` because lifecycle cleanup and admin delete paths can remove evidence.
+- `FOR-IMMUT-05` because storage audit logging is missing or incomplete.
+- `FOR-IMMUT-06` because encryption and key custody are unknown.
+- `FOR-IMMUT-07` because independent post-upload and pre-analysis verification is missing.
+- `FOR-IMMUT-08` because residual risk and compensating controls are not documented.
+
+Expected handling: treat the evidence preservation posture as high risk, move artifacts to approved immutable storage, re-hash and reconcile manifests, restrict custodian access, enable protected audit logs, apply legal hold, and record a named risk owner for any evidence that cannot be re-preserved.


### PR DESCRIPTION
## Summary

Adds immutable evidence storage gates to `forensics-checklist` so evidence preservation covers deletion, overwrite, lifecycle cleanup, unauthorized access, audit coverage, key custody, and independent manifest re-verification instead of relying on hashes alone.

## Changes

- Adds `FOR-IMMUT-01` through `FOR-IMMUT-08` evidence gates and false-positive boundaries.
- Adds an immutable evidence storage output table to the report template.
- Adds a common pitfall explaining why hashing without storage protection is incomplete.
- Adds vulnerable and benign fixtures for mutable evidence shares versus locked evidence vaults with retention, audit logging, key custody, and manifest re-verification.

## Validation

- `git diff --check origin/main...HEAD`
- Markdown fence-balance check over changed files
- Added-line ASCII check
- Marker checks for immutable storage findings and fixture coverage
- `git merge-tree --write-tree origin/main HEAD`

Closes #1789

## Bounty request

Improver Moderate / USD 100 if accepted.