### PR TITLE
Improve SBOM VEX evidence validation

### DIFF
--- a/skills/vuln-management/sbom-analysis/SKILL.md
+++ b/skills/vuln-management/sbom-analysis/SKILL.md
@@ -160,6 +160,40 @@ When a VEX status is "Not Affected," the document must include one of these just
 | **vulnerable_code_cannot_be_controlled_by_adversary** | The vulnerable code is present and reachable but attacker-controlled input cannot reach it | Requires threat model or data-flow analysis |
 | **inline_mitigations_already_exist** | Built-in mitigations (ASLR, sandboxing, etc.) prevent exploitation | Verify mitigations are active and effective |
 
+#### VEX Evidence Validation Gate
+
+Validate VEX statements before using them to reduce risk or downgrade remediation priority. A signed or vendor-published VEX document is not sufficient unless it applies to the exact product, release, component, vulnerability, and deployment context under review.
+
+**VEX validation findings:**
+
+```
+SBOM-VEX-01: VEX product name, supplier, version, CPE, purl, SWID, or release identifier does not match the assessed software
+SBOM-VEX-02: VEX component identifier cannot be mapped to an SBOM component bom-ref, purl, CPE, package URL, SPDX package, or dependency node
+SBOM-VEX-03: VEX vulnerability ID does not match the assessed CVE, GHSA, OSV, or vendor advisory alias set
+SBOM-VEX-04: VEX status is inferred from narrative text instead of an explicit `not_affected`, `affected`, `fixed`, or `under_investigation` value
+SBOM-VEX-05: `not_affected` lacks a CSAF/OpenVEX justification or relies on unsupported reasoning
+SBOM-VEX-06: VEX timestamp predates the SBOM build, software release, affected component upgrade, or deployment profile change without a refreshed statement
+SBOM-VEX-07: VEX source authenticity is untrusted, unsigned, unverifiable, or not traceable to the product supplier, component supplier, or trusted coordinator
+SBOM-VEX-08: Status rationale lacks code-path, configuration, runtime, mitigation, or vendor-attestation evidence needed for the risk tier
+SBOM-VEX-09: A priority downgrade is applied even though one or more required VEX validation checks failed
+```
+
+**Validation procedure:**
+
+1. Match product identity using product name, version, supplier, release identifier, CPE, purl, SWID, or equivalent product identifiers.
+2. Match component identity against SBOM identifiers such as `bom-ref`, purl, CPE, SPDX package ID, component name/version/supplier, and dependency relationships.
+3. Normalize vulnerability aliases across CVE, GHSA, OSV, vendor advisory, and CSAF tracking IDs before declaring a match or mismatch.
+4. Confirm the VEX status is explicit and capture the justification category for every `not_affected` statement.
+5. Compare VEX `document.tracking.current_release_date`, statement timestamp, or OpenVEX `timestamp` against SBOM creation time, build time, product release time, and deployed component version.
+6. Verify source authenticity with vendor domain, signature, checksum, release channel, advisory feed, or trusted coordinator provenance.
+7. Require supporting evidence before downgrading: component absence proof, code-path analysis, disabled feature configuration, runtime reachability test, mitigation evidence, or supplier attestation appropriate to severity.
+
+**False-positive boundaries:**
+
+- Do not flag missing CPE when purl, SWID, package URL, or another stable identifier creates an exact product and component match.
+- Do not reject a VEX statement only because the SBOM uses a different vulnerability alias when the alias mapping is authoritative and documented.
+- Do not require public exploitability details for sensitive products when the vendor provides a signed attestation and enough status, justification, freshness, and product/component identity evidence.
+
 ```
 VEX Assessment:
 - VEX Format:          [CSAF 2.0 | CycloneDX VEX | OpenVEX]
@@ -168,6 +202,19 @@ VEX Assessment:
 - Affected:            [N] (require remediation)
 - Fixed:               [N] (verify deployment)
 - Under Investigation: [N] (monitor for updates)
+```
+
+```
+VEX Evidence Validation:
+- Product Identity Match:     [Pass/Fail/Partial -- identifiers checked]
+- Component Identity Match:   [Pass/Fail/Partial -- SBOM references checked]
+- Vulnerability ID Match:     [Pass/Fail -- aliases checked]
+- Explicit Status:            [Pass/Fail -- no inferred status]
+- Justification Evidence:     [Pass/Fail/N/A -- required for Not Affected]
+- Freshness:                  [Fresh/Stale/Unknown -- compare to SBOM/release/deployment]
+- Source Authenticity:        [Trusted/Untrusted/Unknown]
+- Supporting Evidence:        [Sufficient/Insufficient/Needs human review]
+- Priority Downgrade Allowed: [Yes/No -- No unless required checks pass]
 ```
 
 ### Step 4: Transitive Dependency Analysis
@@ -300,6 +347,13 @@ conflicts), and overall classification.]
 |---|---|---|---|---|
 | [CVE-ID] | [component] | [Not Affected/Affected/Fixed/Under Investigation] | [justification if Not Affected] | [action] |
 
+### VEX Evidence Validation
+[If VEX documents are provided]
+
+| CVE ID | Product Match | Component Match | Vulnerability Match | Explicit Status | Justification | Freshness | Source Authenticity | Supporting Evidence | Downgrade Allowed |
+|---|---|---|---|---|---|---|---|---|---|
+| [CVE-ID] | [Pass/Fail/Partial] | [Pass/Fail/Partial] | [Pass/Fail] | [Pass/Fail] | [Pass/Fail/N/A] | [Fresh/Stale/Unknown] | [Trusted/Untrusted/Unknown] | [Sufficient/Insufficient/Review] | [Yes/No] |
+
 ### Transitive Dependency Risk
 
 | Risk Indicator | Count | Details |
@@ -380,6 +434,8 @@ Published by NTIA in July 2021 as part of Executive Order 14028 implementation. 
 4. **Overlooking license implications in SaaS deployments.** AGPL-3.0 triggers copyleft obligations for network use (SaaS), unlike GPL which only triggers on distribution. Organizations running AGPL-licensed components in SaaS products may have unrecognized compliance obligations. Always flag AGPL components regardless of distribution model.
 
 5. **Failing to track SBOM freshness.** An SBOM is a point-in-time snapshot. Software composition changes with every dependency update, build, or deployment. SBOMs older than the most recent build/release are potentially inaccurate. Check the SBOM timestamp against the software's actual release date and flag stale SBOMs.
+
+6. **Applying VEX to the wrong product, component, or release.** VEX is scoped evidence, not a global waiver. Do not accept a `not_affected` or `fixed` status until product identity, component identity, vulnerability aliases, explicit status, justification, freshness, source authenticity, and supporting evidence all match the assessed release.
 
 ---
 

--- a/skills/vuln-management/sbom-analysis/tests/benign/matched-vex-evidence-validation.md
+++ b/skills/vuln-management/sbom-analysis/tests/benign/matched-vex-evidence-validation.md
@@ -1,0 +1,53 @@
+# Benign: Matched VEX statement with sufficient validation evidence
+
+This fixture should avoid VEX evidence validation findings when the VEX statement is scoped, fresh, authentic, and supported.
+
+## Assessment Context
+
+- Product under review: `Acme Payments Gateway Enterprise`
+- Product version: `4.8.2`
+- Supplier: `Acme Financial Software`
+- Release date: `2026-05-30`
+- SBOM format: CycloneDX 1.5
+- SBOM timestamp: `2026-05-30T14:12:00Z`
+- Component in SBOM: `pkg:maven/com.acme/payments-xml@2.9.1`, bom-ref `pkg:maven/com.acme/payments-xml@2.9.1`
+- Vulnerability under review: `CVE-2026-43110`, alias `GHSA-payg-xml-xxe`
+
+## VEX Statement Presented
+
+- VEX format: CSAF 2.0 VEX profile
+- VEX source: `https://security.acme.example/advisories/acme-vex-2026-43110.json`
+- Signature: detached signature verified against Acme security advisory key
+- VEX product name: `Acme Payments Gateway Enterprise`
+- VEX product version: `4.8.2`
+- Product identifiers: `cpe:2.3:a:acme:payments_gateway_enterprise:4.8.2:*:*:*:*:*:*:*`
+- VEX component identifier: `pkg:maven/com.acme/payments-xml@2.9.1`
+- VEX vulnerability IDs: `CVE-2026-43110`, `GHSA-payg-xml-xxe`, `ACME-2026-XML-02`
+- VEX status: `not_affected`
+- Justification: `vulnerable_code_not_in_execute_path`
+- Statement timestamp: `2026-05-31T10:00:00Z`
+
+## Supporting Evidence
+
+| Validation Check | Evidence |
+|---|---|
+| Product identity | Product name, supplier, version, CPE, and release notes match the SBOM software under review |
+| Component identity | VEX purl exactly matches CycloneDX component purl and bom-ref |
+| Vulnerability aliases | CSAF tracking lists CVE, GHSA, and vendor advisory IDs used by the scanner |
+| Explicit status | CSAF product status field is `not_affected` for product `4.8.2` |
+| Justification | CSAF remediations/flags include `vulnerable_code_not_in_execute_path` |
+| Freshness | VEX timestamp is after the SBOM build and the product release |
+| Source authenticity | Advisory URL is on the vendor security domain and signature verification passed |
+| Supporting evidence | Vendor attestation references build flag `xml.external_entities=false`, integration test `SEC-XML-XXE-NA-482`, and runtime config inventory showing the vulnerable parser path disabled |
+| Priority downgrade | Allowed only for this product release and deployment profile; exception expires if component version or parser configuration changes |
+
+Expected outcome:
+
+- Do not flag `SBOM-VEX-01` because product identity matches.
+- Do not flag `SBOM-VEX-02` because component purl and bom-ref map exactly.
+- Do not flag `SBOM-VEX-03` because vulnerability aliases are documented.
+- Do not flag `SBOM-VEX-04` or `SBOM-VEX-05` because status and justification are explicit.
+- Do not flag `SBOM-VEX-06` because the VEX is newer than the SBOM and release.
+- Do not flag `SBOM-VEX-07` because source authenticity is verified.
+- Do not flag `SBOM-VEX-08` because code-path and configuration evidence support the justification.
+- Do not flag `SBOM-VEX-09` because the downgrade is conditioned on all validation checks passing.

--- a/skills/vuln-management/sbom-analysis/tests/vulnerable/stale-cross-product-vex-downgrade.md
+++ b/skills/vuln-management/sbom-analysis/tests/vulnerable/stale-cross-product-vex-downgrade.md
@@ -1,0 +1,47 @@
+# Vulnerable: Stale cross-product VEX used to downgrade a live vulnerability
+
+This fixture should produce VEX evidence validation findings.
+
+## Assessment Context
+
+- Product under review: `Acme Payments Gateway Enterprise`
+- Product version: `4.8.2`
+- Supplier: `Acme Financial Software`
+- Release date: `2026-05-30`
+- SBOM format: CycloneDX 1.5
+- SBOM timestamp: `2026-05-30T14:12:00Z`
+- Vulnerability under review: `CVE-2026-43110`, alias `GHSA-payg-xml-xxe`
+- Component in SBOM: `pkg:maven/com.acme/payments-xml@2.9.1`, bom-ref `pkg:maven/com.acme/payments-xml@2.9.1`
+
+## VEX Statement Presented
+
+- VEX source: copied from a customer-support ticket attachment
+- VEX product name: `Acme Payments Gateway Community`
+- VEX product version: `4.7.0`
+- VEX supplier: `Acme Labs`
+- VEX component: `payments-xml`
+- VEX component version: `2.6.0`
+- VEX vulnerability ID: `ACME-2025-XML-17`
+- VEX status text: "Enterprise builds should not be impacted in the default profile."
+- VEX explicit status field: missing
+- VEX justification: missing
+- VEX timestamp: `2026-03-01T09:00:00Z`
+- Signature or release channel: none
+
+## Incorrect Review Outcome
+
+The review marks `CVE-2026-43110` as low priority because a VEX-like document says the product is "not impacted." The report does not map `ACME-2025-XML-17` to `CVE-2026-43110`, does not check whether Community 4.7.0 applies to Enterprise 4.8.2, does not compare component version `2.6.0` against SBOM component `2.9.1`, and does not require an explicit `not_affected` status or justification.
+
+Expected findings:
+
+- `SBOM-VEX-01` because product edition, supplier, and version do not match the assessed release.
+- `SBOM-VEX-02` because the VEX component version does not map to the SBOM component identifier.
+- `SBOM-VEX-03` because the vulnerability alias set is not validated.
+- `SBOM-VEX-04` because the status is inferred from narrative text.
+- `SBOM-VEX-05` because `not_affected` has no justification.
+- `SBOM-VEX-06` because the VEX predates the SBOM and product release.
+- `SBOM-VEX-07` because the source is an unauthenticated ticket attachment.
+- `SBOM-VEX-08` because no code-path, configuration, runtime, mitigation, or supplier evidence supports the claim.
+- `SBOM-VEX-09` because the review downgrades priority despite failed validation.
+
+Expected handling: do not downgrade the vulnerability. Treat the VEX as insufficient evidence, request a supplier-published or signed statement for Enterprise 4.8.2 and component `2.9.1`, and continue remediation or compensating controls until the VEX validation checks pass.


### PR DESCRIPTION
## Summary

Adds fixture-backed VEX evidence validation to `sbom-analysis` so VEX statements cannot reduce remediation priority unless they match the exact product, release, component, vulnerability, timestamp, source, and supporting evidence under review.

## Changes

- Adds `SBOM-VEX-01` through `SBOM-VEX-09` validation findings.
- Adds a VEX evidence validation procedure, false-positive boundaries, and output table.
- Adds a common pitfall for applying VEX to the wrong product, component, or release.
- Adds vulnerable and benign fixtures for stale cross-product VEX downgrades versus matched, fresh, authenticated VEX evidence.

## Validation

- `git diff --check origin/main...HEAD`
- Markdown fence-balance check over changed files
- Added-line ASCII check
- Marker checks for VEX validation findings and fixtures
- `git merge-tree --write-tree origin/main HEAD`

Closes #1785

## Bounty request

Improver Moderate / USD 100 if accepted.