### PR TITLE
Improve agent emergency stop drill evidence

### DIFF
--- a/skills/ai-security/agent-security/SKILL.md
+++ b/skills/ai-security/agent-security/SKILL.md
@@ -395,6 +395,50 @@ Grep: "draft|staging|preview|dry_run|dry.run|simulate|sandbox_mode" in **/*.{py,
 | Rollback mechanisms exist but are not tested or lack operator documentation | Medium |
 | No classification of agent actions by reversibility | Medium |
 
+#### Step 6.1 -- Emergency Stop and Rollback Drill Evidence
+
+Do not treat a kill switch, feature flag, platform rollback button, or compensation function as sufficient recovery evidence by itself. Agent systems need measured drills proving that operators can stop unsafe workflows, contain queued or delegated tool calls, preserve state, and recover completed side effects within an acceptable window.
+
+**Emergency stop and rollback findings:**
+
+```
+AGENT-STOP-01: No documented emergency stop trigger exists for unsafe agent workflows
+AGENT-STOP-02: Stop scope is unclear or only disables the UI while background workers, queues, or delegated agents continue
+AGENT-STOP-03: Queued, retrying, scheduled, or delegated tool calls are not cancelled, drained, or blocked after the stop condition
+AGENT-STOP-04: State needed for recovery is missing, such as action ledger, snapshot, transaction ID, deployment version, or pre-action artifact
+AGENT-STOP-05: Rollback or compensation is documented but not executed in a measured drill for the relevant action category
+AGENT-STOP-06: Time-to-stop, time-to-recover, recovery objective, or maximum tolerated loss is missing
+AGENT-STOP-07: Operator runbook omits owner, command/API location, escalation path, approval requirements, or communications plan
+AGENT-STOP-08: Drill failures and partial recoveries are not tracked to remediation owners and due dates
+```
+
+**Drill evidence record:**
+
+```
+EMERGENCY STOP AND ROLLBACK DRILL
+=================================
+Scenario:                 [prompt injection | runaway loop | bad deploy | bad data write | message/payment]
+Agent / Workflow:         [name]
+Stop Trigger:             [operator action, API, circuit breaker, feature flag, policy rule]
+Stop Scope:               [session | tenant | tool class | worker pool | delegated agents | global]
+Queued Calls Contained:   [Yes/No/Partial -- evidence]
+State Capture Evidence:   [snapshot/action ledger/transaction/deployment version/pre-action artifact]
+Recovery Method:          [rollback | compensation | manual repair | not possible]
+Time to Stop:             [duration]
+Time to Recover:          [duration]
+Recovery Objective:       [target duration/data loss/action count]
+Operator Runbook:         [path/link/version]
+Approvals / Escalation:   [approver roles and escalation path]
+Drill Result:             [Pass | Partial | Fail | Not Tested]
+Follow-up Owner / Due:    [owner/date for gaps]
+```
+
+**False-positive boundaries:**
+
+- Do not flag missing automatic rollback for truly irreversible communications when the design uses draft mode, HITL approval, suppression/correction procedures, and tested stakeholder notification.
+- Do not require one global kill switch when scoped stops are safer, provided each scope maps to an explicit workflow, tool class, queue, worker pool, and delegated-agent boundary.
+- Do not mark a tabletop-only exercise as sufficient for high-impact tool calls unless a technical drill is unsafe and the residual risk owner explicitly accepts the limitation.
+
 ---
 
 ### Step 7 -- Multi-Agent Trust Boundaries
@@ -521,6 +565,12 @@ Glob: **/security_architecture*
 | Rollback Capability | [rating] | [one-line summary] | [priority] |
 | Multi-Agent Trust Boundaries | [rating] | [one-line summary] | [priority] |
 
+## Emergency Stop and Rollback Drill Evidence
+
+| Scenario | Agent / Workflow | Stop Trigger | Stop Scope | Queued Calls Contained | State Evidence | Recovery Method | Time to Stop | Time to Recover | Recovery Objective | Runbook | Result | Follow-up Owner / Due |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| [scenario] | [agent/workflow] | [trigger] | [scope] | [Yes/No/Partial] | [snapshot/ledger/version] | [rollback/compensation/manual/not possible] | [duration] | [duration] | [objective] | [path/link] | [Pass/Partial/Fail/Not Tested] | [owner/date] |
+
 ## Recommendations
 [Prioritized list of architectural improvements]
 
@@ -568,6 +618,8 @@ Glob: **/security_architecture*
 4. **Building audit trails that log actions but not context.** An audit log that records "Agent-A called write_file at 14:32:01" is useful for timeline reconstruction but insufficient for root cause analysis. Without logging what the agent was told (the prompt or task), what it reasoned (the chain of thought), and what it received from other agents or tools (the inputs), investigators cannot determine whether the action was legitimate, hallucinated, or injected. Log the full decision context for every consequential action.
 
 5. **Assuming rollback is someone else's problem.** Agent developers frequently rely on downstream systems (databases, deployment platforms, email providers) to handle rollback without verifying that rollback mechanisms actually exist and work. A database transaction can be rolled back, but only if the agent's actions are wrapped in a transaction. An email cannot be recalled. A deployed binary cannot be un-deployed if the deployment pipeline has no rollback. For every tool an agent can invoke, the architecture must document the rollback mechanism and test it.
+
+6. **Mistaking stop controls for recovery controls.** Turning off an agent does not undo queued tool calls, delegated worker activity, external messages, data writes, or deployments already completed. Emergency readiness requires stop evidence, containment evidence, recovery evidence, elapsed-time measurements, and remediation tracking from drills.
 
 ---
 

--- a/skills/ai-security/agent-security/tests/benign/measured-stop-and-recovery-drill.md
+++ b/skills/ai-security/agent-security/tests/benign/measured-stop-and-recovery-drill.md
@@ -1,0 +1,49 @@
+# Benign: Measured emergency stop and recovery drill covers queued and delegated actions
+
+This fixture should avoid emergency stop and rollback drill findings because stop, containment, recovery, timing, and follow-up evidence are documented.
+
+## Architecture Context
+
+- System: `OpsPilot`
+- Agent workflow: production incident assistant
+- Agents: `orchestrator`, `deploy-worker`, `crm-worker`, `notification-worker`
+- Stop control: signed operator API call `POST /agent-control/emergency-stop`
+- Stop scopes: session, tenant, tool class, worker pool, delegated-agent tree, global
+- Drill date: `2026-06-08`
+
+## Emergency Stop and Rollback Drill
+
+| Field | Evidence |
+|---|---|
+| Scenario | prompt-injection run attempts deploy, CRM update, and notification send |
+| Agent / Workflow | `OpsPilot` incident assistant workflow `IR-AUTO-42` |
+| Stop Trigger | on-call lead runs signed emergency-stop API with incident ID and scope `tenant+delegated-tree` |
+| Stop Scope | tenant `acme-prod`, all delegated workers spawned by correlation ID `corr-9f21`, deployment and notification tool classes |
+| Queued Calls Contained | Redis queue moved 22 pending jobs to quarantine, 3 in-flight jobs reached cancellation checkpoint, retries blocked by policy version `stop-2026-06-08-01` |
+| State Capture Evidence | action ledger `ledger-IR-AUTO-42`, database snapshot `snap-20260608-ops`, deployment version `api@2026.06.08-4`, draft notification IDs |
+| Recovery Method | deployment rollback to previous version, CRM compensation script from ledger, notification drafts discarded before send |
+| Time to Stop | 42 seconds from trigger to no runnable jobs |
+| Time to Recover | 11 minutes 34 seconds to restore deployment and CRM state |
+| Recovery Objective | stop under 2 minutes, recover under 30 minutes, zero sent external notifications |
+| Operator Runbook | `runbooks/agent-emergency-stop.md` version `2026.06.01` |
+| Approvals / Escalation | on-call lead plus incident commander; legal/comms notified if messages are sent |
+| Drill Result | Pass |
+| Follow-up Owner / Due | one low-severity observability improvement assigned to platform team, due `2026-06-30` |
+
+## Validation Notes
+
+- The stop API updates a central policy store read by orchestrator and workers.
+- Workers check the stop policy before executing, before retrying, and at cancellation checkpoints.
+- Delegated agents inherit the parent correlation ID, so the stop scope reaches the full delegated tree.
+- External communications are prepared as drafts until after HITL approval, so the drill had no sent messages to recall.
+- Recovery evidence includes before/after hashes for CRM rows touched by the compensation script.
+
+Expected outcome:
+
+- Do not flag `AGENT-STOP-01` because a documented signed emergency stop trigger exists.
+- Do not flag `AGENT-STOP-02` or `AGENT-STOP-03` because scope and queued/delegated containment are tested.
+- Do not flag `AGENT-STOP-04` because state capture evidence is complete.
+- Do not flag `AGENT-STOP-05` because rollback and compensation are executed in the drill.
+- Do not flag `AGENT-STOP-06` because timing and recovery objectives are measured.
+- Do not flag `AGENT-STOP-07` because the runbook, approvals, and escalation path are recorded.
+- Do not flag `AGENT-STOP-08` because follow-up is assigned with an owner and due date.

--- a/skills/ai-security/agent-security/tests/vulnerable/ui-only-kill-switch-with-live-queue.md
+++ b/skills/ai-security/agent-security/tests/vulnerable/ui-only-kill-switch-with-live-queue.md
@@ -1,0 +1,45 @@
+# Vulnerable: UI-only kill switch leaves queued and delegated agent actions running
+
+This fixture should produce emergency stop and rollback drill findings.
+
+## Architecture Context
+
+- System: `OpsPilot`
+- Agent workflow: production incident assistant that can deploy feature flags, update customer status rows, and send customer notifications
+- Agents: `orchestrator`, `deploy-worker`, `crm-worker`, `notification-worker`
+- Tool queue: Redis-backed retry queue with 10-minute retry window
+- Human approval: approval required before initial workflow start, but not before retries or delegated workers
+
+## Claimed Emergency Control
+
+- Operators can click `Disable OpsPilot` in the admin UI.
+- The UI toggle prevents new sessions from starting.
+- The runbook says "disable the agent and roll back the deployment if needed."
+
+## Drill Evidence
+
+No measured drill exists. During a tabletop, the team assumed the UI toggle stopped all activity. A later staging test showed:
+
+| Event | Observation |
+|---|---|
+| Prompt injection detected | `orchestrator` already enqueued 37 tool calls |
+| UI toggle disabled | New UI sessions blocked, but Redis workers kept running |
+| Delegated workers | `deploy-worker` and `notification-worker` continued because they do not read the UI flag |
+| Retry queue | 14 failed calls retried after the stop condition |
+| State capture | No pre-action snapshot for customer status updates |
+| Rollback | Deployment rollback worked, but CRM updates and notifications had only manual cleanup notes |
+| Time measurement | No official time-to-stop, time-to-recover, or recovery objective recorded |
+| Follow-up | Failure noted in chat, no owner or due date created |
+
+Expected findings:
+
+- `AGENT-STOP-01` because no technical stop trigger exists outside the UI toggle.
+- `AGENT-STOP-02` because the stop scope blocks only new UI sessions.
+- `AGENT-STOP-03` because queued, retrying, and delegated tool calls continue.
+- `AGENT-STOP-04` because state needed for CRM recovery is missing.
+- `AGENT-STOP-05` because rollback is only partially executed and not drilled per action category.
+- `AGENT-STOP-06` because time-to-stop, time-to-recover, and recovery objective are missing.
+- `AGENT-STOP-07` because the runbook lacks concrete commands, owners, approvals, and escalation paths.
+- `AGENT-STOP-08` because drill failures are not assigned to remediation owners.
+
+Expected handling: rate this as a high or critical rollback capability gap for production agents, add queue/worker/delegation stop propagation, capture pre-action state, drill each action category, and track remediation until a measured stop/recovery drill passes.


### PR DESCRIPTION
## Summary

Adds fixture-backed emergency stop and rollback drill evidence to `agent-security` so reviews verify that unsafe agent workflows can actually be stopped, queued/delegated tool calls are contained, state is preserved, and recovery is measured.

## Changes

- Adds `AGENT-STOP-01` through `AGENT-STOP-08` findings.
- Adds a drill evidence record, false-positive boundaries, and report output table.
- Adds a common pitfall distinguishing stop controls from recovery controls.
- Adds vulnerable and benign fixtures for UI-only kill switches with live queues versus measured stop/recovery drills.

## Validation

- `git diff --check origin/main...HEAD`
- Markdown fence-balance check over changed files
- Added-line ASCII check
- Marker checks for emergency stop findings and fixtures
- `git merge-tree --write-tree origin/main HEAD`

Closes #1780

## Bounty request

Improver Moderate / USD 100 if accepted.