### PR TITLE
Improve AI privacy deletion propagation checks

### DIFF
--- a/skills/ai-security/ai-data-privacy/SKILL.md
+++ b/skills/ai-security/ai-data-privacy/SKILL.md
@@ -238,6 +238,49 @@ Grep: "backup|snapshot|archive" in **/*.{yaml,yml,json,toml}
 | No automated purge mechanism for expired AI data | Medium |
 | Audit logs contain full prompt/completion text with no redaction | Low |
 
+#### Step 3.1 -- DSAR and Deletion Propagation Evidence
+
+Do not mark DSAR, erasure, consent-withdrawal, or right-to-delete controls as complete based only on deleting the source user row or source document. AI systems commonly copy or derive personal data into prompts, conversation logs, vector embeddings, vector metadata, RAG chunks, analytics events, fine-tuning datasets, evaluation datasets, caches, model checkpoints, and backups.
+
+**Deletion propagation findings:**
+
+```
+DSAR-DEL-01: Deletion request tracking lacks requester identity proofing, scope, regulatory basis, due date, or completion evidence
+DSAR-DEL-02: Source-to-derived data map is missing for prompts, logs, embeddings, vector metadata, datasets, checkpoints, caches, analytics, or backups
+DSAR-DEL-03: Source data is deleted but derived AI stores retain retrievable personal data
+DSAR-DEL-04: Vector IDs, chunk metadata, or RAG source references are not removed or tombstoned with the source record
+DSAR-DEL-05: Fine-tuning, evaluation, or analytics datasets retain personal data without deletion, retraining, unlearning, aggregation, or a documented exception
+DSAR-DEL-06: Backups or archives can restore erased personal data without restore-time purge or expiry controls
+DSAR-DEL-07: Post-delete verification queries, audit logs, or evidence samples are missing or not tied to the request ID
+DSAR-DEL-08: Re-ingestion guards are missing, allowing deleted records to be re-embedded or re-exported from upstream systems
+DSAR-DEL-09: SLA, retry handling, exception owner, or legal-hold handling is missing for partial or failed deletion propagation
+```
+
+**Deletion propagation evidence record:**
+
+```
+DELETION PROPAGATION EVIDENCE
+=============================
+Request ID:             [ticket/case]
+Request Type:           [DSAR | erasure | consent withdrawal | CCPA delete | internal policy]
+Subject Scope:          [user/account/document/customer identifiers]
+Regulatory Basis:       [GDPR Art. 17/19 | CCPA | consent withdrawal | policy]
+Due Date / SLA:         [date/status]
+Source Stores:          [systems and records]
+Derived AI Stores:      [prompt logs, vector DB, RAG chunks, datasets, checkpoints, caches, backups]
+Propagation Actions:    [delete/tombstone/revoke/purge/retrain/unlearn/expire/restore-time purge]
+Verification Evidence:  [queries, audit logs, sample hashes, export checks]
+Exceptions / Holds:     [legal hold, backup expiry, infeasible retraining, none]
+Re-ingestion Guard:     [tombstone, blocklist, source filter, pipeline control]
+Owner / Status:         [owner and Complete/Partial/Exception/Failed]
+```
+
+**False-positive boundaries:**
+
+- Do not flag retained backup media when backups are encrypted, access-controlled, expire under policy, and restore workflows include purge-before-use controls tied to the deletion request.
+- Do not require model retraining for every deletion request when the system documents why trained weights are not reasonably addressable and uses controls such as dataset deletion, future-training exclusion, output filtering, and risk acceptance.
+- Do not flag aggregated analytics that can no longer identify or be linked to the requester, provided the aggregation threshold and unlinkability evidence are documented.
+
 ---
 
 ### Step 4 -- Model Memorization Risk Assessment
@@ -430,9 +473,16 @@ user input -> prompt assembly -> LLM API -> completion -> output -> logging/stor
 | Training data privacy | [Yes/Partial/No] | [description] | [severity] |
 | PII in prompts/completions | [Yes/Partial/No] | [description] | [severity] |
 | Data retention | [Yes/Partial/No] | [description] | [severity] |
+| DSAR/deletion propagation | [Yes/Partial/No] | [description] | [severity] |
 | Memorization risk | [Yes/Partial/No] | [description] | [severity] |
 | EU AI Act compliance | [Yes/Partial/No/N/A] | [description] | [severity] |
 | Consent management | [Yes/Partial/No] | [description] | [severity] |
+
+## Deletion Propagation Evidence
+
+| Request ID | Subject Scope | Source Stores | Derived AI Stores | Propagation Actions | Verification Evidence | Exceptions / Holds | Re-ingestion Guard | Owner / Status |
+|---|---|---|---|---|---|---|---|---|
+| [case] | [subject identifiers] | [systems] | [vector/logs/datasets/checkpoints/backups] | [delete/tombstone/purge/retrain/expire] | [query/log/sample] | [none/exception] | [control] | [owner/status] |
 
 ## Recommendations
 [Prioritized list of remediation actions with regulatory alignment]
@@ -472,6 +522,8 @@ user input -> prompt assembly -> LLM API -> completion -> output -> logging/stor
 
 5. **Ignoring model memorization as a privacy risk.** Organizations that use pre-trained or fine-tuned models often do not test for memorization of personal data. A model that has memorized PII from its training corpus is effectively a data store containing personal data -- it can reproduce that data on specific prompts. This has regulatory implications: if the model contains memorized PII of EU residents, GDPR obligations apply to the model weights themselves, not just the training dataset.
 
+6. **Closing DSARs after source deletion only.** A source-row delete can leave personal data in embeddings, vector metadata, prompt logs, analytics exports, fine-tuning snapshots, evaluation sets, caches, checkpoints, and backups. Close deletion requests only after derived AI stores are purged, tombstoned, excepted with an owner, or verified as unlinkable.
+
 ---
 
 ## References
@@ -480,7 +532,9 @@ user input -> prompt assembly -> LLM API -> completion -> output -> logging/stor
 - OWASP Top 10 for LLM Applications (2025), LLM02: Sensitive Information Disclosure -- https://genai.owasp.org/llmrisk/llm02-sensitive-information-disclosure/
 - EU AI Act, Regulation (EU) 2024/1689 -- https://eur-lex.europa.eu/eli/reg/2024/1689
 - GDPR, Regulation (EU) 2016/679 -- https://eur-lex.europa.eu/eli/reg/2016/679
+- Data Protection Commission: Right to erasure under GDPR Articles 17 and 19 -- https://www.dataprotection.ie/en/individuals/know-your-rights/right-erasure-articles-17-19-gdpr
 - CCPA/CPRA, California Civil Code Sec. 1798.100-199 -- https://leginfo.legislature.ca.gov/
+- California Privacy Rights under the CCPA -- https://privacy.ca.gov/california-privacy-rights/rights-under-the-california-consumer-privacy-act/
 - Carlini, N. et al. (2021). "Extracting Training Data from Large Language Models." USENIX Security Symposium. arXiv:2012.07805
 - Carlini, N. et al. (2023). "Quantifying Memorization Across Neural Language Models." ICLR 2023. arXiv:2202.07646
 - Ippolito, D. et al. (2023). "Preventing Verbatim Memorization in Language Models Gives a False Sense of Privacy." arXiv:2210.17546

--- a/skills/ai-security/ai-data-privacy/tests/benign/verified-derived-store-deletion.md
+++ b/skills/ai-security/ai-data-privacy/tests/benign/verified-derived-store-deletion.md
@@ -1,0 +1,46 @@
+# Benign: Verified deletion propagation across active AI stores
+
+This fixture should avoid DSAR deletion propagation findings because active AI stores are mapped, purged, verified, and protected against re-ingestion.
+
+## System Context
+
+- Product: support assistant with RAG
+- Request ID: `DSAR-2026-0617-082`
+- Request type: CCPA delete request and consent withdrawal
+- Subject: customer `cust_5022`, email `morgan.lee@example.test`
+- SLA due date: `2026-07-01`
+- Owner: privacy engineering
+
+## Deletion Propagation Evidence
+
+| Field | Evidence |
+|---|---|
+| Subject scope | customer profile `cust_5022`, support tickets `SUP-90110` and `SUP-90144`, document IDs `doc_77` and `doc_81` |
+| Regulatory basis | CCPA delete request plus withdrawal of AI training consent |
+| Source stores | customer profile, support ticket DB, document store |
+| Derived AI stores | prompt logs, vector DB, vector metadata, RAG chunks, retrieval cache, analytics export, SFT candidate dataset, backup catalogue |
+| Propagation actions | source delete, vector chunk tombstone, prompt-log token redaction, cache purge, analytics unlinking, SFT candidate row removal, backup restore-time purge marker |
+| Verification evidence | vector query by email/account/doc IDs returned zero active chunks; prompt-log search returned only redacted audit rows; SFT dataset hash changed after row removal |
+| Exceptions / holds | immutable backup retained until 30-day expiry; restore runbook applies purge marker before service recovery |
+| Re-ingestion guard | subject tombstone `privacy_tombstone_5022` blocks source connector, embedding job, and dataset export |
+| SLA status | met; closed after verification on `2026-06-20` |
+
+## Verification Queries
+
+| Query | Result |
+|---|---|
+| vector metadata search for `cust_5022` | zero active chunks, two tombstone records |
+| full-text search for `morgan.lee@example.test` in prompt logs | zero raw hits, one redacted audit reference |
+| SFT candidate dataset scan for support ticket IDs | zero rows after removal |
+| retrieval cache lookup for document IDs | cache miss after purge |
+| source connector dry run | skipped tombstoned IDs and wrote audit event `privacy-skip-5022` |
+
+Expected outcome:
+
+- Do not flag `DSAR-DEL-01` because request tracking includes scope, basis, owner, SLA, and completion evidence.
+- Do not flag `DSAR-DEL-02` because source and derived AI stores are mapped.
+- Do not flag `DSAR-DEL-03` through `DSAR-DEL-05` because active derived stores are purged, tombstoned, redacted, unlinked, or removed.
+- Do not flag `DSAR-DEL-06` because backup retention and restore-time purge controls are documented.
+- Do not flag `DSAR-DEL-07` because verification queries are tied to the request.
+- Do not flag `DSAR-DEL-08` because tombstones block re-ingestion.
+- Do not flag `DSAR-DEL-09` because SLA and exception handling are recorded.

--- a/skills/ai-security/ai-data-privacy/tests/vulnerable/source-only-dsar-delete.md
+++ b/skills/ai-security/ai-data-privacy/tests/vulnerable/source-only-dsar-delete.md
@@ -1,0 +1,51 @@
+# Vulnerable: DSAR closed after source deletion while AI-derived stores retain personal data
+
+This fixture should produce DSAR deletion propagation findings.
+
+## System Context
+
+- Product: support assistant with RAG and fine-tuning experiments
+- Request ID: `DSAR-2026-0616-144`
+- Request type: GDPR erasure request
+- Subject: customer `cust_4817`, email `alex.rivera@example.test`
+- SLA due date: `2026-06-30`
+- Source systems: customer profile table, support ticket system, document store
+
+## Claimed Completion
+
+The privacy ticket was closed after the application deleted `cust_4817` from the customer profile table and removed the visible support ticket. The completion note says "user deleted from app database."
+
+## Residual AI Stores
+
+| Store | Residual Data |
+|---|---|
+| Vector database | chunks from ticket `SUP-88210` still retrievable by email and account ID metadata |
+| Prompt logs | 18 prompt/completion rows include the subject email and billing dispute text |
+| Analytics events | raw event export contains `cust_4817` and support-ticket category |
+| Fine-tuning snapshot | `sft-support-2026-05.jsonl` includes the support ticket transcript |
+| Evaluation dataset | regression test `rag-support-eval-42` includes the same ticket chunk |
+| Cache | retrieval cache key `ticket:SUP-88210` returns the deleted text for 7 days |
+| Backups | restore runbook has no purge step for erased subjects |
+
+## Control Gaps
+
+- Request tracking does not record verified identity, data scope, regulatory basis, or linked AI stores.
+- No source-to-derived data map exists for prompts, embeddings, datasets, caches, or backups.
+- Vector IDs were not deleted or tombstoned.
+- The fine-tuning snapshot and evaluation data keep full personal data with no exception owner.
+- There is no post-delete query proving the subject data is absent.
+- No tombstone or blocklist prevents the source connector from re-embedding the restored ticket.
+- SLA status is marked complete even though derived stores still contain personal data.
+
+Expected findings:
+
+- `DSAR-DEL-01` because request tracking lacks scope and completion evidence.
+- `DSAR-DEL-02` because the source-to-derived AI data map is missing.
+- `DSAR-DEL-03` and `DSAR-DEL-04` because vector chunks and metadata remain retrievable.
+- `DSAR-DEL-05` because fine-tuning, evaluation, and analytics copies remain.
+- `DSAR-DEL-06` because backup restore can reintroduce erased data.
+- `DSAR-DEL-07` because post-delete verification evidence is missing.
+- `DSAR-DEL-08` because no re-ingestion guard exists.
+- `DSAR-DEL-09` because partial deletion is marked complete with no exception owner.
+
+Expected handling: reopen the request, map all derived stores, purge or tombstone vector and cache data, remove or exception-own datasets, add restore-time purge controls, run verification queries, and close only after SLA and exception evidence are recorded.


### PR DESCRIPTION
## Summary

Adds fixture-backed DSAR and deletion propagation evidence to `ai-data-privacy` so reviews verify that source deletes propagate into AI-derived stores such as embeddings, vector metadata, prompt logs, datasets, caches, checkpoints, and backups.

## Changes

- Adds `DSAR-DEL-01` through `DSAR-DEL-09` findings.
- Adds a deletion propagation evidence record, false-positive boundaries, and report output table.
- Adds official GDPR/CCPA right-to-delete references.
- Adds vulnerable and benign fixtures for source-only DSAR closure versus verified derived-store deletion.

## Validation

- `git diff --check origin/main...HEAD`
- Markdown fence-balance check over changed files
- Added-line ASCII check
- Marker checks for DSAR deletion findings and fixtures
- `git merge-tree --write-tree origin/main HEAD`

Closes #1778

## Bounty request

Improver Moderate / USD 100 if accepted.