### PR TITLE
Improve SAST custom rule regression evidence

### DIFF
--- a/skills/devsecops/sast-config/SKILL.md
+++ b/skills/devsecops/sast-config/SKILL.md
@@ -230,6 +230,47 @@ rules:
 - [ ] `languages` is explicitly specified.
 - [ ] `pattern-not` or `pattern-not-inside` handles known safe patterns to reduce false positives.
 
+#### 3.3 Custom Rule Regression Fixture Evidence
+
+Do not accept a custom Semgrep rule or CodeQL query based only on syntax validity, one observed finding, or a screenshot of tool output. Every custom rule should have repeatable positive and negative fixtures, expected-result annotations, and a command that can be run locally or in CI to detect false-positive drift and false-negative regressions.
+
+**Custom rule regression findings:**
+
+```
+SAST-RULE-01: Custom rule or query has no mapped test fixture directory or test file
+SAST-RULE-02: Positive fixture is missing for the vulnerability shape the rule claims to detect
+SAST-RULE-03: Negative fixture is missing for safe wrapper, sanitizer, validation, or approved framework patterns
+SAST-RULE-04: Expected results are not annotated with rule ID, line, message, or result count
+SAST-RULE-05: Regression command is missing, not runnable locally, or not wired to CI
+SAST-RULE-06: Rule drift is not handled when a broadened pattern increases false positives or a narrowed pattern loses original coverage
+SAST-RULE-07: Coverage limits are not documented for languages, frameworks, sources, sinks, sanitizers, or unsupported data-flow paths
+SAST-RULE-08: Suppressions or allowlists are added without corresponding negative fixtures and justification
+```
+
+**Evidence to collect per custom rule:**
+
+```
+CUSTOM RULE REGRESSION EVIDENCE
+===============================
+Rule ID:                 [custom.rule.id or query id]
+Tool / Language:         [Semgrep | CodeQL | other, language]
+Rule File:               [path]
+Positive Fixtures:       [paths and expected result counts]
+Negative Fixtures:       [paths and expected zero-result cases]
+Expected Annotations:    [line comments, .expected files, query test metadata]
+Regression Command:      [semgrep --test | codeql test run | CI job]
+Last Passing Run:        [timestamp, commit, output link/log]
+CI Enforcement:          [required check | warning | local only | absent]
+Coverage Limits:         [known unsupported patterns]
+Drift Handling:          [review owner, update process, false-positive metric]
+```
+
+**False-positive boundaries:**
+
+- Do not require both Semgrep and CodeQL fixtures when the custom rule exists in only one tool, but require the native test mechanism for that tool.
+- Do not flag a deliberately narrow rule for unsupported patterns when coverage limits are documented and a separate backlog item tracks expansion.
+- Do not treat generated test snapshots as sufficient unless expected results are reviewable and tied to the rule ID.
+
 ---
 
 ### Step 4: CodeQL Query Pattern Review
@@ -475,6 +516,12 @@ jobs:
 | Scheduled full scan | Yes/No | <cron schedule> |
 | Results dashboard | Yes/No | <dashboard URL or tool> |
 
+### Custom Rule Regression Evidence
+
+| Rule ID | Tool | Rule File | Positive Fixtures | Negative Fixtures | Expected Annotations | Regression Command | CI Enforcement | Coverage Limits | Status |
+|---|---|---|---|---|---|---|---|---|---|
+| <custom.rule.id> | <Semgrep/CodeQL> | <path> | <paths/counts> | <paths/counts> | <line/expected metadata> | <command> | <required/warn/local/absent> | <limits> | <Pass/Partial/Fail/Not Tested> |
+
 ### Findings
 
 #### [F-001] <Finding Title>
@@ -536,6 +583,8 @@ jobs:
 
 5. **Ignoring SAST scan performance.** If SAST takes 30 minutes on a PR check, developers will find ways to bypass it. Target under 10 minutes for PR scans. Use diff-aware scanning for PRs and reserve full analysis for scheduled scans.
 
+6. **Treating one finding as a rule test.** A custom rule that found one production bug can still be too broad, too narrow, or unstable. Keep positive fixtures for known vulnerable patterns, negative fixtures for safe patterns, expected-result annotations, and a regression command that fails when coverage or false-positive behavior drifts.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -555,8 +604,10 @@ This skill processes SAST configuration files, custom rules, and code patterns t
 - CWE Top 25 (2024): https://cwe.mitre.org/top25/archive/2024/2024_cwe_top25.html
 - Semgrep Documentation: https://semgrep.dev/docs/
 - Semgrep Rule Syntax: https://semgrep.dev/docs/writing-rules/rule-syntax/
+- Semgrep rule contribution tests: https://semgrep.dev/docs/contributing/contributing-to-semgrep-rules-repository
 - Semgrep Registry: https://semgrep.dev/r
 - CodeQL Documentation: https://codeql.github.com/docs/
+- CodeQL custom query testing: https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries
 - CodeQL for GitHub: https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql
 - SonarQube Documentation: https://docs.sonarsource.com/sonarqube/
 

--- a/skills/devsecops/sast-config/tests/benign/custom-rule-regression-fixtures-complete.md
+++ b/skills/devsecops/sast-config/tests/benign/custom-rule-regression-fixtures-complete.md
@@ -1,0 +1,52 @@
+# Benign: Custom SAST rule has positive and negative regression fixtures
+
+This fixture should avoid custom rule regression evidence findings because fixture mapping, annotations, regression command, and drift handling are complete.
+
+## Review Context
+
+- Tool: Semgrep
+- Rule ID: `custom.python.path-join-traversal`
+- Rule file: `.semgrep/custom/path-traversal.yml`
+- Language: Python
+- CI job: `sast-custom-rules`
+
+## Custom Rule Regression Evidence
+
+| Field | Evidence |
+|---|---|
+| Rule ID | `custom.python.path-join-traversal` |
+| Tool / Language | Semgrep / Python |
+| Rule File | `.semgrep/custom/path-traversal.yml` |
+| Positive Fixtures | `.semgrep/tests/path_traversal/vulnerable_join.py` with 3 `# ruleid: custom.python.path-join-traversal` annotations |
+| Negative Fixtures | `.semgrep/tests/path_traversal/safe_join.py` and `canonicalized_upload.py` with 7 `# ok: custom.python.path-join-traversal` annotations |
+| Expected Annotations | committed `# ruleid` and `# ok` annotations plus expected result count in CI log |
+| Regression Command | `semgrep --test .semgrep/custom/path-traversal.yml` |
+| Last Passing Run | commit `abc1234`, CI log `sast-custom-rules#482`, 3 findings and 7 ok assertions |
+| CI Enforcement | required pull-request check for custom rule changes |
+| Coverage Limits | Windows drive-letter paths and archive extraction are out of scope and tracked in `APPSEC-991` |
+| Drift Handling | AppSec owner reviews fixture diff; false-positive rate tracked monthly |
+
+## Fixture Examples
+
+Positive fixture:
+
+```python
+target = os.path.join(UPLOAD_ROOT, request.args["file"])  # ruleid: custom.python.path-join-traversal
+```
+
+Negative fixture:
+
+```python
+target = safe_join(UPLOAD_ROOT, request.args["file"])  # ok: custom.python.path-join-traversal
+```
+
+Expected outcome:
+
+- Do not flag `SAST-RULE-01` because the rule maps to a fixture directory.
+- Do not flag `SAST-RULE-02` because vulnerable fixture annotations exist.
+- Do not flag `SAST-RULE-03` because safe wrapper and canonicalization negative fixtures exist.
+- Do not flag `SAST-RULE-04` because expected results are annotated and counted.
+- Do not flag `SAST-RULE-05` because the native Semgrep test command runs in CI.
+- Do not flag `SAST-RULE-06` because drift handling and owner review are documented.
+- Do not flag `SAST-RULE-07` because coverage limits are documented.
+- Do not flag `SAST-RULE-08` because suppressions require negative fixture coverage or a ticket.

--- a/skills/devsecops/sast-config/tests/vulnerable/custom-rule-without-negative-fixtures.md
+++ b/skills/devsecops/sast-config/tests/vulnerable/custom-rule-without-negative-fixtures.md
@@ -1,0 +1,53 @@
+# Vulnerable: Custom SAST rule accepted without negative fixtures
+
+This fixture should produce custom rule regression evidence findings.
+
+## Review Context
+
+- Tool: Semgrep
+- Rule ID: `custom.python.path-join-traversal`
+- Rule file: `.semgrep/custom/path-traversal.yml`
+- Language: Python
+- Claimed purpose: flag user-controlled path joins that can escape the upload directory
+- CI command: `semgrep --config .semgrep/custom/path-traversal.yml app/`
+
+## Evidence Provided
+
+The team provides one production finding and a screenshot showing the rule fired once. The rule parses and the CI job reports findings.
+
+## Missing Regression Evidence
+
+| Requirement | Status |
+|---|---|
+| Rule-to-test mapping | no `tests/` directory for `custom.python.path-join-traversal` |
+| Positive fixtures | one screenshot only; no committed vulnerable sample with expected result |
+| Negative fixtures | none for `safe_join`, canonicalization, allowlisted filenames, or framework upload helpers |
+| Expected annotations | no `# ruleid` / `# ok` annotations and no expected result count |
+| Regression command | CI runs against production code only, not rule fixtures |
+| Drift handling | no owner or metric when false positives increase |
+| Coverage limits | no note that URL paths, Windows paths, and archive extraction are out of scope |
+| Suppression evidence | two `nosemgrep` comments were added after noise, but no safe fixture explains them |
+
+## Failure Scenario
+
+A later pattern broadening flags safe wrapper calls:
+
+```python
+safe_path = safe_join(UPLOAD_ROOT, user_filename)
+write_upload(safe_path, stream)
+```
+
+Because there is no negative fixture, the false positive ships and developers start adding broad suppressions. Another later edit stops matching the original `os.path.join(base, request.args["file"])` shape, but there is no positive regression test to fail.
+
+Expected findings:
+
+- `SAST-RULE-01` because no mapped fixture directory exists.
+- `SAST-RULE-02` because there is no committed positive fixture.
+- `SAST-RULE-03` because safe wrapper and sanitizer negative fixtures are missing.
+- `SAST-RULE-04` because expected results are not annotated.
+- `SAST-RULE-05` because no fixture regression command is wired to CI or local review.
+- `SAST-RULE-06` because false-positive and false-negative drift are not controlled.
+- `SAST-RULE-07` because coverage limits are absent.
+- `SAST-RULE-08` because suppressions were added without negative fixtures.
+
+Expected handling: require rule fixtures before trusting the custom rule, add `semgrep --test` or equivalent CI coverage, document unsupported patterns, and map every suppression to a negative fixture or ticket.


### PR DESCRIPTION
## Summary

Adds fixture-backed custom rule regression evidence to `sast-config` so custom Semgrep and CodeQL rules are not trusted without positive fixtures, negative fixtures, expected annotations, and a repeatable regression command.

## Changes

- Adds `SAST-RULE-01` through `SAST-RULE-08` findings.
- Adds custom rule regression evidence collection, false-positive boundaries, and output table.
- Adds official Semgrep and CodeQL test references.
- Adds vulnerable and benign fixtures for an untested custom rule versus complete positive/negative regression fixtures.

## Validation

- `git diff --check origin/main...HEAD`
- Markdown fence-balance check over changed files
- Added-line ASCII check
- Marker checks for SAST custom-rule findings and fixtures
- `git merge-tree --write-tree origin/main HEAD`

Closes #1773

## Bounty request

Improver Moderate / USD 100 if accepted.