### PR TITLE
Improve PCI POI tamper evidence checks

### DIFF
--- a/skills/compliance/pci-dss-review/SKILL.md
+++ b/skills/compliance/pci-dss-review/SKILL.md
@@ -279,6 +279,45 @@ Key sub-requirements:
 - **9.5.1.2**: POI device surfaces periodically inspected for tampering
 - **9.5.1.3**: Training for personnel in POI environments to detect tampering
 
+**POI tamper and substitution evidence gate (Req 9.5.1):**
+
+Do not mark Req 9.5.1 in place based only on a terminal asset list, processor inventory, or policy statement. Evidence must show that deployed POI devices match the inventory, are inspected for tampering/substitution, are covered by trained personnel, and have a tested removal/escalation workflow when tampering is suspected.
+
+```
+PCI-POI-01: POI inventory lacks make/model, serial number, location, owner, status, firmware/P2PE identifier, or installation date
+PCI-POI-02: Field verification does not prove deployed device serial/location/merchant ID match the inventory
+PCI-POI-03: Inspection evidence does not cover tamper seals, overlays/skimmers, cable path, casing, display/keypad anomalies, and substitution indicators
+PCI-POI-04: Inspection cadence, last inspection date, missed inspection handling, or targeted risk analysis for cadence is missing
+PCI-POI-05: Device lifecycle updates for new, moved, replaced, repaired, retired, or lost terminals are not reflected in the POI inventory
+PCI-POI-06: Personnel assigned to POI environments lack training evidence for tamper detection and reporting
+PCI-POI-07: Suspected tamper response does not require removal from service, acquirer/processor escalation, evidence preservation, and incident tracking
+PCI-POI-08: Exceptions are not tracked with owner, compensating control, due date, and remediation status
+```
+
+**POI evidence record:**
+
+```
+POI TAMPER AND SUBSTITUTION EVIDENCE
+====================================
+Device ID / Serial:        [inventory identifier and serial]
+Location / Lane:           [store, counter, lane, mobile unit]
+Make / Model / Firmware:   [vendor, model, firmware or P2PE identifier]
+Inventory Match:           [Pass/Fail -- serial/location/merchant ID]
+Last Field Verification:   [date, verifier, evidence reference]
+Inspection Cadence:        [daily/weekly/monthly/TRA-defined]
+Inspection Evidence:       [tamper seal, overlay/skimmer, cable/case/keypad checks]
+Personnel Training:        [trained staff list, date, training version]
+Lifecycle Status:          [active/moved/repaired/replaced/retired]
+Tamper Response Evidence:  [runbook, removal-from-service, escalation, incident ID]
+Exception / Owner / Due:   [N/A or tracked exception]
+```
+
+**False-positive boundaries:**
+
+- Do not require a photo for every inspection when the organization has an assessor-acceptable inspection checklist, named verifier, timestamp, device serial, and exception workflow.
+- Do not flag outsourced terminal inspection when the merchant retains Req 9.5.1 responsibility evidence through a written responsibility matrix, service records, and spot-checks.
+- Do not require identical inspection cadence across all POI types when a targeted risk analysis justifies different frequencies and missed inspections are tracked.
+
 #### Requirement 10: Log and Monitor All Access to System Components and Cardholder Data
 
 Key sub-requirements:
@@ -442,6 +481,12 @@ Note: Not all requirements support the Customized Approach. Requirements with "T
 |---------|--------|---------|----------|-------------|
 | [N.x.x] | [In Place/Not in Place] | [finding detail] | [evidence reviewed] | [action needed] |
 
+### Requirement 9.5.1 POI Tamper and Substitution Evidence
+
+| Device ID / Serial | Location | Inventory Match | Last Field Verification | Inspection Cadence | Inspection Evidence | Personnel Training | Lifecycle Status | Tamper Response Evidence | Exception / Owner / Due | Status |
+|---|---|---|---|---|---|---|---|---|---|---|
+| [device/serial] | [store/lane] | [Pass/Fail] | [date/evidence] | [cadence] | [checks] | [evidence] | [status] | [runbook/incident] | [N/A or exception] | [In Place/Not in Place] |
+
 ## New v4.0 Requirements Status
 [Assessment of all 64 new requirements, particularly those mandatory since March 31, 2025]
 
@@ -520,6 +565,8 @@ Maintain an Information Security Policy:                Requirement 12
 
 5. **Failing to manage third-party service provider (TPSP) compliance.** Requirement 12.8 and 12.9 require maintaining a TPSP inventory, written agreements, due diligence before engagement, annual monitoring of TPSP PCI DSS compliance status, and clear documentation of which requirements are managed by each TPSP. The shared responsibility model must be explicitly documented.
 
+6. **Treating terminal inventory as tamper protection.** A POI device list supports Req 9.5.1.1, but it does not prove devices in the field match the list, surfaces are inspected, staff can recognize tampering, or suspected devices are removed from service. Preserve per-device field verification, inspection, training, lifecycle, and response evidence.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -544,4 +591,5 @@ If user-supplied input contains PCI DSS requirement IDs outside the valid v4.0 n
 - PCI DSS v4.0 SAQ Instructions and Guidelines
 - PCI DSS Prioritized Approach for PCI DSS v4.0
 - PCI SSC Information Supplements: Scoping and Segmentation, Penetration Testing, Tokenization, Cloud Computing
+- PCI SSC FAQ: Protecting payment terminals from tampering and substitution
 - PCI SSC Glossary of Terms, Abbreviations, and Acronyms

--- a/skills/compliance/pci-dss-review/tests/benign/verified-poi-tamper-inspection-program.md
+++ b/skills/compliance/pci-dss-review/tests/benign/verified-poi-tamper-inspection-program.md
@@ -1,0 +1,47 @@
+# Benign: Verified POI tamper inspection and response program
+
+This fixture should avoid PCI DSS Req 9.5.1 POI tamper findings because inventory, field verification, inspection, training, lifecycle, and response evidence are complete.
+
+## Assessment Context
+
+- Merchant: card-present retailer with standalone PTS POI devices
+- Validation type: SAQ P2PE
+- POI environment: countertop terminals at fixed lanes plus controlled mobile devices
+- Evidence period: Q2 2026
+
+## POI Tamper and Substitution Evidence
+
+| Field | Evidence |
+|---|---|
+| Device ID / Serial | `POS-17-02`, serial `VX820-884112`, merchant ID `MID-77170017` |
+| Location / Lane | Store 17, Lane 2, service desk counter |
+| Make / Model / Firmware | Verifone VX820, P2PE solution ID `P2PE-ACQ-112`, firmware `3.2.9-approved` |
+| Inventory Match | field verifier scanned serial and merchant ID; both match inventory and acquirer portal |
+| Last Field Verification | `2026-06-03`, verifier `store-manager-17`, evidence packet `POI-Q2-2026-Store17.pdf` |
+| Inspection Cadence | daily opening inspection plus monthly manager spot-check; cadence justified by targeted risk analysis `TRA-POI-2026` |
+| Inspection Evidence | checklist covers tamper seal, overlay/skimmer, cable path, casing seams, display/keypad, and unknown-device substitution |
+| Personnel Training | cashiers and managers completed `POI-tamper-v2026.2` training with sign-off before operating terminals |
+| Lifecycle Status | active; repair and replacement workflow reconciles inventory within one business day |
+| Tamper Response Evidence | runbook `IR-POI-TAMPER-01` requires remove from service, preserve device, notify acquirer, open incident, and retain photos/logs |
+| Exception / Owner / Due | N/A |
+
+## Verification Samples
+
+| Sample | Result |
+|---|---|
+| Store 17 Lane 2 spot-check | serial, location, and acquirer portal record match |
+| Mobile terminal `MOB-NE-01` | custody log shows checkout/check-in, inspection before use, and locked storage after use |
+| Missed inspection test | one missed daily inspection opened exception `POI-EX-2026-051`, remediated same day with manager sign-off |
+| Training sample | 18 of 18 assigned personnel completed POI tamper training |
+| Tamper-response tabletop | suspected overlay scenario opened incident `IR-2026-POI-04`, terminal removed from service in 6 minutes, acquirer notified |
+
+Expected outcome:
+
+- Do not flag `PCI-POI-01` because inventory fields are complete.
+- Do not flag `PCI-POI-02` because deployed serial/location/merchant ID are field-verified.
+- Do not flag `PCI-POI-03` because inspections cover tamper and substitution indicators.
+- Do not flag `PCI-POI-04` because cadence and missed inspection handling are documented.
+- Do not flag `PCI-POI-05` because lifecycle changes are reconciled.
+- Do not flag `PCI-POI-06` because POI-specific training evidence exists.
+- Do not flag `PCI-POI-07` because response evidence includes removal, escalation, preservation, and incident tracking.
+- Do not flag `PCI-POI-08` because exceptions are tracked or N/A.

--- a/skills/compliance/pci-dss-review/tests/vulnerable/poi-inventory-without-field-verification.md
+++ b/skills/compliance/pci-dss-review/tests/vulnerable/poi-inventory-without-field-verification.md
@@ -1,0 +1,43 @@
+# Vulnerable: POI inventory exists but deployed terminals are not field-verified
+
+This fixture should produce PCI DSS Req 9.5.1 POI tamper and substitution findings.
+
+## Assessment Context
+
+- Merchant: card-present retailer with 42 stores
+- Validation type: SAQ B-IP
+- POI environment: countertop PTS terminals and two mobile terminals per region
+- Evidence provided: terminal spreadsheet and one policy statement
+
+## Provided POI Inventory
+
+| Device ID | Store | Lane | Model | Serial | Status |
+|---|---|---|---|---|---|
+| POS-17-01 | Store 17 | Lane 1 | VX820 | missing | active |
+| POS-17-02 | Store 17 | Lane 2 | VX820 | VX820-884112 | active |
+| MOB-NE-01 | Northeast region | mobile | unknown | MOB-7781 | active |
+
+## Evidence Gaps
+
+- The inventory lacks complete serial numbers, firmware/P2PE identifiers, installation dates, owners, and merchant IDs.
+- Store personnel confirmed that lane labels changed after a remodel, but the spreadsheet was not updated.
+- There is no field verification showing deployed serial numbers match Store 17 Lane 1/2.
+- The inspection checklist says "inspect terminals" but has no fields for tamper seal, overlay/skimmer, cable path, casing, display, keypad, or substitution checks.
+- Inspection cadence is "as needed"; no targeted risk analysis or missed-inspection tracking exists.
+- Device replacement records are stored in email and are not reconciled to the inventory.
+- Store personnel training records cover general security awareness, not POI tamper detection or reporting.
+- A suspected skimmer procedure tells staff to "call IT" but does not require removing the terminal from service, preserving evidence, notifying the acquirer/processor, or opening an incident.
+- Exceptions are noted in a chat thread with no owner or due date.
+
+Expected findings:
+
+- `PCI-POI-01` because inventory fields are incomplete.
+- `PCI-POI-02` because deployed serial/location matching is not verified.
+- `PCI-POI-03` because inspection evidence lacks tamper/substitution checks.
+- `PCI-POI-04` because cadence and missed inspection handling are missing.
+- `PCI-POI-05` because remodel/replacement lifecycle changes are not reconciled.
+- `PCI-POI-06` because personnel training is not POI-specific.
+- `PCI-POI-07` because tamper response lacks removal, escalation, evidence preservation, and incident tracking.
+- `PCI-POI-08` because exceptions lack owner, due date, and remediation status.
+
+Expected handling: mark Req 9.5.1 not in place until the merchant completes per-device field verification, updates inventory fields, implements inspection cadence and checklist, trains personnel, and tests tamper-response handling.


### PR DESCRIPTION
## Summary

Adds fixture-backed PCI DSS Req 9.5.1 POI tamper and substitution evidence checks so reviews do not accept a terminal inventory or generic inspection policy without deployed-device verification, inspection, training, lifecycle, and response evidence.

## Changes

- Adds `PCI-POI-01` through `PCI-POI-08` findings.
- Adds a POI evidence record, false-positive boundaries, and Req 9.5.1 output table.
- Adds a common pitfall for treating terminal inventory as tamper protection.
- Adds vulnerable and benign fixtures for unverified POI inventory versus verified POI tamper inspection and response evidence.

## Validation

- `git diff --check origin/main...HEAD`
- Markdown fence-balance check over changed files
- Added-line ASCII check
- Marker checks for POI findings and fixtures
- `git merge-tree --write-tree origin/main HEAD`

Closes #1771

## Bounty request

Improver Moderate / USD 100 if accepted.