### PR TITLE
Improve DNSSEC chain evidence checks

### DIFF
--- a/skills/network/dns-security/SKILL.md
+++ b/skills/network/dns-security/SKILL.md
@@ -111,6 +111,45 @@ For each authoritative zone, verify:
 - **DS record in parent:** A DS record matching the KSK is published in the parent zone.
 - **NSEC vs. NSEC3:** NSEC3 is preferred to prevent zone enumeration (NIST SP 800-81 Rev 2 Section 4.4).
 
+**DNSSEC chain-of-trust evidence gate:**
+
+Do not mark a public zone's DNSSEC chain as valid based only on registrar UI, a hosted-zone checkbox, or the presence of DNSKEY records. Evidence must prove the active parent DS RRset matches the child KSK DNSKEY digest and that validators can build the chain at the time of review.
+
+```
+DNSSEC-CHAIN-01: Registrar, parent-zone, or registry evidence for active DS records is missing
+DNSSEC-CHAIN-02: Parent DS key tag, algorithm, digest type, digest, or TTL is not recorded
+DNSSEC-CHAIN-03: Child KSK DNSKEY key tag, algorithm, public key, or DNSKEY RRset evidence is not recorded
+DNSSEC-CHAIN-04: Parent DS digest does not match the digest computed from the child KSK DNSKEY
+DNSSEC-CHAIN-05: Multiple DS/DNSKEY records exist but rollover state, active key, or expected overlap window is not documented
+DNSSEC-CHAIN-06: Validation output is missing, stale, uses only a non-validating resolver, or does not show AD/bogus/servfail status
+DNSSEC-CHAIN-07: DNSSEC deployment is enabled in UI but parent DS is absent, disabled, or still pending publication
+DNSSEC-CHAIN-08: Broken-chain findings omit remediation owner, registrar/parent action, and recheck timestamp
+```
+
+**DNSSEC chain evidence record:**
+
+```
+DNSSEC CHAIN-OF-TRUST EVIDENCE
+==============================
+Zone:                    [example.com]
+Review Timestamp:        [UTC timestamp]
+Parent Evidence Source:  [dig DS @parent | registrar export | registry API]
+Parent DS:               [key tag, algorithm, digest type, digest, TTL]
+Child DNSKEY / KSK:      [key tag, algorithm, public key hash/evidence]
+Digest Match:            [Pass/Fail/Not Tested]
+Rollover State:          [steady | pre-publish | double-sign | retiring | unknown]
+Validation Command:      [dig +dnssec | delv | drill | DNSViz]
+Validation Result:       [AD | secure | bogus | servfail | insecure]
+Remediation Owner / ETA: [N/A or owner/date]
+Recheck Timestamp:       [UTC timestamp]
+```
+
+**False-positive boundaries:**
+
+- Do not require a single DS record when an active rollover intentionally publishes multiple DS records and the overlap window is documented.
+- Do not flag a private/internal zone for absent parent DS when it has no public delegation and the trust anchor model is documented separately.
+- Do not reject a registrar export when it is paired with independent DNS query validation from parent nameservers or DNSViz-style validation output.
+
 **Patterns to check in zone files:**
 
 ```
@@ -322,6 +361,12 @@ abcdef0123456789.dnscat.example.com TXT
 |------|--------|-----------|-----------|--------------|-------------|--------|
 | example.com | Yes/No | 13/8/15 | KSK:2048/ZSK:1024 | Yes/No | NSEC3 | Pass/Fail |
 
+### DNSSEC Chain-of-Trust Evidence
+
+| Zone | Parent DS | Child KSK DNSKEY | Digest Match | Rollover State | Validation Command | Validation Result | Evidence Timestamp | Remediation Owner / ETA |
+|---|---|---|---|---|---|---|---|---|
+| example.com | [keytag/alg/digest-type/digest] | [keytag/alg/evidence] | [Pass/Fail] | [state] | [command] | [AD/secure/bogus/servfail/insecure] | [UTC] | [N/A or owner/date] |
+
 ### Resolver Security
 
 | Resolver | DNSSEC Validation | Encrypted Transport | RPZ/Filtering | Query Logging |
@@ -383,6 +428,8 @@ abcdef0123456789.dnscat.example.com TXT
 3. **Relying solely on domain reputation lists for exfiltration detection.** Attackers use attacker-controlled domains that are not yet categorized. Behavioral detection (entropy, volume, query type anomalies) catches novel exfiltration domains that reputation feeds miss.
 
 4. **Ignoring DNS over TCP.** DNS is not UDP-only. DNS over TCP (port 53) supports large responses and is required for zone transfers. Some tunneling tools prefer TCP for reliability. Firewall rules and monitoring must cover both UDP and TCP port 53.
+
+5. **Trusting DNSSEC UI without chain verification.** Registrar or DNS-hosting UI can show DNSSEC enabled while the parent DS is missing, stale, or mismatched. Always record the parent DS RRset, child KSK DNSKEY, digest comparison, rollover state, and validator output before marking the chain of trust valid.
 
 ---
 

--- a/skills/network/dns-security/tests/benign/validated-dnssec-chain-evidence.md
+++ b/skills/network/dns-security/tests/benign/validated-dnssec-chain-evidence.md
@@ -1,0 +1,43 @@
+# Benign: DNSSEC chain evidence validates parent DS against child KSK
+
+This fixture should avoid DNSSEC chain-of-trust findings because parent, child, digest, rollover, and validation evidence are complete.
+
+## Review Context
+
+- Zone: `example-payments.test`
+- DNS host: managed authoritative DNS
+- Registrar: registry API with DNSSEC DS export
+- Review timestamp: `2026-06-09T00:25:00Z`
+
+## DNSSEC Chain-of-Trust Evidence
+
+| Field | Evidence |
+|---|---|
+| Zone | `example-payments.test` |
+| Review Timestamp | `2026-06-09T00:25:00Z` |
+| Parent Evidence Source | `dig DS example-payments.test @parent-ns.test +dnssec` plus registrar DS export `REG-DS-2026-0609.json` |
+| Parent DS | key tag `63109`, algorithm `13`, digest type `2`, digest `88BB...BEEF`, TTL `3600` |
+| Child DNSKEY / KSK | DNSKEY RRset from authoritative server; KSK key tag `63109`, algorithm `13`, SEP flag set |
+| Digest Match | pass; computed SHA-256 digest from child KSK equals parent DS digest |
+| Rollover State | steady state; no active rollover |
+| Validation Command | `delv www.example-payments.test A` and DNSViz report `dnssec-2026-0609` |
+| Validation Result | secure; AD bit present from validating resolver |
+| Remediation Owner / ETA | N/A |
+| Recheck Timestamp | `2026-06-09T00:31:00Z` |
+
+## Verification Notes
+
+- Parent DS and registrar export agree on key tag, algorithm, digest type, and digest.
+- Child DNSKEY key tag and algorithm match the parent DS.
+- Independent validation returns secure status for `www.example-payments.test`.
+- The report states that new DS evidence is required before the next KSK rollover.
+
+Expected outcome:
+
+- Do not flag `DNSSEC-CHAIN-01` or `DNSSEC-CHAIN-02` because parent DS evidence is recorded.
+- Do not flag `DNSSEC-CHAIN-03` because child KSK DNSKEY evidence is recorded.
+- Do not flag `DNSSEC-CHAIN-04` because digest comparison passes.
+- Do not flag `DNSSEC-CHAIN-05` because rollover state is documented.
+- Do not flag `DNSSEC-CHAIN-06` because validation output is current and secure.
+- Do not flag `DNSSEC-CHAIN-07` because UI evidence is not the sole basis.
+- Do not flag `DNSSEC-CHAIN-08` because no remediation is needed and recheck evidence exists.

--- a/skills/network/dns-security/tests/vulnerable/registrar-ui-enabled-mismatched-ds.md
+++ b/skills/network/dns-security/tests/vulnerable/registrar-ui-enabled-mismatched-ds.md
@@ -1,0 +1,44 @@
+# Vulnerable: Registrar UI says DNSSEC enabled but parent DS mismatches child KSK
+
+This fixture should produce DNSSEC chain-of-trust findings.
+
+## Review Context
+
+- Zone: `example-payments.test`
+- DNS host: managed authoritative DNS
+- Registrar UI: "DNSSEC enabled"
+- Assessor conclusion before validation: "DNSSEC in place"
+- Review timestamp: `2026-06-09T00:20:00Z`
+
+## Evidence Collected
+
+| Source | Evidence |
+|---|---|
+| Registrar UI | DNSSEC toggle enabled, no export of active DS RRset |
+| Parent query | `example-payments.test. 3600 IN DS 45712 8 2 11AA...DEAD` |
+| Child DNSKEY | KSK key tag `63109`, algorithm `13`, public key from authoritative DNSKEY RRset |
+| Computed digest | digest type `2`, digest `88BB...BEEF` |
+| Validation command | `dig +dnssec www.example-payments.test A @1.1.1.1` |
+| Validation result | `SERVFAIL`; no AD bit |
+
+## Gaps
+
+- The review records only "DNSSEC enabled" from the UI.
+- Parent DS key tag `45712` does not match child KSK key tag `63109`.
+- Parent DS algorithm `8` does not match child KSK algorithm `13`.
+- Parent DS digest does not match the computed child KSK digest.
+- Rollover state is not documented; no planned overlap window explains the mismatch.
+- No registrar ticket, remediation owner, or recheck timestamp is recorded.
+
+Expected findings:
+
+- `DNSSEC-CHAIN-01` because active registrar/parent evidence is incomplete.
+- `DNSSEC-CHAIN-02` because parent DS values were not recorded in the original review.
+- `DNSSEC-CHAIN-03` because child KSK DNSKEY evidence was not tied to the parent DS.
+- `DNSSEC-CHAIN-04` because the DS digest and key tag mismatch the child KSK.
+- `DNSSEC-CHAIN-05` because rollover state is unknown.
+- `DNSSEC-CHAIN-06` because validation output shows failure and was not used.
+- `DNSSEC-CHAIN-07` because UI-enabled DNSSEC is accepted while the chain is broken.
+- `DNSSEC-CHAIN-08` because remediation owner and recheck timestamp are missing.
+
+Expected handling: mark the DNSSEC chain as broken/critical, update parent DS through the registrar or registry path, document rollover state, and recheck with parent DS query plus validating resolver output.


### PR DESCRIPTION
## Summary

Adds fixture-backed DNSSEC chain-of-trust evidence to `dns-security` so reviewers verify parent DS, child KSK DNSKEY, digest matching, rollover state, and validator output instead of relying on registrar UI claims.

## Changes

- Adds `DNSSEC-CHAIN-01` through `DNSSEC-CHAIN-08` findings.
- Adds a DNSSEC chain evidence record, false-positive boundaries, and output table.
- Adds a common pitfall warning against trusting DNSSEC UI without chain verification.
- Adds vulnerable and benign fixtures for a registrar-enabled but mismatched DS chain versus validated parent DS and child KSK evidence.

## Validation

- `git diff --check origin/main...HEAD`
- Markdown fence-balance check over changed files
- Added-line ASCII check
- Marker checks for DNSSEC chain findings and fixtures
- `git merge-tree --write-tree origin/main HEAD`

Closes #1810

## Bounty request

Improver Moderate / USD 100 if accepted.