### PR TITLE
Improve segmentation path validation evidence

### DIFF
--- a/skills/network/segmentation/SKILL.md
+++ b/skills/network/segmentation/SKILL.md
@@ -243,6 +243,48 @@ Document or verify the existence of a segmentation testing process:
 4. **Test VLAN hopping** via double-tagging from user VLANs. Expected result: traffic dropped.
 5. **Validate that segmentation controls survive failover** (HA firewall failover should not open transit paths).
 
+#### 6.1 Path Validation Evidence Gate
+
+Do not accept zone diagrams, route tables, firewall rules, or security-group intent as proof that segmentation works. Require per-path evidence showing whether tested or inferred communication paths behave as expected, including both representative denied paths and business-critical allowed paths.
+
+**Path validation findings:**
+
+```
+SEG-PATH-01: Source zone, source asset, destination zone, or destination asset is missing for a tested path
+SEG-PATH-02: Protocol, port, direction, or application flow is missing, making the path test non-repeatable
+SEG-PATH-03: Expected result and actual result are not both recorded
+SEG-PATH-04: Test method is missing or relies only on diagrams, route tables, or policy review without traffic evidence
+SEG-PATH-05: High-risk denied paths are not sampled, such as user-to-CDE, DMZ-to-data, workload-to-management, or cross-tenant paths
+SEG-PATH-06: Business-critical allowed paths are not tested, so remediation may break required flows unnoticed
+SEG-PATH-07: Evidence timestamp, tester, tool output, packet/log reference, or confidence level is missing or stale
+SEG-PATH-08: Failed, unexpected-allowed, or unexpected-denied paths lack owner, remediation action, and retest timestamp
+```
+
+**Path validation evidence record:**
+
+```
+SEGMENTATION PATH VALIDATION EVIDENCE
+=====================================
+Path ID:                 [unique ID]
+Source Zone / Asset:     [zone, host, IP, workload, namespace]
+Destination Zone / Asset:[zone, host, IP, service, namespace]
+Protocol / Port:         [tcp/443, udp/53, icmp, app protocol]
+Direction:               [ingress/egress/east-west]
+Expected Result:         [Allowed | Denied]
+Actual Result:           [Allowed | Denied | Partial | Not Tested]
+Test Method:             [nmap, curl, nc, packet capture, flow log, policy simulator]
+Evidence Reference:      [command output, flow log ID, packet capture, screenshot]
+Timestamp / Tester:      [UTC timestamp and tester]
+Confidence:              [High | Medium | Low, with reason]
+Owner / Retest:          [N/A or owner/date]
+```
+
+**False-positive boundaries:**
+
+- Do not require exhaustive all-to-all testing when a documented sampling plan covers every high-risk boundary and critical allowed flow with representative assets.
+- Do not flag policy-simulator evidence when it is paired with at least one traffic or flow-log validation per high-risk boundary.
+- Do not flag blocked ICMP if the business flow is TCP/UDP and the review records protocol-specific allowed/denied evidence.
+
 ---
 
 ## Findings Classification
@@ -283,6 +325,12 @@ Document or verify the existence of a segmentation testing process:
 | DMZ         | App       | Firewall    | Restricted | Pass |
 | App         | Data      | SG only     | Overly permissive | F-002 |
 | User        | Data      | None        | No control | F-001 |
+
+### Path Validation Evidence
+
+| Path ID | Source Zone / Asset | Destination Zone / Asset | Protocol / Port | Expected Result | Actual Result | Test Method | Evidence Reference | Timestamp / Tester | Confidence | Owner / Retest |
+|---|---|---|---|---|---|---|---|---|---|---|
+| [path] | [zone/asset] | [zone/asset] | [protocol/port] | [Allowed/Denied] | [Allowed/Denied/Partial/Not Tested] | [method] | [evidence] | [UTC/tester] | [High/Medium/Low] | [N/A or owner/date] |
 
 ### Findings
 
@@ -344,6 +392,8 @@ Document or verify the existence of a segmentation testing process:
 4. **Overlooking service mesh bypass paths.** Istio and Linkerd enforce policy on mesh-enrolled workloads only. Pods that bypass the sidecar proxy (hostNetwork: true, or init container misconfiguration) are not subject to mesh policy. Verify sidecar injection is enforced.
 
 5. **Assuming Kubernetes namespaces provide network isolation.** Namespaces are a logical organizational boundary. Without a NetworkPolicy or CNI-level enforcement (Calico, Cilium), all pods across all namespaces can communicate freely by default.
+
+6. **Accepting diagrams without path evidence.** A diagram can show intended segmentation while route tables, peering, transit gateways, security groups, or mesh bypasses still allow unexpected traffic. Preserve path-level evidence for representative denied paths and business-critical allowed flows before marking boundaries effective.
 
 ---
 

--- a/skills/network/segmentation/tests/benign/tested-denied-and-allowed-paths.md
+++ b/skills/network/segmentation/tests/benign/tested-denied-and-allowed-paths.md
@@ -1,0 +1,36 @@
+# Benign: Segmentation review records denied and allowed path validation evidence
+
+This fixture should avoid segmentation path validation findings because representative high-risk denied paths and business-critical allowed paths are tested and documented.
+
+## Review Context
+
+- Environment: hybrid cloud with hub-and-spoke VPCs
+- Zones: user, DMZ, app, data, management, PCI CDE
+- Sampling plan: all high-risk boundaries plus critical production flows
+- Review date: `2026-06-09`
+
+## Path Validation Evidence
+
+| Path ID | Source Zone / Asset | Destination Zone / Asset | Protocol / Port | Expected Result | Actual Result | Test Method | Evidence Reference | Timestamp / Tester | Confidence | Owner / Retest |
+|---|---|---|---|---|---|---|---|---|---|---|
+| PV-001 | user / `vdi-12` | PCI CDE / `cde-db-01` | tcp/1433 | Denied | Denied | `nc -vz` plus firewall deny log | FWLOG-88211 | `2026-06-09T00:30:00Z` / netsec | High | N/A |
+| PV-002 | DMZ / `web-02` | data / `db-01` | tcp/5432 | Denied | Denied | packet capture and flow log | PCAP-2026-0609-02 | `2026-06-09T00:37:00Z` / netsec | High | N/A |
+| PV-003 | app / `api-01` | data / `db-01` | tcp/5432 | Allowed | Allowed | `psql` health check and flow log | FLOW-77190 | `2026-06-09T00:41:00Z` / appsec | High | N/A |
+| PV-004 | workload / `orders-pod` | management / `bastion-01` | tcp/22 | Denied | Denied | Cilium policy trace plus flow drop | CILIUM-TRACE-44 | `2026-06-09T00:47:00Z` / platform | Medium | N/A |
+| PV-005 | app spoke / `api-01` | audit spoke / `siem-ingest` | tcp/443 | Allowed | Allowed | policy simulator plus TLS probe | SIM-551, CURL-551 | `2026-06-09T00:53:00Z` / netsec | Medium | N/A |
+
+## Review Notes
+
+- High-risk denied paths include user-to-CDE, DMZ-to-data, and workload-to-management.
+- Allowed paths include database access and SIEM ingestion needed for production.
+- Policy simulator output is paired with traffic or flow-log validation.
+- Evidence includes source, destination, port, expected result, actual result, test method, timestamp, tester, and confidence.
+- No unexpected results remain open; prior finding `SEG-2026-14` was retested and closed.
+
+Expected outcome:
+
+- Do not flag `SEG-PATH-01` through `SEG-PATH-04` because each path is repeatable and evidence-backed.
+- Do not flag `SEG-PATH-05` because high-risk denied paths are sampled.
+- Do not flag `SEG-PATH-06` because business-critical allowed paths are tested.
+- Do not flag `SEG-PATH-07` because timestamp, tester, evidence, and confidence are recorded.
+- Do not flag `SEG-PATH-08` because unexpected results have no open owner/retest gap.

--- a/skills/network/segmentation/tests/vulnerable/diagram-only-segmentation-review.md
+++ b/skills/network/segmentation/tests/vulnerable/diagram-only-segmentation-review.md
@@ -1,0 +1,45 @@
+# Vulnerable: Segmentation review accepts diagrams without path validation evidence
+
+This fixture should produce segmentation path validation findings.
+
+## Review Context
+
+- Environment: hybrid cloud with hub-and-spoke VPCs
+- Zones: user, DMZ, app, data, management, PCI CDE
+- Evidence provided: architecture diagram, firewall export, route-table screenshot
+- Review conclusion: "segmentation validated"
+
+## Missing Path Evidence
+
+| Claimed Boundary | Missing Evidence |
+|---|---|
+| User to PCI CDE | no source asset, destination asset, protocol, expected result, or denied-path test |
+| DMZ to Data | diagram shows firewall, but no test from DMZ host to database port |
+| App to Data | required `tcp/5432` allowed path is not tested after a firewall cleanup |
+| Workload to Management | no test for pod-to-bastion or workload-to-metadata paths |
+| Hub to Spoke | route table screenshot does not prove transit gateway policies block lateral paths |
+
+## Bad Evidence Example
+
+The report includes:
+
+```text
+Segmentation is in place because the network diagram separates app, data, and management zones.
+Firewall rules appear restrictive.
+No active path test was performed due to time constraints.
+```
+
+No command output, flow-log ID, packet capture, policy simulator result, timestamp, tester, or confidence rating is recorded. One later change accidentally blocks `app-01 -> db-01 tcp/5432`, while another leaves `user-vdi -> cde-db tcp/1433` open through a peering route.
+
+Expected findings:
+
+- `SEG-PATH-01` because source/destination assets are missing.
+- `SEG-PATH-02` because protocol, port, and direction are missing.
+- `SEG-PATH-03` because expected and actual results are not recorded.
+- `SEG-PATH-04` because evidence relies only on diagrams and policy review.
+- `SEG-PATH-05` because high-risk denied paths are not sampled.
+- `SEG-PATH-06` because business-critical allowed paths are not tested.
+- `SEG-PATH-07` because timestamp, tester, output, and confidence are missing.
+- `SEG-PATH-08` because unexpected open/broken paths lack owner and retest.
+
+Expected handling: mark segmentation validation incomplete, create a representative path test plan, test high-risk denied paths and critical allowed paths, record evidence, and retest any unexpected results.


### PR DESCRIPTION
## Summary
- Adds a path validation evidence gate to the segmentation review workflow.
- Requires per-path source/destination, protocol/port, expected vs actual result, method, evidence reference, timestamp/tester, confidence, and owner/retest data.
- Adds report output for denied high-risk paths and business-critical allowed paths.
- Adds vulnerable and benign fixtures for diagram-only validation versus tested denied/allowed paths.

## Validation
- `git diff --check origin/main...HEAD`
- Markdown fence-balance check across changed `.md` files
- Added-line ASCII check
- Content marker check for `SEG-PATH-01` through `SEG-PATH-08`, path evidence record, and fixtures
- `git merge-tree --write-tree origin/main HEAD`

Closes #1812

Requested tier: Improver Moderate (USD 100)