### PR TITLE
Improve secrets rotation validation evidence

### DIFF
--- a/skills/devsecops/secrets-management/SKILL.md
+++ b/skills/devsecops/secrets-management/SKILL.md
@@ -296,6 +296,48 @@ NIST SP 800-57 Part 1 Rev 5 Table 1 defines recommended cryptoperiods by key typ
 - Rotation events are logged and monitored.
 - Failed rotations trigger alerts.
 
+#### 4.2.1 Rotation Validation Evidence Gate
+
+Treat the rotation job as the start of validation, not proof that rotation is complete. For every rotated long-lived credential, record evidence that consumers adopted the new secret, the old credential stopped authenticating after the approved rollover window, and post-rotation monitoring shows no fallback use or authentication failures.
+
+**Rotation validation findings:**
+
+```
+SEC-ROT-01: Rotation event ID, timestamp, automation job, or emergency-change ticket is missing
+SEC-ROT-02: Secret type, secret store, version identifier, or active version is missing from the rotation record
+SEC-ROT-03: Consumer inventory is incomplete, so adoption of the new secret cannot be verified
+SEC-ROT-04: Old credential revocation or disablement is missing after the rollover window
+SEC-ROT-05: Old credential test is missing, inconclusive, or still succeeds after rollover closure
+SEC-ROT-06: New credential functional test is missing for at least one required consumer
+SEC-ROT-07: Monitoring evidence is missing for fallback use, authentication errors, or failed consumer refreshes
+SEC-ROT-08: Emergency or manual rotation lacks post-incident review, owner, rollback window, or follow-up validation
+```
+
+**Rotation validation evidence record:**
+
+```
+SECRET ROTATION VALIDATION EVIDENCE
+===================================
+Secret Type / Store:       [API key, DB credential, cert, Vault/AWS SM/GCP SM/Azure KV]
+Secret Version / Alias:    [old version, new version, active alias; never include secret value]
+Rotation Event:            [job ID, ticket, incident, timestamp]
+Consumers:                 [services/jobs/agents expected to use the secret]
+Consumer Update Status:    [updated/redeployed/restarted/not applicable]
+Old Credential Revoked:    [Yes | No | Pending, with timestamp]
+Old Credential Test:       [Denied | Accepted | Not Tested, with evidence reference]
+New Credential Test:       [Accepted | Failed | Not Tested, with evidence reference]
+Monitoring Evidence:       [auth logs, error-rate dashboard, vault access logs, alerts]
+Rollback Window:           [duration, closure time, approver]
+Validation Confidence:     [High | Medium | Low, with reason]
+Owner / Follow-up:         [owner, post-incident review, retest date]
+```
+
+**False-positive boundaries:**
+
+- Do not require an old-credential authentication test when the platform provides immutable revocation evidence and a failed test would expose sensitive production systems.
+- Do not flag dynamic secrets as missing revocation evidence when the lease TTL, revocation logs, and consumer refresh behavior prove expiry.
+- Do not require every consumer to be redeployed when consumers fetch the active alias at runtime and access logs prove they use the new version.
+
 **Finding classification:** No rotation for secrets older than 180 days is **High**. Manual rotation process only is **Medium**. Rotation configured but not monitored is **Medium**.
 
 ---
@@ -389,6 +431,12 @@ spec:
 | API key (Stripe) | AWS SM | 90 days | Yes | 2024-01-15 |
 | TLS cert | cert-manager | 60 days | Yes | Auto |
 
+### Rotation Validation Evidence
+
+| Secret Type / Store | Secret Version / Alias | Rotation Event | Consumers | Consumer Update Status | Old Credential Revoked | Old Credential Test | New Credential Test | Monitoring Evidence | Rollback Window | Validation Confidence | Owner / Follow-up |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| [type/store] | [old/new/alias] | [job/ticket/timestamp] | [services] | [status] | [Yes/No/Pending] | [Denied/Accepted/Not Tested] | [Accepted/Failed/Not Tested] | [logs/metrics/alerts] | [duration/closed] | [High/Medium/Low] | [owner/date] |
+
 ### Findings
 
 #### [F-001] <Finding Title>
@@ -396,6 +444,7 @@ spec:
 - **Control Reference:** OWASP Secrets Mgmt / NIST SP 800-57 Section X
 - **File:** <path to config file>
 - **Description:** <what was found -- NEVER include actual secret values>
+- **Rotation Validation Evidence:** <event, consumers, old revocation, old/new tests, monitoring, confidence>
 - **Remediation:** <concrete fix>
 
 ### Prioritized Remediation Plan
@@ -441,6 +490,8 @@ spec:
 3. **Using environment variables as the secrets "manager."** Environment variables are better than hardcoded secrets in source, but they are still stored in plaintext in process memory, visible in `/proc/PID/environ` on Linux, and logged by many frameworks on crash. A proper secrets manager (Vault, cloud-native) with sidecar injection or API-based retrieval is the target state.
 
 4. **Ignoring secret sprawl across multiple secrets managers.** Large organizations often have Vault, AWS Secrets Manager, Azure Key Vault, and application-specific secret stores running simultaneously. Without a unified inventory, secrets expire unmonitored and rotation gaps emerge. Maintain a single source of truth for secret metadata (type, owner, rotation schedule, storage location).
+
+5. **Assuming a successful rotation job means old credentials are dead.** Rotation automation can create a new version while consumers keep using a cached old secret, a rollback credential remains enabled, or a hardcoded fallback path still authenticates. Verify consumer adoption, old credential revocation, old/new credential tests, and monitoring before marking rotation complete.
 
 ---
 

--- a/skills/devsecops/secrets-management/tests/benign/validated-consumer-adoption-and-revocation.md
+++ b/skills/devsecops/secrets-management/tests/benign/validated-consumer-adoption-and-revocation.md
@@ -1,0 +1,33 @@
+# Benign: Rotation validation proves consumer adoption and old credential revocation
+
+This fixture should avoid rotation validation findings because it records event, consumer, revocation, test, and monitoring evidence without exposing secret values.
+
+## Review Context
+
+- Secret type: database credential
+- Store: HashiCorp Vault dynamic credential path `database/creds/orders-api`
+- Rotation method: lease renewal disabled, new lease issued, old lease revoked
+- Rotation event: `CHG-2026-0609-112`
+- Review date: `2026-06-09`
+
+## Rotation Validation Evidence
+
+| Secret Type / Store | Secret Version / Alias | Rotation Event | Consumers | Consumer Update Status | Old Credential Revoked | Old Credential Test | New Credential Test | Monitoring Evidence | Rollback Window | Validation Confidence | Owner / Follow-up |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| DB credential / Vault | old lease `lease-7741`, new lease `lease-8814` | `CHG-2026-0609-112` at `2026-06-09T01:00:00Z` | `orders-api`, `orders-worker`, `report-cron` | all pods restarted and fetched `lease-8814` | Yes, revoke log `VAULT-AUDIT-9912` at `2026-06-09T01:20:00Z` | Denied, `AUTH-TEST-OLD-334` | Accepted, `AUTH-TEST-NEW-335` | DB auth logs `DBAUTH-771`, error dashboard `MON-882` | 20 minutes, closed by platform owner | High, all consumers and tests recorded | platform owner, next review `2026-07-09` |
+
+## Review Notes
+
+- The table records secret type/store, old and new version identifiers, rotation event, consumers, and consumer update status.
+- The old credential revocation has a vault audit reference and a denied authentication test.
+- The new credential has a successful consumer test.
+- Monitoring includes downstream database authentication logs and service error dashboards.
+- No actual secret value, password, token, or key material is present.
+
+Expected outcome:
+
+- Do not flag `SEC-ROT-01` or `SEC-ROT-02` because event and version metadata are present.
+- Do not flag `SEC-ROT-03` because all consumers are listed and refreshed.
+- Do not flag `SEC-ROT-04` or `SEC-ROT-05` because the old credential was revoked and denied.
+- Do not flag `SEC-ROT-06` or `SEC-ROT-07` because new credential function and monitoring evidence are recorded.
+- Do not flag `SEC-ROT-08` because the owner, rollback closure, and follow-up are documented.

--- a/skills/devsecops/secrets-management/tests/vulnerable/rotation-job-with-live-old-secret.md
+++ b/skills/devsecops/secrets-management/tests/vulnerable/rotation-job-with-live-old-secret.md
@@ -1,0 +1,39 @@
+# Vulnerable: Rotation job succeeds but old credential remains usable
+
+This fixture should produce rotation validation findings without exposing actual secret values.
+
+## Review Context
+
+- Secret type: payment API key
+- Store: AWS Secrets Manager
+- Rotation method: Lambda rotation job with a 24-hour rollback window
+- Rotation event: `SM-ROT-2026-0609-01`
+- Review conclusion: "rotation completed successfully"
+
+## Evidence Provided
+
+| Item | Evidence |
+|---|---|
+| Rotation job | `SM-ROT-2026-0609-01` succeeded at `2026-06-09T00:15:00Z` |
+| New version | alias `AWSCURRENT` points to `version-2026-0609` |
+| Consumers | `checkout-api`, `refund-worker`, `billing-cron` listed in the architecture diagram |
+| Monitoring | rotation Lambda logs only |
+
+## Missing or Bad Validation
+
+- `refund-worker` was not redeployed and still uses a cached old version.
+- Old credential disablement is marked "defer until no errors" with no closure timestamp.
+- No old credential test proves the previous version is denied.
+- No new credential test is recorded for `billing-cron`.
+- Monitoring checks only the rotation job, not downstream authentication errors or fallback use.
+- A later log shows `refund-worker` authenticating through the rollback credential after the rollback window should have closed.
+
+Expected findings:
+
+- `SEC-ROT-03` because consumer adoption is incomplete.
+- `SEC-ROT-04` because old credential revocation is missing after the rollover window.
+- `SEC-ROT-05` because old credential validation is missing and later evidence shows old access still works.
+- `SEC-ROT-06` because the new credential was not tested for every required consumer.
+- `SEC-ROT-07` because post-rotation monitoring does not cover fallback or consumer auth failures.
+
+Expected handling: mark the rotation incomplete, close the rollback window, revoke the old version, redeploy or refresh all consumers, test old and new credential behavior, and record monitoring evidence.


### PR DESCRIPTION
## Summary
- Adds a rotation validation evidence gate for secrets-management reviews.
- Requires event/version metadata, consumer adoption, old credential revocation, old/new credential tests, monitoring evidence, rollback window, confidence, and follow-up owner.
- Adds a rotation validation output table and finding evidence field.
- Adds vulnerable and benign fixtures for a successful rotation job that leaves the old credential usable versus verified consumer adoption and revocation.

## Safety
- Fixtures use only synthetic event IDs, lease IDs, aliases, and log references.
- No actual secret values, tokens, passwords, or key material are included.

## Validation
- `git diff --check origin/main...HEAD`
- Markdown fence-balance check across changed `.md` files
- Added-line ASCII check
- Content marker check for `SEC-ROT-01` through `SEC-ROT-08`, evidence record, and fixtures
- Added-line secret-pattern scan for common token/private-key formats
- `git merge-tree --write-tree origin/main HEAD`

Closes #1820

Requested tier: Improver Moderate (USD 100)