### PR TITLE
Improve DAST finding validation evidence

### DIFF
--- a/skills/devsecops/dast-config/SKILL.md
+++ b/skills/devsecops/dast-config/SKILL.md
@@ -473,6 +473,48 @@ DAST tools report findings per-URL, producing hundreds of duplicate alerts for t
 - Deduplication is applied before metrics reporting.
 - Triage workflow assigns findings to owning teams with SLAs.
 
+#### 7.2 Finding Validation Evidence Gate
+
+Do not file High or Critical remediation tickets from raw scanner output alone. Preserve enough redacted request/response context for an owner to reproduce the issue, then validate severity against exploitability, authentication context, session freshness, compensating controls, and false-positive rationale.
+
+**DAST validation findings:**
+
+```
+DAST-VAL-01: High/Critical finding lacks scanner alert ID, alert type, affected endpoint, or parameter
+DAST-VAL-02: Raw evidence is missing, over-redacted, or omits request/response context needed for reproduction
+DAST-VAL-03: Reproduction steps are missing, not authorized, or not run in an approved non-production target
+DAST-VAL-04: Validation result is missing or left as raw scanner severity without manual confirmation
+DAST-VAL-05: False-positive rationale is missing for dismissed or downgraded findings
+DAST-VAL-06: Authentication context, role, token scope, or session freshness is missing for authenticated findings
+DAST-VAL-07: Severity calibration omits exploitability, data exposure, WAF/compensating controls, duplicates, or endpoint criticality
+DAST-VAL-08: Confirmed finding lacks owner, remediation ticket, SLA, or retest plan
+```
+
+**Finding validation evidence record:**
+
+```
+DAST FINDING VALIDATION EVIDENCE
+================================
+Finding ID:             [scanner ID / dedup ID]
+Alert Type:             [SQLi, XSS, SSRF, auth bypass, etc.]
+Affected Endpoint:      [method URL/path; redact host if needed]
+Parameter / Vector:     [query/body/header/path/cookie field]
+Raw Evidence:           [redacted request/response, scanner payload class, alert excerpt]
+Auth Context:           [anonymous/user/admin/service, token scope, session age]
+Session Freshness:      [fresh login, re-auth evidence, CSRF/nonce handling]
+Reproduction Steps:     [approved target and safe steps]
+Validation Result:      [Confirmed | Partial | Duplicate | False Positive | Unknown]
+False-Positive Rationale:[technical reason when downgraded/dismissed]
+Severity Calibration:   [raw severity -> final severity, rationale]
+Owner / Ticket / Retest:[team, ticket, SLA, retest date]
+```
+
+**False-positive boundaries:**
+
+- Do not require live exploitation when the program only permits passive or replay-safe validation; use controlled replay, code review, or log correlation instead.
+- Do not flag WAF-blocked scanner payloads as confirmed application vulnerabilities unless the app remains exploitable without relying only on WAF behavior.
+- Do not require secrets, tokens, or personal data in evidence; redact sensitive values while preserving method, path, parameter name, status, and payload class.
+
 **Finding classification:** No results triage process is **Medium**. Injection rules set to IGNORE or WARN is **Critical**. No deduplication leading to alert fatigue is **Medium**.
 
 ---
@@ -527,7 +569,14 @@ DAST tools report findings per-URL, producing hundreds of duplicate alerts for t
 - **Control Reference:** OWASP Top 10 AXX / WSTG-XXXX-XX
 - **File:** <path to config file>
 - **Description:** <what was found>
+- **Validation Evidence:** <finding ID, endpoint, parameter, raw evidence, auth context, reproduction, validation result, severity calibration>
 - **Remediation:** <concrete fix with example>
+
+### DAST Finding Validation Evidence
+
+| Finding ID | Alert Type | Affected Endpoint | Parameter / Vector | Raw Evidence | Auth Context | Session Freshness | Reproduction Steps | Validation Result | FP Rationale | Severity Calibration | Owner / Ticket / Retest |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| <id> | <alert> | <endpoint> | <param/vector> | <redacted req/resp> | <role/scope> | <freshness evidence> | <safe steps> | <Confirmed/Partial/Duplicate/FP/Unknown> | <reason> | <raw -> final> | <team/ticket/date> |
 
 ### Prioritized Remediation Plan
 1. **[Critical]** <action item>
@@ -583,6 +632,8 @@ DAST tools report findings per-URL, producing hundreds of duplicate alerts for t
 4. **Treating DAST findings as ground truth without validation.** DAST tools have significant false positive rates, especially for injection findings. Every high-severity DAST finding must be manually validated before filing a remediation ticket. Build validation into the triage workflow.
 
 5. **Running only scheduled weekly scans instead of integrating into CI.** Weekly scans create a feedback loop measured in days. Passive baseline scans in CI (on every PR) give developers immediate feedback on security header regressions and configuration issues, while weekly full scans provide comprehensive active testing coverage.
+
+6. **Filing scanner output without reproduction evidence.** A raw DAST alert is not enough for an engineering ticket. Preserve redacted request/response evidence, auth context, session freshness, reproduction steps, validation result, false-positive rationale, severity calibration, owner, and retest plan.
 
 ---
 

--- a/skills/devsecops/dast-config/tests/benign/validated-high-alert-with-calibration.md
+++ b/skills/devsecops/dast-config/tests/benign/validated-high-alert-with-calibration.md
@@ -1,0 +1,32 @@
+# Benign: High DAST alert has owner-ready validation evidence
+
+This fixture should avoid DAST finding validation findings because the alert is reproducible, calibrated, and linked to ownership evidence.
+
+## Review Context
+
+- Tool: OWASP ZAP full scan plus manual replay
+- Target: approved staging API
+- Raw alert: High reflected XSS on `/support/tickets`
+- Review date: `2026-06-09`
+
+## DAST Finding Validation Evidence
+
+| Finding ID | Alert Type | Affected Endpoint | Parameter / Vector | Raw Evidence | Auth Context | Session Freshness | Reproduction Steps | Validation Result | FP Rationale | Severity Calibration | Owner / Ticket / Retest |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| `ZAP-40012-9910` | Reflected XSS | `GET /support/tickets` | query parameter `filter` | redacted request `REQ-9910`, response snippet `RESP-9910` showing encoded payload context | support user, non-admin token scope | fresh login `AUTH-2026-0609-01`, CSRF token regenerated per replay | replay in staging with harmless marker payload and browser verification | Confirmed | N/A | raw High -> final High because authenticated support users can trigger script in same-role browser context | appsec / `APPSEC-4421` / retest after fix |
+| `ZAP-40018-9922` | SQL Injection | `GET /api/search` | query parameter `q` | redacted request `REQ-9922`, WAF block log `WAF-7788` | normal user token scope | fresh login `AUTH-2026-0609-02` | replayed payload reached WAF, app logs show no database execution | False Positive | blocked before application, parameterized query verified in code review | raw High -> final Informational, track WAF noise tuning | appsec / `APPSEC-4422` / no app retest required |
+
+## Review Notes
+
+- Evidence keeps method, path, parameter, payload class, status, and log references while omitting credentials and personal data.
+- Auth context and session freshness are recorded for authenticated findings.
+- Confirmed and false-positive findings both include rationale and severity calibration.
+- Confirmed finding has owner, ticket, SLA, and retest path.
+
+Expected outcome:
+
+- Do not flag `DAST-VAL-01` through `DAST-VAL-04` because finding identity, evidence, reproduction, and validation result are recorded.
+- Do not flag `DAST-VAL-05` because false-positive rationale is recorded where applicable.
+- Do not flag `DAST-VAL-06` because auth context and session freshness are recorded.
+- Do not flag `DAST-VAL-07` because raw severity is calibrated to final severity.
+- Do not flag `DAST-VAL-08` because confirmed work has owner, ticket, and retest criteria.

--- a/skills/devsecops/dast-config/tests/vulnerable/raw-high-alert-without-validation.md
+++ b/skills/devsecops/dast-config/tests/vulnerable/raw-high-alert-without-validation.md
@@ -1,0 +1,37 @@
+# Vulnerable: High DAST alert is filed without validation evidence
+
+This fixture should produce DAST finding validation findings.
+
+## Review Context
+
+- Tool: OWASP ZAP full scan
+- Target: staging API
+- Raw alert: High SQL injection on `/api/search`
+- Triage action: engineering ticket filed directly from scanner output
+
+## Raw Scanner Output
+
+| Finding ID | Alert Type | Endpoint | Parameter | Raw Evidence | Validation Result |
+|---|---|---|---|---|---|
+| `ZAP-40018-7781` | SQL Injection | `GET /api/search` | `q` | scanner says "possible SQL syntax error" | not recorded |
+
+## Missing Validation
+
+- No redacted request/response pair is attached.
+- No safe reproduction steps were run in staging.
+- The scanner used an admin test token, but the ticket does not record role, token scope, or session age.
+- The scan reused a stale CSRF token from a HAR file, causing many `403` responses.
+- WAF logs show the payload was blocked before reaching the application, but the ticket still claims exploitable SQL injection.
+- There is no false-positive rationale, severity calibration, owner confirmation, or retest plan.
+
+Expected findings:
+
+- `DAST-VAL-02` because request/response context is missing.
+- `DAST-VAL-03` because authorized reproduction steps are missing.
+- `DAST-VAL-04` because raw scanner severity is used as final validation.
+- `DAST-VAL-05` because downgrade or false-positive rationale is missing.
+- `DAST-VAL-06` because auth context and session freshness are missing.
+- `DAST-VAL-07` because severity is not calibrated against WAF behavior and exploitability.
+- `DAST-VAL-08` because the ticket lacks owner-ready validation and retest details.
+
+Expected handling: reproduce safely, record redacted evidence, document auth/session context, classify confirmed vs false positive, calibrate severity, and assign an owner with retest criteria.


### PR DESCRIPTION
## Summary
- Adds a DAST finding validation evidence gate for High/Critical findings.
- Requires scanner ID, endpoint, parameter/vector, redacted raw evidence, auth context, session freshness, reproduction steps, validation result, false-positive rationale, severity calibration, owner/ticket/retest.
- Adds DAST validation output and finding evidence fields.
- Adds vulnerable and benign fixtures for raw scanner ticketing versus owner-ready validation evidence.

## Safety
- Fixtures use synthetic IDs and redacted request/response references only.
- No credentials, tokens, personal data, or real target data are included.

## Validation
- `git diff --check origin/main...HEAD`
- Markdown fence-balance check across changed `.md` files
- Added-line ASCII check
- Content marker check for `DAST-VAL-01` through `DAST-VAL-08`, evidence record, and fixtures
- Added-line secret-pattern scan
- `git merge-tree --write-tree origin/main HEAD`

Closes #1822

Requested tier: Improver Moderate (USD 100)