### PR TITLE
Improve forensic custody verification evidence

### DIFF
--- a/skills/incident-response/forensics-checklist/SKILL.md
+++ b/skills/incident-response/forensics-checklist/SKILL.md
@@ -99,6 +99,51 @@ CUSTODY LOG:
 - Compute and record cryptographic hashes (SHA-256 minimum) at collection time and verify at each transfer
 - Maintain a continuous, unbroken record from collection through final disposition
 
+#### Custody Verification Evidence Gate
+
+Do not treat a custody log as complete when it only lists names, timestamps, and locations. Every custody transfer, storage move, evidence access, and analysis-copy creation needs verification evidence that proves the item remained intact and that access was authorized.
+
+**Custody verification findings:**
+
+```
+FOR-CUST-01: Custody transfer, storage move, access event, or analysis-copy event is missing from the verification record
+FOR-CUST-02: SHA-256 before or after the event is missing, weak, delayed, or not tied to the evidence item
+FOR-CUST-03: Hash match result is missing, mismatched, or lacks documented failure handling
+FOR-CUST-04: Purpose and authorization source are missing for evidence access or transfer
+FOR-CUST-05: Tamper-evident seal, object lock, WORM retention, version ID, or immutable-storage audit evidence is missing
+FOR-CUST-06: Original evidence, verified working copy, and derived analysis output are not distinguished
+FOR-CUST-07: Analysis is performed on original evidence when a verified working copy should be used
+FOR-CUST-08: Custody exception lacks owner, legal/IR disposition, re-verification, and court-readiness status
+```
+
+**Custody verification evidence record:**
+
+```
+FORENSIC CUSTODY VERIFICATION EVIDENCE
+======================================
+Evidence ID:              [EVD-NNNN]
+Evidence State:           [Original | Verified Working Copy | Derived Output]
+Event Type:               [Collection | Transfer | Storage Move | Access | Analysis Copy]
+Event Time (UTC):         [timestamp]
+Released By:              [person/system/source]
+Received / Accessed By:   [person/system/tool]
+Purpose:                  [collection, legal hold, analysis, transfer, preservation]
+Authorization Source:     [ticket, legal hold, warrant, manager approval]
+Storage / Location:       [locker, path, bucket, object version, case vault]
+SHA-256 Before:           [hash before event or N/A for initial collection]
+SHA-256 After:            [hash after event/copy]
+Match Result:             [Match | Mismatch | Not Applicable]
+Tamper Evidence:          [seal number, object lock, WORM policy, audit log, version ID]
+Failure Handling:         [N/A or quarantine/escalation/re-acquisition]
+Owner / Disposition:      [custodian, legal/IR disposition, court-readiness status]
+```
+
+**False-positive boundaries:**
+
+- Do not require a before-hash for initial collection when the acquisition hash is computed immediately and becomes the first hash in the chain.
+- Do not require a physical seal for cloud evidence when immutable storage controls, version IDs, retention policy, and audit logs provide equivalent tamper evidence.
+- Do not flag derived analysis outputs as original evidence when the report clearly distinguishes derivation source, tool, timestamp, and working-copy hash.
+
 ### Step 2: Collect Evidence in Order of Volatility (RFC 3227)
 
 RFC 3227 Section 2.1 defines the order of volatility -- evidence sources ranked from most volatile (shortest lifespan) to least volatile. Collect in this order to minimize evidence loss.
@@ -389,6 +434,11 @@ the order of collection, and any evidence that could not be obtained.]
 ### Chain of Custody
 [Include chain of custody form for each evidence item]
 
+### Custody Verification Evidence
+| Evidence ID | Evidence State | Event Type | Event Time (UTC) | Released By | Received / Accessed By | Purpose | Authorization Source | Storage / Location | SHA-256 Before | SHA-256 After | Match Result | Tamper Evidence | Failure Handling | Owner / Disposition |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| EVD-0001 | Original | Transfer | [timestamp] | [name/system] | [name/system] | [reason] | [ticket/legal hold/approval] | [location/path/version] | [hash] | [hash] | [Match/Mismatch/N/A] | [seal/object lock/WORM/audit ref] | [N/A or action] | [custodian/status] |
+
 ### Integrity Verification
 | Evidence ID | Acquisition Hash | Verification Hash | Match |
 |---|---|---|---|
@@ -448,6 +498,10 @@ Executing forensic tools (or any tools) that reside on the compromised system ri
 ### Pitfall 2: Breaking the Hash Chain
 
 Evidence integrity depends on an unbroken cryptographic hash chain from the moment of collection through analysis and into legal proceedings. Computing the initial hash hours after collection, using weak hash algorithms (MD5 alone), or failing to re-verify hashes after evidence transfers introduces doubt about evidence integrity. Compute SHA-256 hashes immediately upon acquisition, record them in the chain-of-custody form, and verify hashes at every transfer point.
+
+### Pitfall 2a: Logging Custody Without Verification Evidence
+
+A custody spreadsheet that records names and timestamps but omits before/after hashes, access authorization, seal or immutable-storage controls, copy type, and failure handling does not prove evidence integrity. Preserve per-event verification evidence for transfers, accesses, storage moves, and analysis copies.
 
 ### Pitfall 3: Imaging a Live System Without Capturing Memory First
 

--- a/skills/incident-response/forensics-checklist/tests/benign/verified-custody-transfer-and-working-copy.md
+++ b/skills/incident-response/forensics-checklist/tests/benign/verified-custody-transfer-and-working-copy.md
@@ -1,0 +1,34 @@
+# Benign: Custody transfer and analysis copy include verification evidence
+
+This fixture should avoid forensic custody verification findings because every transfer and analysis-copy event records hashes, authorization, tamper evidence, and copy state.
+
+## Review Context
+
+- Incident: `IR-2026-0609`
+- Evidence: memory image `EVD-0101`
+- Storage: object bucket with legal hold and object lock
+- Review date: `2026-06-09`
+
+## Custody Verification Evidence
+
+| Evidence ID | Evidence State | Event Type | Event Time (UTC) | Released By | Received / Accessed By | Purpose | Authorization Source | Storage / Location | SHA-256 Before | SHA-256 After | Match Result | Tamper Evidence | Failure Handling | Owner / Disposition |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| `EVD-0101` | Original | Collection | `2026-06-09T00:20:00Z` | responder-a | case vault | memory acquisition | `IR-2026-0609`, legal hold `LH-442` | bucket `forensics-ir`, object version `v001` | N/A | `aaaaaaaa11111111bbbbbbbb22222222cccccccc33333333dddddddd44444444` | Not Applicable | object lock compliance mode, audit `OBJ-1001` | N/A | custody lead, court-ready |
+| `EVD-0101` | Original | Transfer | `2026-06-09T01:00:00Z` | case vault | forensics-b | verified analysis copy creation | ticket `IR-2026-0609-COPY` | bucket `forensics-ir`, object version `v001` | `aaaaaaaa11111111bbbbbbbb22222222cccccccc33333333dddddddd44444444` | `aaaaaaaa11111111bbbbbbbb22222222cccccccc33333333dddddddd44444444` | Match | object lock compliance mode, audit `OBJ-1009` | N/A | custody lead, court-ready |
+| `EVD-0101-WC1` | Verified Working Copy | Analysis Copy | `2026-06-09T01:08:00Z` | forensics-b | analyst-c | volatile-artifact review | ticket `IR-2026-0609-ANALYSIS` | case workstation encrypted volume | `aaaaaaaa11111111bbbbbbbb22222222cccccccc33333333dddddddd44444444` | `aaaaaaaa11111111bbbbbbbb22222222cccccccc33333333dddddddd44444444` | Match | copy manifest `MAN-0101-WC1` | N/A | analyst-c, analysis copy |
+
+## Review Notes
+
+- Initial collection has no before-hash, which is acceptable because the immediate acquisition hash begins the chain.
+- Each transfer or analysis-copy event records SHA-256 before and after the event.
+- Original evidence, verified working copy, and derived output are distinguished.
+- Access is tied to incident and legal-hold tickets.
+- Immutable storage evidence includes object version and audit references.
+
+Expected outcome:
+
+- Do not flag `FOR-CUST-01` because each event is present.
+- Do not flag `FOR-CUST-02` or `FOR-CUST-03` because hashes and match results are recorded.
+- Do not flag `FOR-CUST-04` or `FOR-CUST-05` because authorization and tamper evidence are present.
+- Do not flag `FOR-CUST-06` or `FOR-CUST-07` because original and working copy handling is clear.
+- Do not flag `FOR-CUST-08` because no unresolved exception remains.

--- a/skills/incident-response/forensics-checklist/tests/vulnerable/custody-log-without-rehash.md
+++ b/skills/incident-response/forensics-checklist/tests/vulnerable/custody-log-without-rehash.md
@@ -1,0 +1,39 @@
+# Vulnerable: Custody log records names but omits per-event verification
+
+This fixture should produce forensic custody verification findings.
+
+## Review Context
+
+- Incident: `IR-2026-0609`
+- Evidence: disk image `EVD-0042`
+- Report conclusion: "chain of custody complete"
+- Custody artifact: spreadsheet with collector, analyst, timestamps, and storage path
+
+## Bad Custody Record
+
+| Evidence ID | Date/Time (UTC) | Released By | Received By | Purpose | Location |
+|---|---|---|---|---|---|
+| `EVD-0042` | `2026-06-09T01:10:00Z` | responder-a | forensics-b | analysis | shared evidence folder |
+| `EVD-0042` | `2026-06-09T04:30:00Z` | forensics-b | analyst-c | malware review | analyst workstation |
+
+## Missing Verification
+
+- No SHA-256 before or after either transfer.
+- No match result or failure handling exists.
+- No ticket, legal hold, or manager approval authorizes analyst access.
+- Storage is a mutable shared folder with no object lock, WORM retention, seal number, or audit reference.
+- The analyst opens the original disk image directly instead of creating a verified working copy.
+- Derived malware strings are later copied into the evidence folder without being marked as derived output.
+
+Expected findings:
+
+- `FOR-CUST-01` because access and analysis-copy events are missing from the verification record.
+- `FOR-CUST-02` because before/after hashes are missing.
+- `FOR-CUST-03` because match result and failure handling are missing.
+- `FOR-CUST-04` because authorization source is missing.
+- `FOR-CUST-05` because tamper evidence and immutable storage controls are missing.
+- `FOR-CUST-06` because original, working copy, and derived output are not distinguished.
+- `FOR-CUST-07` because analysis is performed on original evidence.
+- `FOR-CUST-08` because exceptions have no owner, disposition, or court-readiness status.
+
+Expected handling: quarantine the evidence chain as incomplete, re-verify hashes where possible, move originals to immutable storage, create a verified working copy, and document authorization and disposition.


### PR DESCRIPTION
## Summary
- Adds forensic custody verification evidence gates for transfers, storage moves, access events, and analysis-copy creation.
- Requires evidence state, event type/time, authorization source, storage/location, before/after SHA-256, match result, tamper evidence, failure handling, and owner/disposition.
- Adds custody verification report output.
- Adds vulnerable and benign fixtures for custody logs without re-hashing versus verified transfer and working-copy evidence.

## Safety
- Fixtures use synthetic incident IDs, evidence IDs, object versions, audit references, and hash-like values only.
- No credentials, private keys, or real forensic data are included.

## Validation
- `git diff --check origin/main...HEAD`
- Markdown fence-balance check across changed `.md` files
- Added-line ASCII check
- Content marker check for `FOR-CUST-01` through `FOR-CUST-08`, evidence record, and fixtures
- Added-line secret-pattern scan
- `git merge-tree --write-tree origin/main HEAD`

Closes #1827

Requested tier: Improver Moderate (USD 100)