### PR TITLE
Improve access review attestation evidence

### DIFF
--- a/skills/identity/access-review/SKILL.md
+++ b/skills/identity/access-review/SKILL.md
@@ -149,6 +149,36 @@ AR-CERT-07: No SLA for certification completion (recommended: 14 business days)
 AR-CERT-08: Delegated reviews without accountability (certifier delegates but is not tracked)
 ```
 
+**Certification attestation evidence gates:**
+
+Do not treat a completed campaign as proof of meaningful review unless the
+decision-level attestation evidence binds each entitlement to a qualified
+reviewer, a visible permission meaning, and an enforced outcome.
+
+```
+AR-ATTEST-01: Campaign evidence does not identify campaign ID, review period, system, and source export
+AR-ATTEST-02: Attestation record omits identity, entitlement, resource scope, or permission meaning
+AR-ATTEST-03: Certifier authority is not proven (manager, resource owner, SoD owner, or approved delegate)
+AR-ATTEST-04: Decision evidence is missing approve/revoke/modify/uncertain status and timestamp
+AR-ATTEST-05: Batch size or decision duration indicates rubber-stamping and lacks sampling follow-up
+AR-ATTEST-06: Revoke/modify decisions are not linked to enforcement ticket, execution timestamp, and reconciliation
+AR-ATTEST-07: Role transfer, promotion, emergency access, or material permission change did not trigger re-attestation
+AR-ATTEST-08: Attestation confidence is unknown because evidence source, freshness, or reviewer context is incomplete
+```
+
+**Minimum attestation record fields:**
+
+| Field | Required Evidence |
+|---|---|
+| Campaign | Campaign ID, review period, system, source export or IGA report |
+| Identity | User/service account ID, owner, status, department or workload |
+| Entitlement | Group/role/permission, resource scope, criticality, permission meaning |
+| Certifier | Certifier identity, relationship to access, authority source, delegation chain if any |
+| Decision | Approve/revoke/modify/exception/uncertain, timestamp, rationale, confidence |
+| Review quality | Batch size, decision duration, reviewer comments, sample/audit result when high risk |
+| Enforcement | Ticket/change ID, execution timestamp, post-change access state, reconciliation result |
+| Change triggers | Transfer/promotion/emergency grant/material permission change and re-attestation status |
+
 **Rubber-stamp detection criteria:**
 
 | Indicator | Threshold | Action |
@@ -321,6 +351,7 @@ AR-ENF-08: No metrics or reporting on review completion rates and outcomes
 | **Framework Ref** | NIST SP 800-53 control ID and/or CIS Controls v8 sub-control |
 | **Affected Scope** | Accounts, roles, systems, or platforms impacted |
 | **Evidence** | Specific data supporting the finding (counts, examples, screenshots) |
+| **Attestation Evidence** | Campaign, certifier, entitlement meaning, decision, timestamp, confidence, and enforcement linkage |
 | **Remediation** | Prioritized fix with implementation guidance |
 | **Effort** | Low (< 1 day) / Medium (1-5 days) / High (> 5 days) |
 
@@ -354,6 +385,11 @@ AR-ENF-08: No metrics or reporting on review completion rates and outcomes
 
 ### Detailed Findings
 [Findings table]
+
+### Certification Attestation Evidence
+| Campaign | Identity | Entitlement | Permission Meaning | Certifier / Authority | Decision / Timestamp | Batch / Duration | Enforcement / Reconciliation | Confidence |
+|---|---|---|---|---|---|---|---|---|
+| [campaign ID + period] | [identity] | [entitlement/resource] | [plain-language access meaning] | [manager/resource owner/delegate authority] | [approve/revoke/modify/uncertain + time] | [batch size + decision time] | [ticket/change ID + post-state] | [high/medium/low + reason] |
 
 ### Remediation Roadmap
 - Immediate (0-7 days): [critical findings]
@@ -401,6 +437,7 @@ See the mapping table in the Framework Quick Reference section above for sub-con
 5. **Role explosion masking risk** — When roles proliferate, reviewers cannot meaningfully assess what permissions a role grants. Pair reviews with role rationalization.
 6. **SoD analysis done manually** — Manual SoD checks do not scale and miss cross-system conflicts. Implement conflict rules in IGA tooling.
 7. **Evidence not retained** — Reviews happen but evidence is not preserved for the audit window. Configure IGA tools to retain decisions and timestamps.
+8. **Campaign completion treated as attestation** - A 100% complete access-review campaign is not sufficient unless each decision has certifier authority, entitlement meaning, timestamp, rationale, quality signals, and enforcement evidence.
 
 ---
 

--- a/skills/identity/access-review/tests/benign/decision-level-attestation-with-enforcement.md
+++ b/skills/identity/access-review/tests/benign/decision-level-attestation-with-enforcement.md
@@ -1,0 +1,49 @@
+# Benign Fixture: Decision-Level Attestation With Enforcement
+
+## Scenario
+
+The same quarterly access certification campaign includes decision-level
+attestation evidence. Reviewers can prove who certified each entitlement, why
+the reviewer had authority, what the permission meant, and whether revoke or
+modify decisions were enforced.
+
+## Evidence Snapshot
+
+| Field | Value |
+|---|---|
+| Campaign | `AR-Q2-2026-PROD-SaaS` |
+| Review period | `2026-04-01` to `2026-06-30` |
+| System | `FinanceOps SaaS` |
+| Source export | `iga-decision-export-2026-06-30.json`, SHA-256 recorded in audit vault |
+| Identity | `svc-billing-reconcile`, service account, owner `Billing Platform Team` |
+| Entitlement | `FinanceOps-Settlement-Approver` on settlement queue `prod-na` |
+| Permission meaning | Can approve settlement adjustments up to the configured workflow limit |
+| Certifier | `owner-billing-platform`, resource owner per `SYS-FINOPS-OWNER-2026-Q2` |
+| Decision | `modify`, remove settlement approval and keep read-only reconciliation |
+| Decision timestamp | `2026-06-18T15:42:31Z` |
+| Batch quality | Batch `12`, median decision duration `3m 20s`, sampled by compliance |
+| Enforcement | Ticket `IAM-7421`, change `CHG-10933`, executed `2026-06-19T02:14:09Z` |
+| Reconciliation | Post-change export confirms no approval permission on `2026-06-19T03:00:00Z` |
+| Confidence | High; reviewer authority, permission meaning, decision, and enforcement are linked |
+
+## Positive Controls
+
+- `AR-ATTEST-01`: Campaign evidence identifies campaign ID, period, system, and
+  source export.
+- `AR-ATTEST-02`: The entitlement record includes identity, role, resource scope,
+  criticality, and permission meaning.
+- `AR-ATTEST-03`: Certifier authority is proven by the resource-owner record.
+- `AR-ATTEST-04`: Decision status, timestamp, and rationale are preserved.
+- `AR-ATTEST-05`: Batch size and decision duration do not indicate blind approval;
+  compliance sampling is recorded.
+- `AR-ATTEST-06`: The modify decision links to execution and post-change
+  reconciliation evidence.
+- `AR-ATTEST-07`: A service-account owner change during Q2 triggered
+  re-attestation before campaign closure.
+- `AR-ATTEST-08`: Confidence is high because the evidence chain is complete and fresh.
+
+## Expected Result
+
+Do not flag the campaign as missing attestation evidence. Any remaining finding
+should focus on the underlying entitlement risk, not on access-review evidence
+quality.

--- a/skills/identity/access-review/tests/vulnerable/campaign-complete-without-decision-attestation.md
+++ b/skills/identity/access-review/tests/vulnerable/campaign-complete-without-decision-attestation.md
@@ -1,0 +1,50 @@
+# Vulnerable Fixture: Campaign Complete Without Decision Attestation
+
+## Scenario
+
+The quarterly access certification campaign is marked complete in the IGA tool.
+Auditors receive only a dashboard export and a summary count, so the review cannot
+prove that reviewers understood the entitlements, had authority to certify them,
+or enforced revoke decisions.
+
+## Evidence Snapshot
+
+| Field | Value |
+|---|---|
+| Campaign | `AR-Q2-2026-PROD-SaaS` |
+| Review period | `2026-04-01` to `2026-06-30` |
+| System | `FinanceOps SaaS` |
+| Completion | `100% complete` |
+| Population | `184 users, 612 entitlements` |
+| Export evidence | `iga-dashboard-summary-2026-06-30.csv` |
+| Approval count | `609 approved, 3 revoked` |
+| Reviewer evidence | `manager column present, no authority proof` |
+| Decision evidence | `bulk complete event only` |
+| Enforcement evidence | `no ticket IDs or post-change reconciliation` |
+
+## Problem Indicators
+
+- `AR-ATTEST-02`: The export lists role names but not permission meaning or
+  resource scope, so certifiers may have approved labels they did not understand.
+- `AR-ATTEST-03`: Delegated reviews are accepted without manager, resource owner,
+  or approved-delegate authority evidence.
+- `AR-ATTEST-04`: Individual decisions lack timestamp, rationale, and decision
+  actor per entitlement.
+- `AR-ATTEST-05`: One certifier approved `143` entitlements in `4 minutes` with no
+  sampling follow-up.
+- `AR-ATTEST-06`: Three revoke decisions have no enforcement ticket or
+  post-removal access state.
+- `AR-ATTEST-08`: Confidence is low because the evidence source is a summary
+  dashboard rather than immutable decision-level records.
+
+## Expected Finding
+
+Classify as **Medium** or **High** depending on entitlement criticality. The
+review may satisfy a completion metric, but it does not prove meaningful access
+certification or revocation enforcement.
+
+## Required Remediation
+
+Export decision-level attestation records with campaign ID, identity,
+entitlement, permission meaning, certifier authority, decision timestamp, batch
+quality signals, enforcement ticket, reconciliation result, and confidence.


### PR DESCRIPTION
## Summary

- Adds decision-level certification attestation evidence gates for campaign identity, entitlement meaning, certifier authority, decision timestamp, review quality, enforcement linkage, change triggers, and confidence.
- Adds a vulnerable fixture where a campaign is marked complete using only summary evidence and bulk decisions.
- Adds a benign fixture where attestation records bind reviewer authority, permission meaning, modify decision, ticketed enforcement, and reconciliation evidence.

## Validation

- `git diff --check origin/main...HEAD`
- Markdown fence-balance check over changed `.md` files
- Added-line ASCII check
- Content marker check for `AR-ATTEST-01`, `AR-ATTEST-08`, `Certification Attestation Evidence`, fixture names, `Certifier / Authority`, and `Enforcement / Reconciliation`
- Added-line secret-pattern scan
- `git merge-tree --write-tree origin/main HEAD` -> `76127175e9e7674b3052676cef76632f4603b2ec`

Closes #1816

Requested tier: Improver Moderate (USD 100)