### PR TITLE
Improve api-security parser and export evidence gates

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -51,6 +51,47 @@ For detailed checklist items with vulnerable code patterns, remediation examples
 
 ---
 
+## Evidence Gates for High-Risk API Workflows
+
+Do not mark API1, API4, API5, API8, or API10 controls as passing for the following workflows until the relevant evidence gate is complete.
+
+### HTTP Parameter Pollution and Parser Consistency Gate
+
+Duplicate or conflicting parameters can be parsed differently by gateways, WAFs, framework binders, validators, cache layers, signing code, audit logs, and downstream services. For endpoints that accept security-sensitive parameters, require parser-consistency evidence before clearing the endpoint.
+
+Capture this matrix for each sensitive parameter:
+
+| Endpoint | Parameter | Security role | Gateway/WAF behavior | Framework binding | Validator input | Application input | Cache/signature input | Downstream input | Decision |
+|---|---|---|---|---|---|---|---|---|---|
+| `[path method]` | `[id/tenant/role/redirect/price/etc.]` | `[authz/cache/signature/business]` | `[first/last/list/reject]` | `[first/last/list/reject]` | `[value used]` | `[value used]` | `[value used]` | `[value used]` | `[reject/canonicalize/finding]` |
+
+Required duplicate-parameter probes:
+
+- first-value wins: `?tenant=trusted&tenant=attacker`
+- last-value wins: `?tenant=attacker&tenant=trusted`
+- list binding: repeated keys bind to an array or list
+- comma-join behavior: `?scope=read&scope=admin` becomes `read,admin`
+- mixed query/body/header/path sources for the same logical parameter
+
+> **Gate:** Security-sensitive parameters must be rejected or canonicalized before authentication, authorization, rate limiting, cache-key generation, request signing, audit logging, and business logic. If any layer makes a different decision from a different value, file an API8/API10 finding and map authorization impact to API1/API5 where applicable.
+
+### Bulk Export and Signed Download URL Gate
+
+Async export workflows create secondary objects that often outlive the initial request: export jobs, status IDs, generated files, object-storage keys, and signed URLs. Reviewing only the export creation endpoint is not sufficient.
+
+Capture this evidence for every export or bulk-download workflow:
+
+| Phase | Object | Authorization evidence | Resource controls | Signed URL controls | Storage isolation | Audit fields |
+|---|---|---|---|---|---|---|
+| Create export | `[filters/job]` | `[role + tenant + object scope]` | `[row/byte/concurrency/quota]` | `N/A` | `[tenant/user key prefix]` | `[actor, tenant, filters]` |
+| Poll status | `[job_id]` | `[tenant/user ownership check]` | `[rate limit]` | `N/A` | `N/A` | `[job_id, status]` |
+| Download | `[file_id/object_key]` | `[job/file ownership check]` | `[download quota]` | `[TTL, reuse, revocation]` | `[private ACL]` | `[object count, bytes, destination]` |
+| Cleanup | `[file/job]` | `[retention policy]` | `[expiry/cancel]` | `[URL invalidation]` | `[delete evidence]` | `[correlation ID]` |
+
+> **Gate:** Export creation, job polling, file download, signed URL redemption, cleanup, and retention are separate authorization and resource-control decisions. File API1/API4/API5 findings when job IDs, file IDs, or signed URLs can widen scope, cross tenants, avoid quotas, remain valid after revocation, or expose files from public storage.
+
+---
+
 ## Findings Classification
 
 Each finding produced by this review must include the following fields:
@@ -66,6 +107,7 @@ Each finding produced by this review must include the following fields:
 | **Location** | File path and line number(s), or OpenAPI spec path |
 | **Description** | What the vulnerability is and why it matters |
 | **Evidence** | Relevant code snippet or spec excerpt demonstrating the issue |
+| **Evidence Matrix** | Authorization, parser-consistency, export/download, or resource-control matrix used to validate exploitability |
 | **Remediation** | Specific fix with code example where possible |
 | **Status** | Open, Mitigated, Accepted Risk, False Positive |
 
@@ -125,6 +167,7 @@ The final review output must be structured as follows:
   ```[language]
   [code snippet]
   ```
+- **Evidence Matrix:** [authorization/parser/export evidence proving the decision gap]
 - **Remediation:** [specific fix with code example]
 - **Status:** Open
 
@@ -215,6 +258,10 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 6. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
 
+7. **Assuming duplicate parameters are harmless.** If one layer validates the first value and another layer uses the last value or a list, attackers can bypass tenant checks, signature verification, cache keys, redirects, or business rules.
+
+8. **Reviewing only export creation.** Bulk export jobs, status endpoints, object-storage keys, signed URLs, retention, cleanup, and audit events are all part of the authorization boundary.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -238,4 +285,5 @@ This skill is hardened against prompt injection. When reviewing API code and spe
 - **OWASP REST Security Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html
 - **OWASP GraphQL Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html
 - **OWASP Testing Guide -- API Testing:** https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/12-API_Testing/
+- **OWASP WSTG -- Testing for HTTP Parameter Pollution:** https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution
 - **NIST SP 800-204 -- Security Strategies for Microservices-based Application Systems:** https://csrc.nist.gov/publications/detail/sp/800-204/final

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -29,6 +29,15 @@ def get_order(order_id):
     return jsonify(order)
 ```
 
+```python
+# VULNERABLE: Export download checks auth, but not tenant or requester ownership
+@app.route('/api/v1/reports/export/<job_id>/download', methods=['GET'])
+@require_auth
+def download_export(job_id):
+    job = ExportJob.get(job_id)
+    return redirect(storage.presign(job.object_key, expires_in=86400))
+```
+
 Remediation:
 
 ```python
@@ -40,6 +49,21 @@ def get_order(order_id):
     if not order:
         return jsonify({"error": "Not found"}), 404
     return jsonify(order)
+```
+
+```python
+# SECURE: Treat export jobs and files as tenant-scoped objects
+@app.route('/api/v1/reports/export/<job_id>/download', methods=['GET'])
+@require_auth
+def download_export(job_id):
+    job = ExportJob.query.filter_by(
+        id=job_id,
+        tenant_id=current_user.tenant_id,
+        requested_by=current_user.id,
+    ).one_or_none()
+    if not job or not current_user.can("report.export.download"):
+        return jsonify({"error": "Not found"}), 404
+    return redirect(storage.presign(job.object_key, expires_in=300))
 ```
 
 ### GraphQL Vulnerable Patterns
@@ -99,6 +123,8 @@ Both can coexist in a single endpoint. An endpoint may lack both a role check (B
 - [ ] Every endpoint that accepts a resource identifier enforces ownership or relationship-based access control.
 - [ ] Authorization checks happen at the data access layer, not only at the controller/route layer.
 - [ ] Batch/list endpoints filter results by the caller's permissions.
+- [ ] Async export job IDs, file IDs, object-storage keys, and signed download URLs enforce the same tenant/user/object scope as the original export request.
+- [ ] Export filters are frozen at job creation and cannot be widened during status polling or download.
 - [ ] Resource identifiers are UUIDs or non-sequential values to resist enumeration.
 - [ ] GraphQL resolvers enforce authorization on every field that returns sensitive data.
 
@@ -267,6 +293,13 @@ query {
 app.use(express.json()); // Default limit may be very large or unconfigured
 ```
 
+```text
+# VULNERABLE: Bulk export has no export-specific resource controls
+POST /api/v1/audit-events/export
+filters: arbitrary date range, all users, all event types
+limits: no row cap, byte cap, concurrency cap, tenant quota, timeout, cancellation, or retention
+```
+
 ### Remediation Guidance
 
 - Implement rate limiting at the API gateway and/or application layer. Use sliding window or token bucket algorithms. Set per-endpoint limits based on expected legitimate usage.
@@ -275,6 +308,7 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - For GraphQL: enforce query depth limits (e.g., max depth 5), complexity analysis (weighted field costs), and batch query limits.
 - Set execution timeouts for database queries and downstream API calls.
 - Implement cost alerts and circuit breakers for operations that trigger billable third-party APIs.
+- Add export-specific controls for bulk jobs: maximum rows, maximum bytes, date-window caps, concurrency limits, tenant quotas, cancellation, timeouts, retention, and cleanup.
 
 ### Review Checklist
 
@@ -284,6 +318,7 @@ app.use(express.json()); // Default limit may be very large or unconfigured
 - [ ] GraphQL queries have depth limits, complexity limits, and batch restrictions.
 - [ ] Database queries and downstream calls have execution timeouts.
 - [ ] Billable operations have cost controls and alerting.
+- [ ] Bulk export jobs have row, byte, date-range, concurrency, retention, and cancellation limits independent of ordinary list-endpoint pagination.
 
 ---
 
@@ -450,6 +485,15 @@ DocumentBuilder builder = factory.newDocumentBuilder();
 Document doc = builder.parse(request.getInputStream());
 ```
 
+```http
+# VULNERABLE: gateway validates the first tenant_id but the app uses the last
+GET /api/v1/reports?tenant_id=trusted-tenant&tenant_id=attacker-tenant HTTP/1.1
+Authorization: Bearer user-token
+
+# Gateway policy input: tenant_id=trusted-tenant
+# Express/qs handler input: tenant_id=attacker-tenant
+```
+
 ### Remediation Guidance
 
 - Configure CORS with an explicit allowlist of permitted origins. Never use `*` with `credentials: true`.
@@ -462,6 +506,7 @@ Document doc = builder.parse(request.getInputStream());
 - Disable XML External Entity processing: set `factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)`.
 - Enforce TLS 1.2+ with strong cipher suites. Disable TLS 1.0 and 1.1.
 - Automate configuration scanning in CI/CD to detect drift from security baselines.
+- Reject duplicate security-sensitive parameters, or canonicalize them once before gateway policy, authentication, authorization, cache-key generation, request signing, audit logging, and application handlers.
 
 ### Review Checklist
 
@@ -472,6 +517,8 @@ Document doc = builder.parse(request.getInputStream());
 - [ ] TLS 1.2+ is enforced with strong cipher suites.
 - [ ] XML parsers disable external entity processing and DTD loading.
 - [ ] Default credentials are changed or removed on all infrastructure components.
+- [ ] Duplicate query, body, path, and header parameters have documented parser behavior across gateway/WAF, framework binding, validators, caches, signing logic, audit logs, and downstream services.
+- [ ] Security-sensitive duplicate parameters are rejected or canonicalized before any security decision.
 
 ---
 
@@ -544,6 +591,18 @@ const data = await enrichmentData.json();
 res.send(`<div class="bio">${data.biography}</div>`);  // Stored XSS via third party
 ```
 
+```javascript
+// VULNERABLE: downstream service receives a different role value than the gateway validated
+app.post('/api/v1/invite', requireAuth, async (req, res) => {
+  // Gateway checked role=viewer, but body parser preserved both values as an array.
+  await partnerApi.createInvite({
+    email: req.body.email,
+    role: req.body.role.at(-1),
+  });
+  res.sendStatus(202);
+});
+```
+
 ### Remediation Guidance
 
 - Treat all data from external and internal APIs as untrusted input. Validate and sanitize before use.
@@ -552,6 +611,7 @@ res.send(`<div class="bio">${data.biography}</div>`);  // Stored XSS via third p
 - Implement timeouts, retry limits with backoff, and circuit breakers on all outbound API calls.
 - Restrict redirects on outbound calls. If following redirects, re-validate the destination URL.
 - Use parameterized queries when inserting data from any source, including trusted internal APIs.
+- Normalize or reject duplicate parameters before forwarding requests to upstream services so the caller, gateway, application, and downstream service all authorize and process the same value.
 
 ### Review Checklist
 
@@ -560,3 +620,50 @@ res.send(`<div class="bio">${data.biography}</div>`);  // Stored XSS via third p
 - [ ] Response schemas from third-party APIs are validated before processing.
 - [ ] Outbound calls have timeouts, retry limits, and circuit breakers.
 - [ ] Redirect following is disabled or restricted on outbound HTTP calls.
+- [ ] Downstream service calls do not receive a different duplicate-parameter value than the value validated by the API gateway, request validator, or authorization middleware.
+
+---
+
+## Cross-Cutting Evidence Checklist: HTTP Parameter Pollution
+
+Use this checklist for API1, API5, API8, and API10 reviews whenever repeated parameters can influence authorization, cache keys, signatures, redirects, prices, quantities, filters, tenant IDs, object IDs, roles, or scopes.
+
+### Parser-Consistency Tests
+
+- [ ] `?id=authorized&id=unauthorized` and the reverse order are both tested.
+- [ ] Repeated form fields, JSON arrays, duplicated JSON keys where supported by the parser, and repeated headers are tested when applicable.
+- [ ] Gateway/WAF, framework router, validation layer, application handler, cache/CDN, request-signature logic, audit logs, and downstream services all document which value they consume.
+- [ ] Sensitive duplicates are rejected with a deterministic 400-class response, or are canonicalized once before any security decision.
+- [ ] Findings include the exact layer mismatch, the value each layer used, and the resulting impact.
+
+### Secure Pattern
+
+```javascript
+function requireSingleParam(req, name) {
+  const raw = req.query[name];
+  if (Array.isArray(raw)) {
+    throw new BadRequestError(`Duplicate ${name} parameters are not allowed`);
+  }
+  return raw;
+}
+
+app.get('/api/v1/reports', requireAuth, (req, res) => {
+  const tenantId = requireSingleParam(req, 'tenant_id');
+  authorizeTenant(currentUser, tenantId);
+  return listReports({ tenantId });
+});
+```
+
+---
+
+## Cross-Cutting Evidence Checklist: Bulk Exports and Signed URLs
+
+Use this checklist for export, report download, backup download, audit log export, evidence package, attachment bundle, and data warehouse extract workflows.
+
+- [ ] Export creation verifies function permission plus tenant/object/filter scope.
+- [ ] Export job status endpoints enforce ownership of `job_id`.
+- [ ] Download endpoints enforce ownership of file IDs and object-storage keys before issuing redirects or signed URLs.
+- [ ] Signed URLs have short TTLs, are non-reusable where feasible, and are invalidated on role change, tenant offboarding, account suspension, or incident containment.
+- [ ] Generated files live in private storage with tenant/user-scoped key prefixes and no public ACLs.
+- [ ] Export jobs enforce row caps, byte caps, date-window caps, concurrency limits, quotas, cancellation, and cleanup.
+- [ ] Audit logs capture actor, tenant, filters, object count, byte size, destination, job ID, file ID, and correlation ID.

--- a/skills/appsec/api-security/tests/benign/export-download-scoped-url.md
+++ b/skills/appsec/api-security/tests/benign/export-download-scoped-url.md
@@ -1,0 +1,28 @@
+# Benign: scoped export download with short-lived signed URL
+
+```python
+@app.get('/api/v1/reports/export/<job_id>/download')
+@require_auth
+def download_export(job_id):
+    job = ExportJob.query.filter_by(
+        id=job_id,
+        tenant_id=current_user.tenant_id,
+        requested_by=current_user.id,
+    ).one_or_none()
+    if not job or not current_user.can("report.export.download"):
+        return jsonify({"error": "Not found"}), 404
+
+    audit_log.record(
+        actor=current_user.id,
+        tenant=current_user.tenant_id,
+        job_id=job.id,
+        object_count=job.object_count,
+        bytes=job.byte_size,
+    )
+    return redirect(storage.presign(job.object_key, expires_in=300))
+```
+
+Expected skill behavior:
+
+- Do not flag the workflow as BOLA when job ownership, tenant scope, function permission, private storage, short TTL, and audit evidence are present.
+- Continue checking row, byte, concurrency, retention, and cleanup controls for API4 coverage.

--- a/skills/appsec/api-security/tests/benign/hpp-duplicate-rejection.md
+++ b/skills/appsec/api-security/tests/benign/hpp-duplicate-rejection.md
@@ -1,0 +1,22 @@
+# Benign: duplicate security parameters rejected before security decisions
+
+```javascript
+function singleQueryParam(req, name) {
+  const value = req.query[name];
+  if (Array.isArray(value)) {
+    throw new BadRequestError(`Duplicate ${name} parameters are not allowed`);
+  }
+  return value;
+}
+
+app.get('/api/v1/reports', requireAuth, (req, res) => {
+  const tenantId = singleQueryParam(req, 'tenant_id');
+  authorizeTenant(currentUser, tenantId);
+  return res.json(listReports({ tenantId }));
+});
+```
+
+Expected skill behavior:
+
+- Do not flag merely because the endpoint has a tenant parameter.
+- Accept the control when duplicate values are rejected before authorization, cache-key generation, signing, audit logging, and business logic.

--- a/skills/appsec/api-security/tests/vulnerable/export-download-bola.md
+++ b/skills/appsec/api-security/tests/vulnerable/export-download-bola.md
@@ -1,0 +1,17 @@
+# Vulnerable: export download BOLA and long-lived signed URL
+
+```python
+@app.get('/api/v1/reports/export/<job_id>/download')
+@require_auth
+def download_export(job_id):
+    # Any authenticated user who learns a job_id can receive a signed URL for
+    # another tenant's export file. The URL is reusable for 24 hours.
+    job = ExportJob.get(job_id)
+    return redirect(storage.presign(job.object_key, expires_in=86400))
+```
+
+Expected skill behavior:
+
+- Flag as API1:2023 Broken Object Level Authorization.
+- Flag signed URL lifecycle weakness when sensitive exports are long-lived, reusable, or not revoked after authorization changes.
+- Require export evidence for create, status, download, signed URL, storage isolation, cleanup, and audit phases.

--- a/skills/appsec/api-security/tests/vulnerable/hpp-parser-mismatch.md
+++ b/skills/appsec/api-security/tests/vulnerable/hpp-parser-mismatch.md
@@ -1,0 +1,29 @@
+# Vulnerable: HTTP Parameter Pollution parser mismatch
+
+```javascript
+// Gateway policy validates the first tenant_id value, but the Express handler
+// later uses the last value. The authorization decision and business logic act
+// on different tenants.
+app.get('/api/v1/reports', requireAuth, (req, res) => {
+  const tenantId = Array.isArray(req.query.tenant_id)
+    ? req.query.tenant_id.at(-1)
+    : req.query.tenant_id;
+
+  // Missing duplicate-parameter rejection before the security decision.
+  authorizeTenant(currentUser, tenantId);
+  return res.json(listReports({ tenantId }));
+});
+```
+
+Probe:
+
+```http
+GET /api/v1/reports?tenant_id=trusted-tenant&tenant_id=attacker-tenant HTTP/1.1
+Authorization: Bearer user-token
+```
+
+Expected skill behavior:
+
+- Flag as API8/API10 parser-consistency risk.
+- Map impact to API1/API5 if the mismatch changes tenant, object, role, or scope authorization.
+- Require evidence showing which value each layer consumed.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** api-security
**Skill path:** `skills/appsec/api-security/`

### What Was Wrong
The skill covered OWASP API Top 10 categories but did not force reviewers to gather concrete evidence for two common API review blind spots:

- HTTP Parameter Pollution / duplicate-parameter parser mismatches across gateways, validators, apps, caches, signing logic, logs, and downstream services.
- Async bulk export workflows where authorization and resource controls must be checked separately for export creation, status polling, generated files, signed URLs, storage isolation, cleanup, and retention.

Closes #1715.
Closes #1750.

### What This PR Fixes
- Adds main workflow evidence gates for HPP parser consistency and bulk export / signed download URLs.
- Adds an `Evidence Matrix` field to findings and output guidance so reviewers preserve exploitability proof.
- Expands the detailed OWASP API checklist with vulnerable and secure examples, API1/API4/API8/API10 checklist items, and cross-cutting review checklists.
- Adds vulnerable and benign test cases demonstrating both the missed variants and safe patterns that should not be over-flagged.

### Evidence

**Before (skill misses this / false positive on this):**
```http
GET /api/v1/reports?tenant_id=trusted-tenant&tenant_id=attacker-tenant HTTP/1.1
```
The gateway may validate the first value while the application, cache key, signing code, or downstream service uses the last value.

```python
@app.get('/api/v1/reports/export/<job_id>/download')
@require_auth
def download_export(job_id):
    job = ExportJob.get(job_id)
    return redirect(storage.presign(job.object_key, expires_in=86400))
```
The initial export endpoint may be authorized, while the download phase lacks tenant ownership and signed URL lifecycle controls.

**After (now correctly handled):**
```text
The skill now requires parser-consistency and export/download evidence matrices before API1/API4/API5/API8/API10 controls can be marked passing.
```

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass

### Bounty Tier
- [ ] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [ ] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [x] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Crypto or PayPal details can be provided privately after maintainer acceptance.

## Validation
- `git diff --check`
- Frontmatter check equivalent to `.github/workflows/lint-skills.yml`: passed for 50 files
- Prompt injection scan equivalent to `.github/workflows/injection-scan.yml`: passed
- Index file existence check equivalent to `.github/workflows/validate-index.yml`: passed for 50 entries