### PR TITLE
Improve IAM unused permission evidence

### DIFF
--- a/skills/identity/iam-review/SKILL.md
+++ b/skills/identity/iam-review/SKILL.md
@@ -176,6 +176,36 @@ IAM-PRIV-07: Cross-account access without external ID or condition keys
 IAM-PRIV-08: Resource-based policies granting public or overly broad access
 ```
 
+**Unused permission evidence gates:**
+
+Do not recommend permission removal or role downscoping from a single provider
+"last used" summary alone. Bind each unused-permission finding to the data
+source, observation window, permission/resource scope, business owner context,
+secondary telemetry, and rollback plan.
+
+```
+IAM-UPERM-01: Unused-permission finding lacks principal, policy/role, action, and resource scope
+IAM-UPERM-02: Usage data source is missing or too coarse for the claimed action/resource finding
+IAM-UPERM-03: Observation window is shorter than the business process, job schedule, or provider lookback limit
+IAM-UPERM-04: Last-used evidence is action-only and does not prove unused access at the resource scope
+IAM-UPERM-05: Secondary evidence is missing (CloudTrail/sign-in logs/app logs/job history/ticket history)
+IAM-UPERM-06: Business owner confirmation is missing for periodic, break-glass, migration, or audit permissions
+IAM-UPERM-07: Chained role assumption, permission boundary, SCP, or service-linked role behavior is not evaluated
+IAM-UPERM-08: Downscope confidence, staged rollout, monitoring, and rollback evidence are not documented
+```
+
+**Minimum unused permission evidence record:**
+
+| Field | Required Evidence |
+|---|---|
+| Principal | User, group, role, service account, workload identity, or chained role path |
+| Permission | Policy/role, action, resource scope, conditions, boundary/SCP context |
+| Usage source | Access Analyzer, IAM Recommender, Policy Analyzer, audit logs, app logs, job history |
+| Time basis | Last used timestamp, observation window, provider lookback/granularity limits |
+| Secondary evidence | Cloud/API logs, business process calendar, batch/job history, tickets, owner notes |
+| Risk context | Data/system criticality, service-linked role behavior, chained/effective permissions |
+| Decision | Keep/downscope/remove/monitor, owner approval, confidence, staged rollout, rollback plan |
+
 **Platform-specific checks:**
 
 | Platform | Check | What to look for |
@@ -380,6 +410,7 @@ For each finding, produce a row with:
 | **Framework Ref** | NIST SP 800-63B section, NIST SP 800-207 tenet, or CIS Control ID |
 | **Affected Scope** | Accounts, roles, policies, or platforms impacted |
 | **Evidence** | Specific configuration, policy, or data supporting the finding |
+| **Unused Permission Evidence** | Principal, action, resource scope, usage source/window, owner confirmation, confidence, and rollback plan |
 | **Remediation** | Prioritized fix with implementation guidance |
 | **Effort** | Low (< 1 day) / Medium (1-5 days) / High (> 5 days) |
 
@@ -413,6 +444,11 @@ For each finding, produce a row with:
 
 ### Detailed Findings
 [Findings table — see above]
+
+### Unused Permission Evidence
+| Principal | Policy / Role | Action / Resource Scope | Usage Source / Window | Secondary Evidence | Owner Confirmation | Decision / Confidence | Rollback |
+|---|---|---|---|---|---|---|---|
+| [identity or role path] | [policy/role] | [action + resource] | [data source + dates + granularity] | [logs/jobs/tickets] | [owner + date] | [keep/downscope/remove + confidence] | [rollback method + monitor] |
 
 ### Remediation Roadmap
 [Prioritized actions: immediate (0-7 days), short-term (30 days), medium-term (90 days)]

--- a/skills/identity/iam-review/tests/benign/resource-scoped-unused-permission-validation.md
+++ b/skills/identity/iam-review/tests/benign/resource-scoped-unused-permission-validation.md
@@ -1,0 +1,47 @@
+# Benign Fixture: Resource-Scoped Unused Permission Validation
+
+## Scenario
+
+An IAM role has broad S3 read access across two buckets. Action-level usage shows
+`s3:GetObject` was used, but resource-scoped evidence proves the role only reads
+the billing exports bucket and never reads the legacy invoices bucket.
+
+## Evidence Snapshot
+
+| Field | Value |
+|---|---|
+| Principal | `arn:aws:iam::111122223333:role/prod-billing-processor` |
+| Policy | `BillingProcessorReadPolicy` |
+| Permission | `s3:GetObject` |
+| Resource scope under review | `arn:aws:s3:::legacy-invoices-prod/*` |
+| Still-required scope | `arn:aws:s3:::billing-exports-prod/*` |
+| Usage data source | CloudTrail data events and S3 server access logs |
+| Observation window | `2026-01-01` to `2026-06-30` |
+| Last used for reviewed scope | No reads found in 181 days |
+| Provider limitation handled | Action-level use kept separate from resource-level use |
+| Secondary evidence | Batch jobs `BILL-DAILY-*`, tickets `FIN-1831`, app logs `billing-prod` |
+| Business owner | `Billing Platform Team`, confirmed `2026-06-27` |
+| Decision | Remove only `legacy-invoices-prod/*`, keep `billing-exports-prod/*` |
+| Confidence | High |
+| Rollback | Versioned policy rollback `CHG-18391`, monitor denied S3 reads for 14 days |
+
+## Positive Controls
+
+- `IAM-UPERM-01`: The finding identifies principal, policy, action, and resource
+  scope.
+- `IAM-UPERM-02`: The evidence source supports the specific S3 resource scope.
+- `IAM-UPERM-03`: The observation window covers monthly, quarterly, and
+  semiannual billing jobs.
+- `IAM-UPERM-04`: Action-level usage is not treated as proof that all resources
+  are used.
+- `IAM-UPERM-05`: Secondary CloudTrail, S3, job, ticket, and app evidence agree.
+- `IAM-UPERM-06`: The business owner confirmed the legacy bucket is retired.
+- `IAM-UPERM-07`: Trust policy, permission boundary, and chained role paths were
+  checked for effective access.
+- `IAM-UPERM-08`: Downscope confidence, staged deploy, denied-read monitoring,
+  and rollback evidence are documented.
+
+## Expected Result
+
+Recommend a targeted downscope of the unused resource-level permission. Do not
+remove the still-used `s3:GetObject` permission on the billing exports bucket.

--- a/skills/identity/iam-review/tests/vulnerable/unused-permission-short-window-removal.md
+++ b/skills/identity/iam-review/tests/vulnerable/unused-permission-short-window-removal.md
@@ -1,0 +1,50 @@
+# Vulnerable Fixture: Unused Permission Removed From Short Window
+
+## Scenario
+
+An IAM role is downscoped because the provider access summary reports no use of
+`kms:Decrypt` in the last 30 days. The role supports a quarterly disaster
+recovery restore job, so the permission is periodic rather than unused.
+
+## Evidence Snapshot
+
+| Field | Value |
+|---|---|
+| Principal | `arn:aws:iam::111122223333:role/prod-backup-restore` |
+| Policy | `ProdBackupRestorePolicy` |
+| Permission | `kms:Decrypt` |
+| Resource scope | `arn:aws:kms:us-east-1:111122223333:key/prod-backup-key` |
+| Usage data source | IAM service last accessed summary |
+| Observation window | `2026-05-01` to `2026-05-31` |
+| Last used | `not reported` |
+| Provider limitation | Service summary does not include quarterly job context |
+| Secondary evidence | Not checked |
+| Business owner | Not contacted |
+| Change | Permission removed directly from production role |
+| Rollback | None documented |
+
+## Problem Indicators
+
+- `IAM-UPERM-02`: The usage source is too coarse to prove the specific
+  action/resource pair is unused.
+- `IAM-UPERM-03`: The 30-day observation window is shorter than the quarterly
+  disaster recovery process.
+- `IAM-UPERM-05`: CloudTrail KMS events, restore job logs, and backup tickets were
+  not reviewed.
+- `IAM-UPERM-06`: The backup platform owner did not confirm whether the
+  permission is still needed.
+- `IAM-UPERM-08`: The downscope has no staged rollout, restore-test monitoring, or
+  rollback plan.
+
+## Expected Finding
+
+Classify as **Medium** or **High** depending on restore criticality. The role may
+look inactive in a short provider summary, but removal can break disaster
+recovery and should not be recommended without complete unused-permission
+evidence.
+
+## Required Remediation
+
+Rebuild the unused-permission finding using a window that covers the business
+process, resource-scoped telemetry, backup job evidence, owner confirmation,
+staged downscope, monitoring, and rollback evidence.


### PR DESCRIPTION
## Summary

- Adds unused permission evidence gates for principal/action/resource scope, usage source, observation window, provider granularity, secondary telemetry, owner confirmation, effective access, downscope confidence, and rollback.
- Adds a vulnerable fixture where a short-window provider summary causes removal of a quarterly restore permission.
- Adds a benign fixture where resource-scoped telemetry validates a targeted S3 downscope while preserving still-used access.

## Validation

- `git diff --check origin/main...HEAD`
- Markdown fence-balance check over changed `.md` files
- Added-line ASCII check
- Content marker check for `IAM-UPERM-01`, `IAM-UPERM-08`, `Unused Permission Evidence`, fixture names, `Owner Confirmation`, and `Rollback`
- Added-line secret-pattern scan
- `git merge-tree --write-tree origin/main HEAD` -> `90697b4a41c231d779409305027aad26f2b87d66`

Closes #1818

Requested tier: Improver Moderate (USD 100)