### PR TITLE
Improve AWS evidence freshness checks

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -91,6 +91,50 @@ Record all discovered files. If no AWS configurations are found, report that fin
 
 ---
 
+### Step 1.5: Build the Evidence Inventory and Freshness Model
+
+**Objective:** Separate intended configuration from verified deployed AWS state
+before scoring CIS controls. IaC is useful evidence, but it is not proof that
+the current account and region are compliant unless it is tied to live/exported
+state, scope coverage, freshness, and confidence.
+
+Classify evidence for each control:
+
+```
+AWS-EVID-01: Evidence basis is not recorded (IaC intent, live CLI/API export, Security Hub, AWS Config, CloudTrail, or partial/manual evidence)
+AWS-EVID-02: Evidence freshness is missing or outside the control's acceptable review window
+AWS-EVID-03: Account, region, organization unit, and resource coverage are incomplete or unknown
+AWS-EVID-04: IaC-only evidence is treated as deployed-state proof without plan/apply/export linkage
+AWS-EVID-05: Partial regional or account evidence is scored as global compliance
+AWS-EVID-06: Compensating controls such as SCPs, CloudTrail data events, Access Analyzer, or AWS Config auto-remediation are not documented
+AWS-EVID-07: Evidence limitations and source reliability are omitted from the finding
+AWS-EVID-08: Confidence is not assigned before marking a control Pass, Fail, or Not Evaluable
+```
+
+**Evidence basis vocabulary:**
+
+| Evidence Basis | Use For | Confidence Notes |
+|---|---|---|
+| IaC intent | Terraform, CloudFormation, CDK, policy source | Good design evidence; not live proof by itself |
+| Live/exported state | AWS CLI/API exports, config snapshots, console exports | Stronger when fresh and account/region complete |
+| Continuous control | AWS Config, Security Hub, Access Analyzer, SCPs, CloudTrail events | Strong when rule scope, last run, and remediation status are known |
+| Partial evidence | Single region, sampled account, screenshot, owner statement | Use only with explicit limitations and lower confidence |
+| Missing evidence | No artifact or stale/unscoped artifact | Mark Not Evaluable or low confidence, not Pass |
+
+**Minimum evidence inventory fields:**
+
+| Field | Required Evidence |
+|---|---|
+| Control | CIS recommendation ID and control title |
+| Evidence basis | IaC intent, live/exported state, continuous control, partial evidence, or missing evidence |
+| Source | File/export/tool/report name, command, account, region, and collection method |
+| Freshness | Evidence timestamp, review timestamp, acceptable age, and stale/valid result |
+| Coverage | Account IDs, regions, OUs, resource classes, and known exclusions |
+| Limitations | Provider granularity, missing regions/accounts, sampling, IaC drift, or manual assertion limits |
+| Confidence | High/medium/low with rationale before Pass/Fail/Not Evaluable is assigned |
+
+---
+
 ### Step 2 through Step 6: CIS Benchmark Evaluation (Sections 1-5)
 
 Evaluate all AWS configurations against CIS AWS v3.0.0 Sections 1 through 5, covering Identity and Access Management, Storage, Logging, Monitoring, and Networking.
@@ -156,7 +200,18 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration or code snippet>
+- **Evidence Basis:** IaC intent / live-exported state / continuous control / partial evidence / missing evidence
+- **Evidence Freshness:** timestamp, acceptable age, stale/valid result
+- **Coverage:** account, region, OU, and resource scope covered by the evidence
+- **Limitations:** missing scope, provider granularity, drift risk, or compensating controls
+- **Confidence:** High / Medium / Low with rationale
 - **Remediation:** <specific fix with code example>
+
+### Evidence Inventory
+
+| CIS Control | Evidence Basis | Source / Command | Freshness | Coverage | Limitations | Confidence |
+|---|---|---|---|---|---|---|
+| [CIS X.Y] | [basis] | [file/export/tool/command] | [timestamp + age result] | [accounts/regions/resources] | [known limits] | [high/medium/low + reason] |
 
 ### Prioritized Remediation Plan
 
@@ -200,6 +255,7 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
 5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
 6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
+7. **Treating IaC as live AWS proof.** Terraform or CloudFormation can show intended controls while deployed resources drift, partial regions remain unreviewed, or exports are stale. Record evidence basis, freshness, coverage, limitations, and confidence before scoring.
 
 ---
 

--- a/skills/cloud/aws-review/tests/benign/fresh-live-evidence-with-compensating-controls.md
+++ b/skills/cloud/aws-review/tests/benign/fresh-live-evidence-with-compensating-controls.md
@@ -1,0 +1,45 @@
+# Benign Fixture: Fresh Live Evidence With Compensating Controls
+
+## Scenario
+
+The AWS CIS review uses fresh live exports and continuous-control evidence to
+support control scoring. The reviewer records evidence basis, coverage, limits,
+compensating controls, and confidence for each control before assigning status.
+
+## Evidence Snapshot
+
+| Field | Value |
+|---|---|
+| Account | `111122223333` |
+| Organization unit | `prod-payments` |
+| Regions reviewed | `us-east-1`, `us-west-2`, `eu-west-1` |
+| CIS control | `2.1.4 S3 Block Public Access` |
+| Evidence basis | Live/exported state plus continuous control |
+| Source export | `aws s3control get-public-access-block --account-id 111122223333` |
+| Export timestamp | `2026-06-30T09:15:00Z` |
+| AWS Config rule | `s3-account-level-public-access-blocks-periodic`, last success `2026-06-30T09:20:00Z` |
+| CloudTrail data events | Enabled for production buckets, checked `2026-06-30T09:25:00Z` |
+| SCP coverage | `DenyS3PublicAccessChanges`, reviewed `2026-06-01T12:00:00Z` |
+| Coverage | All production accounts in OU and all enabled commercial regions |
+| Known limitation | GovCloud accounts excluded and listed as out of scope |
+| Status assigned | Pass |
+| Confidence | High |
+
+## Positive Controls
+
+- `AWS-EVID-01`: Evidence basis distinguishes live export, continuous control,
+  and SCP control evidence.
+- `AWS-EVID-02`: Export, Config, CloudTrail, and SCP evidence include timestamps
+  and freshness status.
+- `AWS-EVID-03`: Account, OU, region, and resource coverage are documented.
+- `AWS-EVID-04`: IaC intent is not used as the sole proof of live state.
+- `AWS-EVID-05`: Excluded GovCloud scope is explicit rather than silently scored.
+- `AWS-EVID-06`: SCP and AWS Config auto-remediation are documented as
+  compensating controls.
+- `AWS-EVID-07`: Scope limits and evidence limitations are included.
+- `AWS-EVID-08`: High confidence is assigned with rationale before Pass status.
+
+## Expected Result
+
+Accept the Pass result for the scoped environment. Any follow-up should target
+the explicitly excluded GovCloud accounts, not the reviewed production OU.

--- a/skills/cloud/aws-review/tests/vulnerable/iac-only-stale-evidence-pass.md
+++ b/skills/cloud/aws-review/tests/vulnerable/iac-only-stale-evidence-pass.md
@@ -1,0 +1,48 @@
+# Vulnerable Fixture: IaC-Only Stale Evidence Marked Pass
+
+## Scenario
+
+The AWS CIS review marks S3 public access and CloudTrail controls as passing
+because Terraform files contain secure settings. The reviewer does not collect
+fresh live exports, account/region coverage, AWS Config status, or drift
+evidence from the deployed environment.
+
+## Evidence Snapshot
+
+| Field | Value |
+|---|---|
+| Account | `111122223333` |
+| Regions claimed | `us-east-1`, `us-west-2`, `eu-west-1` |
+| CIS controls | `2.1.4`, `3.1`, `3.3` |
+| Evidence basis | IaC intent only |
+| Source | `terraform/security-baseline/s3.tf`, `terraform/logging/cloudtrail.tf` |
+| Last file update | `2025-11-14` |
+| Review date | `2026-06-30` |
+| Live AWS export | Not collected |
+| AWS Config | Not checked |
+| CloudTrail event history | Not checked |
+| Coverage limitation | No account or region export proves deployed state |
+| Result assigned | Pass |
+
+## Problem Indicators
+
+- `AWS-EVID-01`: The control result does not separate IaC intent from live
+  deployed state.
+- `AWS-EVID-02`: Evidence freshness is stale relative to the review date.
+- `AWS-EVID-03`: Account and region coverage are claimed but not proven.
+- `AWS-EVID-04`: IaC-only evidence is treated as deployed-state proof.
+- `AWS-EVID-05`: The review scores global compliance without regional exports.
+- `AWS-EVID-08`: Confidence is not assigned before marking the controls Pass.
+
+## Expected Finding
+
+Classify as **Medium** governance risk, or **High** if the missing live evidence
+covers critical logging or storage exposure controls. The controls should be
+marked Not Evaluable or low-confidence until fresh live/exported state and
+coverage evidence are collected.
+
+## Required Remediation
+
+Collect live AWS CLI/API exports or AWS Config/Security Hub evidence for each
+account and region, document timestamps, coverage, limitations, drift checks,
+and confidence before scoring the CIS controls.


### PR DESCRIPTION
## Summary

- Adds an AWS evidence inventory and freshness model before CIS control scoring.
- Requires evidence basis, source, freshness, coverage, limitations, and confidence before marking controls pass/fail/not evaluable.
- Adds vulnerable/benign fixtures for IaC-only stale evidence versus fresh live/exported evidence with continuous controls and documented scope limits.

## Validation

- `git diff --check origin/main...HEAD`
- Markdown fence-balance check over changed `.md` files
- Added-line ASCII check
- Content marker check for `AWS-EVID-01`, `AWS-EVID-08`, `Evidence Inventory`, fixture names, `Evidence Basis`, and `Evidence Freshness`
- Added-line secret-pattern scan
- `git merge-tree --write-tree origin/main HEAD` -> `ab1ed08bdf28be24b8a8b1e22d7782fb411d34cf`

Closes #1804

Requested tier: Improver Moderate (USD 100)