### PR TITLE
Improve pipeline-security artifact integrity evidence

### DIFF
--- a/skills/devsecops/pipeline-security/SKILL.md
+++ b/skills/devsecops/pipeline-security/SKILL.md
@@ -392,6 +392,8 @@ docker.sock
 - No SBOM (Software Bill of Materials) generation in the build pipeline.
 - Downloaded dependencies or tools without checksum verification.
 - Missing provenance attestation (SLSA provenance, in-toto, Sigstore).
+- Signatures, SBOMs, or provenance generated for one artifact while deployment pulls a different mutable tag or unverified package.
+- Deployment steps that reference image tags, package names, or release assets without verifying the digest, signing identity, provenance subject, and SBOM subject match the build output.
 
 **Grep patterns:**
 
@@ -414,7 +416,23 @@ image: nginx@sha256:abcdef...  # GOOD
 image: nginx:latest            # BAD
 ```
 
-**Finding format:** Report whether artifacts are signed, whether provenance is generated, whether SBOMs are produced, and whether container images use digest pinning.
+**Artifact integrity evidence gate:** Before marking CICD-SEC-9 as passing, capture evidence that the exact artifact deployed is the same artifact that was built, signed, attested, and described by the SBOM.
+
+| Artifact | Build run | Immutable digest | Signature / attestation | Signing identity | Provenance subject | SBOM subject | Verification command/policy | Deployment reference | Result |
+|----------|-----------|------------------|-------------------------|------------------|--------------------|--------------|-----------------------------|---------------------|--------|
+| `<image/package>` | `<run id/url>` | `<sha256:...>` | `<cosign/in-toto/SLSA>` | `<OIDC issuer/subject>` | `<digest matches?>` | `<digest matches?>` | `<verify step or admission policy>` | `<digest/tag used by deploy>` | `Pass/Fail/Unknown` |
+
+**Finding format:** Report whether artifacts are signed, whether provenance is generated, whether SBOMs are produced, whether container images use digest pinning, and whether deployment verifies that the digest, signature, provenance subject, and SBOM subject all refer to the same artifact.
+
+**Review checklist:**
+
+- [ ] Build output is recorded with an immutable digest.
+- [ ] Signature or attestation verifies against an expected trust root and signing identity.
+- [ ] Provenance subject digest matches the build output digest.
+- [ ] SBOM subject digest or package URL matches the build output digest.
+- [ ] Deployment references the immutable digest, not only a mutable tag such as `latest`, `main`, or a semver tag.
+- [ ] A CI verification step, deployment admission policy, or release gate enforces signature/provenance/SBOM verification before deployment.
+- [ ] Evidence comes from the same build run and artifact, not from a different branch, rebuild, architecture, or release asset.
 
 ---
 
@@ -488,6 +506,7 @@ Produce the final report using the following structure:
 - **File:** <path to relevant config>
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
+- **Evidence:** <artifact integrity table, permission evidence, runner evidence, or other control-specific proof>
 - **Remediation:** <specific fix>
 
 ### Prioritized Remediation Plan
@@ -510,6 +529,16 @@ Produce the final report using the following structure:
 ## Output Format
 
 The final deliverable is a structured assessment report as shown in Step 4 above. All findings must reference specific control IDs (CICD-SEC-1 through CICD-SEC-10) and SLSA build levels (L1, L2, L3). Every finding must include the file path and, where possible, the relevant line numbers.
+
+---
+
+## Common Pitfalls
+
+1. **Generated-but-not-enforced attestations.** Producing a provenance file, signature, or SBOM does not protect the deployment if the deploy job never verifies it.
+2. **Mutable deployment references.** A pipeline can sign `my-app@sha256:abc...` and still deploy `my-app:latest`, allowing tag drift or registry replacement.
+3. **Mixed artifact evidence.** Do not combine a signature from one build, an SBOM from another build, and a deployment reference from a third build when scoring CICD-SEC-9.
+4. **Unverified signing identity.** A valid cryptographic signature is incomplete evidence unless the signer identity, issuer, repository, workflow, and branch/ref are expected.
+5. **Architecture or platform mismatch.** Multi-arch images and package bundles need per-platform digest evidence; one signed manifest does not automatically prove every deployed platform artifact is verified.
 
 ---
 

--- a/skills/devsecops/pipeline-security/tests/benign/artifact-verified-before-deploy.md
+++ b/skills/devsecops/pipeline-security/tests/benign/artifact-verified-before-deploy.md
@@ -1,0 +1,39 @@
+# Benign: artifact digest, signature, provenance, SBOM, and deployment are bound
+
+```yaml
+name: release
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      image_digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - id: build
+        run: |
+          docker build -t ghcr.io/example/api:${GITHUB_SHA} .
+          docker push ghcr.io/example/api:${GITHUB_SHA}
+          echo "digest=sha256:0123456789abcdef" >> "$GITHUB_OUTPUT"
+      - run: cosign sign --yes ghcr.io/example/api@${{ steps.build.outputs.digest }}
+      - run: syft ghcr.io/example/api@${{ steps.build.outputs.digest }} -o spdx-json > sbom.json
+      - uses: actions/attest-build-provenance@3d6433db5e00a34f33760f318dc53946bca6da92
+        with:
+          subject-name: ghcr.io/example/api
+          subject-digest: ${{ steps.build.outputs.digest }}
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - run: cosign verify ghcr.io/example/api@${{ needs.build.outputs.image_digest }} --certificate-identity-regexp '^https://github.com/example/api/'
+      - run: kubectl set image deploy/api api=ghcr.io/example/api@${{ needs.build.outputs.image_digest }}
+```
+
+Expected skill behavior:
+
+- Do not flag CICD-SEC-9 merely because the pipeline generates artifacts.
+- Treat as passing evidence when the same immutable digest is signed, used as the provenance subject, described by the SBOM, verified, and deployed by digest.

--- a/skills/devsecops/pipeline-security/tests/vulnerable/artifact-generated-not-enforced.md
+++ b/skills/devsecops/pipeline-security/tests/vulnerable/artifact-generated-not-enforced.md
@@ -1,0 +1,29 @@
+# Vulnerable: artifact evidence generated but deployment uses mutable tag
+
+```yaml
+name: release
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - run: docker build -t ghcr.io/example/api:${{ github.sha }} .
+      - run: docker push ghcr.io/example/api:${{ github.sha }}
+      - run: cosign sign --yes ghcr.io/example/api:${{ github.sha }}
+      - run: syft ghcr.io/example/api:${{ github.sha }} -o spdx-json > sbom.json
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - run: kubectl set image deploy/api api=ghcr.io/example/api:latest
+```
+
+Expected skill behavior:
+
+- Flag CICD-SEC-9 because signature and SBOM evidence are generated for one tag while deployment uses a mutable `latest` reference.
+- Require immutable digest evidence and a verification step or admission policy before deployment.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** pipeline-security
**Skill path:** `skills/devsecops/pipeline-security/`

### What Was Wrong
The skill evaluated CICD-SEC-9 by checking whether signatures, provenance, SBOMs, and digest pinning exist, but it did not require evidence that these controls are bound to the same artifact and enforced before deployment.

That can over-credit pipelines that generate attestations while deployments still pull mutable tags or skip verification.

Closes #1824.

### What This PR Fixes
- Adds CICD-SEC-9 artifact integrity evidence requirements.
- Requires artifact, build run, digest, signature/attestation, signing identity, provenance subject, SBOM subject, verification command/policy, and deployment reference.
- Adds a dedicated artifact integrity evidence table and review checklist.
- Adds an `Evidence` field to detailed findings so reports preserve control-specific proof.
- Adds common pitfalls for generated-but-not-enforced attestations, mutable deploy references, mixed artifact evidence, unverified signing identity, and multi-architecture mismatch.
- Adds vulnerable and benign test cases for the new gate.

### Evidence

**Before (skill misses this / false positive on this):**
```yaml
- run: cosign sign --yes ghcr.io/example/api:${{ github.sha }}
- run: syft ghcr.io/example/api:${{ github.sha }} -o spdx-json > sbom.json
- run: kubectl set image deploy/api api=ghcr.io/example/api:latest
```
The pipeline generates signature/SBOM evidence, but deployment uses a mutable tag that is not verified.

**After (now correctly handled):**
```text
CICD-SEC-9 now requires the deployed artifact digest to match the signature, provenance subject, SBOM subject, verification step/admission policy, and deployment reference.
```

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing tests still pass

### Bounty Tier
- [ ] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Crypto or PayPal details can be provided privately after maintainer acceptance.

## Validation
- `git diff --check`
- Frontmatter check equivalent to `.github/workflows/lint-skills.yml`: passed for 50 files
- Prompt injection scan equivalent to `.github/workflows/injection-scan.yml`: passed
- Index file existence check equivalent to `.github/workflows/validate-index.yml`: passed for 50 entries