### PR TITLE
Improve detection Sigma conversion evidence

### DIFF
--- a/skills/secops/detection-engineering/SKILL.md
+++ b/skills/secops/detection-engineering/SKILL.md
@@ -345,6 +345,43 @@ detections/
 5. **Deploy:** Push converted rules to SIEM via API (Sentinel Analytics Rules API, Splunk REST API)
 6. **Monitor:** Track rule performance metrics (fire rate, TP rate, MTTD)
 
+### Step 6.1: Backend Conversion Semantics Evidence
+
+**Objective:** Prove the converted target-SIEM query preserves the Sigma rule's
+meaning before declaring the detection deployable. Passing Sigma YAML validation
+is not enough if conversion changes field mappings, operators, case handling,
+grouping, negation, correlation, or backend limits.
+
+Collect these evidence gates for every target backend:
+
+```
+DE-CONV-01: Target backend, converter package/version, backend config, and exact command are missing
+DE-CONV-02: Generated query and converter warning/error output are not preserved
+DE-CONV-03: Field mapping evidence is missing, partial, or points to the wrong table/index/data model
+DE-CONV-04: Unsupported modifiers/operators are ignored or treated as generic warnings
+DE-CONV-05: Logic parity is not checked for selections, filters, negation, grouping, list handling, or correlation windows
+DE-CONV-06: Manual edits or post-processing are not recorded before deployment
+DE-CONV-07: Known-positive and known-negative sample execution evidence is incomplete
+DE-CONV-08: Query runtime, scanned volume, timeout/row-limit risk, and backend constraints are not captured
+```
+
+**Conversion evidence record:**
+
+| Field | Required Evidence |
+|---|---|
+| Rule and backend | Sigma rule ID, target backend, SIEM product/table/index, converter version |
+| Command | Exact conversion command, backend config, generated query, warnings/errors |
+| Mapping | Sigma field, backend field, data model/table/index, mapping status, limitations |
+| Operators | Modifiers/operators used, supported/rewritten/dropped status, semantic risk |
+| Logic parity | Selection/filter/negation/grouping/correlation parity check and result |
+| Manual edits | Post-processing diff, owner, reason, and drift-control method |
+| Sample execution | Known-positive result, known-negative result, fixture IDs or raw-event references |
+| Performance | Runtime, scanned volume, timeout/row-limit constraints, deployment decision |
+
+Do not move a converted rule to `stable`, `Operational`, or production deployment
+unless conversion evidence is complete or the residual semantic risk is accepted
+with a documented owner and compensating test plan.
+
 ---
 
 ## 4. Findings Classification
@@ -392,6 +429,7 @@ Produce detection engineering deliverables in this structure:
 ### Deployment Notes
 - **Target SIEM:** [Platform]
 - **Converted Query:** [KQL/SPL/EQL equivalent if requested]
+- **Conversion Evidence:** [converter version, command, mapping, warnings, manual edits, TP/TN execution, performance]
 - **Estimated False Positive Rate:** [Low / Medium / High]
 - **Tuning Recommendations:** [Specific filter additions]
 ```
@@ -493,6 +531,15 @@ Detection rules are not write-once artifacts. Log sources change, environments e
 ### Pitfall 5: Mapping Detections to ATT&CK Techniques Incorrectly
 
 Overly broad or incorrect ATT&CK mappings undermine coverage analysis. A rule that detects a specific PowerShell obfuscation technique should map to T1059.001 (PowerShell) and potentially T1027 (Obfuscated Files or Information), not to the parent T1059 alone. Use sub-technique IDs when the detection is specific to a sub-technique. Validate mappings against the ATT&CK technique definition and procedure examples.
+
+### Pitfall 6: Trusting Converted Queries Without Semantic Evidence
+
+Sigma conversion can produce syntactically valid KQL, SPL, EQL, or QRadar queries
+that no longer preserve the original detection. Field mappings can point at empty
+tables, modifiers such as `contains|all` or `re` can be rewritten, case
+sensitivity can change, and backend limits can truncate results. Capture
+conversion command, generated query, mapping, warnings, manual edits, TP/TN
+sample execution, and performance evidence before deployment.
 
 ---
 

--- a/skills/secops/detection-engineering/tests/benign/conversion-parity-with-tp-tn-evidence.md
+++ b/skills/secops/detection-engineering/tests/benign/conversion-parity-with-tp-tn-evidence.md
@@ -1,0 +1,46 @@
+# Benign Fixture: Conversion Parity With TP/TN Evidence
+
+## Scenario
+
+A Sigma PowerShell rule is converted to Sentinel KQL and Splunk SPL. The detection
+engineer records converter versions, backend configs, field mapping, unsupported
+operator status, logic parity, manual edit status, known-positive and
+known-negative execution, and query performance before deployment.
+
+## Evidence Snapshot
+
+| Field | Value |
+|---|---|
+| Sigma rule ID | `7f7d1f0e-1111-4a22-9f00-000000000179` |
+| Target backends | Microsoft Sentinel KQL, Splunk SPL |
+| Converter | `sigma-cli 0.10.0`, `pysigma-backend-sentinel 0.4.1`, `pysigma-backend-splunk 1.1.0` |
+| Commands | `sigma convert -t sentinel -p sentinel/mde ...`; `sigma convert -t splunk -p splunk/sysmon ...` |
+| Generated query evidence | Saved as `converted/sentinel.kql` and `converted/splunk.spl` |
+| Field mapping | `CommandLine -> ProcessCommandLine` for Sentinel, `CommandLine -> CommandLine` for Splunk |
+| Operators | `contains|all` preserved as `has_all` in KQL and `AND` token checks in SPL |
+| Logic parity | Selections, filters, negation, and grouping reviewed against fixture expectations |
+| Manual edits | None; conversion output deployed verbatim |
+| Known-positive fixture | `tp-powershell-encoded-001.json`, matched in both backends |
+| Known-negative fixture | `tn-admin-getprocess-001.json`, no match in both backends |
+| Runtime | Sentinel `0.8s`, Splunk `1.3s`, scanned volume within rule budget |
+| Deployment decision | Stable for test workspace; production deploy after 7-day burn-in |
+
+## Positive Controls
+
+- `DE-CONV-01`: Backend, converter versions, profile, and exact commands are
+  recorded.
+- `DE-CONV-02`: Generated queries and warning output are preserved.
+- `DE-CONV-03`: Field mapping evidence matches the active data model.
+- `DE-CONV-04`: Modifier behavior is explicitly checked.
+- `DE-CONV-05`: Logic parity covers selections, filters, negation, grouping, and
+  list handling.
+- `DE-CONV-06`: Manual-edit status is documented.
+- `DE-CONV-07`: Known-positive and known-negative fixtures both execute with
+  expected results.
+- `DE-CONV-08`: Runtime and scanned-volume evidence support deployment.
+
+## Expected Result
+
+Accept the converted queries as deployment-ready for the scoped test workspace.
+Retain the conversion evidence with the Sigma rule so future backend upgrades or
+data-model changes can be regression-tested.

--- a/skills/secops/detection-engineering/tests/vulnerable/converted-query-misses-known-positive.md
+++ b/skills/secops/detection-engineering/tests/vulnerable/converted-query-misses-known-positive.md
@@ -1,0 +1,51 @@
+# Vulnerable Fixture: Converted Query Misses Known Positive
+
+## Scenario
+
+A Sigma rule for suspicious PowerShell command execution passes YAML validation
+and converts to Microsoft Sentinel KQL. The conversion silently maps
+`CommandLine|contains|all` to a backend field that is not populated in the
+tenant's active data model. The generated query is syntactically valid but misses
+the known-positive sample event.
+
+## Evidence Snapshot
+
+| Field | Value |
+|---|---|
+| Sigma rule ID | `7f7d1f0e-1111-4a22-9f00-000000000179` |
+| Target backend | Microsoft Sentinel KQL |
+| Converter | `sigma-cli 0.10.0`, backend `sentinel` |
+| Command | `sigma convert -t sentinel -p sentinel/sysmon powershell_encoded.yml` |
+| Generated query | `DeviceProcessEvents | where CommandLine has_all (...)` |
+| Warning output | `field CommandLine mapped by default profile` |
+| Field mapping evidence | Not checked against active table schema |
+| Unsupported operator handling | `contains|all` accepted without parity test |
+| Manual edits | None |
+| Known-positive fixture | `tp-powershell-encoded-001.json` |
+| Known-positive result | `0 rows` |
+| Known-negative fixture | Not executed |
+| Runtime evidence | Not captured |
+| Deployment decision | Marked stable |
+
+## Problem Indicators
+
+- `DE-CONV-01`: Backend config is recorded, but active SIEM table/schema is not.
+- `DE-CONV-03`: Field mapping points to `CommandLine`, while the tenant emits
+  `ProcessCommandLine`.
+- `DE-CONV-04`: `contains|all` is not proven equivalent after conversion.
+- `DE-CONV-05`: Logic parity is assumed from conversion success.
+- `DE-CONV-07`: Known-positive execution misses the expected event and no
+  known-negative test is run.
+- `DE-CONV-08`: Runtime and backend constraints are not captured.
+
+## Expected Finding
+
+Classify as **High** if the rule is deployment-bound for a priority ATT&CK
+technique. The Sigma source is valid, but the converted query is not deployment
+ready because it misses a known-positive event.
+
+## Required Remediation
+
+Record backend schema evidence, correct the field mapping, preserve warnings,
+run known-positive and known-negative fixtures, document any manual edits, and
+capture runtime/scanned-volume evidence before marking the rule stable.


### PR DESCRIPTION
## Summary

- Adds backend conversion semantics evidence gates for Sigma-to-SIEM conversion.
- Requires converter/backend version, exact command, generated query, warning output, field mapping, operator support, logic parity, manual edits, TP/TN execution, and performance evidence.
- Adds vulnerable/benign fixtures for a converted query that misses a known-positive sample versus conversion parity with TP/TN evidence.

## Validation

- `git diff --check origin/main...HEAD`
- Markdown fence-balance check over changed `.md` files
- Added-line ASCII check
- Content marker check for `DE-CONV-01`, `DE-CONV-08`, `Backend Conversion Semantics Evidence`, fixture names, `Known-positive`, and `Known-negative`
- Added-line secret-pattern scan
- `git merge-tree --write-tree origin/main HEAD` -> `46c7aaac81cc4edc4b9f3dbf6756991e618b50fe`

Closes #1797

Requested tier: Improver Moderate (USD 100)