### PR TITLE
Improve dotnet webhook receiver evidence

### DIFF
--- a/skills/appsec/api-security/csharp-dotnet.md
+++ b/skills/appsec/api-security/csharp-dotnet.md
@@ -869,6 +869,90 @@ builder.Services.AddHttpClient("PartnerApi", client =>
 
 ---
 
+## ASP.NET Core Inbound Webhook Receiver Evidence Gates
+
+Inbound webhooks are API endpoints that consume provider-controlled callbacks
+from Stripe, GitHub, GitLab, and internal partners. In ASP.NET Core, the most
+common failure is parsing or model-binding JSON before verifying the provider
+signature over the exact raw request body.
+
+### Minimal API -- Vulnerable
+
+```csharp
+// VULNERABLE: Parses JSON before verifying the signature over raw bytes.
+app.MapPost("/webhooks/stripe", async (HttpRequest request, AppDbContext db) =>
+{
+    var evt = await request.ReadFromJsonAsync<StripeEvent>();
+    if (!request.Headers.ContainsKey("Stripe-Signature"))
+        return Results.Unauthorized();
+
+    await ApplyStripeSideEffects(evt!, db);
+    return Results.Ok();
+});
+```
+
+### Minimal API -- Secure
+
+```csharp
+app.MapPost("/webhooks/stripe", async (HttpRequest request, IWebhookVerifier verifier, AppDbContext db) =>
+{
+    request.EnableBuffering();
+    using var reader = new StreamReader(request.Body, Encoding.UTF8, leaveOpen: true);
+    var rawBody = await reader.ReadToEndAsync();
+    request.Body.Position = 0;
+
+    var signature = request.Headers["Stripe-Signature"].ToString();
+    var verification = verifier.VerifyStripe(rawBody, signature, DateTimeOffset.UtcNow);
+    if (!verification.Success)
+        return Results.Unauthorized();
+
+    if (!await db.ProcessedWebhookEvents.TryInsertAsync(verification.EventId, verification.DeliveryId))
+        return Results.Ok(); // idempotent retry
+
+    var evt = JsonSerializer.Deserialize<StripeEvent>(rawBody);
+    if (!AllowedStripeEvents.Contains(evt!.Type))
+        return Results.BadRequest();
+
+    await ApplyStripeSideEffects(evt, db);
+    return Results.Ok();
+});
+```
+
+### Webhook Evidence Gates
+
+```
+DOTNET-WH-01: Handler parses JSON, model binds, or reads [FromBody] before raw-body signature verification
+DOTNET-WH-02: Provider signature header and timestamp are not validated with constant-time comparison and tolerance window
+DOTNET-WH-03: Delivery ID or event ID is not stored before side effects, making provider retries non-idempotent
+DOTNET-WH-04: Event allowlist is missing for provider event types or actions
+DOTNET-WH-05: Tenant, account, repository, project, or environment binding is not verified against local configuration
+DOTNET-WH-06: Webhook secret source and rotation window are not environment-scoped or bounded for old secrets
+DOTNET-WH-07: Provider retry behavior, duplicate deliveries, and out-of-order events are not tested
+DOTNET-WH-08: Review evidence omits raw-body capture method, header mapping, replay decision, side-effect boundary, and audit logging
+```
+
+### Provider Header Mapping
+
+| Provider | Authenticity Header | Replay / Idempotency Header | Binding Evidence |
+|---|---|---|---|
+| Stripe | `Stripe-Signature` | event `id`, timestamp in signature | account, livemode/testmode, event type allowlist |
+| GitHub | `X-Hub-Signature-256` | `X-GitHub-Delivery` | repository/org, event type, installation ID |
+| GitLab | `X-Gitlab-Token` or provider signature scheme | event UUID when available | project path/id, event type, protected branch/environment |
+| Custom partner | HMAC or asymmetric signature header | delivery ID/event ID/timestamp | tenant/account, shared secret version, allowed source |
+
+### Webhook Review Checklist -- .NET
+
+- [ ] Raw body is captured with `EnableBuffering()` or equivalent before any JSON parsing, model binding, or `[FromBody]` DTO binding.
+- [ ] Signature verification covers the exact raw request body and provider timestamp, with a bounded replay tolerance window.
+- [ ] HMAC or signature comparisons use constant-time comparison such as `CryptographicOperations.FixedTimeEquals`.
+- [ ] Delivery IDs or event IDs are inserted before side effects and enforce idempotency for provider retries.
+- [ ] Event types/actions are allowlisted and unknown events fail closed or are ignored safely.
+- [ ] Tenant/account/repository/project/environment binding is checked before applying side effects.
+- [ ] Webhook secrets are environment-scoped and old-secret acceptance is bounded during rotation.
+- [ ] Tests cover invalid signatures, stale timestamps, duplicate deliveries, wrong tenant/repository, disallowed event types, and retry-safe side effects.
+
+---
+
 ## ASP.NET Core Minimal API Security Patterns
 
 Minimal APIs (.NET 7+) have a different surface than controller-based APIs. Security-relevant patterns to review:
@@ -1223,6 +1307,22 @@ HttpClientHandler.*ServerCertificateCustomValidation.*true
 MapPost\(.*login.*\)(?![\s\S]*?RequireRateLimiting)
 MapPost\(.*register.*\)(?![\s\S]*?RequireRateLimiting)
 MapPost\(.*password.*\)(?![\s\S]*?RequireRateLimiting)
+```
+
+### Inbound Webhook Receiver Risks
+
+```
+# JSON/body parsing before signature verification
+ReadFromJsonAsync<
+\[FromBody\].*(Webhook|Stripe|GitHub|GitLab|Event)
+JsonSerializer\.Deserialize.*Request\.Body
+# Signature headers present without raw-body verification/idempotency review
+Stripe-Signature
+X-Hub-Signature-256
+X-GitHub-Delivery
+X-Gitlab-Token
+# Look for these without EnableBuffering, FixedTimeEquals, replay timestamp checks,
+# delivery/event-id storage, and tenant/repository/project binding.
 ```
 
 ---

--- a/skills/appsec/api-security/tests/benign/dotnet-webhook-raw-body-idempotent.md
+++ b/skills/appsec/api-security/tests/benign/dotnet-webhook-raw-body-idempotent.md
@@ -1,0 +1,43 @@
+# Benign Fixture: .NET Webhook Raw Body and Idempotency Evidence
+
+## Scenario
+
+An ASP.NET Core webhook receiver verifies GitHub webhooks over the exact raw
+request body before JSON parsing. It stores `X-GitHub-Delivery` before side
+effects and verifies repository, event type, environment, and secret version.
+
+## Evidence Snapshot
+
+| Field | Value |
+|---|---|
+| Endpoint | `POST /webhooks/github` |
+| Framework | ASP.NET Core controller, .NET 8 |
+| Raw-body capture | `Request.EnableBuffering()` and raw UTF-8 read before deserialization |
+| Signature header | `X-Hub-Signature-256` |
+| Delivery header | `X-GitHub-Delivery` |
+| Constant-time compare | `CryptographicOperations.FixedTimeEquals` |
+| Replay control | Delivery ID insert happens before side effects |
+| Event allowlist | `push`, `pull_request`, `workflow_run` only |
+| Binding | Repository owner/name and installation ID match configured tenant |
+| Environment scope | Production endpoint accepts only production secret version |
+| Rotation | Old secret accepted for 24 hours with versioned audit entry |
+| Retry behavior | Duplicate delivery returns 200 without duplicate side effects |
+| Audit log | Signature result, delivery ID, event type, repository, and decision |
+
+## Positive Controls
+
+- `DOTNET-WH-01`: Raw body is verified before parsing.
+- `DOTNET-WH-02`: Signature and timestamp policy are enforced with constant-time comparison.
+- `DOTNET-WH-03`: Delivery ID storage enforces idempotency before side effects.
+- `DOTNET-WH-04`: Event types are allowlisted.
+- `DOTNET-WH-05`: Repository and installation are bound to local tenant config.
+- `DOTNET-WH-06`: Secret source and rotation window are environment-scoped.
+- `DOTNET-WH-07`: Duplicate, stale, invalid, and wrong-repository deliveries are tested.
+- `DOTNET-WH-08`: Review evidence captures raw-body handling, header mapping,
+  replay decision, side-effect boundary, and audit logging.
+
+## Expected Result
+
+Do not flag the receiver as missing webhook authenticity or replay controls. Any
+remaining finding should focus on provider-specific business logic, not the
+receiver evidence gates.

--- a/skills/appsec/api-security/tests/vulnerable/dotnet-webhook-parses-before-signature.md
+++ b/skills/appsec/api-security/tests/vulnerable/dotnet-webhook-parses-before-signature.md
@@ -1,0 +1,46 @@
+# Vulnerable Fixture: .NET Webhook Parses Before Signature
+
+## Scenario
+
+An ASP.NET Core Minimal API endpoint accepts Stripe-style webhook callbacks. The
+handler calls `ReadFromJsonAsync` before verifying `Stripe-Signature`, then
+applies side effects without storing the event ID first.
+
+## Evidence Snapshot
+
+| Field | Value |
+|---|---|
+| Endpoint | `POST /webhooks/stripe` |
+| Framework | ASP.NET Core Minimal API, .NET 8 |
+| Body handling | `request.ReadFromJsonAsync<StripeEvent>()` before signature verification |
+| Signature header | `Stripe-Signature` checked for presence only |
+| Timestamp tolerance | Not enforced |
+| Constant-time compare | Not used |
+| Event allowlist | Missing |
+| Idempotency | No processed event table before side effects |
+| Tenant binding | Uses event customer ID without local account binding |
+| Secret rotation | Single unversioned secret from shared config |
+| Retry behavior | Duplicate deliveries trigger duplicate invoice credit |
+
+## Problem Indicators
+
+- `DOTNET-WH-01`: JSON is parsed before raw-body signature verification.
+- `DOTNET-WH-02`: Signature timestamp and constant-time comparison are missing.
+- `DOTNET-WH-03`: Event ID is not stored before side effects.
+- `DOTNET-WH-04`: Unknown event types are accepted.
+- `DOTNET-WH-05`: Tenant/account binding is not checked.
+- `DOTNET-WH-06`: Secret rotation is not environment-scoped or bounded.
+- `DOTNET-WH-07`: Duplicate provider retries are not tested.
+- `DOTNET-WH-08`: Evidence omits raw-body capture and side-effect boundary.
+
+## Expected Finding
+
+Classify as **High** if webhook side effects affect billing, provisioning, or
+authorization state. The handler is vulnerable to signature-bypass mistakes,
+replay, and duplicate side effects.
+
+## Required Remediation
+
+Capture the raw body before parsing, verify the provider signature and timestamp,
+store delivery/event IDs before side effects, enforce event allowlists and tenant
+binding, and test duplicate/stale/invalid deliveries.


### PR DESCRIPTION
## Summary

- Adds ASP.NET Core inbound webhook receiver evidence gates to the .NET API security supplement.
- Covers raw-body signature verification before JSON parsing, provider header mapping, replay/idempotency, event allowlists, tenant/repository/project binding, environment-scoped secret rotation, and retry-safe side effects.
- Adds vulnerable/benign fixtures for parsing before signature verification versus raw-body verification with idempotency evidence.

## Validation

- `git diff --check origin/main...HEAD`
- Markdown fence-balance check over changed `.md` files
- Added-line ASCII check
- Content marker check for `DOTNET-WH-01`, `DOTNET-WH-08`, `ASP.NET Core Inbound Webhook Receiver Evidence Gates`, fixture names, `Stripe-Signature`, and `X-GitHub-Delivery`
- Added-line secret-pattern scan
- `git merge-tree --write-tree origin/main HEAD` -> `72c31b9149b2072264e4a58e372f6f7faa533d01`

Closes #1796

Requested tier: Improver Moderate (USD 100)