### PR TITLE
Add OpenTelemetry trace-log correlation evidence gates

### DIFF
--- a/skills/secops/log-analysis/SKILL.md
+++ b/skills/secops/log-analysis/SKILL.md
@@ -289,6 +289,34 @@ Combine data from multiple log sources to reconstruct attack sequences and incre
 | **IOC sweep** | Search for known indicators across all log sources | Search all logs for a specific IP, domain, hash, or user agent string |
 | **Statistical correlation** | Identify events that co-occur more frequently than expected | Hosts that generate both DNS queries to DGA domains and outbound connections on unusual ports |
 
+#### OpenTelemetry Trace-Log Correlation Evidence Gate
+
+For application investigations, do not treat request IDs or timestamp proximity as complete correlation when OpenTelemetry traces are available or expected. Validate that logs can be joined to traces, spans, resources, and semantic attributes before raising confidence.
+
+| Check ID | Evidence to collect | Failure condition |
+|----------|---------------------|-------------------|
+| `OTEL-CORR-01` | Log records include OpenTelemetry `TraceId` and `SpanId`, or a documented vendor-field mapping to those fields | Logs only contain ad hoc `request_id`, `correlation_id`, or session IDs with no trace/span join |
+| `OTEL-CORR-02` | `TraceFlags` / sampled status and trace retention policy for the analysis window | Error or security logs are retained but matching spans are sampled away without a documented expected-gap decision |
+| `OTEL-CORR-03` | Resource attributes match between logs and spans, especially `service.name`, `service.namespace`, `deployment.environment`, and cloud or Kubernetes identifiers | Logs and spans disagree on service or environment context, making pivots ambiguous |
+| `OTEL-CORR-04` | Non-OTLP log formats map fields such as `trace_id`, `traceId`, `x-b3-traceid`, or W3C `traceparent` to OpenTelemetry fields | Vendor-specific trace fields are used without a documented normalization rule |
+| `OTEL-CORR-05` | HTTP, RPC, database, messaging, or queue semantic attributes needed for the investigation are present and stable | The trace join loses route, method, status, peer, topic, queue, or database context needed to explain the event |
+| `OTEL-CORR-06` | Known-positive trace-log join test for the suspicious event family and at least one known-negative or unrelated request | Correlation is asserted without proving that joins find expected related events and reject unrelated events |
+| `OTEL-CORR-07` | Clock skew and event-time handling are documented for logs and spans | Span start/end times and log timestamps cannot be ordered reliably inside the investigation window |
+| `OTEL-CORR-08` | Correlation confidence is scored as High / Medium / Low with missing-context reasons | The report states that logs and traces are correlated without confidence or evidence-gap notes |
+
+**OpenTelemetry correlation output fields:**
+
+| Field | Value |
+|-------|-------|
+| Trace field source | [native OpenTelemetry / vendor mapping / absent] |
+| Trace identifiers observed | [TraceId, SpanId, TraceFlags, traceparent, x-b3-traceid, etc.] |
+| Resource-context match | [matched / partial / mismatched, with service and environment values] |
+| Sampling and retention status | [always on / tail sampled / head sampled / unknown, with retention window] |
+| Semantic attributes verified | [http.route, http.request.method, server.address, messaging.destination.name, db.system, etc.] |
+| Join validation | [known-positive result, known-negative result, query or trace explorer reference] |
+| Timing confidence | [clock source, skew, event-time vs ingest-time note] |
+| Correlation confidence | [High / Medium / Low plus missing-context reasons] |
+
 **Cross-source correlation example -- Compromised Account Investigation:**
 
 ```
@@ -380,6 +408,18 @@ Produce log analysis findings in this structure:
 ### Visibility Gaps
 [Log sources that were not available but would have provided relevant data]
 
+### OpenTelemetry Trace-Log Correlation
+| Field | Value |
+|-------|-------|
+| Trace Field Source | [native OpenTelemetry / vendor mapping / absent] |
+| Identifiers Present | [TraceId, SpanId, TraceFlags, traceparent, x-b3-traceid, etc.] |
+| Resource Context Match | [matched / partial / mismatched] |
+| Sampling / Retention Status | [policy and expected gaps] |
+| Semantic Attributes Verified | [attributes used for the investigation] |
+| Join Validation Evidence | [known-positive and known-negative checks] |
+| Timing Confidence | [clock source and skew note] |
+| Correlation Confidence | [High / Medium / Low with reasons] |
+
 ### Recommendations
 - [ ] [Action 1]
 - [ ] [Action 2]
@@ -450,6 +490,10 @@ A single Event ID can have very different meanings depending on the context. Eve
 ### Pitfall 5: Not Establishing Baselines Before Looking for Anomalies
 
 Attempting to identify anomalous behavior without knowing what normal behavior looks like leads to both false positives (flagging normal activity as suspicious) and false negatives (missing truly anomalous activity that blends into an unfamiliar baseline). Invest in baseline establishment for high-value log sources before relying on anomaly-based analysis.
+
+### Pitfall 6: Treating Request IDs as Trace Correlation
+
+Application logs often include `request_id`, `correlation_id`, or load balancer IDs that are useful but not equivalent to OpenTelemetry trace context. If the analysis cannot map logs to `TraceId`, `SpanId`, resource attributes, sampling status, and semantic attributes, reduce confidence and document the missing trace-log evidence instead of presenting the pivot as complete.
 
 ---
 

--- a/skills/secops/log-analysis/tests/benign/otel-trace-log-correlation-evidence.md
+++ b/skills/secops/log-analysis/tests/benign/otel-trace-log-correlation-evidence.md
@@ -1,0 +1,42 @@
+# Benign Fixture: OpenTelemetry Trace-Log Correlation Evidence
+
+## Scenario
+
+A SOC analyst investigates a suspected credential stuffing burst against a
+checkout service. Logs, traces, and backend spans all carry normalized
+OpenTelemetry context, and the analyst validates both positive and negative
+joins before using the trace pivot in the incident timeline.
+
+## Evidence Snapshot
+
+| Field | Value |
+|---|---|
+| Analysis window | `2026-06-01T14:00:00Z` to `2026-06-01T14:30:00Z` |
+| Application service | `checkout-api` |
+| Trace field source | Native OpenTelemetry log records |
+| Identifiers present | `TraceId`, `SpanId`, `TraceFlags`, W3C `traceparent` |
+| Resource attributes | `service.name=checkout-api`, `service.namespace=payments`, `deployment.environment=prod` |
+| Trace sampling | Tail sampling keeps all 4xx/5xx and auth-failure traces for 14 days |
+| Semantic attributes | `http.request.method`, `http.route`, `http.response.status_code`, `server.address`, `db.system` |
+| Vendor mapping | Legacy `trace_id` field is mapped to OpenTelemetry `TraceId` in the parser config |
+| Join validation | Known-positive `TraceId=4bf92f3577b34da6a3ce929d0e0e4736` joins log error, API span, and database span |
+| Negative validation | Unrelated `TraceId=7d9c2f0e8c1346bd8f97c9a106c2d44a` does not join to the incident user or route |
+| Timing basis | Logs and spans use event time from NTP-synchronized hosts; max skew observed is 800 ms |
+| Correlation confidence | High, with no unresolved missing-context reasons |
+
+## Positive Controls
+
+- `OTEL-CORR-01`: Logs include native `TraceId` and `SpanId`.
+- `OTEL-CORR-02`: Sampling and retention preserve the relevant error/security traces.
+- `OTEL-CORR-03`: Resource attributes match between logs and spans.
+- `OTEL-CORR-04`: Legacy trace fields have a documented OpenTelemetry mapping.
+- `OTEL-CORR-05`: HTTP and database semantic attributes support the investigation.
+- `OTEL-CORR-06`: Known-positive and known-negative join tests were performed.
+- `OTEL-CORR-07`: Clock skew and event-time handling are documented.
+- `OTEL-CORR-08`: The report assigns High confidence with evidence backing it.
+
+## Expected Result
+
+Do not flag the trace pivot as unsupported. Any remaining finding should focus
+on the credential stuffing activity or application defense gaps, not on missing
+OpenTelemetry trace-log correlation evidence.

--- a/skills/secops/log-analysis/tests/vulnerable/otel-logs-without-trace-context.md
+++ b/skills/secops/log-analysis/tests/vulnerable/otel-logs-without-trace-context.md
@@ -1,0 +1,50 @@
+# Vulnerable Fixture: OpenTelemetry Logs Without Trace Context
+
+## Scenario
+
+A SOC analyst investigates suspicious checkout failures in a microservice
+platform. The application logs include ad hoc request IDs, but the team claims
+the events are correlated to traces without proving OpenTelemetry trace context,
+sampling, resource attributes, or semantic attributes.
+
+## Evidence Snapshot
+
+| Field | Value |
+|---|---|
+| Analysis window | `2026-06-01T14:00:00Z` to `2026-06-01T14:30:00Z` |
+| Application service | `checkout-api` |
+| Log field used for pivot | `request_id=req-88a7` |
+| Native OpenTelemetry fields | Missing `TraceId`, `SpanId`, and `TraceFlags` |
+| Vendor mapping | None documented for `request_id` to OpenTelemetry trace context |
+| Trace sampling | Head sampling at 5 percent, no exception for error/security events |
+| Resource attributes | Logs say `service.name=checkout`, traces say `service.name=payments-api` |
+| Environment context | Logs say `deployment.environment=prod`, trace explorer defaults to `staging` |
+| Semantic attributes | Missing `http.route`, `http.request.method`, `server.address`, and `db.system` |
+| Join validation | No known-positive trace-log join test; no known-negative rejection test |
+| Timing basis | Log timestamps are ingest time; spans use host event time with unknown skew |
+| Reported confidence | "Confirmed correlated" with no missing-context reasons |
+
+## Problem Indicators
+
+- `OTEL-CORR-01`: Logs lack `TraceId` and `SpanId`, and no vendor mapping exists.
+- `OTEL-CORR-02`: Sampled-away spans are possible but not treated as expected gaps.
+- `OTEL-CORR-03`: Resource attributes disagree across logs and spans.
+- `OTEL-CORR-04`: Non-OTLP fields are not normalized to OpenTelemetry fields.
+- `OTEL-CORR-05`: Security-relevant semantic attributes are absent.
+- `OTEL-CORR-06`: The report lacks known-positive and known-negative join evidence.
+- `OTEL-CORR-07`: Timestamp and clock-skew handling are not documented.
+- `OTEL-CORR-08`: Correlation confidence is overstated without evidence-gap reasons.
+
+## Expected Finding
+
+Classify the correlation as **Low confidence**. The analyst may keep the
+request-ID timeline as a lead, but the report must not claim trace-log
+correlation until OpenTelemetry identifiers, resource consistency, sampling
+expectations, semantic attributes, and join validation are collected.
+
+## Required Remediation
+
+Instrument logs with OpenTelemetry trace context, document vendor-field
+normalization, align resource attributes, preserve error/security spans or mark
+sampled gaps, verify required semantic attributes, and add known-positive plus
+known-negative join tests before reporting trace correlation.


### PR DESCRIPTION
## Summary
- Adds an OpenTelemetry trace-log correlation evidence gate to log-analysis with checks for TraceId/SpanId, TraceFlags, sampling, resource context, vendor-field mapping, semantic attributes, join validation, timing, and confidence.
- Extends the output template with an OpenTelemetry correlation evidence table.
- Adds vulnerable and benign fixtures for request-ID-only correlation versus validated trace-log joins.

## Bounty
Addresses #1696 as an Improver contribution.

## Validation
- git diff --cached --check
- Markdown fence-balance check over staged .md files
- Added-line ASCII check
- Required marker check for OTEL-CORR-01 through OTEL-CORR-08
- Added-line secret-pattern scan
- git diff --check origin/main...HEAD
- git merge-tree --write-tree origin/main HEAD