### PR TITLE
Improve gcp-review effective org policy evidence

### DIFF
--- a/skills/cloud/gcp-review/SKILL.md
+++ b/skills/cloud/gcp-review/SKILL.md
@@ -88,6 +88,37 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
+### Effective Org Policy Evidence Gate
+
+For CIS controls that can be enforced by Google Cloud organization policy, do not score the control from a raw Terraform resource alone. Organization policies are inherited across organization, folder, project, and tag scopes, and dry-run policies do not enforce protection. Require evidence of the evaluated effective policy before marking the control Pass, Fail, or downgraded.
+
+Apply this gate to constraints that commonly affect CIS review outcomes, including:
+
+- `constraints/compute.skipDefaultNetworkCreation`
+- `constraints/compute.vmExternalIpAccess`
+- `constraints/iam.disableServiceAccountKeyCreation`
+- `constraints/storage.publicAccessPrevention`
+- domain-restricted sharing and similar IAM or storage constraints
+
+Collect or request evidence from `gcloud org-policies get-effective-policy`, Cloud Asset Inventory policy exports, Security Command Center findings with scoped policy metadata, or equivalent reviewed configuration that resolves hierarchy and inheritance. If only project-level Terraform is available and higher-level policy state is unknown, mark the affected control **Not Evaluable** instead of assuming pass or fail.
+
+Record the following fields in the finding evidence:
+
+| Field | Required Evidence |
+|-------|-------------------|
+| Constraint | Full constraint name, such as `constraints/storage.publicAccessPrevention` |
+| Resource scope | Organization, folder, project, bucket, or instance scope reviewed |
+| Effective policy source | The scope that supplies the active policy after inheritance |
+| Enforced spec | Active `spec` result, not only Terraform intent |
+| Dry-run status | Whether `dryRunSpec` exists and whether it differs from active enforcement |
+| Exceptions | Folder, project, or tag exceptions that alter the effective result |
+| Exception governance | Owner, business justification, expiry, and last review for accepted exceptions |
+| Evidence timestamp | Collection time for live exports or CLI output |
+
+When `dryRunSpec` is secure but active `spec` is not enforced, keep the control failed and note that remediation is planned but not active. When a secure organization baseline has a folder, project, or tag exception, score the effective posture for each reviewed resource, not the parent baseline alone.
+
+---
+
 ### Step 9: Compile Assessment Report
 
 
@@ -148,6 +179,7 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration or code snippet>
+- **Effective Org Policy Evidence:** <constraint, resource scope, effective source, active spec, dry-run status, exceptions, timestamp; required for org-policy-enforced controls>
 - **Remediation:** <specific fix with code example>
 
 ### Prioritized Remediation Plan
@@ -189,11 +221,13 @@ Produce the final report using the structure defined in the Output Format sectio
 ## Common Pitfalls
 
 1. **Missing org-level policy checks.** Many CIS controls (e.g., 3.1 default network, 5.1 public access) can be enforced via org policies. Check both resource-level configuration and org policy constraints.
-2. **Confusing GCP-managed vs. user-managed service account keys.** CIS 1.4 only flags user-managed keys (created via `google_service_account_key`). Keys automatically managed by GCP services are acceptable.
-3. **VPC flow logs must be per-subnet.** CIS 3.8 requires flow logs on every subnet, not just the VPC. Each `google_compute_subnetwork` must have a `log_config` block.
-4. **Cloud SQL authorized_networks vs. private IP.** CIS 6.5 flags `0.0.0.0/0` in authorized networks, but CIS 6.6 goes further and recommends disabling public IP entirely in favor of private networking.
-5. **BigQuery dataset-level vs. table-level CMEK.** CIS 7.2 checks table-level encryption, while CIS 7.3 checks the dataset default. Both should be evaluated independently.
-6. **Default compute service account identification.** The default SA follows the pattern `PROJECT_NUMBER-compute@developer.gserviceaccount.com`. Grep for this pattern, not just the string "default."
+2. **Treating dry-run org policy as enforced.** `dryRunSpec` is advisory only. Score the active `spec` or effective policy, and report dry-run evidence as remediation intent.
+3. **Ignoring inherited exceptions.** Folder, project, and tag exceptions can override a secure parent baseline. Evaluate the effective policy at the reviewed resource scope.
+4. **Confusing GCP-managed vs. user-managed service account keys.** CIS 1.4 only flags user-managed keys (created via `google_service_account_key`). Keys automatically managed by GCP services are acceptable.
+5. **VPC flow logs must be per-subnet.** CIS 3.8 requires flow logs on every subnet, not just the VPC. Each `google_compute_subnetwork` must have a `log_config` block.
+6. **Cloud SQL authorized_networks vs. private IP.** CIS 6.5 flags `0.0.0.0/0` in authorized networks, but CIS 6.6 goes further and recommends disabling public IP entirely in favor of private networking.
+7. **BigQuery dataset-level vs. table-level CMEK.** CIS 7.2 checks table-level encryption, while CIS 7.3 checks the dataset default. Both should be evaluated independently.
+8. **Default compute service account identification.** The default SA follows the pattern `PROJECT_NUMBER-compute@developer.gserviceaccount.com`. Grep for this pattern, not just the string "default."
 
 ---
 

--- a/skills/cloud/gcp-review/benchmark-checklist.md
+++ b/skills/cloud/gcp-review/benchmark-checklist.md
@@ -322,6 +322,8 @@ resource "google_organization_policy" {
 }
 ```
 
+Before marking this control as passed by org policy, collect effective policy evidence for the reviewed project. A parent-level `constraints/compute.skipDefaultNetworkCreation` policy only proves compliance when the effective project policy shows the active `spec` is enforced and no folder, project, or tag exception resets it.
+
 ### CIS 3.2 -- Ensure Legacy Networks Do Not Exist for Older Projects
 
 Check for legacy networks (non-VPC):
@@ -563,6 +565,8 @@ resource "google_organization_policy" {
   }
 }
 ```
+
+Do not treat `dryRunSpec` as enforcement for public access prevention. The control only passes when the bucket or project effective policy shows active `spec` enforcement, or when the bucket's own `public_access_prevention` setting is enforced. If a folder, project, or tag exception permits public buckets, score the effective bucket/project posture and document the exception owner, justification, expiry, and review date.
 
 ### CIS 5.2 -- Ensure that Cloud Storage Buckets Have Uniform Bucket-Level Access Enabled
 

--- a/skills/cloud/gcp-review/tests/benign/effective-org-policy-enforced.yaml
+++ b/skills/cloud/gcp-review/tests/benign/effective-org-policy-enforced.yaml
@@ -1,0 +1,22 @@
+case: effective-org-policy-enforced
+expect: benign
+cis_controls:
+  - "1.4"
+constraint: constraints/iam.disableServiceAccountKeyCreation
+resource_scope: projects/analytics-prod
+effective_policy:
+  source: organizations/1234567890
+  spec:
+    rules:
+      - enforce: true
+  dryRunSpec: null
+  exceptions: []
+  collected_at: "2026-06-08T17:45:00Z"
+terraform_snippet:
+  project_policy:
+    constraint: iam.disableServiceAccountKeyCreation
+    boolean_policy:
+      enforced: false
+expected_finding:
+  status: Pass
+  reason: raw project Terraform is non-enforced, but current effective policy is inherited and enforced from the organization.

--- a/skills/cloud/gcp-review/tests/benign/governed-sandbox-exception.yaml
+++ b/skills/cloud/gcp-review/tests/benign/governed-sandbox-exception.yaml
@@ -1,0 +1,29 @@
+case: governed-sandbox-exception
+expect: benign
+cis_controls:
+  - "4.9"
+constraint: constraints/compute.vmExternalIpAccess
+resource_scope: projects/sandbox-training
+effective_policy:
+  source: folders/7777
+  spec:
+    rules:
+      - condition:
+          title: allow-training-lab
+          expression: resource.matchTag('tagKeys/123', 'allow-external-ip')
+        allowAll: true
+      - denyAll: true
+  dryRunSpec: null
+  exceptions:
+    - scope: projects/sandbox-training
+      tag: allow-external-ip=true
+      owner: security-training@example.com
+      justification: isolated lab environment
+      expiry: "2026-07-31"
+      last_reviewed: "2026-06-01"
+instances:
+  - name: lab-jumpbox
+    external_ip: true
+expected_finding:
+  status: Informational
+  reason: exception is explicit, scoped, owned, expiring, and reviewed; report it separately instead of failing the parent baseline.

--- a/skills/cloud/gcp-review/tests/vulnerable/dry-run-policy-not-enforced.yaml
+++ b/skills/cloud/gcp-review/tests/vulnerable/dry-run-policy-not-enforced.yaml
@@ -1,0 +1,22 @@
+case: dry-run-policy-not-enforced
+expect: vulnerable
+cis_controls:
+  - "5.1"
+constraint: constraints/storage.publicAccessPrevention
+resource_scope: projects/marketing-prod
+org_policy:
+  spec:
+    rules:
+      - enforce: false
+  dryRunSpec:
+    rules:
+      - enforce: true
+bucket:
+  name: public-marketing-assets
+  public_access_prevention: inherited
+  iam:
+    - role: roles/storage.objectViewer
+      member: allUsers
+expected_finding:
+  status: Fail
+  reason: dryRunSpec is secure but the active spec is not enforced, so public access prevention is not active.

--- a/skills/cloud/gcp-review/tests/vulnerable/folder-tag-exception-allows-external-ip.yaml
+++ b/skills/cloud/gcp-review/tests/vulnerable/folder-tag-exception-allows-external-ip.yaml
@@ -1,0 +1,26 @@
+case: folder-tag-exception-allows-external-ip
+expect: vulnerable
+cis_controls:
+  - "4.9"
+constraint: constraints/compute.vmExternalIpAccess
+organization_policy:
+  source: organizations/1234567890
+  effective_default: deny_all
+folder_exception:
+  folder: folders/5555
+  tag: allow-external-ip=true
+  owner: data-science-platform@example.com
+  expiry: null
+project:
+  id: data-science-sandbox
+  folder: folders/5555
+  tags:
+    allow-external-ip: "true"
+instance:
+  name: notebook-runner-1
+  network_interface:
+    access_config:
+      - nat_ip: 203.0.113.10
+expected_finding:
+  status: Fail
+  reason: the effective project policy allows an exception and the VM has an external IP.


### PR DESCRIPTION
Closes #2008

## Summary
- Adds an `Effective Org Policy Evidence Gate` to `gcp-review` for CIS controls that can be enforced through inherited GCP organization policies.
- Requires reviewers to distinguish active `spec` from `dryRunSpec`, capture effective policy source/scope, and document folder/project/tag exceptions before scoring pass/fail.
- Updates checklist guidance for default network creation and Cloud Storage public access prevention where org-policy evidence often changes the outcome.

## Fixtures
- `skills/cloud/gcp-review/tests/vulnerable/dry-run-policy-not-enforced.yaml`
- `skills/cloud/gcp-review/tests/vulnerable/folder-tag-exception-allows-external-ip.yaml`
- `skills/cloud/gcp-review/tests/benign/effective-org-policy-enforced.yaml`
- `skills/cloud/gcp-review/tests/benign/governed-sandbox-exception.yaml`

## Validation
- `git diff --cached --check`
- Parsed all four YAML fixtures with PyYAML
- Verified the `Effective Org Policy Evidence Gate`, `dryRunSpec`, effective policy, and exception governance markers are present
- Verified fixture count: 2 vulnerable and 2 benign

## Bounty
Requesting Improver Moderate ($100) if accepted. Payment details can be shared privately after acceptance.