### PR TITLE
Improve IaC state backend evidence

### DIFF
--- a/skills/cloud/iac-security/SKILL.md
+++ b/skills/cloud/iac-security/SKILL.md
@@ -96,6 +96,34 @@ Evaluate all IaC configurations across eight security domains: Hardcoded Secrets
 
 For detailed tool-specific rule sets, detection patterns, vulnerable code examples, and remediation guidance for Checkov, tfsec, and KICS equivalents across all eight domains, see [tool-rules.md](tool-rules.md) in this skill directory.
 
+#### Terraform/OpenTofu State Backend and Drift Evidence Gate
+
+Treat Terraform/OpenTofu state as a control-plane and secret-bearing asset. Do not mark IaC secure only because resource definitions pass static checks; verify backend security, state access, secret minimization, and drift evidence.
+
+| Check ID | Evidence to collect | Failure condition |
+|----------|---------------------|-------------------|
+| `IAC-STATE-01` | Backend type and location for every workspace or stack, including local, S3, GCS, AzureRM, Terraform Cloud, or OpenTofu equivalent | Local or undocumented backend stores production state outside governed storage |
+| `IAC-STATE-02` | Backend encryption, KMS/CMK ownership, public access block, bucket/container ACLs, and network restrictions | Remote state can be read publicly, cross-account broadly, or without encryption evidence |
+| `IAC-STATE-03` | State locking, versioning, retention, object lock/immutability, and recovery procedure | State can be overwritten concurrently or rolled back without version/recovery evidence |
+| `IAC-STATE-04` | IAM/RBAC split for state read, plan, apply, import, force-unlock, and backend administration | Same broad principal can read secrets from state and apply production changes without approval |
+| `IAC-STATE-05` | Sensitive attribute inventory for resources that persist values in state, including database passwords, generated secrets, private keys, kubeconfigs, and connection strings | Review assumes `sensitive = true` keeps values out of state or ignores provider attributes persisted in plaintext state |
+| `IAC-STATE-06` | Drift detection cadence, last drift run, plan output, reviewed deltas, and owner sign-off | IaC passes static scan but live infrastructure differs from reviewed code |
+| `IAC-STATE-07` | Backend audit logs for reads, writes, deletes, lock operations, and failed access attempts | State access cannot be attributed or monitored |
+| `IAC-STATE-08` | State migration, workspace separation, and break-glass/restore evidence for incidents | Shared state, manual state edits, or recovery paths are undocumented and untested |
+
+**State backend output fields:**
+
+| Field | Value |
+|-------|-------|
+| Backend type and scope | [local / S3 / GCS / AzureRM / Terraform Cloud / mixed; workspaces covered] |
+| Encryption and access status | [KMS/CMK, public block, IAM/RBAC, network restriction] |
+| Locking and recovery status | [lock table, versioning, retention, restore test] |
+| State reader vs apply permissions | [separated / partially separated / same broad principal] |
+| Sensitive values in state | [none found / known provider attributes / unknown; evidence reference] |
+| Drift detection status | [cadence, last run, owner, unresolved drift] |
+| State audit coverage | [read/write/delete/lock logs and retention] |
+| State governance confidence | [High / Medium / Low plus missing evidence] |
+
 ---
 
 
@@ -170,6 +198,18 @@ Produce the final report using the structure defined in the Output Format sectio
 - State locking: <enabled / disabled>
 - Lock file committed: <yes / no>
 
+### State Backend and Drift Evidence
+| Field | Value |
+|-------|-------|
+| Backend Type and Scope | <local / S3 / GCS / AzureRM / Terraform Cloud / mixed; workspaces covered> |
+| Encryption and Access Status | <KMS/CMK, public block, IAM/RBAC, network restriction> |
+| Locking and Recovery Status | <lock table, versioning, retention, restore test> |
+| State Reader vs Apply Permissions | <separated / partially separated / same broad principal> |
+| Sensitive Values in State | <none found / known provider attributes / unknown; evidence reference> |
+| Drift Detection Status | <cadence, last run, owner, unresolved drift> |
+| State Audit Coverage | <read/write/delete/lock logs and retention> |
+| State Governance Confidence | <High / Medium / Low plus missing evidence> |
+
 ### Prioritized Remediation Plan
 
 1. **[Critical]** <finding> -- <action>
@@ -230,6 +270,7 @@ This skill applies checks equivalent to the following high-impact rules:
 5. **Confusing `aws_s3_bucket_acl` with `aws_s3_bucket_public_access_block`.** The public access block overrides ACLs. Check both, but the access block is the stronger control.
 6. **Terraform state file secrets.** Even when variables are marked `sensitive`, they may appear in plaintext in the state file. Verify state encryption and access controls.
 7. **Provider-specific encryption defaults.** Some providers encrypt by default (e.g., AWS S3 since January 2023). Know the defaults before flagging missing explicit encryption configuration.
+8. **Treating clean code as proof of clean infrastructure.** Remote state can contain older secrets, manual imports, drifted live resources, and broad state-reader permissions even when the latest `.tf` files scan clean. Require backend, state access, secret-in-state, drift, and audit evidence before closing IaC risk.
 
 ---
 

--- a/skills/cloud/iac-security/tests/benign/terraform-state-backend-governed-drift-evidence.md
+++ b/skills/cloud/iac-security/tests/benign/terraform-state-backend-governed-drift-evidence.md
@@ -1,0 +1,42 @@
+# Benign Fixture: Terraform State Backend Governed with Drift Evidence
+
+## Scenario
+
+A Terraform production stack uses a governed remote backend. The review collects
+backend security, state access, secret minimization, drift detection, and audit
+evidence before marking the IaC control-plane posture acceptable.
+
+## Evidence Snapshot
+
+| Field | Value |
+|---|---|
+| Stack | `payments-prod` |
+| Backend | S3 backend with workspace-specific prefix `payments/prod/terraform.tfstate` |
+| Backend encryption | SSE-KMS using `alias/tfstate-prod`, key owned by platform security |
+| Public access block | Enabled for bucket and account |
+| Network restriction | Backend access through CI and approved admin network only |
+| State locking | DynamoDB lock table with point-in-time recovery |
+| Versioning / recovery | Bucket versioning enabled; restore drill completed `2026-05-31` |
+| State readers | Read-only break-glass group separate from plan/apply roles |
+| Apply permissions | CI OIDC role can plan/apply only after protected-branch approval |
+| Sensitive values | Provider state reviewed; database secret is referenced by secret ARN, not plaintext value |
+| Drift evidence | Weekly drift plan completed `2026-06-06`; no unresolved prod drift |
+| Audit logs | S3 data events, KMS decrypt events, and lock table writes retained in SIEM |
+| Workspace separation | Dev, staging, and prod use separate prefixes, roles, and KMS conditions |
+
+## Positive Controls
+
+- `IAC-STATE-01`: Backend type, location, and workspace coverage are documented.
+- `IAC-STATE-02`: Encryption, public access block, IAM, and network controls are evidenced.
+- `IAC-STATE-03`: Locking, versioning, retention, and restore evidence are present.
+- `IAC-STATE-04`: State read, plan, apply, and backend admin privileges are separated.
+- `IAC-STATE-05`: Sensitive state attributes are inventoried and minimized.
+- `IAC-STATE-06`: Drift detection has cadence, recent run evidence, and owner sign-off.
+- `IAC-STATE-07`: Backend audit logs cover reads, writes, decrypts, and locks.
+- `IAC-STATE-08`: Workspace separation and recovery paths are documented and tested.
+
+## Expected Result
+
+Do not flag the backend as exposing state or overstating IaC posture. Any
+remaining IaC findings should focus on resource-level misconfigurations, not
+state backend governance or drift evidence.

--- a/skills/cloud/iac-security/tests/vulnerable/terraform-state-backend-exposes-secrets-and-drift.md
+++ b/skills/cloud/iac-security/tests/vulnerable/terraform-state-backend-exposes-secrets-and-drift.md
@@ -1,0 +1,48 @@
+# Vulnerable Fixture: Terraform State Backend Exposes Secrets and Drift
+
+## Scenario
+
+A Terraform review passes because the current `.tf` files use variables and
+secure-looking resources. The production state backend is a shared S3 bucket
+without a complete access boundary, and the state still contains historical
+database credentials plus drifted live infrastructure.
+
+## Evidence Snapshot
+
+| Field | Value |
+|---|---|
+| Stack | `payments-prod` |
+| Backend | `s3://shared-state/prod.tfstate` |
+| Backend encryption | `encrypt = false`; no CMK evidence |
+| Public access block | Not evidenced |
+| State locking | No DynamoDB lock table / no native lock evidence |
+| Versioning / recovery | Disabled; no restore test |
+| State readers | `Developers` group can `s3:GetObject` on all state prefixes |
+| Apply permissions | Same `Developers` group can assume `TerraformApplyRole` |
+| Sensitive values | State includes `aws_db_instance.master_password` and generated kubeconfig output |
+| Drift evidence | Last drift run unknown; live security group has manual `0.0.0.0/0` ingress |
+| Audit logs | S3 data events disabled; state reads not attributable |
+| Workspace separation | Dev and prod states share the same bucket prefix |
+
+## Problem Indicators
+
+- `IAC-STATE-01`: Production state backend is not governed per workspace.
+- `IAC-STATE-02`: Backend encryption, public block, and access boundaries are missing.
+- `IAC-STATE-03`: Locking, versioning, retention, and recovery evidence are absent.
+- `IAC-STATE-04`: State read and production apply permissions are not separated.
+- `IAC-STATE-05`: Sensitive provider attributes persist in state.
+- `IAC-STATE-06`: Live infrastructure drift is not detected or reviewed.
+- `IAC-STATE-07`: Backend audit logs do not cover state reads and writes.
+- `IAC-STATE-08`: Shared workspace and recovery paths are undocumented.
+
+## Expected Finding
+
+Classify as **High** because state compromise can reveal secrets and enable
+control-plane manipulation even when the current IaC source appears clean.
+
+## Required Remediation
+
+Move state to a governed backend, enable encryption with owned keys, block
+public/cross-account access, enforce locking/versioning/recovery, separate
+read/plan/apply/admin permissions, rotate secrets found in state, run drift
+detection, and enable backend data-event auditing.


### PR DESCRIPTION
## Summary
- Adds Terraform/OpenTofu state backend and drift evidence gates to iac-security without removing the existing review workflow.
- Covers backend type/location, encryption/access boundaries, locking/versioning/recovery, read/apply permission separation, sensitive values in state, drift cadence, audit logs, and workspace recovery evidence.
- Adds vulnerable and benign fixtures for exposed state with secrets/drift versus governed state backend evidence.

## Bounty
Addresses #1575 as an Improver contribution.

## Validation
- git diff --cached --check
- Markdown fence-balance check over staged .md files
- Added-line ASCII check
- Required marker check for IAC-STATE-01 through IAC-STATE-08
- Sensitive/public-contact pattern scan
- git diff --check origin/main...HEAD
- git merge-tree --write-tree origin/main HEAD

## Push note
The HTTPS push to the fork reset twice, so the branch was created through GitHub Git Data API using exact local git blob bytes. The remote tree matches local HEAD tree.