### PR TITLE
Improve dns-security takeover evidence gates

### DIFF
--- a/skills/network/dns-security/SKILL.md
+++ b/skills/network/dns-security/SKILL.md
@@ -294,13 +294,41 @@ abcdef0123456789.dnscat.example.com TXT
 
 ---
 
+### Step 7: Dangling Record and Subdomain Takeover Review
+
+DNSSEC, RPZ, and protective DNS do not prove that a third-party target is still owned by the organization. Review public authoritative records for stale references that could be claimed by another tenant.
+
+Inspect these record types:
+
+- `CNAME`, `ALIAS`, and `ANAME` records pointing to SaaS, CDN, storage, pages, app hosting, or load-balancer targets.
+- `NS` delegations for subzones, especially delegated nameservers under cloud DNS providers or registrar-managed domains.
+- Cloud DNS hosted zones that are deleted, parked, migrated, or no longer linked to the organization's account.
+- Migration or parking records retained after service decommissioning.
+
+Require takeover evidence before scoring severity:
+
+| Evidence Field | Required Check |
+|----------------|----------------|
+| Record owner | Business owner, service owner, or asset inventory reference |
+| Target provider | Vendor or platform, such as Pages, Heroku, Azure Static Web Apps, CloudFront, S3, Netlify, or cloud DNS |
+| Reservation status | Whether the target hostname, bucket, app, distribution, or zone is still reserved by the organization |
+| Claimability | Vendor-specific evidence showing whether another tenant can claim the target |
+| Runtime response | HTTP/TLS/DNS response, provider error code, or API inventory output |
+| Delegation health | For `NS`, nameserver domain registration, cloud zone existence, and account ownership |
+| Last verification | Timestamp and method used to verify ownership or non-claimability |
+| Exception governance | Owner, expiry, and migration/removal plan for parked or intentionally retained records |
+
+Classify confirmed claimable records as **High** for a single subdomain and **Critical** for stale `NS` delegation that exposes an entire subzone. If the target is reserved, not claimable, and recently verified, document it as Pass or Informational rather than flagging a dangling-looking record. If ownership or claimability cannot be proven, mark the record **Not Evaluable** or **Medium** pending verification based on exposure and business criticality.
+
+---
+
 ## Findings Classification
 
 | Severity | Definition |
 |----------|-----------|
-| **Critical** | Broken DNSSEC chain of trust (missing DS record in parent); authoritative zones serving invalid signatures. |
-| **High** | DNSSEC validation disabled on resolvers; no DNS filtering/RPZ; unsigned public authoritative zones; DNS bypass paths around protective DNS; no DNS query logging; weak signing algorithms. |
-| **Medium** | Plaintext DNS forwarding over untrusted networks; stale RPZ feeds; undocumented NTAs; no NRD blocking; no exfiltration detection; DoH bypass not controlled. |
+| **Critical** | Broken DNSSEC chain of trust (missing DS record in parent); authoritative zones serving invalid signatures; stale `NS` delegation that allows takeover of an entire subzone. |
+| **High** | DNSSEC validation disabled on resolvers; no DNS filtering/RPZ; unsigned public authoritative zones; DNS bypass paths around protective DNS; no DNS query logging; weak signing algorithms; confirmed claimable dangling CNAME/ALIAS/ANAME target. |
+| **Medium** | Plaintext DNS forwarding over untrusted networks; stale RPZ feeds; undocumented NTAs; no NRD blocking; no exfiltration detection; DoH bypass not controlled; dangling-looking third-party DNS target with unverified ownership or claimability. |
 | **Low** | Missing documentation of DNS architecture; resolver software not at latest version; cosmetic configuration issues. |
 
 ---
@@ -344,6 +372,12 @@ abcdef0123456789.dnscat.example.com TXT
 - Volumetric thresholds: <Configured / Not configured>
 - SIEM integration: <Yes / No>
 
+### Dangling Record and Takeover Review
+
+| Record | Type | Target | Owner | Reservation Status | Claimability | Last Verified | Status |
+|--------|------|--------|-------|--------------------|--------------|---------------|--------|
+| docs.example.com | CNAME | vendor.example-host.com | Docs team | Active / Unknown / Missing | Claimable / Not claimable / Unknown | YYYY-MM-DD | Pass / Fail / Not Evaluable |
+
 ### Prioritized Remediation Plan
 1. **[Critical]** <action item with control reference>
 2. **[High]** <action item with control reference>
@@ -383,6 +417,8 @@ abcdef0123456789.dnscat.example.com TXT
 3. **Relying solely on domain reputation lists for exfiltration detection.** Attackers use attacker-controlled domains that are not yet categorized. Behavioral detection (entropy, volume, query type anomalies) catches novel exfiltration domains that reputation feeds miss.
 
 4. **Ignoring DNS over TCP.** DNS is not UDP-only. DNS over TCP (port 53) supports large responses and is required for zone transfers. Some tunneling tools prefer TCP for reliability. Firewall rules and monitoring must cover both UDP and TCP port 53.
+
+5. **Treating signed DNS records as ownership proof.** DNSSEC can prove the organization published a record, but it does not prove the target service, bucket, CDN distribution, or delegated zone is still reserved by the organization.
 
 ---
 

--- a/skills/network/dns-security/tests/benign/active-cloud-dns-delegation.yaml
+++ b/skills/network/dns-security/tests/benign/active-cloud-dns-delegation.yaml
@@ -1,0 +1,20 @@
+case: active-cloud-dns-delegation
+expect: benign
+record:
+  name: dev.example.com
+  type: NS
+  values:
+    - ns-cloud-a1.googledomains.com
+    - ns-cloud-a2.googledomains.com
+delegation_evidence:
+  parent_zone: example.com
+  child_zone_exists: true
+  cloud_account_owner: platform-dns@example.com
+  zone_id: managedZones/dev-example-com
+  nameserver_set_matches_provider_inventory: true
+  last_verified: "2026-06-08"
+asset_inventory:
+  owner: platform-networking@example.com
+expected_finding:
+  status: Pass
+  reason: delegated zone exists in the organization's cloud account and nameserver inventory matches the parent delegation.

--- a/skills/network/dns-security/tests/benign/reserved-vendor-cname.yaml
+++ b/skills/network/dns-security/tests/benign/reserved-vendor-cname.yaml
@@ -1,0 +1,21 @@
+case: reserved-vendor-cname
+expect: benign
+record:
+  name: docs.example.com
+  type: CNAME
+  target: vendor.example-host.com
+  public: true
+provider_evidence:
+  provider: documentation hosting vendor
+  response: "404 custom domain reserved"
+  claimability: not_claimable
+  reservation_status: active
+  account_id: acct-12345
+  last_verified: "2026-06-08"
+asset_inventory:
+  owner: docs-platform@example.com
+  service_status: parked
+  removal_plan: migrate to docs-new.example.com by 2026-07-31
+expected_finding:
+  status: Informational
+  reason: dangling-looking target is still reserved by the organization and recently verified as not claimable.

--- a/skills/network/dns-security/tests/vulnerable/claimable-saas-cname.yaml
+++ b/skills/network/dns-security/tests/vulnerable/claimable-saas-cname.yaml
@@ -1,0 +1,19 @@
+case: claimable-saas-cname
+expect: vulnerable
+record:
+  name: docs.example.com
+  type: CNAME
+  target: old-project.pages-provider.example
+  public: true
+provider_evidence:
+  provider: example pages hosting
+  response: "404 project not found"
+  claimability: claimable_by_new_tenant
+  reservation_status: missing
+  last_verified: "2026-06-08"
+asset_inventory:
+  owner: null
+  service_status: decommissioned
+expected_finding:
+  severity: High
+  reason: public CNAME target is no longer reserved and can be claimed by another tenant.

--- a/skills/network/dns-security/tests/vulnerable/stale-ns-delegation.yaml
+++ b/skills/network/dns-security/tests/vulnerable/stale-ns-delegation.yaml
@@ -1,0 +1,18 @@
+case: stale-ns-delegation
+expect: vulnerable
+record:
+  name: dev.example.com
+  type: NS
+  values:
+    - ns1.deleted-zone.cloud-dns.example
+    - ns2.deleted-zone.cloud-dns.example
+delegation_evidence:
+  parent_zone: example.com
+  child_zone_exists: false
+  cloud_account_owner: unknown
+  nameserver_domain_registered: true
+  claimability: zone_can_be_recreated_by_other_account
+  last_verified: "2026-06-08"
+expected_finding:
+  severity: Critical
+  reason: stale NS delegation can expose the entire delegated subzone to takeover.


### PR DESCRIPTION
Closes #1912

## Summary
- Adds a `Dangling Record and Subdomain Takeover Review` step to `dns-security` for stale CNAME/ALIAS/ANAME targets, NS delegations, cloud DNS zones, and parked migration records.
- Requires owner, provider, reservation status, claimability, runtime response, delegation health, last verification, and exception governance before scoring severity.
- Updates severity guidance and output tables so signed DNS records are not mistaken for proof that the third-party target is still owned.

## Fixtures
- `skills/network/dns-security/tests/vulnerable/claimable-saas-cname.yaml`
- `skills/network/dns-security/tests/vulnerable/stale-ns-delegation.yaml`
- `skills/network/dns-security/tests/benign/reserved-vendor-cname.yaml`
- `skills/network/dns-security/tests/benign/active-cloud-dns-delegation.yaml`

## Validation
- `git diff --cached --check`
- Parsed all four YAML fixtures with PyYAML
- Verified takeover review, reservation status, claimability, stale NS, and DNSSEC ownership-proof markers are present
- Verified fixture count: 2 vulnerable and 2 benign

## Bounty
Requesting Improver Moderate ($100) if accepted. Payment details can be shared privately after acceptance.