### PR TITLE
Improve secure-code-review template context gates

### DIFF
--- a/skills/appsec/secure-code-review/SKILL.md
+++ b/skills/appsec/secure-code-review/SKILL.md
@@ -45,7 +45,7 @@ Before examining any code, establish the review boundary.
 ## Step 2: Input Validation and Injection Review
 
 **ASVS Reference:** V5 -- Validation, Sanitization and Encoding
-**CWE Coverage:** CWE-79 (XSS), CWE-89 (SQL Injection), CWE-78 (OS Command Injection), CWE-22 (Path Traversal), CWE-77 (Command Injection), CWE-20 (Improper Input Validation)
+**CWE Coverage:** CWE-79 (XSS), CWE-89 (SQL Injection), CWE-78 (OS Command Injection), CWE-22 (Path Traversal), CWE-77 (Command Injection), CWE-20 (Improper Input Validation), CWE-1336 (Template Engine Injection)
 
 ### 2.1 Controls to Verify
 
@@ -107,9 +107,51 @@ Remediation: Canonicalize the resolved path and verify it remains within the exp
 - [ ] Every point where user input enters the system is identified.
 - [ ] All SQL queries use parameterized statements or a query builder -- no string concatenation.
 - [ ] HTML output is encoded contextually (HTML body, attribute, JavaScript, URL).
+- [ ] Server-side template rendering separates template source control from rendered data and documents sandbox, loader, global, and autoescape evidence.
+- [ ] Raw/safe template overrides (`mark_safe`, `|safe`, triple-stash, `Html.Raw`, `SafeString`) are allowed only with context-specific sanitizer evidence.
 - [ ] OS commands, if unavoidable, use allowlisted arguments and avoid shell interpretation.
 - [ ] File path operations validate and canonicalize against a base directory.
 - [ ] Regular expressions used for validation are anchored (`^...$`) and tested for ReDoS.
+
+### 2.4 Template Sandbox and Context-Escaping Evidence Gate
+
+Use this gate whenever the reviewed code renders server-side templates, tenant-editable templates, email HTML, rich-text fields, or framework helpers that can bypass normal escaping. Split server-side template injection (template source control and sandbox posture) from XSS (context-specific output encoding).
+
+| Check ID | Evidence to collect | Failure condition |
+|---|---|---|
+| `SCR-TPL-01` | Template source and selection path for every render call, including fixed template name, allowlisted template ID, or user-controlled template string | User input is compiled or interpreted as template source through APIs such as `from_string`, `Template(...)`, inline render helpers, or tenant template editing without approval evidence |
+| `SCR-TPL-02` | Sandbox or restricted-environment status for engines that support untrusted or tenant-editable templates | Untrusted templates run in the default unrestricted engine or can access inheritance, imports, filesystem loaders, or object introspection without constraints |
+| `SCR-TPL-03` | Exposed globals, filters, functions, loaders, and implicit context objects | Dangerous objects such as app config, request/session objects, environment variables, filesystem loaders, class/object helpers, or process execution helpers are exposed to templates |
+| `SCR-TPL-04` | Autoescape status by engine, extension, and template type, including HTML pages and HTML email | Autoescape is disabled, extension-based autoescape misses the rendered template, or the review assumes framework defaults without configuration evidence |
+| `SCR-TPL-05` | Output sink context for each rendered value: HTML body, HTML attribute, URL, JavaScript string, CSS, text email, or HTML email | The same sanitizer or escaping claim is reused across incompatible contexts, or no context-specific encoder is evidenced |
+| `SCR-TPL-06` | Raw/safe override inventory, including `mark_safe`, `|safe`, triple-stash, `Html.Raw`, `SafeString`, and equivalent helpers | User-controlled data is marked safe before a documented sanitizer allowlist and sink-specific regression test |
+| `SCR-TPL-07` | Sanitizer configuration, allowed tags/attributes/protocols, and provenance of rich-text fields | Review accepts a generic "sanitized" label without the sanitizer policy, input source, and output verification |
+| `SCR-TPL-08` | Regression evidence with a known-bad SSTI payload, XSS payloads per sink context, and a benign allowed-rich-text case | Template rendering is approved from checklist language only, with no fixture or runtime evidence for the dangerous and benign paths |
+
+**Template evidence output fields:**
+
+| Field | Value |
+|---|---|
+| Template engine and source control | [Jinja / Django / Twig / Handlebars / Liquid / ERB / Razor; fixed, allowlisted, tenant-editable, or user-controlled source] |
+| Sandbox and loader posture | [sandboxed / restricted / unrestricted; loader paths and inheritance/import constraints] |
+| Exposed globals and helpers | [safe minimal context / dangerous globals present / unknown] |
+| Autoescape and output contexts | [enabled contexts, disabled contexts, and sink-specific encoders] |
+| Raw/safe override status | [none / justified with sanitizer evidence / unsafe override] |
+| Sanitizer policy | [library, allowed tags, attributes, protocols, strip behavior, and test evidence] |
+| Regression coverage | [SSTI payload, XSS payloads by context, benign rich-text case] |
+| Template review confidence | [High / Medium / Low plus missing evidence] |
+
+**Template-focused grep patterns:**
+
+| Engine / framework | Pattern to inspect |
+|---|---|
+| Jinja / Flask | `from_string\|render_template_string\|Environment\(\|autoescape\s*=\s*False\|mark_safe\|\|safe` |
+| Django | `mark_safe\|SafeString\|format_html\|Template\(\|autoescape\s+off` |
+| Twig / Symfony | `createTemplate\|render\(\|raw\|autoescape\s+false` |
+| Handlebars / Mustache | `\{\{\{\|SafeString\|noEscape\|compile\(` |
+| Liquid / Shopify-style | `parse\(\|render\(\|raw` |
+| ERB / Rails | `html_safe\|raw\(\|ERB\.new` |
+| ASP.NET / Razor | `Html\.Raw\|IHtmlContent\|MarkupString` |
 
 ---
 

--- a/skills/appsec/secure-code-review/tests/benign/restricted-template-context-escaping-evidence.md
+++ b/skills/appsec/secure-code-review/tests/benign/restricted-template-context-escaping-evidence.md
@@ -1,0 +1,83 @@
+# Benign Fixture: Restricted Template Rendering with Context Evidence
+
+## Scenario
+
+A profile and campaign-email flow renders user-provided text and limited rich
+text without granting template-source control to users. The review collects
+template selection, sandbox, autoescape, sanitizer, and regression evidence
+before deciding the rendering path is acceptable.
+
+## Code Snapshot
+
+```python
+from flask import abort, request, render_template
+from jinja2 import select_autoescape
+from jinja2.sandbox import SandboxedEnvironment
+from markupsafe import Markup
+import bleach
+
+ALLOWED_TEMPLATES = {
+    "profile": "profile.html",
+    "campaign": "email/campaign.html",
+}
+
+CTA_TAGS = ["a", "strong"]
+CTA_ATTRIBUTES = {"a": ["href", "rel"]}
+
+tenant_env = SandboxedEnvironment(autoescape=select_autoescape(["html", "xml"]))
+tenant_env.globals.clear()
+
+def choose_template(template_id):
+    template_name = ALLOWED_TEMPLATES.get(template_id)
+    if template_name is None:
+        abort(400)
+    return template_name
+
+@app.post("/profile")
+def profile():
+    return render_template(
+        choose_template(request.form["template_id"]),
+        bio=request.form["bio"],
+    )
+
+@app.post("/campaign")
+def campaign_email():
+    cleaned_cta = bleach.clean(
+        request.form["cta_html"],
+        tags=CTA_TAGS,
+        attributes=CTA_ATTRIBUTES,
+        protocols=["https"],
+        strip=True,
+    )
+    return render_template("email/campaign.html", cta=Markup(cleaned_cta))
+```
+
+## Evidence Snapshot
+
+| Field | Value |
+|---|---|
+| Template engine and source control | Jinja; only IDs in `ALLOWED_TEMPLATES` select fixed templates |
+| Sandbox and loader posture | Tenant-editable rendering uses `SandboxedEnvironment`; globals cleared |
+| Exposed globals and helpers | Minimal explicit context: `bio` and sanitized `cta` only |
+| Autoescape and output contexts | Autoescape enabled for HTML/XML; profile `bio` renders as HTML body text |
+| Raw/safe override status | Only sanitized CTA HTML is wrapped in `Markup` for the email body |
+| Sanitizer policy | Bleach allowlist: `a`, `strong`, `href`, `rel`, HTTPS-only links, strip disallowed markup |
+| Regression coverage | SSTI literal remains inert; script tags stripped; unsafe URL protocols stripped; allowed link preserved |
+| Template review confidence | High |
+
+## Positive Controls
+
+- `SCR-TPL-01`: Users select from fixed allowlisted templates, not raw template source.
+- `SCR-TPL-02`: Tenant-editable rendering uses a sandboxed environment.
+- `SCR-TPL-03`: Dangerous globals and broad helpers are not exposed.
+- `SCR-TPL-04`: Autoescape is enabled for HTML templates.
+- `SCR-TPL-05`: Profile text and HTML email CTA contexts are reviewed separately.
+- `SCR-TPL-06`: The only raw/safe override occurs after sanitizer allowlist enforcement.
+- `SCR-TPL-07`: Sanitizer tags, attributes, protocols, and strip behavior are documented.
+- `SCR-TPL-08`: Regression evidence covers SSTI, disallowed XSS, unsafe URLs, and benign allowed markup.
+
+## Expected Result
+
+Do not flag this path as template-source injection or unsafe raw HTML merely
+because it uses templates and limited rich text. Any remaining finding should be
+based on missing evidence in a specific sink context, not a generic XSS label.

--- a/skills/appsec/secure-code-review/tests/vulnerable/user-controlled-template-source-email-html.md
+++ b/skills/appsec/secure-code-review/tests/vulnerable/user-controlled-template-source-email-html.md
@@ -1,0 +1,69 @@
+# Vulnerable Fixture: User-Controlled Template Source and Raw Email HTML
+
+## Scenario
+
+A code review accepts a Flask rendering flow because the output is "sanitized"
+in a general XSS checklist. The same change also compiles a user-controlled
+template string, exposes application configuration to that template, disables
+autoescape, and marks customer-supplied email HTML safe before rendering.
+
+## Code Snapshot
+
+```python
+from flask import current_app, request, render_template
+from jinja2 import Environment, FileSystemLoader
+from markupsafe import Markup
+
+env = Environment(
+    loader=FileSystemLoader("templates"),
+    autoescape=False,
+)
+
+@app.post("/preview")
+def preview():
+    template = env.from_string(request.json["template"])
+    return template.render(user=current_user, config=current_app.config)
+
+@app.post("/campaign")
+def campaign_email():
+    cta = Markup(request.form["cta_html"])
+    return render_template("email/campaign.html", cta=cta)
+```
+
+## Evidence Snapshot
+
+| Field | Value |
+|---|---|
+| Template engine and source control | Jinja; preview endpoint compiles `request.json["template"]` |
+| Sandbox and loader posture | Default unrestricted `Environment`; filesystem loader available |
+| Exposed globals and helpers | `current_user` and app `config` are passed into user-controlled templates |
+| Autoescape and output contexts | `autoescape=False`; campaign CTA renders in HTML email body |
+| Raw/safe override status | `Markup(request.form["cta_html"])` marks untrusted HTML safe |
+| Sanitizer policy | None documented for template source or CTA HTML |
+| Regression coverage | No SSTI or email HTML XSS tests |
+| Template review confidence | Low |
+
+## Problem Indicators
+
+- `SCR-TPL-01`: User input is compiled as template source.
+- `SCR-TPL-02`: Untrusted templates run in an unrestricted engine.
+- `SCR-TPL-03`: App configuration is exposed to user-controlled template code.
+- `SCR-TPL-04`: Autoescape is disabled for rendered HTML.
+- `SCR-TPL-05`: HTML email context is not reviewed separately from text preview.
+- `SCR-TPL-06`: User-controlled CTA HTML is marked safe before validation.
+- `SCR-TPL-07`: No sanitizer allowlist or protocol policy is documented.
+- `SCR-TPL-08`: No known-bad SSTI or sink-specific XSS regression exists.
+
+## Expected Finding
+
+Classify as **High** because the preview path enables server-side template
+injection and the email path can render attacker-controlled HTML in a high-trust
+customer communication channel.
+
+## Required Remediation
+
+Use fixed or allowlisted template names, move tenant-editable templates to a
+sandboxed environment with restricted loaders and helpers, remove dangerous
+globals, enable autoescape for HTML templates and email HTML, sanitize rich text
+with an explicit allowlist before any raw/safe override, and add regression tests
+for SSTI payloads, HTML body escaping, URL attributes, and benign allowed markup.


### PR DESCRIPTION
## Summary
- Closes #1573
- Adds a template sandbox and context-escaping evidence gate to `secure-code-review` while preserving the existing review workflow.
- Splits SSTI template-source/sandbox review from XSS output-context review with `SCR-TPL-01` through `SCR-TPL-08` evidence checks.
- Adds vulnerable and benign fixtures for user-controlled Jinja template source, dangerous globals, disabled autoescape, raw email HTML, allowlisted templates, sandboxed rendering, and sanitizer-backed safe markup.

## Verification
- `git diff --cached --check`
- Markdown fence-balance check over staged `.md` files
- Added-line ASCII check
- Marker check for `SCR-TPL-01` through `SCR-TPL-08`
- Added-line sensitive-pattern scan (decorator-only `@app.post` email-regex false positive reviewed)
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`

## Bounty
/claim #1573

Preferred payment method: crypto or PayPal after maintainer acceptance.