### PR TITLE
Improve iso27001-gap planned change evidence gates

### DIFF
--- a/skills/compliance/iso27001-gap/SKILL.md
+++ b/skills/compliance/iso27001-gap/SKILL.md
@@ -189,7 +189,30 @@ Evaluate the risk assessment process:
 
 ---
 
-### Step 4: Annex A Control Assessment
+### Step 4: Planned ISMS Change Review (Clauses 6.3 and 8.1)
+
+Evaluate whether planned changes to the ISMS are controlled before scoring the affected clauses and controls as conforming. This gate applies when a change affects ISMS scope, objectives, interested parties, risk criteria, risk treatment, suppliers, cloud services, control ownership, locations, technologies, or Annex A applicability.
+
+Do not treat a software change ticket or pull request approval as sufficient evidence by itself. A.8.32 technical change management evidence may support the review, but Clause 6.3 and Clause 8.1 require planned changes to be considered at the ISMS and operational-control level.
+
+Record the following evidence:
+
+| Field | Required Evidence |
+|-------|-------------------|
+| Change trigger | New supplier, location, business process, cloud service, data processing activity, control owner, risk criterion, or scope boundary |
+| ISMS impact | Clauses, Annex A controls, assets, risks, interested parties, and objectives affected |
+| Risk review | Linked risk assessment or documented rationale that risk treatment remains valid |
+| SoA review | Controls added, removed, re-scored, or re-justified in the Statement of Applicability |
+| Approval | Risk owner, ISMS owner, and affected control owner approval where applicable |
+| Transition or rollback | Reversion path, phased transition, fallback control, or reason rollback is not applicable |
+| Operating evidence | Evidence that the change was implemented as approved and monitored after implementation |
+| Post-change review | Residual risk acceptance, lessons learned, and follow-up actions |
+
+If any required evidence is missing for a significant ISMS change, mark the affected clause or control **Not Evaluable** or **Nonconforming** with a reason code such as `missing-risk-review`, `missing-soa-impact`, `missing-approval`, `missing-transition-plan`, or `missing-post-change-review`.
+
+---
+
+### Step 5: Annex A Control Assessment
 
 Assess each Annex A control for: (a) applicability per SoA, (b) implementation status, (c) evidence of effectiveness, (d) gaps.
 
@@ -311,7 +334,7 @@ Use the following maturity scoring:
 
 ---
 
-### Step 5: Statement of Applicability (SoA)
+### Step 6: Statement of Applicability (SoA)
 
 Build or review the SoA. For each of the 93 Annex A controls, document:
 
@@ -323,7 +346,7 @@ Exclusions are permitted only where the control is genuinely not applicable to t
 
 ---
 
-### Step 6: Internal Audit Readiness (Clause 9.2)
+### Step 7: Internal Audit Readiness (Clause 9.2)
 
 Assess internal audit program against requirements:
 
@@ -337,7 +360,7 @@ Assess internal audit program against requirements:
 
 ---
 
-### Step 7: Management Review Readiness (Clause 9.3)
+### Step 8: Management Review Readiness (Clause 9.3)
 
 Verify management review covers all required inputs:
 
@@ -412,6 +435,12 @@ Classify each finding using the following severity levels:
 
 ## Risk Assessment Findings
 [Summary of risk methodology review, gaps in risk register, treatment plan status]
+
+## Planned ISMS Change Evidence
+
+| Change ID | Trigger | Clauses / Controls Impacted | Risk Review | SoA Review | Approval | Transition / Rollback | Post-Change Review | Status |
+|-----------|---------|-----------------------------|-------------|------------|----------|-----------------------|--------------------|--------|
+| ISMS-CHG-001 | [scope/supplier/cloud/control change] | [6.3, 8.1, A.x.y] | [link/status] | [link/status] | [owner/status] | [link/status] | [link/status] | [Conforming / Not Evaluable / Nonconforming] |
 
 ## Prioritized Remediation Roadmap
 
@@ -512,6 +541,8 @@ Each control in ISO 27002:2022 is tagged with five attributes:
 4. **Neglecting the 11 new controls introduced in the 2022 revision.** Organizations transitioning from 2013 often miss that controls like A.5.7 (Threat intelligence), A.5.23 (Cloud services security), A.8.9 (Configuration management), A.8.11 (Data masking), A.8.12 (Data leakage prevention), and A.8.16 (Monitoring activities) require explicit consideration in the SoA even if determined not applicable.
 
 5. **Scope exclusions without adequate justification.** Excluding organizational units, locations, or controls from ISMS scope requires documented justification demonstrating the exclusion does not affect the organization's ability or responsibility to provide information security. Auditors will challenge poorly justified exclusions.
+
+6. **Treating technical change approval as complete ISMS change planning.** Pull request approval, CAB approval, or deployment success can prove a technical change was authorized, but it does not prove Clause 6.3 planning unless risk, SoA, interested-party, scope, transition, and post-change evidence are reviewed when the ISMS itself is affected.
 
 ---
 

--- a/skills/compliance/iso27001-gap/tests/benign/controlled-isms-scope-change.yaml
+++ b/skills/compliance/iso27001-gap/tests/benign/controlled-isms-scope-change.yaml
@@ -1,0 +1,26 @@
+case: controlled-isms-scope-change
+expect: benign
+clauses:
+  - "6.3"
+  - "8.1"
+change:
+  id: ISMS-CHG-2026-042
+  type: planned
+  trigger: expand ISMS scope to include EU support function
+  risk_assessment_link: RISK-2026-117
+  interested_parties_reviewed: true
+  soa_controls_reviewed:
+    - A.5.19
+    - A.5.20
+    - A.5.23
+    - A.8.3
+  approval:
+    risk_owner: vp-support
+    isms_owner: ciso
+  transition_or_rollback_plan: retain prior support workflow until supplier DPA and access controls are approved
+  post_change_review:
+    completed_at: "2026-06-08T10:00:00Z"
+    residual_risk_accepted_by: ciso
+expected_finding:
+  status: Conforming
+  reason: planned ISMS scope change includes risk, SoA, approval, transition, and post-change evidence.

--- a/skills/compliance/iso27001-gap/tests/benign/minor-technical-change-a832-only.yaml
+++ b/skills/compliance/iso27001-gap/tests/benign/minor-technical-change-a832-only.yaml
@@ -1,0 +1,17 @@
+case: minor-technical-change-a832-only
+expect: benign
+clauses:
+  - "A.8.32"
+change:
+  id: APP-CHG-2026-019
+  type: minor-application-patch
+  scope_change: false
+  risk_criteria_change: false
+  control_owner_change: false
+  interested_party_impact: false
+  pull_request_approved: true
+  tests_passed: true
+  rollback_plan: redeploy previous container image
+expected_finding:
+  status: Conforming
+  reason: change is technical only and does not affect ISMS scope, objectives, risk treatment, interested parties, or SoA applicability.

--- a/skills/compliance/iso27001-gap/tests/vulnerable/scope-change-without-risk-review.yaml
+++ b/skills/compliance/iso27001-gap/tests/vulnerable/scope-change-without-risk-review.yaml
@@ -1,0 +1,24 @@
+case: scope-change-without-risk-review
+expect: vulnerable
+clauses:
+  - "6.3"
+  - "8.1"
+change:
+  id: ISMS-CHG-2026-051
+  type: planned
+  trigger: outsource payments support to a new provider
+  scope_change: true
+  interested_parties_reviewed: false
+  risk_assessment_link: null
+  soa_controls_reviewed: []
+  approval: null
+  transition_or_rollback_plan: null
+  post_change_review: null
+expected_finding:
+  status: Nonconforming
+  reason_codes:
+    - missing-risk-review
+    - missing-soa-impact
+    - missing-approval
+    - missing-transition-plan
+    - missing-post-change-review

--- a/skills/compliance/iso27001-gap/tests/vulnerable/technical-change-no-isms-impact-review.yaml
+++ b/skills/compliance/iso27001-gap/tests/vulnerable/technical-change-no-isms-impact-review.yaml
@@ -1,0 +1,19 @@
+case: technical-change-no-isms-impact-review
+expect: vulnerable
+clauses:
+  - "6.3"
+  - "8.1"
+  - "A.8.32"
+change:
+  id: OPS-2026-012
+  type: production-identity-provider-migration
+  pull_request_approved: true
+  cab_approved: true
+  deployment_successful: true
+  isms_impact_review: missing
+  risk_register_updated: false
+  interested_parties_reviewed: false
+  management_review_input: missing
+expected_finding:
+  status: Not Evaluable
+  reason: technical change evidence exists, but ISMS impact and risk-treatment evidence are missing.


### PR DESCRIPTION
Closes #2016

## Summary
- Adds a Clause 6.3 / Clause 8.1 `Planned ISMS Change Review` gate to `iso27001-gap`.
- Requires risk, SoA, interested-party, approval, transition/rollback, operating, and post-change evidence when changes affect ISMS scope, objectives, risks, suppliers, cloud services, control ownership, or Annex A applicability.
- Adds report output fields and a pitfall clarifying that technical change approval alone is not complete ISMS planned-change evidence.

## Fixtures
- `skills/compliance/iso27001-gap/tests/vulnerable/scope-change-without-risk-review.yaml`
- `skills/compliance/iso27001-gap/tests/vulnerable/technical-change-no-isms-impact-review.yaml`
- `skills/compliance/iso27001-gap/tests/benign/controlled-isms-scope-change.yaml`
- `skills/compliance/iso27001-gap/tests/benign/minor-technical-change-a832-only.yaml`

## Validation
- `git diff --check`
- `git diff --cached --check`
- Parsed all four YAML fixtures with PyYAML
- Verified planned-change gate, output table, reason-code, and pitfall markers are present
- Verified fixture count: 2 vulnerable and 2 benign

## Bounty
Requesting Improver Moderate ($100) if accepted. Payment details can be shared privately after acceptance.