### PR TITLE
Improve OWASP randomness and redirect SSRF evidence

### DIFF
--- a/skills/appsec/owasp-top-10-web/SKILL.md
+++ b/skills/appsec/owasp-top-10-web/SKILL.md
@@ -138,6 +138,15 @@ Access-Control-Allow-Origin.*\*|cors\(\{.*origin.*true
 - Insufficient randomness — use of `Math.random()`, `random.random()`, or similar non-CSPRNG functions for security-sensitive values.
 - Secrets committed to version control (`.env` files, config files with credentials).
 
+**Randomness context gate:** Treat non-CSPRNG APIs as findings only when the value protects confidentiality, integrity, authentication, authorization, payment, abuse prevention, or another security decision. Record the value name, sink, and decision before escalating.
+
+| Check ID | Evidence to collect | Failure condition |
+|---|---|---|
+| `OWASP-RAND-01` | Random value purpose and sink: session token, password reset token, CSRF token, OAuth `state`, invite code, nonce, MFA code, payment decision, rate-limit bypass, or non-security UI/test use | Finding is based on `Math.random()`, `random.random()`, or `rand()` without proving a security-sensitive sink |
+| `OWASP-RAND-02` | Entropy source and generation API, including whether browser, Node.js, Python, Java, Go, Ruby, or framework CSPRNG APIs are used | Security-sensitive values use predictable PRNGs or time/sequence-derived randomness |
+| `OWASP-RAND-03` | Benign-context rationale for UI animation, visual jitter, randomized test data, non-security sampling, placeholder art, or A/B layout display | Benign randomness is reported as A02 without a security impact |
+| `OWASP-RAND-04` | Token length, encoding, uniqueness, expiration, replay handling, and storage/logging behavior | CSPRNG exists but output is too short, reusable, logged, or not bound to the intended request/session |
+
 **CWE Mappings:**
 
 | CWE | Name |
@@ -562,6 +571,8 @@ log.*req\.body|log.*request\.getParameter|logger\.info\(.*\+.*req
 - PDF generators, image resizers, link previewers, or import-from-URL features.
 - Lack of allowlist validation on destination URLs (scheme, host, port, path).
 - No blocking of requests to private/reserved IP ranges (127.0.0.0/8, 10.0.0.0/8, 169.254.169.254, 172.16.0.0/12, 192.168.0.0/16, fd00::/8).
+- HTTP clients that follow redirects without revalidating every hop and the final resolved destination.
+- DNS rebinding or late-resolution gaps where validation occurs before the request but not at connect time or redirect time.
 
 **CWE Mappings:**
 
@@ -577,6 +588,8 @@ log.*req\.body|log.*request\.getParameter|logger\.info\(.*\+.*req
 requests\.get\(|requests\.post\(|urllib\.request|http\.get\(|fetch\(|axios\(|HttpClient|WebClient|curl_exec
 # URL parameters
 url=|dest=|redirect=|uri=|callback=|src=.*http
+# Redirect-following SSRF indicators
+allow_redirects\s*=\s*True|followRedirects\s*:\s*true|CheckRedirect|setInstanceFollowRedirects\s*\(\s*true
 # Cloud metadata (hardcoded blocking check)
 169\.254\.169\.254|metadata\.google|metadata\.azure
 ```
@@ -587,8 +600,20 @@ url=|dest=|redirect=|uri=|callback=|src=.*http
 - Block all requests to private and reserved IP ranges, link-local addresses, and cloud metadata endpoints at the network and application layers.
 - Do not send raw server-side responses to the client — parse expected data and return only the necessary fields.
 - Disable HTTP redirects in server-side HTTP clients, or re-validate the destination after each redirect.
+- Validate the full redirect chain: original URL, each `Location` target, post-DNS IP, scheme, host, port, and final destination must all remain in policy.
+- Set redirect-depth limits and fail closed on malformed redirects, scheme changes, DNS rebinding, metadata hosts, private IPs, and link-local ranges.
 - Deploy network-level segmentation so the application server cannot reach internal services it does not need.
 - For webhook features, validate callback URLs at registration time and again at invocation time (DNS rebinding defense).
+
+**Redirect-following SSRF evidence gate:**
+
+| Check ID | Evidence to collect | Failure condition |
+|---|---|---|
+| `OWASP-SSRF-01` | User-controlled URL source, HTTP client, redirect setting, and maximum redirect depth | Server-side fetch follows redirects from user input without documented controls |
+| `OWASP-SSRF-02` | Allowlist check for scheme, host, port, and path before the first request | Validation accepts arbitrary or wildcard destinations |
+| `OWASP-SSRF-03` | Per-hop revalidation of every redirect `Location`, including scheme changes and relative redirects | Only the first URL is validated; redirected targets are trusted automatically |
+| `OWASP-SSRF-04` | DNS resolution timing and IP-range enforcement at connect time and after redirects | DNS rebinding, metadata, loopback, private, link-local, or IPv6 ULA destinations can be reached |
+| `OWASP-SSRF-05` | Response handling and audit evidence: redirect chain, final URL/IP, blocked reason, and sanitized output | Raw internal responses are proxied to the caller or redirect-chain evidence is missing |
 
 ---
 

--- a/skills/appsec/owasp-top-10-web/tests/benign/ui-random-and-validated-redirect-fetch.md
+++ b/skills/appsec/owasp-top-10-web/tests/benign/ui-random-and-validated-redirect-fetch.md
@@ -1,0 +1,90 @@
+# Benign Fixture: UI Randomness and Validated Redirect Fetch
+
+## Scenario
+
+A reviewer sees `Math.random()` and redirect-capable URL fetching. The random
+value only controls UI animation timing, while security tokens use a CSPRNG. The
+fetch helper validates the original URL and every redirect hop before connecting.
+
+## Code Snapshot
+
+```javascript
+const animationDelayMs = Math.floor(Math.random() * 800);
+setTimeout(() => animateToast(), animationDelayMs);
+
+app.post("/reset", async (req, res) => {
+  const resetCode = crypto.randomBytes(32).toString("base64url");
+  await resetStore.save({
+    userId: req.body.userId,
+    tokenHash: await hashToken(resetCode),
+    expiresAt: Date.now() + 15 * 60 * 1000,
+  });
+  await mailer.sendResetLink(req.body.email, `https://app.example/reset/${resetCode}`);
+  res.sendStatus(204);
+});
+```
+
+```python
+import ipaddress
+import requests
+from urllib.parse import urljoin, urlparse
+
+ALLOWED_HOSTS = {"images.partner.example"}
+
+def validate_destination(candidate):
+    parsed = urlparse(candidate)
+    if parsed.scheme != "https" or parsed.hostname not in ALLOWED_HOSTS:
+        raise ValueError("destination not allowed")
+
+    for address in resolve_host(parsed.hostname):
+        ip = ipaddress.ip_address(address)
+        if ip.is_private or ip.is_loopback or ip.is_link_local:
+            raise ValueError("blocked private destination")
+
+def import_avatar(url):
+    validate_destination(url)
+    session = requests.Session()
+    response = session.get(url, allow_redirects=False, timeout=3)
+
+    redirect_chain = []
+    while response.is_redirect:
+        next_url = urljoin(response.url, response.headers["Location"])
+        validate_destination(next_url)
+        redirect_chain.append(next_url)
+        if len(redirect_chain) > 3:
+            raise ValueError("too many redirects")
+        response = session.get(next_url, allow_redirects=False, timeout=3)
+
+    return parse_expected_image_metadata(response.content)
+```
+
+## Evidence Snapshot
+
+| Field | Value |
+|---|---|
+| Random value purpose | UI animation delay only |
+| Random API | `Math.random()` for UI; `crypto.randomBytes(32)` for reset token |
+| Token controls | Hash at rest, 32 random bytes, 15-minute expiry |
+| URL source | User-provided avatar URL |
+| First-hop validation | HTTPS and exact host allowlist |
+| Redirect behavior | Redirects handled manually with a depth limit |
+| Final destination validation | Each hop checks scheme, host, DNS result, private, loopback, and link-local ranges |
+| Response handling | Parser extracts expected image metadata instead of returning raw internal content |
+
+## Positive Controls
+
+- `OWASP-RAND-01`: `Math.random()` does not feed a security-sensitive sink.
+- `OWASP-RAND-02`: Reset tokens use a CSPRNG.
+- `OWASP-RAND-03`: UI animation randomness is documented as a non-finding.
+- `OWASP-RAND-04`: Security token length, hashing, and expiry are evidenced.
+- `OWASP-SSRF-01`: Redirect behavior and maximum depth are documented.
+- `OWASP-SSRF-02`: Initial URL validation uses exact scheme and host allowlist.
+- `OWASP-SSRF-03`: Each redirect `Location` is revalidated.
+- `OWASP-SSRF-04`: DNS/IP private-range checks happen for every hop.
+- `OWASP-SSRF-05`: Redirect chain is bounded and raw response proxying is avoided.
+
+## Expected Result
+
+Do not report A02 for the UI animation delay. Do not report A10 merely because
+the feature imports an external avatar URL; only report if an actual redirect,
+DNS, IP-range, or raw-response control is missing.

--- a/skills/appsec/owasp-top-10-web/tests/vulnerable/random-token-and-redirect-ssrf.md
+++ b/skills/appsec/owasp-top-10-web/tests/vulnerable/random-token-and-redirect-ssrf.md
@@ -1,0 +1,71 @@
+# Vulnerable Fixture: Random Token and Redirect-Following SSRF
+
+## Scenario
+
+A web review finds both `Math.random()` and a URL fetch helper. The random value
+is security-sensitive because it becomes a password reset token. The fetch helper
+checks the first hostname but follows redirects without validating the final
+destination.
+
+## Code Snapshot
+
+```javascript
+app.post("/reset", async (req, res) => {
+  const resetCode = Math.random().toString(36).slice(2);
+  await resetStore.save({ userId: req.body.userId, resetCode });
+  await mailer.sendResetLink(req.body.email, `https://app.example/reset/${resetCode}`);
+  res.sendStatus(204);
+});
+```
+
+```python
+import ipaddress
+import requests
+from urllib.parse import urlparse
+
+ALLOWED_HOSTS = {"images.partner.example"}
+
+def import_avatar(url):
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or parsed.hostname not in ALLOWED_HOSTS:
+        raise ValueError("destination not allowed")
+
+    response = requests.get(url, allow_redirects=True, timeout=3)
+    return response.text
+```
+
+## Evidence Snapshot
+
+| Field | Value |
+|---|---|
+| Random value purpose | Password reset token |
+| Random API | `Math.random()` |
+| Token controls | No CSPRNG, no length/entropy target, token appears in reset URL |
+| URL source | User-controlled avatar import URL |
+| First-hop validation | Scheme and host allowlist only |
+| Redirect behavior | `allow_redirects=True`; no per-hop validation |
+| Final destination validation | Missing DNS/IP/private-range/metadata checks after redirects |
+| Response handling | Raw response body is returned to the caller |
+
+## Problem Indicators
+
+- `OWASP-RAND-01`: The random value protects password reset authorization.
+- `OWASP-RAND-02`: A predictable PRNG generates a security-sensitive token.
+- `OWASP-RAND-04`: Token entropy, uniqueness, replay, and storage controls are not evidenced.
+- `OWASP-SSRF-01`: User-controlled server-side fetch follows redirects.
+- `OWASP-SSRF-03`: Redirect `Location` targets are not revalidated.
+- `OWASP-SSRF-04`: Final IP/private-range and DNS rebinding checks are missing.
+- `OWASP-SSRF-05`: Raw fetched content is returned without redirect-chain evidence.
+
+## Expected Findings
+
+Classify the reset token issue under **A02: Cryptographic Failures / CWE-330**.
+Classify the fetch helper under **A10: SSRF / CWE-918** because an allowed
+partner URL can redirect to an internal or metadata destination.
+
+## Required Remediation
+
+Use a CSPRNG such as `crypto.randomBytes` or `crypto.getRandomValues` for reset
+tokens, bind tokens to user/session and expiry, and avoid logging tokens. For
+the fetch helper, disable redirects or validate each redirect hop and final
+connect-time IP against the allowlist, blocked ranges, and metadata endpoints.


### PR DESCRIPTION
## Summary
- Closes #1025
- Adds context gates so non-CSPRNG APIs are reported only when they feed security-sensitive decisions.
- Adds redirect-following SSRF evidence gates for first-hop, per-hop, DNS/IP, private-range, metadata, and raw-response validation.
- Adds vulnerable and benign fixtures for reset-token randomness, UI-only randomness, redirect-following SSRF, and validated redirect fetching.

## Verification
- `git diff --cached --check`
- Markdown fence-balance check over staged `.md` files
- Added-line ASCII check
- Marker check for `OWASP-RAND-01` through `OWASP-RAND-04` and `OWASP-SSRF-01` through `OWASP-SSRF-05`
- Added-line sensitive-pattern scan
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`

## Bounty
/claim #1025

Preferred payment method: crypto or PayPal after maintainer acceptance.