### PR TITLE
Add ISO SoA evidence linkage fixtures

### DIFF
--- a/skills/compliance/iso27001-gap/SKILL.md
+++ b/skills/compliance/iso27001-gap/SKILL.md
@@ -319,6 +319,26 @@ Build or review the SoA. For each of the 93 Annex A controls, document:
 | Control ID | Control Title | Applicable? | Justification (if excluded) | Implementation Status | Maturity Score | Gap Description |
 ```
 
+#### 5.1 SoA Evidence Linkage Gate
+
+For every included or excluded Annex A control, require audit-ready traceability before treating the SoA row as complete:
+
+- `ISO-SOA-01` **Control decision completeness**: record the control ID, control title, included/excluded decision, decision rationale, and implementation status.
+- `ISO-SOA-02` **Risk or requirement linkage**: link the decision to at least one risk register item, legal requirement, contractual requirement, interested-party requirement, business objective, or documented scope constraint.
+- `ISO-SOA-03` **Treatment decision linkage**: record the selected treatment decision such as treat, accept, avoid, transfer, or not applicable, plus the risk owner or approval source.
+- `ISO-SOA-04` **Scope and asset boundary**: state the business unit, product, location, platform, process, or asset boundary where the decision applies.
+- `ISO-SOA-05` **Design and operating evidence**: distinguish design evidence such as policies or procedures from operating evidence such as tickets, logs, review samples, audit records, or monitoring results.
+- `ISO-SOA-06` **Evidence ownership and currentness**: capture evidence artifact, owner, date, period covered, and currentness status: current, stale, or unknown.
+- `ISO-SOA-07` **Excluded-control support**: require excluded controls to cite the ISMS scope, obligations, and risk treatment basis proving the exclusion does not affect conformity.
+- `ISO-SOA-08` **Unknown/finding behavior**: mark the row `Unknown` or raise a finding when risk linkage, treatment decision, owner, date, scope boundary, or evidence currentness is missing.
+
+Use this matrix for each SoA row:
+
+```
+| Control ID | Decision | Rationale | Risk/Requirement Link | Treatment Decision | Scope/Asset Boundary | Design Evidence | Operating Evidence | Evidence Owner | Evidence Date/Period | Currentness | Result |
+|------------|----------|-----------|-----------------------|--------------------|----------------------|-----------------|--------------------|----------------|----------------------|-------------|--------|
+```
+
 Exclusions are permitted only where the control is genuinely not applicable to the ISMS scope. A control cannot be excluded solely because it is difficult to implement.
 
 ---
@@ -409,6 +429,12 @@ Classify each finding using the following severity levels:
 - Controls applicable: [count] / 93
 - Controls excluded: [count] — [list with justification]
 - Average maturity of applicable controls: [score] / 5.0
+
+### SoA Evidence Linkage Matrix
+
+| Control ID | Decision | Rationale | Risk/Requirement Link | Treatment Decision | Scope/Asset Boundary | Design Evidence | Operating Evidence | Evidence Owner | Evidence Date/Period | Currentness | Result |
+|------------|----------|-----------|-----------------------|--------------------|----------------------|-----------------|--------------------|----------------|----------------------|-------------|--------|
+| A.5.1 | [Included/Excluded] | [why] | [risk/legal/contract/interested-party/business link] | [treat/accept/avoid/transfer/not applicable] | [scope] | [policy/procedure] | [sample/log/ticket/audit record] | [owner] | [date and period] | [Current/Stale/Unknown] | [Pass/Fail/Unknown] |
 
 ## Risk Assessment Findings
 [Summary of risk methodology review, gaps in risk register, treatment plan status]
@@ -512,6 +538,8 @@ Each control in ISO 27002:2022 is tagged with five attributes:
 4. **Neglecting the 11 new controls introduced in the 2022 revision.** Organizations transitioning from 2013 often miss that controls like A.5.7 (Threat intelligence), A.5.23 (Cloud services security), A.8.9 (Configuration management), A.8.11 (Data masking), A.8.12 (Data leakage prevention), and A.8.16 (Monitoring activities) require explicit consideration in the SoA even if determined not applicable.
 
 5. **Scope exclusions without adequate justification.** Excluding organizational units, locations, or controls from ISMS scope requires documented justification demonstrating the exclusion does not affect the organization's ability or responsibility to provide information security. Auditors will challenge poorly justified exclusions.
+
+6. **Publishing a SoA without risk and evidence links.** A SoA row that says "implemented" or "not applicable" without a risk/requirement link, treatment decision, evidence owner, evidence date, and currentness status is not audit-ready. Treat missing linkage as `Unknown` or a finding rather than implied conformity.
 
 ---
 

--- a/skills/compliance/iso27001-gap/tests/benign/soa-risk-linked-current-evidence.md
+++ b/skills/compliance/iso27001-gap/tests/benign/soa-risk-linked-current-evidence.md
@@ -1,0 +1,17 @@
+# Benign: Risk-Linked SoA With Current Evidence
+
+## Scenario
+
+The organization reviews the SoA for the customer data platform during the 2026 certification readiness cycle.
+
+## SoA Evidence Linkage Matrix
+
+| Control ID | Decision | Rationale | Risk/Requirement Link | Treatment Decision | Scope/Asset Boundary | Design Evidence | Operating Evidence | Evidence Owner | Evidence Date/Period | Currentness | Result |
+|------------|----------|-----------|-----------------------|--------------------|----------------------|-----------------|--------------------|----------------|----------------------|-------------|--------|
+| A.5.23 | Included | Cloud service controls are required for customer analytics workloads | RISK-014 cloud misconfiguration; contract CT-442 security schedule | Treat via cloud service governance controls | Customer data platform, AWS prod accounts 1001 and 1002, EU and US regions | Cloud service security policy CSSP-2026-04 | CSPM exception review CHG-8841; supplier assurance review VR-221 | Cloud Security Manager | 2026-05-01 through 2026-05-31 | Current | Pass |
+| A.8.16 | Included | Monitoring is required for production data access and incident detection | RISK-027 privileged misuse; customer SLA-18 logging obligation | Treat via SIEM monitoring and escalation | Production analytics clusters and identity logs | Logging standard LOG-2026-02 | SIEM alert samples SIEM-1221 through SIEM-1236; weekly review tickets SECOPS-771 to SECOPS-774 | SecOps Lead | 2026-05-06 through 2026-06-03 | Current | Pass |
+| A.7.3 | Excluded | No office, visitor area, or physical secure zone is in the ISMS scope | Scope statement SCOPE-2026 excludes physical premises; RISK-031 accepted for remote-only workforce | Not applicable approved by ISMS owner | Remote-only SaaS team; no physical offices in scope | ISMS scope statement SCOPE-2026 | Management review MR-2026-05 approval of physical-scope exclusion | ISMS Manager | 2026-05-20 | Current | Pass |
+
+## Expected Review Result
+
+The skill should treat these rows as SoA-ready because they satisfy `ISO-SOA-01` through `ISO-SOA-08`: every decision has a rationale, risk or requirement link, treatment decision, scope boundary, design evidence, operating evidence where applicable, owner, date or period, currentness, and explicit result.

--- a/skills/compliance/iso27001-gap/tests/vulnerable/soa-without-risk-evidence-links.md
+++ b/skills/compliance/iso27001-gap/tests/vulnerable/soa-without-risk-evidence-links.md
@@ -1,0 +1,26 @@
+# Vulnerable: SoA Rows Without Risk and Evidence Links
+
+## Scenario
+
+The organization is preparing for ISO 27001 certification and exports a Statement of Applicability spreadsheet for the cloud analytics platform.
+
+## Provided SoA Rows
+
+| Control ID | Decision | Rationale | Implementation Status | Evidence |
+|------------|----------|-----------|-----------------------|----------|
+| A.5.23 | Included | Cloud security is handled by the platform team | Implemented | Cloud security policy |
+| A.8.16 | Included | Monitoring exists | Implemented | SIEM screenshot |
+| A.5.31 | Excluded | Legal does not apply to this product | Not applicable | N/A |
+
+## Missing Evidence
+
+- `ISO-SOA-02`: no risk register item, legal requirement, contractual requirement, interested-party requirement, or business objective is linked to the decisions.
+- `ISO-SOA-03`: no risk treatment decision or risk owner approval is recorded.
+- `ISO-SOA-04`: the rows do not define the business unit, platform, region, or asset boundary covered by each decision.
+- `ISO-SOA-05`: the evidence only includes design artifacts and screenshots; there is no operating evidence such as samples, logs, tickets, or review records.
+- `ISO-SOA-06`: no evidence owner, evidence date, or period covered is recorded.
+- `ISO-SOA-07`: the excluded legal control has no scope, obligation, or risk-treatment support.
+
+## Expected Review Result
+
+The skill should not mark these SoA rows as audit-ready. The result should be `Unknown` or a finding because `ISO-SOA-08` requires missing risk linkage, treatment decision, owner, date, scope boundary, or evidence currentness to block implied conformity.


### PR DESCRIPTION
## Summary
- Closes #1843
- Adds a SoA evidence linkage gate for included and excluded Annex A control decisions.
- Requires risk/requirement linkage, treatment decision, scope boundary, design and operating evidence, owner/date/currentness, and Unknown/finding behavior when linkage is missing.
- Adds vulnerable and benign fixtures for unsupported SoA rows versus risk-linked, current, owner-backed evidence.

## Verification
- `git diff --cached --check`
- Markdown fence-balance check over staged `.md` files
- Added-line ASCII check
- Marker check for `ISO-SOA-01` through `ISO-SOA-08`
- Added-line sensitive-pattern scan
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`

## Bounty
/claim #1843

Preferred payment method: crypto or PayPal after maintainer acceptance.