### PR TITLE
Improve privileged-access shadow admin evidence gates

### DIFF
--- a/skills/identity/privileged-access/SKILL.md
+++ b/skills/identity/privileged-access/SKILL.md
@@ -133,6 +133,43 @@ PAM-INV-10: Third-party/vendor privileged access not inventoried
 | **Databases** | DBA accounts, `sa` (SQL Server), `sys`/`system` (Oracle), `postgres` superuser |
 | **Kubernetes** | `cluster-admin` ClusterRoleBinding holders, namespace admins |
 
+### Step 1A: Shadow Administrator and Transitive Privilege Discovery
+
+**Objective:** Detect accounts that are effectively privileged even when they are not listed in a named admin group or onboarded to PAM.
+
+**NIST SP 800-53 Reference:** AC-6(5) -- Privileged Accounts; AC-6(7) -- Review of User Privileges
+**CIS Controls v8 Reference:** Control 5.4 -- Restrict Administrator Privileges
+
+Shadow administrators often appear through indirect paths: nested groups, delegated directory rights, CI/CD service accounts, cloud IAM wildcard policies, Kubernetes impersonation, or emergency access exceptions. Treat these as privileged when they can create, modify, assume, reset, approve, or impersonate privileged identities.
+
+**Evidence to collect:**
+
+- **Transitive group expansion:** nested Active Directory, Entra ID, LDAP, or IdP groups that eventually grant administrator roles.
+- **Privilege-escalating IAM permissions:** cloud policies allowing `iam:PassRole`, `sts:AssumeRole`, `iam:*`, role assignment writes, service account key creation, or owner/editor grants.
+- **Delegated identity administration:** password reset, MFA reset, group membership write, app consent, role eligibility management, or privileged approval rights.
+- **Automation and CI/CD principals:** build agents, deployment bots, Terraform runners, and ticketing integrations that can modify admin roles or privileged infrastructure.
+- **Break-glass and exception paths:** emergency accounts, temporary overrides, or vendor accounts excluded from PAM onboarding or periodic access review.
+
+**What to look for:**
+
+```
+PAM-SHADOW-01: Nested groups grant administrator access but are absent from the privileged account inventory
+PAM-SHADOW-02: Cloud IAM policy permits privilege escalation (PassRole/AssumeRole/role assignment write) without PAM controls
+PAM-SHADOW-03: CI/CD or automation principal can create or modify privileged roles without JIT approval
+PAM-SHADOW-04: Helpdesk or delegated admin role can reset MFA/passwords for privileged users without dual control
+PAM-SHADOW-05: Service account keys, SSH certificates, or kubeconfigs provide privileged access outside vault/session recording
+PAM-SHADOW-06: Break-glass or vendor exceptions are excluded from access review, alerting, or post-use rotation
+PAM-SHADOW-07: Privileged approval rights are self-approvable or held by the same team requesting elevation
+PAM-SHADOW-08: IAM conditions, permission boundaries, or deny policies are assumed but not evidenced
+```
+
+**False-positive guardrails:**
+
+- Do not flag a nested group solely because it is nested; flag it when the resolved effective permissions reach privileged functions.
+- Do not flag read-only auditor, security reader, or log-reader roles unless they can alter security controls, secrets, or privileged identity state.
+- Do not treat a CI/CD principal as privileged only because it deploys application code; require evidence that it can change identity, infrastructure, secrets, production break-glass access, or administrative control planes.
+- Mark the result **Not Evaluable** when only screenshots or role names are supplied without policy JSON, group membership export, role assignment data, or equivalent evidence.
+
 ---
 
 ### Step 2: PAM Tool Assessment
@@ -400,6 +437,7 @@ PAM-VAULT-12: No secrets scanning in code repositories to detect credential leak
 
 ### Findings by Category
 - Privileged Account Inventory (Step 1): [count]
+- Shadow Administrator / Transitive Privilege Discovery (Step 1A): [count]
 - PAM Tool Assessment (Step 2): [count]
 - JIT Access (Step 3): [count]
 - Break-Glass Procedures (Step 4): [count]
@@ -408,6 +446,11 @@ PAM-VAULT-12: No secrets scanning in code repositories to detect credential leak
 
 ### Detailed Findings
 [Findings table]
+
+### Shadow Administrator Evidence
+| Principal | Privilege Path | Effective Capability | PAM/JIT Coverage | Review Evidence | Status |
+|---|---|---|---|---|---|
+| [group/service account/user] | [nested group, IAM policy, CI role, delegated admin] | [what it can administer] | [covered/not covered] | [export, policy, ticket, approval] | [Pass/Fail/Not Evaluable] |
 
 ### Remediation Roadmap
 - Immediate (0-7 days): [critical findings — credential exposure, uncontrolled root access]
@@ -457,6 +500,8 @@ PAM-VAULT-12: No secrets scanning in code repositories to detect credential leak
 6. **Session recording without review** — recording sessions without monitoring or alerting provides forensic value but not prevention. Add real-time alerting.
 7. **Ignoring service account privilege** — PAM programs often focus on human admin accounts and neglect service accounts with equally powerful permissions.
 8. **No PAM HA/DR** — if the PAM tool is a single point of failure, its outage creates either a lockout or a break-glass event. Architect for resilience.
+9. **Counting only named admin groups** — effective privilege can be hidden behind nested groups, delegated role assignment rights, CI/CD deployment identities, or IAM permissions that can create new administrators.
+10. **Accepting role names without policy evidence** — labels such as "operator" or "support" are not enough. Resolve the actual allowed actions, deny conditions, permission boundaries, and group expansion before closing a shadow-admin finding.
 
 ---
 
@@ -502,4 +547,5 @@ that may contain adversarial content.
 
 | Version | Date | Changes |
 |---|---|---|
+| 1.0.1 | 2026-06-09 | Add shadow administrator and transitive privilege discovery evidence gates. |
 | 1.0.0 | 2025-03-06 | Initial release |

--- a/skills/identity/privileged-access/tests/benign/deployer-with-boundary-and-jit.yaml
+++ b/skills/identity/privileged-access/tests/benign/deployer-with-boundary-and-jit.yaml
@@ -1,0 +1,30 @@
+scenario: deployer-with-boundary-and-jit
+platform: aws
+evidence_type: iam_policy_and_change_ticket
+principal:
+  type: service_account
+  name: github-actions-service-deployer
+  pam_onboarded: true
+  jit_required: true
+policy_statements:
+  - effect: Allow
+    actions:
+      - ecs:UpdateService
+      - codedeploy:CreateDeployment
+    resources:
+      - arn:aws:ecs:us-east-1:123456789012:service/prod/*
+permission_boundary:
+  denies:
+    - iam:*
+    - sts:AssumeRole
+    - organizations:*
+approval:
+  change_ticket: CHG-2026-0612
+  approver: release-manager
+  expires_at: "2026-06-09T12:00:00Z"
+effective_capabilities:
+  can_modify_privileged_identity: false
+  can_change_secrets: false
+  can_admin_control_plane: false
+expected_status: pass
+false_positive_guardrail: deployment automation is not a PAM finding when policy evidence proves it cannot alter identity, secrets, or administrative control planes

--- a/skills/identity/privileged-access/tests/benign/read-only-security-reader.yaml
+++ b/skills/identity/privileged-access/tests/benign/read-only-security-reader.yaml
@@ -1,0 +1,22 @@
+scenario: read-only-security-reader
+platform: azure
+evidence_type: role_assignment_export
+principal:
+  name: secops-audit-readers
+  type: group
+role_assignments:
+  - role: Security Reader
+    scope: /providers/Microsoft.Management/managementGroups/prod
+    allowed_actions:
+      - Microsoft.Security/*/read
+      - Microsoft.Authorization/roleAssignments/read
+    denied_actions:
+      - Microsoft.Authorization/roleAssignments/write
+      - Microsoft.Authorization/elevateAccess/action
+      - Microsoft.KeyVault/vaults/secrets/write
+effective_capabilities:
+  can_modify_privileged_identity: false
+  can_reset_mfa_or_password: false
+  can_assume_admin_role: false
+expected_status: pass
+false_positive_guardrail: read-only security roles should not be reported as shadow admins without write, reset, assume, or approve capability

--- a/skills/identity/privileged-access/tests/vulnerable/cicd-passrole-shadow-admin.yaml
+++ b/skills/identity/privileged-access/tests/vulnerable/cicd-passrole-shadow-admin.yaml
@@ -1,0 +1,28 @@
+scenario: cicd-passrole-shadow-admin
+platform: aws
+evidence_type: iam_policy_json
+principal:
+  type: service_account
+  name: github-actions-prod-deployer
+  pam_onboarded: false
+  jit_required: false
+policy_statements:
+  - effect: Allow
+    actions:
+      - iam:PassRole
+      - iam:AttachRolePolicy
+      - sts:AssumeRole
+    resources:
+      - arn:aws:iam::123456789012:role/prod-admin
+      - arn:aws:iam::123456789012:role/*
+controls_claimed:
+  permission_boundary: not_provided
+  deny_policy: not_provided
+  approval_ticket: missing
+expected_findings:
+  - id: PAM-SHADOW-02
+    severity: high
+    reason: CI/CD principal can pass or assume privileged roles without PAM or JIT evidence
+  - id: PAM-SHADOW-03
+    severity: high
+    reason: automation can modify privileged role policy outside an approval-gated workflow

--- a/skills/identity/privileged-access/tests/vulnerable/nested-helpdesk-shadow-admin.yaml
+++ b/skills/identity/privileged-access/tests/vulnerable/nested-helpdesk-shadow-admin.yaml
@@ -1,0 +1,27 @@
+scenario: nested-helpdesk-shadow-admin
+platform: active-directory
+evidence_type: group_membership_export
+privileged_inventory:
+  named_admin_groups:
+    - Domain Admins
+    - Enterprise Admins
+  pam_onboarded_groups:
+    - Domain Admins
+group_paths:
+  - principal: helpdesk-tier2
+    nested_through:
+      - workstation-admins
+      - delegated-account-operators
+    effective_capabilities:
+      - reset_privileged_user_passwords
+      - modify_mfa_methods
+      - add_members_to_server-admins
+    pam_coverage: none
+    access_review_evidence: missing
+expected_findings:
+  - id: PAM-SHADOW-01
+    severity: high
+    reason: nested delegated groups grant privileged identity administration but are absent from the PAM inventory
+  - id: PAM-SHADOW-04
+    severity: high
+    reason: helpdesk role can reset privileged credentials without dual control or review evidence


### PR DESCRIPTION
Closes #2020

## Summary
- Adds a dedicated `Step 1A` for shadow administrator and transitive privilege discovery in `privileged-access`.
- Adds PAM-SHADOW reason codes for nested groups, cloud IAM privilege escalation, CI/CD principals, delegated identity administration, break-glass exceptions, self-approval, and missing boundary evidence.
- Adds output evidence fields plus false-positive guardrails so read-only roles and bounded deployment automation are not over-reported.
- Adds 4 fixtures: 2 vulnerable and 2 benign.

## Validation
- `git diff --check`
- `git diff --cached --check`
- Parsed all 4 YAML fixtures with PyYAML
- Checked markers for Step 1A, PAM-SHADOW reason codes, Not Evaluable guidance, Shadow Administrator Evidence output, and changelog version
- Fixture count: vulnerable=2, benign=2

## Bounty
Requested bounty: $100