### PR TITLE
Add PCI evidence freshness fixtures

### DIFF
--- a/skills/compliance/pci-dss-review/SKILL.md
+++ b/skills/compliance/pci-dss-review/SKILL.md
@@ -442,6 +442,23 @@ Note: Not all requirements support the Customized Approach. Requirements with "T
 |---------|--------|---------|----------|-------------|
 | [N.x.x] | [In Place/Not in Place] | [finding detail] | [evidence reviewed] | [action needed] |
 
+### Evidence Freshness and Sample Matrix
+
+Before marking any sub-requirement `In Place`, capture assessor-verifiable evidence metadata:
+
+- `PCI-EVID-01` **Testing procedure mapping**: identify the PCI DSS testing method used for the sub-requirement: examine, observe, interview, test, or customized approach validation.
+- `PCI-EVID-02` **Evidence artifact**: record the exact artifact, system export, sample set, ticket, log source, interview record, observation record, or test output reviewed.
+- `PCI-EVID-03` **Evidence owner and collector**: record who owns the evidence and who collected or validated it.
+- `PCI-EVID-04` **Evidence date and period covered**: capture the collection date plus the operating period covered by the evidence.
+- `PCI-EVID-05` **CDE and connected-to scope coverage**: identify systems, accounts, applications, network segments, vendors, security-impacting systems, or TPSP responsibilities sampled.
+- `PCI-EVID-06` **Frequency requirement met**: for recurring controls, confirm the evidence covers the required cadence across the assessment period.
+- `PCI-EVID-07` **Freshness status**: mark evidence `Current`, `Stale`, or `Unknown` based on the assessment window, control population, CDE scope, and control change history.
+- `PCI-EVID-08` **Unknown/finding behavior**: mark the result `Unknown` or `Not in Place` when testing procedure, sample scope, owner, date, period, CDE coverage, or freshness cannot be verified.
+
+| Sub-Req | Testing Procedure | Artifact | Owner/Collector | Evidence Date/Period | Sample Scope | CDE Coverage | Frequency Met | Freshness | Result |
+|---------|-------------------|----------|-----------------|----------------------|--------------|--------------|---------------|-----------|--------|
+| [N.x.x] | [Examine/Observe/Interview/Test] | [artifact] | [owner/collector] | [date/period] | [systems/accounts/vendors/logs] | [complete/partial/unknown] | [Yes/No/N/A/Unknown] | [Current/Stale/Unknown] | [Pass/Fail/Unknown] |
+
 ## New v4.0 Requirements Status
 [Assessment of all 64 new requirements, particularly those mandatory since March 31, 2025]
 
@@ -519,6 +536,8 @@ Maintain an Information Security Policy:                Requirement 12
 4. **Treating compensating controls as permanent solutions.** Compensating controls must be reassessed annually and are expected to be temporary measures while the organization works toward meeting the original requirement. Assessors scrutinize long-standing compensating controls and may reject those that have become routine without progress toward full compliance.
 
 5. **Failing to manage third-party service provider (TPSP) compliance.** Requirement 12.8 and 12.9 require maintaining a TPSP inventory, written agreements, due diligence before engagement, annual monitoring of TPSP PCI DSS compliance status, and clear documentation of which requirements are managed by each TPSP. The shared responsibility model must be explicitly documented.
+
+6. **Marking stale or unsampled evidence as compliant.** A current screenshot, policy, or single-system export does not prove operating effectiveness across the full CDE, connected-to systems, TPSP responsibilities, or required assessment period. Missing sample scope, owner, date, period covered, frequency proof, or freshness status should block `Requirement in Place`.
 
 ---
 

--- a/skills/compliance/pci-dss-review/tests/benign/current-sampled-evidence.md
+++ b/skills/compliance/pci-dss-review/tests/benign/current-sampled-evidence.md
@@ -1,0 +1,18 @@
+# Benign: Current Sampled PCI Evidence
+
+## Scenario
+
+The assessor reviews evidence for the same merchant after the PCI team provides a complete evidence package.
+
+## Evidence Freshness and Sample Matrix
+
+| Sub-Req | Testing Procedure | Artifact | Owner/Collector | Evidence Date/Period | Sample Scope | CDE Coverage | Frequency Met | Freshness | Result |
+|---------|-------------------|----------|-----------------|----------------------|--------------|--------------|---------------|-----------|--------|
+| 10.4.1.1 | Examine and test automated log review | SIEM daily review exports LOG-2026-05-01 through LOG-2026-05-31; alert queue samples SECOPS-901 to SECOPS-932 | SecOps Manager / QSA | 2026-05-01 through 2026-05-31 | All CDE firewalls, WAF, IAM, database audit logs, and security-impacting jump hosts | Complete | Yes, daily review evidence covers the month | Current | Pass |
+| 8.4.2 | Examine MFA configuration and test user samples | IdP MFA policy export MFA-2026-06-01; sample tests for admins, developers, support, and service-provider users | Identity Lead / QSA | 2026-06-01 | 32 users across all CDE access paths and remote access groups | Complete | N/A | Current | Pass |
+| 11.4.5 | Examine segmentation test report and test retest records | Segmentation test report PEN-2026-Q2 plus retest record RT-881 | Network Security Owner / QSA | 2026-04-10 through 2026-04-25 | Primary CDE VLAN, backup CDE VLAN, jump segment, monitoring segment, and connected-to corporate networks | Complete | Yes, annual segmentation test completed after network change CHG-771 | Current | Pass |
+| 12.8.5 | Examine TPSP compliance monitoring | TPSP AOC package AOC-2026-05, responsibility matrix RM-2026-05, and annual review ticket VRM-411 | Vendor Risk Manager / ISA | 2026-05-20 | Payment processor, tokenization provider, managed WAF provider, and logging provider | Complete | Yes, annual monitoring completed | Current | Pass |
+
+## Expected Review Result
+
+The skill should allow `Requirement in Place` where the evidence satisfies `PCI-EVID-01` through `PCI-EVID-08`: testing method, artifact, owner/collector, date/period, sample scope, CDE coverage, required cadence, freshness, and result are all documented.

--- a/skills/compliance/pci-dss-review/tests/vulnerable/stale-unsampled-evidence.md
+++ b/skills/compliance/pci-dss-review/tests/vulnerable/stale-unsampled-evidence.md
@@ -1,0 +1,27 @@
+# Vulnerable: Stale and Unsampled PCI Evidence
+
+## Scenario
+
+The assessor is reviewing PCI DSS v4.0 evidence for a Level 1 merchant covering the 2026 assessment period.
+
+## Submitted Evidence
+
+| Sub-Req | Claimed Status | Evidence |
+|---------|----------------|----------|
+| 10.4.1.1 | In Place | Screenshot of SIEM dashboard from 2025-11-15 |
+| 8.4.2 | In Place | MFA configuration export for one admin group |
+| 11.4.5 | In Place | Segmentation test summary that lists only the primary CDE VLAN |
+| 12.8.5 | In Place | TPSP AOC for payment processor, no responsibility matrix |
+
+## Missing Evidence
+
+- `PCI-EVID-01`: no examine/observe/interview/test procedure is mapped to the sub-requirements.
+- `PCI-EVID-03`: no evidence owner or collector is recorded.
+- `PCI-EVID-04`: the SIEM screenshot predates the assessment period and no period covered is stated.
+- `PCI-EVID-05`: sample scope omits connected-to systems, service accounts, secondary CDE segments, and TPSP responsibilities.
+- `PCI-EVID-06`: recurring controls do not prove the required cadence across the assessment period.
+- `PCI-EVID-07`: freshness is not assessed against control changes or CDE scope.
+
+## Expected Review Result
+
+The skill should not mark these sub-requirements `In Place`. Under `PCI-EVID-08`, missing sample scope, owner, date, period, CDE coverage, frequency proof, or freshness status should produce `Unknown` or `Not in Place`.


### PR DESCRIPTION
## Summary
- Closes #1841
- Adds a PCI DSS evidence freshness and sample matrix before sub-requirements are marked In Place.
- Requires testing-procedure mapping, artifact, owner/collector, date/period, sample scope, CDE coverage, frequency proof, freshness, and Unknown behavior.
- Adds vulnerable and benign fixtures for stale/unsampled evidence versus current sampled assessor-verifiable evidence.

## Verification
- `git diff --cached --check`
- Markdown fence-balance check over staged `.md` files
- Added-line ASCII check
- Marker check for `PCI-EVID-01` through `PCI-EVID-08`
- Added-line sensitive-pattern scan
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`

## Bounty
/claim #1841

Preferred payment method: crypto or PayPal after maintainer acceptance.