### PR TITLE
Add model artifact verification fixtures

### DIFF
--- a/skills/ai-security/model-supply-chain/SKILL.md
+++ b/skills/ai-security/model-supply-chain/SKILL.md
@@ -382,6 +382,23 @@ Assess whether architectural and procedural controls exist to detect model backd
 |---|---|---|---|---|---|
 | [name] | [source] | [format] | [Yes/No] | [Yes/No] | [Complete/Partial/Missing] |
 
+## Artifact Verification Evidence
+
+For each production or evaluation model artifact, replace Yes/No verification fields with reproducible evidence:
+
+- `MSC-ART-01` **Exact artifact identity**: record the model, artifact type, source URL or registry, repository owner, and storage location used for deployment or evaluation.
+- `MSC-ART-02` **Immutable revision**: record the commit, immutable revision, release tag, object version, or registry digest; floating branches, `latest`, and unpinned model names are not sufficient.
+- `MSC-ART-03` **Digest evidence**: record the SHA-256 digest for weights, adapters, tokenizer files, and critical configuration files.
+- `MSC-ART-04` **Signature or attestation**: record the signature, Sigstore/cosign entry, SLSA/in-toto provenance, or equivalent attestation reference where available.
+- `MSC-ART-05` **Trust root**: identify the key, certificate identity, transparency log, internal registry policy, or trusted publisher identity used to validate the signature or attestation.
+- `MSC-ART-06` **Independent verification source**: verify the digest or signature against a source not controlled by the same mutable artifact location, such as a signed release, attestation service, or first-ingest internal registry record.
+- `MSC-ART-07` **Verifier and timestamp**: record who ran the verification, when it ran, and the verification command or pipeline run.
+- `MSC-ART-08` **Deployment binding and result**: bind the verified artifact to the deployed model image, endpoint, or evaluation job and mark `Pass`, `Fail`, or `Unknown`.
+
+| Model | Artifact | Source | Revision | SHA-256 | Signature/Attestation | Trust Root | Independent Verification Source | Verifier/Time | Deployment Binding | Result |
+|---|---|---|---|---|---|---|---|---|---|---|
+| [name] | [weights/tokenizer/adapter/config] | [source] | [commit/digest/tag] | [sha256] | [ref] | [root] | [source] | [who/when] | [endpoint/image/job] | [Pass/Fail/Unknown] |
+
 ## Findings
 
 ### Finding [N]: [Title]
@@ -440,6 +457,8 @@ Assess whether architectural and procedural controls exist to detect model backd
 4. **Assuming Hugging Face models are vetted.** Hugging Face Hub is a hosting platform, not a curation service. Any user can upload any model. While Hugging Face has introduced malware scanning and model signing capabilities, the majority of hosted models have no cryptographic provenance. Treat Hugging Face models as untrusted artifacts requiring verification, the same way you treat npm packages.
 
 5. **Evaluating models only on benchmarks.** Standard benchmarks measure general capability, not supply chain integrity. A backdoored model will perform normally on benchmarks by design. Behavioral differential testing with curated, domain-specific test sets that probe for targeted manipulation is required to surface backdoors.
+
+6. **Treating Yes/No verification fields as audit evidence.** `Checksum Verified: Yes` is not reproducible unless the report includes the exact revision, digest, signature or attestation reference, trust root, independent verification source, verifier, timestamp, and deployment binding. Same-registry checksums or mutable model-card values should be treated as `Unknown`.
 
 ---
 

--- a/skills/ai-security/model-supply-chain/tests/benign/attested-model-artifact-verification.md
+++ b/skills/ai-security/model-supply-chain/tests/benign/attested-model-artifact-verification.md
@@ -1,0 +1,17 @@
+# Benign: Attested Model Artifact Verification
+
+## Scenario
+
+The model release pipeline verifies every production artifact before promoting it to the managed inference endpoint.
+
+## Artifact Verification Evidence
+
+| Model | Artifact | Source | Revision | SHA-256 | Signature/Attestation | Trust Root | Independent Verification Source | Verifier/Time | Deployment Binding | Result |
+|---|---|---|---|---|---|---|---|---|---|---|
+| fraud-bert | `model.safetensors` | `registry.internal/ml/fraud-bert` | OCI digest `sha256:6f1d4c2a9e8b7d6c5a4f3e2d1c0b9a887766554433221100ffeeddccbbaa9988` | `6f1d4c2a9e8b7d6c5a4f3e2d1c0b9a887766554433221100ffeeddccbbaa9988` | cosign bundle `rekor://uuid/fraud-bert-2026-06-01` | Fulcio cert for `release-bot@acme.example`; Rekor log inclusion proof | Internal first-ingest manifest `MIRROR-2026-0601` plus signed release notes | Release pipeline `ml-release-4412` at 2026-06-01T10:18:00Z | Endpoint `fraud-prod-v3`, image digest `sha256:5b48d0c2e91a7a4b8a1fbb6cc21a77c7c0dff44112233445566778899aabbccd` | Pass |
+| fraud-bert | `tokenizer.json` | `registry.internal/ml/fraud-bert` | OCI digest `sha256:6f1d4c2a9e8b7d6c5a4f3e2d1c0b9a887766554433221100ffeeddccbbaa9988` | `31f9c6f2c4e7d3a1b8c0aab14499887766554433221100ffeeddccbbaa998877` | in-toto attestation `attestations/fraud-bert-tokenizer-2026-06-01.intoto.jsonl` | Internal model registry signing policy `POL-ML-REG-12` | First-ingest manifest `MIRROR-2026-0601` | Release pipeline `ml-release-4412` at 2026-06-01T10:18:00Z | Endpoint `fraud-prod-v3` | Pass |
+| fraud-bert | `config.json` | `registry.internal/ml/fraud-bert` | OCI digest `sha256:6f1d4c2a9e8b7d6c5a4f3e2d1c0b9a887766554433221100ffeeddccbbaa9988` | `42bb9efcc0a11223344556677889900aabbccddeeff0011223344556677889900` | in-toto attestation `attestations/fraud-bert-config-2026-06-01.intoto.jsonl` | Internal model registry signing policy `POL-ML-REG-12` | First-ingest manifest `MIRROR-2026-0601` | Release pipeline `ml-release-4412` at 2026-06-01T10:18:00Z | Endpoint `fraud-prod-v3` | Pass |
+
+## Expected Review Result
+
+The skill should treat the artifact verification as reproducible because `MSC-ART-01` through `MSC-ART-08` are satisfied: exact artifact identity, immutable revision, digests, signature or attestation, trust root, independent verification source, verifier/time, deployment binding, and result are recorded.

--- a/skills/ai-security/model-supply-chain/tests/vulnerable/mutable-model-artifact-self-checksum.md
+++ b/skills/ai-security/model-supply-chain/tests/vulnerable/mutable-model-artifact-self-checksum.md
@@ -1,0 +1,29 @@
+# Vulnerable: Mutable Model Artifact With Self-Referential Checksum
+
+## Scenario
+
+The inference service downloads a production fraud model from a public model registry during container startup.
+
+## Model Inventory
+
+| Model | Source | Format | Checksum Verified | Pinned Version | Model Card |
+|---|---|---|---|---|---|
+| fraud-bert | `https://modelhub.example.com/acme/fraud-bert` | safetensors | Yes | No, uses `main` | Partial |
+
+## Verification Notes
+
+The deployment script downloads `model.safetensors`, `tokenizer.json`, and `config.json` from the same mutable registry path, then downloads `SHA256SUMS` from that same path. No signed release, attestation service, transparency log, or first-ingest internal registry record is checked.
+
+## Missing Evidence
+
+- `MSC-ART-02`: no immutable commit, object version, release tag, or registry digest is recorded.
+- `MSC-ART-03`: tokenizer and config digests are not recorded.
+- `MSC-ART-04`: no signature, Sigstore/cosign entry, SLSA provenance, or in-toto attestation is linked.
+- `MSC-ART-05`: no trusted key, certificate identity, transparency log, or publisher identity is identified.
+- `MSC-ART-06`: the checksum comes from the same mutable source as the artifact.
+- `MSC-ART-07`: no verifier, timestamp, or verification command is recorded.
+- `MSC-ART-08`: no evidence proves that the verified digest is the one deployed to production.
+
+## Expected Review Result
+
+The skill should not treat `Checksum Verified: Yes` as sufficient. The artifact verification result should be `Unknown` or `Fail` because the revision is mutable and the checksum source is self-referential.


### PR DESCRIPTION
## Summary
- Closes #1835
- Adds reproducible model artifact verification evidence for exact artifact identity, immutable revisions, SHA-256 digests, signatures/attestations, trust roots, independent verification sources, verifier/time, and deployment binding.
- Adds vulnerable and benign fixtures for same-source checksum verification versus attested, independently verified production artifacts.

## Verification
- `git diff --cached --check`
- Markdown fence-balance check over staged `.md` files
- Added-line ASCII check
- Marker check for `MSC-ART-01` through `MSC-ART-08`
- Added-line sensitive-pattern scan
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`

## Bounty
/claim #1835

Preferred payment method: crypto or PayPal after maintainer acceptance.