### PR TITLE
Improve patch exploit evidence freshness gates

### DIFF
--- a/skills/vuln-management/patch-prioritization/SKILL.md
+++ b/skills/vuln-management/patch-prioritization/SKILL.md
@@ -110,6 +110,37 @@ Assign or validate SLA tiers using the following matrix. SLA tiers are derived f
 3. **Upward adjustment only:** If EPSS or KEV status indicates higher urgency than the SSVC decision alone, escalate the tier; never use EPSS to downgrade an SSVC Immediate decision
 4. **Asset criticality modifier:** For non-critical assets (dev, test, sandbox), the SLA tier may be relaxed by one level with documented justification
 
+### Step 2A: Exploit Maturity Evidence and Source Freshness
+
+Before assigning or changing an SLA tier, validate that the exploitability signals used in the decision are current, attributable, and traceable to authoritative evidence.
+
+**Framework mapping:** SSVC 2.1 exploitation state, EPSS v3 daily scoring, CISA KEV catalog evidence
+
+**Evidence freshness requirements:**
+
+- **CISA KEV:** Use the current machine-readable feed or record the catalog retrieval date. Treat KEV status as **Not Evaluable** when the feed is older than 24 hours for P0/P1 decisions.
+- **EPSS:** Record the EPSS score date and percentile. Treat missing or stale dates as insufficient evidence for escalation or deferral.
+- **Exploit maturity:** Distinguish active exploitation, weaponized exploit, public PoC, private proof, rumor, and no known exploit. Do not collapse all "PoC available" claims into active exploitation.
+- **Source quality:** Prefer vendor advisories, CISA KEV, CERT/CC, FIRST EPSS, reputable exploit databases, scanner plugin metadata with timestamps, or internally validated incident evidence.
+- **Asset applicability:** Confirm the exploit path applies to the affected asset version, configuration, exposure, and reachable attack surface.
+
+**What to look for:**
+
+```
+PATCH-EXPLOIT-01: SLA tier changed based on KEV/EPSS data without retrieval date or source URL
+PATCH-EXPLOIT-02: EPSS score is stale, missing percentile, or copied from a non-authoritative source
+PATCH-EXPLOIT-03: Public PoC is treated as active exploitation without incident, telemetry, KEV, or reputable threat-intel evidence
+PATCH-EXPLOIT-04: Exploit evidence does not apply to the deployed version, configuration, or exposed attack surface
+PATCH-EXPLOIT-05: Risk exception cites compensating controls but does not test them against the specific exploit path
+PATCH-EXPLOIT-06: Ransomware or mass-exploitation label is asserted without source, date, or campaign evidence
+```
+
+**False-positive guardrails:**
+
+- Do not downgrade a confirmed KEV finding because EPSS is low; KEV is evidence of known exploitation.
+- Do not escalate to P0 solely because a GitHub gist or blog mentions a PoC unless the source, date, affected version, and exploit path are validated.
+- Do not reject a compensating control solely because no vendor patch exists; evaluate whether the control blocks the specific exploit preconditions and whether verification evidence is current.
+
 ### Step 3: EPSS Trend Analysis
 
 Analyze EPSS score trajectory to identify vulnerabilities with increasing exploitation likelihood.
@@ -307,6 +338,12 @@ findings requiring immediate action.]
 |---|---|---|---|---|
 | [CVE-ID] | [score] | [score] | [Surging/Rising] | [Action] |
 
+### Exploit Evidence Freshness
+
+| CVE ID | KEV Source Date | EPSS Date | Exploit Maturity | Source Quality | Asset Applicability | Status |
+|---|---|---|---|---|---|---|
+| [CVE-ID] | [date/source] | [date] | [active/weaponized/PoC/none] | [authoritative/unverified] | [confirmed/not confirmed] | [Pass/Fail/Not Evaluable] |
+
 ### Prioritized Patch Schedule
 
 | Priority | CVE ID(s) | Target System | Patch | Scheduled Window | SLA Deadline | Status |
@@ -373,6 +410,10 @@ Known Exploited Vulnerabilities catalog maintained by CISA. Contains CVEs with c
 4. **Ignoring EPSS trend direction.** A CVE with a low absolute EPSS score but a rapidly rising trend (e.g., from 0.02 to 0.15 in two weeks) signals that exploit development is progressing. Treating EPSS as a static snapshot rather than a time series misses emerging threats. Always evaluate 7/30/90-day trends.
 
 5. **Scheduling patches without rollback plans.** Patch deployment failures without rollback procedures cause unplanned outages that erode trust in the patching program. Every patch window must include a validated rollback procedure, tested in a non-production environment where possible.
+
+6. **Using stale exploitability snapshots for emergency decisions.** A cached KEV export or old EPSS CSV may be acceptable for backlog reporting, but not for P0/P1 SLA changes. Record retrieval dates and refresh authoritative sources before emergency scheduling.
+
+7. **Confusing public PoC with active exploitation.** A proof-of-concept can justify higher urgency, but active exploitation requires stronger evidence such as KEV listing, incident telemetry, reputable threat intelligence, or verified campaign reporting.
 
 ---
 

--- a/skills/vuln-management/patch-prioritization/tests/benign/kev-not-downgraded-by-low-epss.yaml
+++ b/skills/vuln-management/patch-prioritization/tests/benign/kev-not-downgraded-by-low-epss.yaml
@@ -1,0 +1,18 @@
+scenario: kev-not-downgraded-by-low-epss
+cve: CVE-2026-10003
+proposed_sla_tier: P1
+decision_inputs:
+  cisa_kev:
+    listed: true
+    source_url: https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json
+    retrieved_at: "2026-06-09T01:00:00Z"
+  epss:
+    score: 0.02
+    percentile: 0.44
+    score_date: "2026-06-09"
+  ssvc_decision: Out-of-Cycle
+asset:
+  exposure: internal
+  criticality: high
+expected_status: pass
+false_positive_guardrail: confirmed KEV evidence should not be downgraded solely because current EPSS is low

--- a/skills/vuln-management/patch-prioritization/tests/benign/verified-compensating-control-for-unpatched-cve.yaml
+++ b/skills/vuln-management/patch-prioritization/tests/benign/verified-compensating-control-for-unpatched-cve.yaml
@@ -1,0 +1,21 @@
+scenario: verified-compensating-control-for-unpatched-cve
+cve: CVE-2026-10004
+proposed_sla_tier: P2
+patch_available: false
+decision_inputs:
+  cisa_kev:
+    listed: false
+    retrieved_at: "2026-06-09T01:00:00Z"
+  epss:
+    score: 0.18
+    percentile: 0.86
+    score_date: "2026-06-09"
+  exploit_maturity: public_poc
+compensating_control:
+  type: waf_virtual_patch
+  blocks_specific_exploit_path: true
+  tested_against_poc_at: "2026-06-08T18:00:00Z"
+  coverage: all_internet_facing_assets
+  expires_at: "2026-06-23T00:00:00Z"
+expected_status: pass
+false_positive_guardrail: lack of vendor patch is not itself a failure when a current verified control blocks the specific exploit path and has an expiration

--- a/skills/vuln-management/patch-prioritization/tests/vulnerable/poc-treated-as-active-exploitation.yaml
+++ b/skills/vuln-management/patch-prioritization/tests/vulnerable/poc-treated-as-active-exploitation.yaml
@@ -1,0 +1,26 @@
+scenario: poc-treated-as-active-exploitation
+cve: CVE-2026-10002
+proposed_sla_tier: P0
+decision_inputs:
+  exploit_claim: active_exploitation
+  source:
+    type: unverified_blog
+    url: https://example.invalid/poc-not-active-exploit
+    published_at: "2026-06-01T00:00:00Z"
+  cisa_kev:
+    listed: false
+    retrieved_at: "2026-06-09T01:00:00Z"
+  epss:
+    score: 0.09
+    percentile: 0.71
+    score_date: "2026-06-09"
+asset_applicability:
+  affected_version_confirmed: true
+  exploit_preconditions_confirmed: false
+expected_findings:
+  - id: PATCH-EXPLOIT-03
+    severity: medium
+    reason: public PoC is treated as active exploitation without authoritative incident, KEV, telemetry, or threat-intel evidence
+  - id: PATCH-EXPLOIT-04
+    severity: medium
+    reason: exploit preconditions are not confirmed for the deployed configuration

--- a/skills/vuln-management/patch-prioritization/tests/vulnerable/stale-kev-epss-emergency-tier.yaml
+++ b/skills/vuln-management/patch-prioritization/tests/vulnerable/stale-kev-epss-emergency-tier.yaml
@@ -1,0 +1,23 @@
+scenario: stale-kev-epss-emergency-tier
+cve: CVE-2026-10001
+proposed_sla_tier: P0
+decision_inputs:
+  cisa_kev:
+    listed: true
+    source_url: https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json
+    retrieved_at: "2026-05-30T00:00:00Z"
+  epss:
+    score: 0.82
+    percentile: missing
+    score_date: missing
+  ssvc_decision: Immediate
+asset:
+  exposure: internet-facing
+  criticality: high
+expected_findings:
+  - id: PATCH-EXPLOIT-01
+    severity: high
+    reason: emergency SLA depends on KEV/EPSS evidence without current retrieval date and complete score metadata
+  - id: PATCH-EXPLOIT-02
+    severity: medium
+    reason: EPSS evidence is missing score date and percentile


### PR DESCRIPTION
Closes #2026

## Summary
- Adds `Step 2A` for exploit maturity evidence and source freshness to `patch-prioritization`.
- Adds PATCH-EXPLOIT reason codes for stale KEV/EPSS data, missing score metadata, PoC-vs-active-exploit confusion, asset applicability gaps, untested controls, and unsourced ransomware/mass-exploitation labels.
- Adds output fields for KEV source date, EPSS date, exploit maturity, source quality, and asset applicability.
- Adds false-positive guardrails for KEV not being downgraded by low EPSS and verified controls for unpatched CVEs.
- Adds 4 fixtures: 2 vulnerable and 2 benign.

## Validation
- `git diff --check`
- `git diff --cached --check`
- Parsed all 4 YAML fixtures with PyYAML
- Checked markers for Step 2A, PATCH-EXPLOIT reason codes, Not Evaluable guidance, Exploit Evidence Freshness output, and PoC guardrail
- Fixture count: vulnerable=2, benign=2

## Bounty
Requested bounty: $100