### PR TITLE
Add OWASP exploitability evidence fixtures

### DIFF
--- a/skills/appsec/owasp-top-10-web/SKILL.md
+++ b/skills/appsec/owasp-top-10-web/SKILL.md
@@ -635,8 +635,28 @@ Present findings in this structure:
 - **Location:** [file:line or file:function]
 - **Description:** [Clear explanation of the vulnerability, including how it could be exploited]
 - **Evidence:** [Code snippet or configuration excerpt]
+- **Exploitability Evidence:** [entry point, source-to-sink trace, exploit preconditions, and missing/bypassed controls]
+- **Compensating Controls Checked:** [framework controls, middleware, WAF, validation, authorization, rate limits, CSP, or other controls reviewed]
+- **False-Positive Rationale:** [why the finding is not a false positive, or why it was downgraded/discarded]
 - **Remediation:** [Specific, actionable fix with code example where applicable]
 - **Verification:** [How to confirm the fix is effective]
+
+### Exploitability Evidence Matrix
+
+For High and Critical findings, require:
+
+- `OWASP-EXP-01` **Reachable entry point**: record the public route, controller/action, handler, RPC, webhook, job trigger, or browser-exposed flow that reaches the vulnerable code.
+- `OWASP-EXP-02` **Attacker-controlled source**: identify the parameter, header, body field, cookie, file upload, path segment, or third-party callback field controlled by an attacker.
+- `OWASP-EXP-03` **Vulnerable sink**: identify the SQL, template, command, filesystem, redirect, SSRF fetch, authz decision, crypto operation, or browser sink affected.
+- `OWASP-EXP-04` **Source-to-sink trace**: document the call chain and transformations from source to sink, including sanitizers or validators that do or do not apply.
+- `OWASP-EXP-05` **Exploit preconditions**: capture role, auth state, tenant/object ownership, feature flag, deployment mode, configuration, and environmental assumptions.
+- `OWASP-EXP-06` **Compensating controls checked**: review framework protections, centralized middleware, WAF/CRS rules, CSP, rate limits, CSRF defenses, encoder behavior, allowlists, and policy enforcement.
+- `OWASP-EXP-07` **Severity calibration**: downgrade or discard findings where controls fully block exploitation, the code is unreachable, or only non-security data is affected.
+- `OWASP-EXP-08` **Proof and negative evidence**: include a safe exploit sketch, test reference, log/WAF evidence, or negative test where feasible.
+
+| Finding | Entry Point | Attacker Source | Sink | Source-to-Sink Trace | Preconditions | Controls Checked | FP/Severity Rationale | Proof/Negative Evidence |
+|---------|-------------|-----------------|------|----------------------|---------------|------------------|-----------------------|-------------------------|
+| [id] | [route/handler] | [field] | [sink] | [trace] | [conditions] | [controls] | [rationale] | [test/evidence] |
 
 ---
 
@@ -686,6 +706,8 @@ Present findings in this structure:
 4. **Reporting deprecated algorithms without context.** MD5 used for non-security checksums (e.g., cache busting, ETags) is not a cryptographic failure. Only flag weak algorithms when they protect sensitive data, passwords, or integrity-critical operations. State the security impact clearly.
 
 5. **Ignoring transitive dependencies.** A project may have zero direct vulnerable dependencies but inherit critical CVEs through transitive dependencies. Always analyze the full dependency tree, not just top-level declarations.
+
+6. **Omitting exploitability evidence from severe findings.** High and Critical findings should not rely on a code snippet alone. If the report lacks a reachable entry point, attacker-controlled source, vulnerable sink, preconditions, compensating-control review, and false-positive rationale, downgrade the confidence or mark the finding for validation.
 
 ## Prompt Injection Safety Notice
 

--- a/skills/appsec/owasp-top-10-web/tests/benign/exploitability-evidence-complete.md
+++ b/skills/appsec/owasp-top-10-web/tests/benign/exploitability-evidence-complete.md
@@ -1,0 +1,15 @@
+# Benign: Complete Exploitability Evidence
+
+## Scenario
+
+The review reports an authenticated cross-tenant object access issue and includes exploitability evidence.
+
+## Exploitability Evidence Matrix
+
+| Finding | Entry Point | Attacker Source | Sink | Source-to-Sink Trace | Preconditions | Controls Checked | FP/Severity Rationale | Proof/Negative Evidence |
+|---------|-------------|-----------------|------|----------------------|---------------|------------------|-----------------------|-------------------------|
+| WEB-17 | `GET /api/v2/invoices/{invoice_id}` in `invoice_controller.show` | Authenticated user controls `invoice_id` path segment | `InvoiceRepository.find_by_id(invoice_id)` returns invoice before tenant policy check | route path -> controller param -> repository lookup -> serializer emits invoice JSON -> tenant check runs only on list endpoint | Attacker has any valid account in tenant B and guesses invoice ID from tenant A | JWT auth present; route middleware verifies login only; no object ownership check in show action; WAF/CSP/rate limit do not prevent IDOR; list endpoint tenant filter confirmed separate | High severity is retained because cross-tenant invoice data is returned to a low-privilege authenticated user; not Critical because no write or admin action is reached | Positive test `tests/security/test_invoice_idor.py::test_cross_tenant_show_denied` fails before fix; negative test for same-tenant access passes |
+
+## Expected Review Result
+
+The skill should accept the finding as well-supported because `OWASP-EXP-01` through `OWASP-EXP-08` are documented: reachable entry point, attacker-controlled source, vulnerable sink, trace, preconditions, controls checked, severity rationale, and proof/negative evidence.

--- a/skills/appsec/owasp-top-10-web/tests/vulnerable/exploitability-evidence-missing.md
+++ b/skills/appsec/owasp-top-10-web/tests/vulnerable/exploitability-evidence-missing.md
@@ -1,0 +1,28 @@
+# Vulnerable: Severe Finding Without Exploitability Evidence
+
+## Scenario
+
+The review reports a Critical SQL injection in a web application after finding string interpolation near a database query.
+
+## Reported Finding
+
+| Field | Value |
+|---|---|
+| OWASP Category | A03:2021 Injection |
+| Location | `src/reports/admin_debug.py:88` |
+| Evidence | `db.raw(f"select * from audit where id = {audit_id}")` |
+| Severity | Critical |
+| Verification | Fix by using parameters |
+
+## Missing Evidence
+
+- `OWASP-EXP-01`: no reachable route, handler, job trigger, or browser flow is linked to `admin_debug.py`.
+- `OWASP-EXP-02`: no attacker-controlled parameter, header, body field, cookie, or callback field is identified.
+- `OWASP-EXP-04`: no source-to-sink trace shows that untrusted input reaches `audit_id`.
+- `OWASP-EXP-05`: no exploit preconditions are documented, including admin-only access, feature flag state, or production deployment mode.
+- `OWASP-EXP-06`: centralized authorization, ORM parameterization wrappers, WAF rules, and input validators were not checked.
+- `OWASP-EXP-08`: no safe exploit sketch, positive test, negative test, or log evidence is provided.
+
+## Expected Review Result
+
+The skill should not keep this as a confident Critical finding based only on a code snippet. It should require exploitability validation, downgrade confidence, or mark the finding for follow-up until `OWASP-EXP-01` through `OWASP-EXP-08` are documented.


### PR DESCRIPTION
## Summary
- Closes #1833
- Adds exploitability evidence fields for entry point, attacker source, sink, source-to-sink trace, exploit preconditions, compensating controls, severity/false-positive rationale, and proof or negative evidence.
- Adds vulnerable and benign fixtures for code-snippet-only severe findings versus complete exploitability evidence.

## Verification
- `git diff --cached --check`
- Markdown fence-balance check over staged `.md` files
- Added-line ASCII check
- Marker check for `OWASP-EXP-01` through `OWASP-EXP-08`
- Added-line sensitive-pattern scan
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`

## Bounty
/claim #1833

Preferred payment method: crypto or PayPal after maintainer acceptance.