### PR TITLE
Improve agent-security resource budget enforcement gates

### DIFF
--- a/skills/ai-security/agent-security/SKILL.md
+++ b/skills/ai-security/agent-security/SKILL.md
@@ -208,6 +208,48 @@ Evaluate whether the agent architecture is designed from the ground up around le
 
 ---
 
+### Step 2A -- Resource Budget Enforcement Evidence
+
+Evaluate whether resource controls are enforced across the whole agent workflow, not merely declared as per-request settings.
+
+**What to look for in code and configuration:**
+
+- **Cumulative budget ledger:** Are model tokens, runtime, tool calls, external API spend, storage, browser automation, code execution, email sends, and sub-agent fan-out charged against a shared tenant/user/session/job ledger?
+- **Quota scope:** Are limits enforced per tenant, user, workspace, session, agent, tool, and batch job where applicable?
+- **Retry and fallback accounting:** Do retries, timeout recovery, provider fallback, and recursive tool calls decrement the same budget instead of receiving fresh limits?
+- **Tool-cost metering:** Are non-LLM tools such as web search, browser automation, shell/code execution, storage, email, and paid APIs metered and capped?
+- **Concurrency controls:** Are parallel sessions, sub-agents, background jobs, and queue workers limited so attackers cannot multiply budget through fan-out?
+- **Fail-closed behavior:** When the budget ledger, metering service, or policy decision point is unavailable, does the agent stop or enter a safe degraded mode?
+- **Alerting and kill switch:** Are thresholds, anomaly alerts, owner notifications, and emergency termination controls configured for runaway spend or denial-of-service conditions?
+
+**Detection methods:** Search for budget and metering terms (`budget`, `quota`, `ledger`, `meter`, `cost`, `usage`, `tokens`, `tool_calls`, `retry`, `fallback`, `concurrency`, `semaphore`, `queue`, `circuit_breaker`, `kill_switch`) and verify enforcement occurs before tool/model execution.
+
+**Resource budget evidence checklist:**
+
+| Control | Desired State | Common Violation |
+|---|---|---|
+| Shared ledger | All model, tool, retry, fallback, and sub-agent costs decrement one authoritative budget | Per-request limits reset on every call |
+| Scope | Tenant/user/session/tool/job quotas all enforced where relevant | Only global rate limit exists |
+| Retry/fallback | Retries and alternate providers consume original budget | Timeout creates fresh budget |
+| Tool costs | Non-LLM tools are metered and capped | Only tokens are counted |
+| Concurrency | Parallel sessions and sub-agents have fan-out limits | Each worker receives independent quota |
+| Fail mode | Metering failure blocks high-cost actions | Agent proceeds when ledger is unavailable |
+| Operations | Alerts, owner, kill switch, and residual bypass paths documented | Billing alert fires after spend is already incurred |
+
+**What constitutes a finding:**
+
+| Condition | Severity |
+|---|---|
+| No cumulative budget ledger for model, tool, retry, fallback, and sub-agent costs | High |
+| Retry or fallback provider paths bypass metering or receive a fresh budget | High |
+| External tool costs are unmetered for tools with spend, compute, storage, or side effects | High |
+| Budget enforcement fails open when the ledger or policy service is unavailable | High |
+| No concurrency/fan-out limit for parallel sessions, background jobs, or sub-agents | Medium |
+| No alert threshold, owner notification, or kill switch for runaway agent spend | Medium |
+| Batch jobs reuse interactive user budgets without explicit owner and cap | Medium |
+
+---
+
 ### Step 3 -- Human-in-the-Loop Gate Placement
 
 Evaluate the design, placement, and robustness of human approval gates in the agent workflow.
@@ -568,6 +610,8 @@ Glob: **/security_architecture*
 4. **Building audit trails that log actions but not context.** An audit log that records "Agent-A called write_file at 14:32:01" is useful for timeline reconstruction but insufficient for root cause analysis. Without logging what the agent was told (the prompt or task), what it reasoned (the chain of thought), and what it received from other agents or tools (the inputs), investigators cannot determine whether the action was legitimate, hallucinated, or injected. Log the full decision context for every consequential action.
 
 5. **Assuming rollback is someone else's problem.** Agent developers frequently rely on downstream systems (databases, deployment platforms, email providers) to handle rollback without verifying that rollback mechanisms actually exist and work. A database transaction can be rolled back, but only if the agent's actions are wrapped in a transaction. An email cannot be recalled. A deployed binary cannot be un-deployed if the deployment pipeline has no rollback. For every tool an agent can invoke, the architecture must document the rollback mechanism and test it.
+
+6. **Treating per-request limits as a real budget.** A `max_tokens` value, timeout, or API gateway rate limit does not prove cost containment when retries, fallback providers, parallel sessions, sub-agents, browser automation, code execution, storage, and paid APIs are outside the same ledger. Verify the enforcement point and fail mode before crediting resource controls.
 
 ---
 

--- a/skills/ai-security/agent-security/tests/benign/batch-job-owned-budget.yaml
+++ b/skills/ai-security/agent-security/tests/benign/batch-job-owned-budget.yaml
@@ -1,0 +1,19 @@
+scenario: batch-job-owned-budget
+job_type: nightly-agent-analysis
+owner: data-platform
+budget_enforcement:
+  job_budget_id: batch-2026-0609
+  separate_from_interactive_users: true
+  max_runtime_minutes: 45
+  max_tool_calls: 120
+  max_storage_mb: 500
+  max_sub_agents: 3
+  retry_budget_shared: true
+  fallback_budget_shared: true
+  fail_mode: closed
+operations:
+  alert_threshold_percent: 75
+  kill_switch: batch-controller.stop_job
+  residual_bypass_paths_reviewed: true
+expected_status: pass
+false_positive_guardrail: batch jobs can use separate budgets when they have an explicit owner, cap, kill switch, shared retry/fallback accounting, and reviewed bypass paths

--- a/skills/ai-security/agent-security/tests/benign/shared-ledger-with-fail-closed-metering.yaml
+++ b/skills/ai-security/agent-security/tests/benign/shared-ledger-with-fail-closed-metering.yaml
@@ -1,0 +1,27 @@
+scenario: shared-ledger-with-fail-closed-metering
+budget_enforcement:
+  ledger_id: tenant-user-session-job-ledger
+  scopes:
+    - tenant
+    - user
+    - session
+    - agent
+    - tool
+    - batch_job
+  metered_resources:
+    model_tokens: true
+    retries: true
+    fallback_providers: true
+    web_search: true
+    browser_automation: true
+    code_execution: true
+    storage: true
+    email: true
+  fail_mode: closed
+  enforcement_point: before_model_or_tool_execution
+operations:
+  alert_threshold_percent: 80
+  owner_notification: platform-oncall
+  kill_switch: circuit_breaker.agent_runtime
+expected_status: pass
+false_positive_guardrail: resource controls should be credited when all model/tool/retry/fallback costs hit one fail-closed ledger before execution

--- a/skills/ai-security/agent-security/tests/vulnerable/per-request-limits-no-session-ledger.yaml
+++ b/skills/ai-security/agent-security/tests/vulnerable/per-request-limits-no-session-ledger.yaml
@@ -1,0 +1,21 @@
+scenario: per-request-limits-no-session-ledger
+agent:
+  max_tokens: 8000
+  timeout_seconds: 120
+  rate_limit: "100 requests/minute"
+budget_enforcement:
+  cumulative_session_ledger: false
+  tenant_quota: missing
+  user_quota: missing
+  tool_quota: missing
+workflow:
+  sequential_requests_allowed: unlimited
+  sub_agents_spawn_budget: fresh_per_sub_agent
+  background_jobs_budget: fresh_per_job
+expected_findings:
+  - id: AGENT-BUDGET-01
+    severity: high
+    reason: per-request limits reset across sequential calls, sub-agents, and jobs instead of sharing a cumulative ledger
+  - id: AGENT-BUDGET-05
+    severity: medium
+    reason: fan-out through sub-agents and background jobs has no concurrency or shared budget cap

--- a/skills/ai-security/agent-security/tests/vulnerable/retry-fallback-and-tool-cost-bypass.yaml
+++ b/skills/ai-security/agent-security/tests/vulnerable/retry-fallback-and-tool-cost-bypass.yaml
@@ -1,0 +1,28 @@
+scenario: retry-fallback-and-tool-cost-bypass
+agent:
+  token_budget: 20000
+retry:
+  max_retries: 5
+  decrements_budget: false
+fallback_providers:
+  - name: secondary-llm
+    receives_fresh_budget: true
+tools:
+  web_search:
+    cost_metering: false
+  browser_automation:
+    cost_metering: false
+  code_execution:
+    cost_metering: false
+metering_service:
+  fail_mode: open
+expected_findings:
+  - id: AGENT-BUDGET-02
+    severity: high
+    reason: retries and fallback provider calls bypass the original budget ledger
+  - id: AGENT-BUDGET-03
+    severity: high
+    reason: non-LLM tools with compute, API, and automation cost are unmetered
+  - id: AGENT-BUDGET-04
+    severity: high
+    reason: budget enforcement fails open when metering is unavailable


### PR DESCRIPTION
Closes #1380

## Summary
- Adds `Step 2A` for resource budget enforcement evidence to `agent-security`.
- Requires cumulative budget ledgers across tenant/user/session/tool/job scope, retries, fallback providers, sub-agents, batch jobs, and non-LLM tools.
- Adds explicit checks for concurrency limits, fail-closed metering, alert thresholds, owners, kill switches, and residual bypass paths.
- Adds 4 fixtures: 2 vulnerable and 2 benign.

## Validation
- `git diff --check`
- `git diff --cached --check`
- Parsed all 4 YAML fixtures with PyYAML
- Checked markers for Step 2A, cumulative ledger, retry/fallback accounting, tool-cost metering, and fail-closed behavior
- Fixture count: vulnerable=2, benign=2

## Bounty
Requested bounty: $100