### PR TITLE
Add GCP evidence freshness fixtures

### DIFF
--- a/skills/cloud/gcp-review/SKILL.md
+++ b/skills/cloud/gcp-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-GCP-v2.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -78,6 +78,25 @@ Use Glob to locate all GCP-related infrastructure definitions.
 
 Record all discovered files. If no GCP configurations are found, report that finding and halt.
 
+Before scoring any CIS control, build a GCP evidence freshness inventory:
+
+```
+| Evidence ID | Basis | Source / Query | Collected By | Collection Date | Org / Folder / Project Scope | Region / Service Scope | Controls Supported | Limitations | Confidence |
+|-------------|-------|----------------|--------------|-----------------|------------------------------|------------------------|--------------------|-------------|------------|
+| GCP-EVID-01 | IaC intent / live-exported / partial / missing | <Terraform, Deployment Manager, gcloud, Cloud Asset Inventory, SCC, Policy Analyzer> | <owner/tool> | <date> | <org/folders/projects> | <regions/services> | <CIS IDs> | <coverage gaps/drift risk> | High / Medium / Low |
+```
+
+Apply these evidence gates before assigning Pass or Fail:
+
+- **GCP-EVID-01 Evidence basis:** classify each artifact as IaC intent, current live/exported state, partial evidence, or missing evidence. IaC alone is intended state and cannot prove deployed state when drift is in scope.
+- **GCP-EVID-02 Source provenance:** identify the exact source or query, such as `gcloud`, Cloud Asset Inventory, Security Command Center, Policy Analyzer, org policy export, IAM policy export, or console export.
+- **GCP-EVID-03 Date and freshness:** record the collection date and compare it to the control's change velocity. Fast-changing IAM, firewall, and service-account-key evidence needs fresher support than stable inherited org policy.
+- **GCP-EVID-04 Scope coverage:** map evidence to the assessed organization, folder, project, region, and service set. Partial project or regional exports cannot support full-environment Pass results.
+- **GCP-EVID-05 Inherited authority:** when parent organization or folder policy evidence covers child projects, document the hierarchy, inheritance path, excluded descendants, and policy assignment scope.
+- **GCP-EVID-06 Limitations and conflicts:** record stale exports, missing services, unreviewed folders, conflicting IaC/live state, or sources that only observe a subset of resources.
+- **GCP-EVID-07 Drift and change controls:** check recent IAM, org policy, firewall, key, SCC, and project change logs where available. A stale artifact with no change-control evidence should be lower-confidence or Not Evaluable.
+- **GCP-EVID-08 Result confidence:** set High only when source, date, scope, inheritance, limitations, and drift checks support the conclusion. Use Medium/Low or Not Evaluable when evidence is stale, partial, or IaC-only.
+
 ---
 
 ### Step 2 through Step 8: CIS Benchmark Evaluation (Sections 1-7)
@@ -92,6 +111,12 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 
 Produce the final report using the structure defined in the Output Format section.
+
+Before finalizing, ensure every Passed or Failed control references at least one
+inventory row and includes evidence basis, source, date, coverage, limitations,
+and confidence. If deployed-state drift matters and current live/exported
+evidence is unavailable, mark the control Not Evaluable or lower confidence
+instead of treating IaC intent as proof of the active GCP environment.
 
 ---
 
@@ -117,6 +142,16 @@ Produce the final report using the structure defined in the Output Format sectio
 - Date: <assessment date>
 - Framework: CIS Google Cloud Platform Foundation Benchmark v2.0.0
 - Files reviewed: <list of IaC files>
+- Evidence basis: <IaC intent / live-exported / partial / missing / mixed>
+- Evidence freshness: <collection dates, git commits, and change-window rationale>
+- Org/Folder/Project/Region coverage: <scope assessed and gaps>
+- Evidence limitations: <stale exports, missing services, inherited-scope gaps, live-state gaps>
+
+### Evidence Freshness Inventory
+
+| Evidence ID | Basis | Source / Query | Date | Scope | Controls Supported | Limitations | Confidence |
+|-------------|-------|----------------|------|-------|--------------------|-------------|------------|
+| GCP-EVID-01 | <basis> | <artifact/query> | <date> | <org/folder/project/region/service> | <CIS IDs> | <gaps> | High / Medium / Low |
 
 ### Executive Summary
 - Total CIS recommendations evaluated: <N>
@@ -148,6 +183,12 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration or code snippet>
+- **Evidence ID(s):** <GCP-EVID-## rows used>
+- **Evidence Source:** <IaC file / gcloud export / Cloud Asset Inventory / SCC / Policy Analyzer / live observation>
+- **Evidence Date:** <timestamp, commit, or observation date>
+- **Coverage:** <org, folder, project, region, service, and inherited scope>
+- **Limitations:** <missing projects/services, stale exports, drift risk, or source constraints>
+- **Confidence:** High / Medium / Low
 - **Remediation:** <specific fix with code example>
 
 ### Prioritized Remediation Plan
@@ -194,6 +235,7 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Cloud SQL authorized_networks vs. private IP.** CIS 6.5 flags `0.0.0.0/0` in authorized networks, but CIS 6.6 goes further and recommends disabling public IP entirely in favor of private networking.
 5. **BigQuery dataset-level vs. table-level CMEK.** CIS 7.2 checks table-level encryption, while CIS 7.3 checks the dataset default. Both should be evaluated independently.
 6. **Default compute service account identification.** The default SA follows the pattern `PROJECT_NUMBER-compute@developer.gserviceaccount.com`. Grep for this pattern, not just the string "default."
+7. **Treating IaC as live deployed evidence.** Terraform, Deployment Manager, and policy files show intended state, not necessarily active GCP state. For controls affected by console changes, inherited org/folder policies, regional services, or recent IAM/firewall/key changes, require fresh live/exported evidence or mark the conclusion lower-confidence or Not Evaluable.
 
 ---
 
@@ -225,4 +267,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Added GCP evidence freshness, coverage, inherited-scope, drift, and confidence gates plus report fields.
 - **1.0.0** -- Initial release. Full coverage of CIS Google Cloud Platform Foundation Benchmark v2.0.0 sections 1 through 7.

--- a/skills/cloud/gcp-review/tests/benign/live-current-inherited-evidence.md
+++ b/skills/cloud/gcp-review/tests/benign/live-current-inherited-evidence.md
@@ -1,0 +1,50 @@
+---
+name: live-current-inherited-evidence
+expected: high-confidence
+skill: gcp-review
+---
+
+# GCP Review Fixture: Current Live Evidence with Inherited Scope
+
+Use this fixture to verify that `gcp-review` can assign high confidence when live/exported evidence is current, scoped, and reconciled with inherited organization and folder policies.
+
+## Review Scope
+
+- Organization: `organizations/222222222222`
+- Folder: `folders/333333333333`
+- Projects in scope: `payments-prod`, `payments-dr`, `analytics-prod`
+- Regions in scope: `us-central1`, `us-east1`, `europe-west1`
+- Review date: `2026-06-09`
+
+## Evidence Inventory
+
+| Evidence ID | Basis | Source / Query | Collection Date | Scope | Controls Supported | Limitations | Confidence |
+|-------------|-------|----------------|-----------------|-------|--------------------|-------------|------------|
+| GCP-EVID-01 | Live-exported | Cloud Asset Inventory snapshot `cai-org-222222222222-2026-06-08.json` | 2026-06-08 | Org, folder, all three projects, global and regional assets | IAM, org policy, firewall, storage, Cloud SQL, BigQuery | Excludes deleted assets older than 35 days | High |
+| GCP-EVID-02 | Live-exported | `gcloud asset search-all-iam-policies --scope=organizations/222222222222` | 2026-06-08 | Org, folder, project inherited IAM | CIS 1.x | Read-only export, reconciled with CAI | High |
+| GCP-EVID-03 | Live-exported | Policy Analyzer query for effective allow policies | 2026-06-08 | `folders/333333333333` descendants | IAM inheritance and effective access | Covers included child projects, excludes sandbox folder by documented scope | High |
+| GCP-EVID-04 | Live-exported | Hierarchical firewall policy and VPC firewall export | 2026-06-08 | Shared VPC host plus service projects in all three regions | CIS 3.x | None for reviewed scope | High |
+| GCP-EVID-05 | Live-exported | Security Command Center posture findings export | 2026-06-08 | All in-scope projects | Logging, storage, VM, SQL, BigQuery posture | SCC mute rules reviewed separately | High |
+| GCP-EVID-06 | Live-exported | Admin Activity audit logs for IAM, org policy, firewall, and service account key changes | 2026-06-01 to 2026-06-09 | Org, folder, all in-scope projects | Drift-sensitive controls | Seven-day window matches daily change-control review | High |
+| GCP-EVID-07 | Mixed | Terraform plan and deployment pipeline records | 2026-06-08 | Production modules for all in-scope projects | Intended state cross-check | Used only to reconcile live state, not as sole proof | Medium |
+| GCP-EVID-08 | Result confidence | Reviewer conclusion | 2026-06-09 | Full review scope | All CIS sections | Live evidence is current and scope gaps are documented | High |
+
+## Expected Review Behavior
+
+- Findings should cite the specific `GCP-EVID-##` rows used for each Passed, Failed, or Not Evaluable control.
+- Parent folder and organization policy evidence can support child projects only because `GCP-EVID-01`, `GCP-EVID-02`, and `GCP-EVID-03` document the inheritance path and excluded scope.
+- Terraform evidence in `GCP-EVID-07` can corroborate live exports but should not override fresher live evidence.
+- Controls with matching CAI, SCC, Policy Analyzer, firewall, and audit-log evidence may be High confidence.
+- If any reviewed project, folder, region, or service falls outside these rows, the finding should record a limitation instead of claiming full coverage.
+
+## Acceptable High-Confidence Finding Shape
+
+```text
+Status: Pass
+Evidence ID(s): GCP-EVID-01, GCP-EVID-02, GCP-EVID-03, GCP-EVID-06
+Evidence Source: Cloud Asset Inventory, Policy Analyzer, and Admin Activity logs
+Evidence Date: 2026-06-08
+Coverage: organizations/222222222222, folders/333333333333, payments-prod, payments-dr, analytics-prod
+Limitations: deleted assets older than 35 days are outside the CAI snapshot
+Confidence: High
+```

--- a/skills/cloud/gcp-review/tests/vulnerable/iac-only-stale-partial-evidence.md
+++ b/skills/cloud/gcp-review/tests/vulnerable/iac-only-stale-partial-evidence.md
@@ -1,0 +1,51 @@
+---
+name: iac-only-stale-partial-evidence
+expected: not-evaluable
+skill: gcp-review
+---
+
+# GCP Review Fixture: IaC-Only, Stale, and Partial Evidence
+
+Use this fixture to verify that `gcp-review` does not mark CIS GCP controls as Pass when evidence is stale, partial, or only describes intended Terraform state.
+
+## Review Scope
+
+- Organization: `organizations/222222222222`
+- Folder: `folders/333333333333`
+- Projects in scope: `payments-prod`, `payments-dr`, `analytics-prod`
+- Regions in scope: `us-central1`, `us-east1`, `europe-west1`
+- Review date: `2026-06-09`
+
+## Evidence Inventory
+
+| Evidence ID | Basis | Source / Query | Collection Date | Scope | Controls Supported | Limitations | Confidence |
+|-------------|-------|----------------|-----------------|-------|--------------------|-------------|------------|
+| GCP-EVID-01 | IaC intent | `terraform/envs/prod/**/*.tf` at commit `9f2c51a` | 2025-11-03 | `payments-prod` only | IAM, VPC firewall, Cloud SQL | Does not prove deployed state, excludes `payments-dr` and `analytics-prod`, no folder inheritance evidence | Low |
+| GCP-EVID-02 | Partial live export | `gcloud projects get-iam-policy payments-prod --format=json` | 2026-01-12 | `payments-prod` IAM only | CIS 1.x | 148 days old, no IAM change log, no service account key export, no folder/org inherited bindings | Low |
+| GCP-EVID-03 | Partial live export | `gcloud compute firewall-rules list --project payments-prod --format=json` | 2026-01-12 | `payments-prod`, `us-central1` | CIS 3.x | Missing `us-east1`, `europe-west1`, shared VPC host project, and hierarchical firewall policies | Low |
+| GCP-EVID-04 | Missing | Cloud Asset Inventory export | Missing | None | All deployed-state controls | No CAI snapshot is available | Low |
+| GCP-EVID-05 | Missing | Security Command Center findings export | Missing | None | Monitoring and posture controls | SCC evidence not provided | Low |
+| GCP-EVID-06 | Missing | Policy Analyzer / org policy inheritance query | Missing | None | IAM and org policy controls | Cannot prove parent folder policy applies to children | Low |
+| GCP-EVID-07 | Missing | Admin Activity audit log change review | Missing | None | Drift-sensitive controls | No evidence that IAM, firewall, or org policy was unchanged since January | Low |
+| GCP-EVID-08 | Result confidence | Reviewer conclusion | 2026-06-09 | Full scope requested | All CIS sections | Evidence is stale and incomplete | Low |
+
+## Expected Review Behavior
+
+- Do not mark IAM, firewall, Cloud SQL, logging, or storage controls as Pass for the full organization.
+- Mark deployed-state controls as `Not Evaluable` when they rely on `GCP-EVID-01` IaC intent alone.
+- Record `payments-dr`, `analytics-prod`, folder inheritance, shared VPC, and regional service gaps in limitations.
+- Treat the January `gcloud` exports as stale unless a change log proves no relevant drift occurred.
+- Require Cloud Asset Inventory, SCC, Policy Analyzer, org policy, or fresh `gcloud` evidence before raising confidence.
+
+## Anti-Pattern Under Test
+
+The review fails this fixture if it says:
+
+```text
+Status: Pass
+Evidence: Terraform denies public SSH and enables audit logging.
+Coverage: all production projects
+Confidence: High
+```
+
+That conclusion ignores GCP-EVID-01 through GCP-EVID-08: Terraform is only intended state, the live exports are stale and partial, and no parent inheritance or drift evidence supports full-scope confidence.


### PR DESCRIPTION
﻿## Summary
- Closes #1808
- Adds GCP evidence freshness gates for evidence basis, source/date, project/folder/org/region coverage, inherited authority, limitations, drift signals, confidence, and Not Evaluable behavior.
- Adds vulnerable and benign fixtures for IaC-only stale/partial evidence versus current live/exported inherited evidence.

## Verification
- `git diff --cached --check`
- Markdown fence-balance check over staged `.md` files
- Added-line ASCII check
- Marker check for `GCP-EVID-01` through `GCP-EVID-08`
- Added-line sensitive-pattern scan
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`

## Bounty
/claim #1808

Preferred payment method: crypto or PayPal after maintainer acceptance.
