### PR TITLE
Add Azure evidence freshness fixtures

### DIFF
--- a/skills/cloud/azure-review/SKILL.md
+++ b/skills/cloud/azure-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-Azure-v2.1.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -78,6 +78,25 @@ Use Glob to locate all Azure-related infrastructure definitions.
 
 Record all discovered files. If no Azure configurations are found, report that finding and halt.
 
+Before scoring any CIS control, build an Azure evidence freshness inventory:
+
+```
+| Evidence ID | Basis | Source / Query | Collected By | Collection Date | Tenant / Management Group / Subscription Scope | Region / Resource Scope | Controls Supported | Limitations | Confidence |
+|-------------|-------|----------------|--------------|-----------------|-----------------------------------------------|-------------------------|--------------------|-------------|------------|
+| AZ-EVID-01 | IaC intent / live-exported / partial / missing | <Terraform, Bicep, ARM, az, Resource Graph, Defender, Azure Policy> | <owner/tool> | <date> | <tenant/management groups/subscriptions> | <regions/resource groups/services> | <CIS IDs> | <coverage gaps/drift risk> | High / Medium / Low |
+```
+
+Apply these evidence gates before assigning Pass or Fail:
+
+- **AZ-EVID-01 Evidence basis:** classify each artifact as IaC intent, current live/exported state, partial evidence, or missing evidence. IaC alone is intended state and cannot prove deployed Azure state when drift is in scope.
+- **AZ-EVID-02 Source provenance:** identify the exact source or query, such as `az`, Azure Resource Graph, Defender for Cloud, Azure Policy, Entra ID, PIM, Activity Log, or portal export.
+- **AZ-EVID-03 Date and freshness:** record the collection date and compare it to the control's change velocity. RBAC, PIM, Conditional Access, NSG, Key Vault, and Defender-plan evidence usually needs fresher support than stable inherited Azure Policy.
+- **AZ-EVID-04 Scope coverage:** map evidence to the assessed tenant, management group, subscription, region, resource group, and service set. Partial subscription or regional exports cannot support full-environment Pass results.
+- **AZ-EVID-05 Inherited authority:** when management group, Azure Policy, or parent-scope RBAC evidence covers child subscriptions, document the hierarchy, assignment path, excluded children, and enforcement mode.
+- **AZ-EVID-06 Effective access path:** evaluate PIM activation history, eligible assignments, permanent assignments, Conditional Access, and emergency access exclusions before concluding that stale static RBAC evidence represents actual access.
+- **AZ-EVID-07 Drift and conflicts:** check recent Activity Log, policy assignment, Conditional Access, NSG, Defender, Key Vault, and RBAC changes where available. A stale artifact with no change-control evidence should be lower-confidence or Not Evaluable.
+- **AZ-EVID-08 Result confidence:** set High only when source, date, scope, inheritance, effective access, limitations, and drift checks support the conclusion. Use Medium/Low or Not Evaluable when evidence is stale, partial, or IaC-only.
+
 ---
 
 ### Step 2 through Step 10: CIS Benchmark Evaluation (Sections 1-9)
@@ -94,6 +113,13 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, Bic
 ### Step 11: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
+
+Before finalizing, ensure every Passed or Failed control references at least one
+inventory row and includes evidence basis, source, date, coverage, limitations,
+effective-access context, and confidence. If deployed-state drift matters and
+current live/exported evidence is unavailable, mark the control Not Evaluable or
+lower confidence instead of treating IaC intent as proof of the active Azure
+environment.
 
 ---
 
@@ -119,6 +145,16 @@ Produce the final report using the structure defined in the Output Format sectio
 - Date: <assessment date>
 - Framework: CIS Microsoft Azure Foundations Benchmark v2.1.0
 - Files reviewed: <list of IaC files>
+- Evidence basis: <IaC intent / live-exported / partial / missing / mixed>
+- Evidence freshness: <collection dates, git commits, and change-window rationale>
+- Tenant/Management Group/Subscription/Region coverage: <scope assessed and gaps>
+- Evidence limitations: <stale exports, missing services, inherited-scope gaps, live-state gaps>
+
+### Evidence Freshness Inventory
+
+| Evidence ID | Basis | Source / Query | Date | Scope | Controls Supported | Limitations | Confidence |
+|-------------|-------|----------------|------|-------|--------------------|-------------|------------|
+| AZ-EVID-01 | <basis> | <artifact/query> | <date> | <tenant/management-group/subscription/region/resource> | <CIS IDs> | <gaps> | High / Medium / Low |
 
 ### Executive Summary
 - Total CIS recommendations evaluated: <N>
@@ -152,6 +188,13 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration or code snippet>
+- **Evidence ID(s):** <AZ-EVID-## rows used>
+- **Evidence Source:** <IaC file / az export / Resource Graph / Defender / Azure Policy / PIM / live observation>
+- **Evidence Date:** <timestamp, commit, or observation date>
+- **Coverage:** <tenant, management group, subscription, region, resource group, service, and inherited scope>
+- **Effective Access Context:** <PIM, eligible/permanent assignment, Conditional Access, break-glass exclusions, if applicable>
+- **Limitations:** <missing subscriptions/services, stale exports, drift risk, or source constraints>
+- **Confidence:** High / Medium / Low
 - **Remediation:** <specific fix with code example>
 
 ### Prioritized Remediation Plan
@@ -200,6 +243,7 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **NSG rules using service tags.** A rule with `source_address_prefix = "Internet"` is equivalent to `0.0.0.0/0`. Both must be flagged for CIS 6.1 and 6.2.
 5. **Key Vault purge protection is irreversible.** CIS 8.5 requires `purge_protection_enabled = true`. Note this cannot be disabled once enabled -- flag this for awareness during remediation.
 6. **App Service TLS version on both Linux and Windows.** Check `azurerm_linux_web_app` and `azurerm_windows_web_app` resources separately.
+7. **Treating IaC as live deployed evidence.** Terraform, Bicep, ARM templates, and policy files show intended state, not necessarily active Azure state. For controls affected by portal changes, management group inheritance, PIM activation, Conditional Access drift, regional services, or recent RBAC/NSG/Key Vault changes, require fresh live/exported evidence or mark the conclusion lower-confidence or Not Evaluable.
 
 ---
 
@@ -231,4 +275,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Added Azure evidence freshness, coverage, inherited-scope, effective-access, drift, and confidence gates plus report fields.
 - **1.0.0** -- Initial release. Full coverage of CIS Microsoft Azure Foundations Benchmark v2.1.0 sections 1 through 9.

--- a/skills/cloud/azure-review/tests/benign/live-current-management-group-pim-evidence.md
+++ b/skills/cloud/azure-review/tests/benign/live-current-management-group-pim-evidence.md
@@ -1,0 +1,51 @@
+---
+name: live-current-management-group-pim-evidence
+expected: high-confidence
+skill: azure-review
+---
+
+# Azure Review Fixture: Current Live Evidence with Management Group and PIM Scope
+
+Use this fixture to verify that `azure-review` can assign high confidence when live/exported evidence is current, scoped, and reconciled with management group inheritance, PIM, Conditional Access, and Azure Policy state.
+
+## Review Scope
+
+- Tenant: `contoso.example`
+- Management group: `mg-payments-prod`
+- Subscriptions in scope: `sub-payments-prod`, `sub-payments-dr`, `sub-analytics-prod`
+- Regions in scope: `eastus`, `westus3`, `westeurope`
+- Review date: `2026-06-09`
+
+## Evidence Inventory
+
+| Evidence ID | Basis | Source / Query | Collection Date | Scope | Controls Supported | Limitations | Confidence |
+|-------------|-------|----------------|-----------------|-------|--------------------|-------------|------------|
+| AZ-EVID-01 | Live-exported | Azure Resource Graph export `arg-tenant-contoso-2026-06-08.json` | 2026-06-08 | Tenant, `mg-payments-prod`, all three subscriptions, all in-scope regions | RBAC, NSG, Storage, VM, SQL, Key Vault, App Service | Excludes deleted resources outside Activity Log retention | High |
+| AZ-EVID-02 | Live-exported | `az policy assignment list --scope /providers/Microsoft.Management/managementGroups/mg-payments-prod` | 2026-06-08 | Management group and inherited child subscriptions | Azure Policy and Defender coverage | Excludes sandbox subscriptions outside review scope | High |
+| AZ-EVID-03 | Live-exported | Entra ID Conditional Access policy export plus named-location inventory | 2026-06-08 | Tenant-wide user and workload access policies | CIS 1.x | Break-glass exclusions are separately listed and approved | High |
+| AZ-EVID-04 | Live-exported | PIM eligible assignment and activation history export | 2026-06-08 | Privileged roles across management group and child subscriptions | Identity and effective access | Covers 90-day activation history and current eligibilities | High |
+| AZ-EVID-05 | Live-exported | Defender for Cloud regulatory compliance export | 2026-06-08 | All in-scope subscriptions | Defender, VM, SQL, Storage, Key Vault posture | Mute rules reviewed separately | High |
+| AZ-EVID-06 | Live-exported | Activity Log review for RBAC, policy, CA, NSG, Key Vault, and Defender changes | 2026-06-01 to 2026-06-09 | Tenant and in-scope subscriptions | Drift-sensitive controls | Seven-day window matches daily change-control review | High |
+| AZ-EVID-07 | Mixed | Bicep and Terraform pipeline records | 2026-06-08 | Production modules for all in-scope subscriptions | Intended state cross-check | Used only to reconcile live state, not as sole proof | Medium |
+| AZ-EVID-08 | Result confidence | Reviewer conclusion | 2026-06-09 | Full review scope | All CIS sections | Live evidence is current and scope gaps are documented | High |
+
+## Expected Review Behavior
+
+- Findings should cite the specific `AZ-EVID-##` rows used for each Passed, Failed, or Not Evaluable control.
+- Management group policy and RBAC evidence can support child subscriptions only because `AZ-EVID-01`, `AZ-EVID-02`, and `AZ-EVID-04` document the inheritance path and excluded scope.
+- PIM and Conditional Access conclusions should include effective-access context from `AZ-EVID-03` and `AZ-EVID-04`.
+- IaC evidence in `AZ-EVID-07` can corroborate live exports but should not override fresher live evidence.
+- If any reviewed subscription, region, or service falls outside these rows, the finding should record a limitation instead of claiming full coverage.
+
+## Acceptable High-Confidence Finding Shape
+
+```text
+Status: Pass
+Evidence ID(s): AZ-EVID-01, AZ-EVID-02, AZ-EVID-03, AZ-EVID-04, AZ-EVID-06
+Evidence Source: Azure Resource Graph, Azure Policy, Conditional Access, PIM, and Activity Log exports
+Evidence Date: 2026-06-08
+Coverage: tenant contoso.example, mg-payments-prod, sub-payments-prod, sub-payments-dr, sub-analytics-prod
+Effective Access Context: PIM eligible assignments and 90-day activation history reviewed; break-glass exclusions approved
+Limitations: deleted resources outside Activity Log retention are not represented in ARG
+Confidence: High
+```

--- a/skills/cloud/azure-review/tests/vulnerable/iac-only-stale-pim-ca-evidence.md
+++ b/skills/cloud/azure-review/tests/vulnerable/iac-only-stale-pim-ca-evidence.md
@@ -1,0 +1,52 @@
+---
+name: iac-only-stale-pim-ca-evidence
+expected: not-evaluable
+skill: azure-review
+---
+
+# Azure Review Fixture: IaC-Only, Stale PIM, and Conditional Access Drift
+
+Use this fixture to verify that `azure-review` does not mark CIS Azure controls as Pass when evidence is stale, partial, or only describes intended Terraform/Bicep state.
+
+## Review Scope
+
+- Tenant: `contoso.example`
+- Management group: `mg-payments-prod`
+- Subscriptions in scope: `sub-payments-prod`, `sub-payments-dr`, `sub-analytics-prod`
+- Regions in scope: `eastus`, `westus3`, `westeurope`
+- Review date: `2026-06-09`
+
+## Evidence Inventory
+
+| Evidence ID | Basis | Source / Query | Collection Date | Scope | Controls Supported | Limitations | Confidence |
+|-------------|-------|----------------|-----------------|-------|--------------------|-------------|------------|
+| AZ-EVID-01 | IaC intent | `terraform/envs/prod/**/*.tf` at commit `41b1c0d` | 2025-11-17 | `sub-payments-prod` only | RBAC, NSG, Key Vault, Defender | Does not prove deployed state, excludes DR and analytics subscriptions, no management group inheritance proof | Low |
+| AZ-EVID-02 | Partial live export | `az role assignment list --subscription sub-payments-prod` | 2025-12-22 | `sub-payments-prod` permanent assignments only | CIS 1.x | No PIM eligible assignment or activation history, no management group inherited RBAC, stale by 169 days | Low |
+| AZ-EVID-03 | Partial live export | `az network nsg list --subscription sub-payments-prod --query []` | 2026-01-04 | `sub-payments-prod`, `eastus` | CIS 6.x | Missing `westus3`, `westeurope`, Azure Firewall policy, and peered/shared services subscription | Low |
+| AZ-EVID-04 | Missing | Azure Resource Graph subscription-wide inventory | Missing | None | All deployed-state controls | No ARG evidence for full tenant or all subscriptions | Low |
+| AZ-EVID-05 | Missing | Defender for Cloud regulatory compliance export | Missing | None | Defender, VM, SQL, Storage, Key Vault | Cannot confirm Defender plan state or recommendations | Low |
+| AZ-EVID-06 | Missing | PIM activation and eligible-assignment export | Missing | None | Identity and effective access controls | Cannot distinguish permanent stale RBAC from JIT access path | Low |
+| AZ-EVID-07 | Missing | Conditional Access policy inventory and Activity Log review | Missing | None | Identity, access, monitoring | Cannot detect new partner-portal policy or CA drift since old review | Low |
+| AZ-EVID-08 | Result confidence | Reviewer conclusion | 2026-06-09 | Full scope requested | All CIS sections | Evidence is stale, partial, and lacks effective-access context | Low |
+
+## Expected Review Behavior
+
+- Do not mark RBAC, PIM, Conditional Access, NSG, Defender, Key Vault, or Storage controls as Pass for the full tenant.
+- Mark deployed-state controls as `Not Evaluable` when they rely on `AZ-EVID-01` IaC intent alone.
+- Record missing management group inheritance, `sub-payments-dr`, `sub-analytics-prod`, regional coverage, PIM activation history, and Conditional Access drift in limitations.
+- Treat the old `az` exports as stale unless Activity Log and change-control evidence proves no relevant drift occurred.
+- Require Resource Graph, Defender, Azure Policy, PIM, Conditional Access, or fresh `az` evidence before raising confidence.
+
+## Anti-Pattern Under Test
+
+The review fails this fixture if it says:
+
+```text
+Status: Pass
+Evidence: Terraform requires MFA and denies public NSG management access.
+Coverage: all production subscriptions
+Effective Access Context: not needed
+Confidence: High
+```
+
+That conclusion ignores AZ-EVID-01 through AZ-EVID-08: Terraform is only intended state, the live exports are stale and partial, PIM/Conditional Access evidence is missing, and no management group inheritance or drift evidence supports full-scope confidence.


### PR DESCRIPTION
﻿## Summary
- Closes #1806
- Adds Azure evidence freshness gates for evidence basis, source/date, tenant/management-group/subscription/region coverage, inherited authority, PIM/effective-access context, limitations, drift signals, confidence, and Not Evaluable behavior.
- Adds vulnerable and benign fixtures for IaC-only stale/partial evidence versus current live/exported management-group and PIM evidence.

## Verification
- `git diff --cached --check`
- Markdown fence-balance check over staged `.md` files
- Added-line ASCII check
- Marker check for `AZ-EVID-01` through `AZ-EVID-08`
- Added-line sensitive-pattern scan
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`

## Bounty
/claim #1806

Preferred payment method: crypto or PayPal after maintainer acceptance.
