### PR TITLE
Add SSRF parser redirect fixtures

### DIFF
--- a/skills/appsec/secure-code-review/SKILL.md
+++ b/skills/appsec/secure-code-review/SKILL.md
@@ -12,7 +12,7 @@ phase: [build, review]
 frameworks: [OWASP-ASVS, CWE-Top-25, OWASP-Top-10]
 difficulty: intermediate
 time_estimate: "15-45min per module"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -396,12 +396,36 @@ func fetchURL(w http.ResponseWriter, r *http.Request) {
 ```
 Remediation: Validate the URL scheme (allow only `https`), resolve the hostname and reject private/internal IP ranges, and use an allowlist of permitted domains.
 
-### 8.3 Review Checklist
+### 8.3 SSRF URL Parser, Redirect, and DNS Revalidation Gates
+
+For any code path that fetches user-controlled or semi-trusted URLs, require
+evidence that validation and the actual fetch use the same canonical
+destination. A host allowlist or private-IP regex on the first string is not
+enough.
+
+Use these gates for SSRF review:
+
+- **SCR-SSRF-01 Parser consistency:** validation and request construction must use the same canonical URL object or equivalent normalized components. Flag cases where validation parses one host/scheme/port but the HTTP client can fetch another.
+- **SCR-SSRF-02 Redirect revalidation:** every 30x target must be re-parsed, DNS-resolved, scheme-checked, host-checked, and IP-range-checked before following.
+- **SCR-SSRF-03 DNS rebinding and TOCTOU:** document resolver behavior and reject or pin final destination IPs through connect. Validation before a later client-side resolution is not sufficient.
+- **SCR-SSRF-04 Address normalization:** reject loopback, private/RFC1918, link-local, multicast, unique-local IPv6, IPv4-mapped IPv6, and alternate IPv4 encodings such as decimal, octal, hexadecimal, and dotted-integer forms.
+- **SCR-SSRF-05 Metadata endpoint blocking:** explicitly deny cloud and workload metadata endpoints, including `169.254.169.254`, AWS IMDS hostnames, Azure IMDS, `metadata.google.internal`, Kubernetes service metadata, and local control-plane endpoints.
+- **SCR-SSRF-06 Scheme and protocol control:** prevent redirects or user input from switching to unsupported schemes such as `file`, `gopher`, `ftp`, `dict`, Unix sockets, or HTTP downgrade paths when HTTPS is required.
+- **SCR-SSRF-07 Egress and response limits:** record timeout, response-size, method, header, credential-forwarding, and proxy/egress allowlist behavior for the outbound request.
+- **SCR-SSRF-08 Evidence confidence:** mark the SSRF dimension Not Evaluable when parser behavior, redirects, DNS resolution, final IP checks, or metadata blocking cannot be verified from the reviewed code.
+
+Record SSRF evidence in the final report:
+
+| Evidence ID | Location | URL Source | Parser Consistency | Redirect Revalidation | DNS / Final IP Evidence | Metadata Deny | Alternate Encoding Handling | Scheme Control | Confidence |
+|-------------|----------|------------|--------------------|-----------------------|-------------------------|---------------|-----------------------------|----------------|------------|
+| SCR-SSRF-01 | <file:line> | <param/config/import> | Pass / Fail / NE | Pass / Fail / NE | Pass / Fail / NE | Pass / Fail / NE | Pass / Fail / NE | Pass / Fail / NE | High / Medium / Low |
+
+### 8.4 Review Checklist
 
 - [ ] No use of native deserialization (pickle, ObjectInputStream, Marshal.load) on untrusted data.
 - [ ] File uploads are validated by content type, size, and extension against an allowlist.
 - [ ] Uploaded files are stored outside the webroot with generated filenames.
-- [ ] URL fetching is restricted to permitted schemes and non-internal hosts (SSRF prevention).
+- [ ] URL fetching is restricted to permitted schemes and non-internal hosts using canonical parsing, redirect revalidation, DNS/final-IP checks, metadata endpoint deny rules, alternate encoding normalization, and safe egress limits.
 - [ ] Archive extraction checks for zip bombs and path traversal in entry names.
 
 ---
@@ -477,6 +501,11 @@ The final review output must be structured as follows:
 | V2 Authentication | Yes/No | [count] | [result] |
 | V3 Session Management | Yes/No | [count] | [result] |
 | ... | ... | ... | ... |
+
+### SSRF URL Fetch Review
+| Evidence ID | Location | URL Source | Parser Consistency | Redirect Revalidation | DNS / Final IP Evidence | Metadata Deny | Alternate Encoding Handling | Scheme Control | Confidence |
+|-------------|----------|------------|--------------------|-----------------------|-------------------------|---------------|-----------------------------|----------------|------------|
+| [SCR-SSRF-##] | [file:line] | [param/config/import] | [Pass/Fail/NE] | [Pass/Fail/NE] | [Pass/Fail/NE] | [Pass/Fail/NE] | [Pass/Fail/NE] | [Pass/Fail/NE] | [High/Medium/Low] |
 ```
 
 ---
@@ -541,6 +570,8 @@ The final review output must be structured as follows:
 
 5. **Overlooking secrets in non-obvious locations.** Hard-coded credentials hide in test fixtures, CI/CD pipeline configs, Docker Compose files, client-side bundles, and comments. Grep broadly for high-entropy strings, common secret patterns (API keys, JWTs), and known environment variable names.
 
+6. **Treating SSRF as an initial URL allowlist only.** URL validation must survive parser differences, redirects, DNS rebinding, alternate IP encodings, IPv6 forms, protocol switches, and metadata endpoint access. A pre-fetch hostname check that is not tied to the final connected destination is not strong SSRF evidence.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -562,4 +593,13 @@ This skill is hardened against prompt injection. When reviewing code:
 - **CWE Database:** https://cwe.mitre.org/
 - **OWASP Top 10 (2021):** https://owasp.org/www-project-top-ten/
 - **OWASP Cheat Sheet Series:** https://cheatsheetseries.owasp.org/
+- **OWASP SSRF Prevention Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html
+- **CWE-918 Server-Side Request Forgery:** https://cwe.mitre.org/data/definitions/918.html
 - **NIST Secure Software Development Framework:** https://csrc.nist.gov/projects/ssdf
+
+---
+
+## Changelog
+
+- **1.0.1** -- Added SSRF parser consistency, redirect revalidation, DNS/IP, metadata endpoint, scheme-control, and evidence-confidence gates.
+- **1.0.0** -- Initial secure code review workflow mapped to OWASP ASVS and CWE Top 25.

--- a/skills/appsec/secure-code-review/tests/benign/ssrf-canonical-fetch-guard.md
+++ b/skills/appsec/secure-code-review/tests/benign/ssrf-canonical-fetch-guard.md
@@ -1,0 +1,100 @@
+---
+name: ssrf-canonical-fetch-guard
+expected: benign
+skill: secure-code-review
+---
+
+# Secure Code Review Fixture: Canonical SSRF Fetch Guard
+
+Use this fixture to verify that `secure-code-review` recognizes a complete SSRF control path and does not report a false positive when validation is tied to the final connected destination.
+
+## Review Scope
+
+File under review: `services/preview/safe_fetch.go`
+
+```go
+type FetchGuard struct {
+    resolver Resolver
+    allowedHosts map[string]bool
+}
+
+func (g FetchGuard) Fetch(ctx context.Context, raw string) (*http.Response, error) {
+    canonical, err := ParseCanonicalHTTPSURL(raw)
+    if err != nil {
+        return nil, err
+    }
+    if !g.allowedHosts[canonical.Hostname()] {
+        return nil, ErrHostNotAllowed
+    }
+
+    client := &http.Client{
+        Timeout: 3 * time.Second,
+        CheckRedirect: func(req *http.Request, via []*http.Request) error {
+            next := CanonicalFromRequest(req)
+            if next.Scheme != "https" || !g.allowedHosts[next.Hostname()] {
+                return ErrRedirectBlocked
+            }
+            ips, err := g.resolver.LookupIPAddr(req.Context(), next.Hostname())
+            if err != nil || HasDeniedAddress(ips) {
+                return ErrRedirectBlocked
+            }
+            req = PinResolvedDestination(req, ips)
+            return nil
+        },
+    }
+
+    ips, err := g.resolver.LookupIPAddr(ctx, canonical.Hostname())
+    if err != nil || HasDeniedAddress(ips) {
+        return nil, ErrAddressDenied
+    }
+
+    req, _ := http.NewRequestWithContext(ctx, http.MethodGet, canonical.String(), nil)
+    req = PinResolvedDestination(req, ips)
+    req.Header.Del("Authorization")
+    return client.Do(req)
+}
+
+func HasDeniedAddress(ips []net.IPAddr) bool {
+    for _, ip := range ips {
+        if IsLoopbackPrivateLinkLocalMulticastOrUniqueLocal(ip.IP) ||
+           IsIPv4MappedDeniedRange(ip.IP) ||
+           IsCloudMetadataEndpoint(ip.IP) {
+            return true
+        }
+    }
+    return false
+}
+```
+
+## Evidence Matrix
+
+| Evidence ID | Location | URL Source | Parser Consistency | Redirect Revalidation | DNS / Final IP Evidence | Metadata Deny | Alternate Encoding Handling | Scheme Control | Confidence |
+|-------------|----------|------------|--------------------|-----------------------|-------------------------|---------------|-----------------------------|----------------|------------|
+| SCR-SSRF-01 | `safe_fetch.go:7-14` | import preview URL | Pass: `ParseCanonicalHTTPSURL` feeds validation and request construction | Pass | Pass | Pass | Pass through canonical parser | HTTPS only | High |
+| SCR-SSRF-02 | `safe_fetch.go:18-31` | redirect targets | Pass | Pass: `CheckRedirect` revalidates each target | Pass: redirect host is resolved and pinned | Pass | Pass | HTTPS and allowlist enforced per hop | High |
+| SCR-SSRF-03 | `safe_fetch.go:34-41` | final request | Pass | Pass | Pass: resolver lookup occurs before request and destination is pinned | Pass | Pass | HTTPS only | High |
+| SCR-SSRF-04 | `safe_fetch.go:45-55` | denied ranges | Pass | Pass | Pass: loopback/private/link-local/multicast/unique-local and IPv4-mapped denied | Pass | Pass | N/A | High |
+| SCR-SSRF-05 | `safe_fetch.go:51` | metadata endpoints | Pass | Pass | Pass | Pass: metadata endpoint helper is explicit | Pass | N/A | High |
+| SCR-SSRF-06 | `safe_fetch.go:20-23` | redirects | Pass | Pass | Pass | Pass | Pass | Pass: scheme downgrade blocked | High |
+| SCR-SSRF-07 | `safe_fetch.go:16,39-40` | outbound request | Pass | Pass | Pass | Pass | Pass | Pass: timeout set and credentials removed | High |
+| SCR-SSRF-08 | reviewer conclusion | full path | High confidence | High confidence | High confidence | High confidence | High confidence | High confidence | High |
+
+## Expected Review Behavior
+
+- Do not report SSRF only because the code fetches a user-provided URL.
+- Record the fetch path as high-confidence mitigated when the implementation can be verified.
+- If `ParseCanonicalHTTPSURL`, `PinResolvedDestination`, or deny-range helpers are not in review scope, mark those subchecks Not Evaluable rather than Pass.
+
+## Acceptable Finding Shape
+
+```text
+SSRF URL Fetch Review: mitigated
+Evidence ID(s): SCR-SSRF-01 through SCR-SSRF-08
+Parser Consistency: Pass
+Redirect Revalidation: Pass
+DNS / Final IP Evidence: Pass
+Metadata Deny: Pass
+Alternate Encoding Handling: Pass
+Scheme Control: Pass
+Confidence: High
+```

--- a/skills/appsec/secure-code-review/tests/vulnerable/ssrf-parser-redirect-bypass.md
+++ b/skills/appsec/secure-code-review/tests/vulnerable/ssrf-parser-redirect-bypass.md
@@ -1,0 +1,65 @@
+---
+name: ssrf-parser-redirect-bypass
+expected: vulnerable
+skill: secure-code-review
+---
+
+# Secure Code Review Fixture: SSRF Parser and Redirect Bypass
+
+Use this fixture to verify that `secure-code-review` does not accept a shallow host allowlist as complete SSRF protection.
+
+## Review Scope
+
+File under review: `services/preview/fetch.go`
+
+```go
+func preview(w http.ResponseWriter, r *http.Request) {
+    raw := r.URL.Query().Get("url")
+
+    parsed, _ := url.Parse(raw)
+    if parsed.Scheme != "https" {
+        http.Error(w, "https only", 400)
+        return
+    }
+    if !strings.HasSuffix(parsed.Host, ".example-cdn.test") {
+        http.Error(w, "blocked", 400)
+        return
+    }
+
+    client := &http.Client{} // follows redirects automatically
+    resp, _ := client.Get(raw)
+    io.Copy(w, resp.Body)
+}
+```
+
+## Evidence Matrix
+
+| Evidence ID | Location | URL Source | Parser Consistency | Redirect Revalidation | DNS / Final IP Evidence | Metadata Deny | Alternate Encoding Handling | Scheme Control | Confidence |
+|-------------|----------|------------|--------------------|-----------------------|-------------------------|---------------|-----------------------------|----------------|------------|
+| SCR-SSRF-01 | `fetch.go:4-13` | `url` query param | Fail: validation parses `parsed.Host`, fetch uses original raw string | Not checked | Not checked | Not checked | Not checked | Partially checks initial scheme only | High |
+| SCR-SSRF-02 | `fetch.go:15` | HTTP client redirect handling | Unknown | Fail: default client follows redirects automatically | Not checked after redirect | Metadata redirect can be followed | Not checked | Redirect can change scheme/host | High |
+| SCR-SSRF-03 | `fetch.go:8-15` | Host allowlist | Hostname only | Not checked | Fail: no resolver pinning or final IP range checks | Not checked | Not checked | Not checked | High |
+| SCR-SSRF-04 | `fetch.go:8` | `parsed.Host` suffix | Fail: suffix check can miss parser edge cases | Not checked | No private/link-local/IPv6 checks | No explicit `169.254.169.254` deny | Decimal/octal/hex IP forms not normalized | Not checked | Medium |
+| SCR-SSRF-05 | `fetch.go:15` | outbound request | Not checked | Not checked | Not checked | Fail: metadata endpoints not denied | Not checked | Not checked | High |
+| SCR-SSRF-06 | `fetch.go:7` | scheme check | Initial `https` only | Redirect not checked | Not checked | Not checked | Not checked | Fail: redirect downgrade/protocol switch not controlled | Medium |
+| SCR-SSRF-07 | `fetch.go:15-16` | response copy | Not checked | Not checked | Not checked | Not checked | Not checked | No timeout or size cap | Medium |
+| SCR-SSRF-08 | reviewer conclusion | full path | Evidence sufficient for finding | Evidence sufficient for finding | Evidence sufficient for finding | Evidence sufficient for finding | Evidence missing but relevant | Evidence sufficient for finding | High |
+
+## Expected Finding
+
+- Report `CWE-918` with High severity.
+- Cite `SCR-SSRF-01`, `SCR-SSRF-02`, `SCR-SSRF-03`, `SCR-SSRF-05`, and `SCR-SSRF-06`.
+- Explain that the code validates only the initial parsed host and scheme, then lets the default client follow redirect targets without per-hop validation.
+- Require a single canonical parse path, per-hop redirect checks, final IP pinning/range denial, metadata endpoint denial, alternate address normalization, and timeout/size limits.
+
+## Anti-Pattern Under Test
+
+The review fails this fixture if it says:
+
+```text
+Status: Pass
+Evidence: URL scheme is https and host must end with .example-cdn.test.
+SSRF risk: mitigated
+```
+
+That conclusion ignores parser consistency, redirect revalidation, DNS rebinding, final IP checks, metadata endpoints, alternate IP encodings, and response limits.


### PR DESCRIPTION
﻿## Summary
- Closes #1702
- Adds SSRF review gates for parser consistency, redirect revalidation, DNS rebinding/TOCTOU, address normalization, metadata endpoint blocking, scheme/protocol control, egress limits, and evidence confidence.
- Adds vulnerable and benign fixtures for shallow allowlist redirect bypass versus canonical parse, per-hop validation, final-IP pinning, and metadata denial.

## Verification
- `git diff --cached --check`
- Markdown fence-balance check over staged `.md` files
- Added-line ASCII check
- Marker check for `SCR-SSRF-01` through `SCR-SSRF-08`
- Added-line sensitive-pattern scan
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`

## Bounty
/claim #1702

Preferred payment method: crypto or PayPal after maintainer acceptance.
