### PR TITLE
Add AWS public snapshot sharing fixtures

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-AWS-v3.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -55,6 +55,7 @@ The CIS Amazon Web Services Foundations Benchmark v3.0.0 is a consensus-driven s
 - S3 bucket policies and ACL configurations
 - VPC, security group, and NACL definitions
 - CloudTrail and CloudWatch configuration files
+- RDS snapshot, EBS snapshot, AMI launch-permission, and EBS block-public-access exports when backup/image artifacts are in scope
 
 ---
 
@@ -96,6 +97,32 @@ Record all discovered files. If no AWS configurations are found, report that fin
 Evaluate all AWS configurations against CIS AWS v3.0.0 Sections 1 through 5, covering Identity and Access Management, Storage, Logging, Monitoring, and Networking.
 
 For detailed CIS benchmark checklist items with specific Terraform patterns, grep patterns, and configuration examples for all five sections, see [benchmark-checklist.md](benchmark-checklist.md) in this skill directory.
+
+### Step 6A: Supplemental Public Snapshot and Image Sharing Evidence
+
+When the environment includes RDS, EBS, AMIs, backup automation, or account image pipelines, add a supplemental storage-artifact review. Do not report these as CIS recommendation IDs unless the reviewed benchmark explicitly includes them; report them as AWS snapshot/image artifact evidence because private live resources do not prove private backup artifacts.
+
+| ID | Evidence Gate | What to Verify | Finding Behavior |
+|---|---|---|---|
+| AWS-SNAP-01 | RDS manual snapshot restore attributes | Capture `describe-db-snapshots --snapshot-type manual --include-public` and `describe-db-snapshot-attributes` evidence. Public `restore` attributes such as `all` are exposure evidence even if the live DB is private. | Fail when production-derived or sensitive manual snapshots are public; Not Evaluable when only live RDS IaC is available. |
+| AWS-SNAP-02 | EBS snapshot createVolumePermission | Capture `describe-snapshot-attribute --attribute createVolumePermission` for in-scope Regions and identify `Group=all` or unapproved account sharing. | Fail for public snapshots unless an effective block neutralizes public access and residual raw sharing is documented. |
+| AWS-SNAP-03 | Regional EBS block public access mode | Capture `get-snapshot-block-public-access-state` per Region and distinguish `block-all-sharing`, `block-new-sharing`, and unblocked states. | Do not treat one Region or `block-new-sharing` alone as proof that existing public snapshots are private. |
+| AWS-SNAP-04 | AMI launch permissions | Capture `describe-image-attribute --attribute launchPermission` and map public AMIs to referenced snapshots where possible. | Fail when public AMIs expose launchable production images or snapshot-derived sensitive data. |
+| AWS-SNAP-05 | Artifact sensitivity and lineage | Identify whether snapshots/AMIs are production-derived, regulated, customer-data-bearing, or sanitized test artifacts. | Calibrate severity by data sensitivity and lineage rather than live resource posture alone. |
+| AWS-SNAP-06 | Explicit cross-account sharing governance | For non-public sharing, require approved account list, owner, purpose, ticket, expiry/review date, and revocation evidence. | Medium or Not Evaluable when sharing exists without governance, even if not public. |
+| AWS-SNAP-07 | Coverage denominator | Record account, Region, artifact type, and inventory source so absent findings are tied to the reviewed scope. | Not Evaluable when an assessment lacks live snapshot/AMI inventory for in-scope Regions. |
+| AWS-SNAP-08 | Remediation evidence | For public artifacts, require private attribute verification after remediation plus block-public-access mode or exception review evidence. | Keep findings open until both raw artifact attributes and account/Region guardrails are verified. |
+
+Add these fields to relevant detailed findings:
+
+- `Artifact Type`: RDS snapshot / EBS snapshot / AMI
+- `Artifact ID and Region`
+- `Public Attribute`: `restore`, `createVolumePermission`, or `launchPermission`
+- `Block Public Access State`
+- `Shared Accounts`
+- `Data Sensitivity / Lineage`
+- `Coverage Source`
+- `Remediation Verification`
 
 ---
 
@@ -200,6 +227,7 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
 5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
 6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
+7. **Assuming private live resources imply private backup artifacts.** A private RDS instance, encrypted EBS volume, or non-public subnet does not prove manual snapshots, copied snapshots, or AMI launch permissions are private. Review snapshot and AMI attributes separately.
 
 ---
 
@@ -231,4 +259,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Added supplemental public RDS snapshot, EBS snapshot, AMI launch-permission, block-public-access, sharing-governance, and remediation-evidence gates with artifact-specific output fields.
 - **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 (62 recommendations).

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -251,6 +251,67 @@ publicly_accessible = true
 publicly_accessible = false
 ```
 
+### Supplemental -- Public RDS/EBS Snapshot and AMI Sharing Evidence
+
+This supplemental gate is not a CIS recommendation ID. Apply it when RDS, EBS, AMIs, backup automation, image pipelines, or live AWS exports are in scope.
+
+**AWS-SNAP-01 -- RDS manual snapshot restore attributes**
+
+Required evidence:
+
+```text
+aws rds describe-db-snapshots --snapshot-type manual --include-public
+aws rds describe-db-snapshot-attributes --db-snapshot-identifier <snapshot-id>
+```
+
+Fail when a production-derived or sensitive manual DB snapshot has a public `restore` attribute such as `all`. Mark Not Evaluable when the review only includes live RDS IaC and has no snapshot inventory.
+
+**AWS-SNAP-02 -- EBS snapshot createVolumePermission**
+
+Required evidence:
+
+```text
+aws ec2 describe-snapshot-attribute --snapshot-id <snapshot-id> --attribute createVolumePermission
+```
+
+Fail when `createVolumePermission` includes `Group=all` unless effective account/Region guardrails are documented and the raw public attribute is being remediated.
+
+**AWS-SNAP-03 -- Regional EBS block public access state**
+
+Required evidence per Region:
+
+```text
+aws ec2 get-snapshot-block-public-access-state --region <region>
+```
+
+Record whether the Region is `block-all-sharing`, `block-new-sharing`, or unblocked. Do not treat `block-new-sharing` as proof that already-public snapshots are private.
+
+**AWS-SNAP-04 -- AMI launch permissions**
+
+Required evidence:
+
+```text
+aws ec2 describe-image-attribute --image-id <ami-id> --attribute launchPermission
+```
+
+Fail when production-derived AMIs are public or when referenced snapshot lineage is missing for a public or externally shared image.
+
+**AWS-SNAP-05 through AWS-SNAP-08 -- Governance and remediation**
+
+For each public or externally shared artifact, record:
+
+- artifact type, ID, account, Region, and inventory source;
+- data sensitivity and production/test lineage;
+- explicit shared accounts, owner, ticket, expiry/review date, and business purpose;
+- remediation verification showing the artifact attribute is private or the exception is approved;
+- post-remediation block-public-access state where EBS snapshots are involved.
+
+**Common false-positive guardrails:**
+
+- Encrypted RDS snapshots cannot be public, but explicit account sharing still needs approval and expiry evidence.
+- A public AMI and an EBS snapshot are related but not identical evidence paths; review both when image lineage is relevant.
+- A clean Terraform definition for a private DB or encrypted volume is insufficient evidence for manual snapshots, copied snapshots, or AMI permissions.
+
 ### CIS 2.4.1 -- Ensure that encryption is enabled for EFS file systems
 
 Check for EFS encryption configuration:

--- a/skills/cloud/aws-review/tests/benign/private-snapshot-governed-sharing.md
+++ b/skills/cloud/aws-review/tests/benign/private-snapshot-governed-sharing.md
@@ -1,0 +1,53 @@
+# Benign: Private Snapshots With Governed Sharing
+
+## Scenario
+
+Production snapshots exist, but public sharing is blocked and a private analytics copy has documented governance.
+
+## Evidence
+
+```text
+aws rds describe-db-snapshot-attributes --db-snapshot-identifier prod-ledger-2026-06-01
+restore:
+  - 111122223333
+
+aws ec2 describe-snapshot-attribute --snapshot-id snap-0ledgercopy --attribute createVolumePermission
+createVolumePermission:
+  - UserId: 111122223333
+
+aws ec2 get-snapshot-block-public-access-state --region us-east-1
+State: block-all-sharing
+
+aws ec2 describe-image-attribute --image-id ami-0privategolden --attribute launchPermission
+launchPermission:
+  - UserId: 111122223333
+```
+
+## Governance Evidence
+
+- Account `111122223333` is the approved analytics account in the same AWS Organization.
+- Ticket: `SEC-7421`.
+- Owner: Data Platform.
+- Purpose: monthly sanitized analytics copy.
+- Expiry/review date: 2026-07-31.
+- Data lineage: sanitized copy job `ledger-snapshot-redaction-v4`.
+- Remediation check: no `Group=all` restore, create-volume, or launch permissions found in us-east-1.
+
+## Expected Skill Behavior
+
+The AWS review should not report this as public snapshot exposure.
+
+Required satisfied gates:
+
+- `AWS-SNAP-01` records non-public RDS snapshot restore sharing.
+- `AWS-SNAP-02` records explicit account-only EBS snapshot sharing.
+- `AWS-SNAP-03` records `block-all-sharing` for the reviewed Region.
+- `AWS-SNAP-04` records non-public AMI launch permission.
+- `AWS-SNAP-05` captures sanitized lineage.
+- `AWS-SNAP-06` captures owner, ticket, purpose, expiry, and approved account.
+- `AWS-SNAP-07` captures account and Region coverage.
+- `AWS-SNAP-08` records verification evidence.
+
+## Correct Classification
+
+Informational or Pass for public exposure, with a governed private-sharing note.

--- a/skills/cloud/aws-review/tests/vulnerable/public-snapshot-and-ami-sharing.md
+++ b/skills/cloud/aws-review/tests/vulnerable/public-snapshot-and-ami-sharing.md
@@ -1,0 +1,58 @@
+# Vulnerable: Public Backup and Image Artifacts
+
+## Scenario
+
+The live database and EC2 fleet appear private, but backup artifacts are publicly shareable.
+
+## Evidence
+
+```text
+aws rds describe-db-snapshot-attributes --db-snapshot-identifier prod-orders-2026-06-01
+restore:
+  - all
+
+aws ec2 describe-snapshot-attribute --snapshot-id snap-0prodorders --attribute createVolumePermission
+createVolumePermission:
+  - Group: all
+
+aws ec2 get-snapshot-block-public-access-state --region us-east-1
+State: block-new-sharing
+
+aws ec2 describe-image-attribute --image-id ami-0prodweb --attribute launchPermission
+launchPermission:
+  - Group: all
+```
+
+## Live Resource Context
+
+```hcl
+resource "aws_db_instance" "orders" {
+  identifier            = "prod-orders"
+  publicly_accessible   = false
+  storage_encrypted     = true
+  backup_retention_period = 7
+}
+
+resource "aws_ebs_encryption_by_default" "enabled" {
+  enabled = true
+}
+```
+
+## Expected Skill Behavior
+
+The AWS review should not pass storage exposure based only on the live RDS and EBS configuration.
+
+Required findings:
+
+- `AWS-SNAP-01` fails because the RDS manual snapshot restore attribute is public.
+- `AWS-SNAP-02` fails because the EBS snapshot grants `Group=all`.
+- `AWS-SNAP-03` warns that `block-new-sharing` does not prove already-public snapshots are private.
+- `AWS-SNAP-04` fails because the production AMI has public launch permission.
+- `AWS-SNAP-05` should require production data lineage and sensitivity evidence.
+- `AWS-SNAP-06` should require sharing owner, business purpose, ticket, expiry, and revocation evidence.
+- `AWS-SNAP-07` should record Region and account coverage.
+- `AWS-SNAP-08` should keep the finding open until private attributes and guardrails are reverified.
+
+## Correct Classification
+
+High or Critical depending on confirmed data sensitivity and production lineage.


### PR DESCRIPTION
/claim #1737

## Summary
- Adds a supplemental AWS snapshot/image artifact evidence gate without treating it as a CIS recommendation ID.
- Covers RDS manual snapshot restore attributes, EBS `createVolumePermission`, regional EBS block public access state, AMI launch permissions, artifact sensitivity/lineage, cross-account sharing governance, coverage, and remediation verification.
- Adds vulnerable and benign fixtures for private live resources with public backup artifacts versus governed private sharing with block-all-sharing evidence.

## Verification
- `git diff --cached --check`
- Markdown fence-balance check for changed Markdown files
- Added-line ASCII check
- Marker check for `AWS-SNAP-01` through `AWS-SNAP-08`
- Added-line sensitive-pattern scan
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`

## Bounty
Requesting Improver Moderate ($100) if accepted/merged. Preferred payout: PayPal or crypto after maintainer acceptance.