### PR TITLE
Add SIEM late-arrival evidence fixtures

### DIFF
--- a/skills/secops/siem-rules/SKILL.md
+++ b/skills/secops/siem-rules/SKILL.md
@@ -12,7 +12,7 @@ phase: [operate]
 frameworks: [MITRE-ATT&CK-v16]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -56,6 +56,7 @@ Before beginning, gather or confirm:
 - [ ] **Environment baseline:** Normal volume and patterns for the data source (e.g., average daily failed logon count, typical admin logon hours).
 - [ ] **Alert priority and response:** Desired severity level and expected analyst response procedure.
 - [ ] **Performance constraints:** Query time window, maximum execution time, and scheduled frequency.
+- [ ] **Time semantics and latency evidence:** Event-time field, ingestion/index-time field, measured latency distribution, clock-skew tolerance, timezone normalization, lookback buffer, and deduplication strategy for overlapping scheduled windows.
 - [ ] **Existing rules:** Any current rules covering similar detections that may overlap or conflict.
 
 ---
@@ -456,6 +457,56 @@ Suppression:         Enabled, 1 hour
 Entity mapping:      Account -> UserPrincipalName, IP -> IPAddress, Host -> Computer
 ```
 
+### Step 4A: Time Semantics and Late-Arrival Evidence
+
+For scheduled rules, prove which timestamp controls detection logic and how late-arriving data is handled. Rules that only query a narrow event-time window can miss delayed events; rules that only use ingestion or index time can distort attack sequence logic, baselines, and analyst timelines.
+
+| ID | Evidence Gate | What to Verify | Finding Behavior |
+|---|---|---|---|
+| SIEM-TIME-01 | Event-time field | Identify the authoritative event timestamp used for attack sequence logic, such as `TimeGenerated`, `_time`, `EventTime`, or source log timestamp. | Not Evaluable when the rule has no documented event-time source. |
+| SIEM-TIME-02 | Ingestion/index-time field | Identify the SIEM arrival timestamp, such as `ingestion_time()` in KQL or `_indextime` in SPL. | Fail when scheduled detection ignores measured late-arrival risk. |
+| SIEM-TIME-03 | Latency distribution | Measure or document p50/p95/p99 source-to-SIEM delay by log source and environment. | Not Evaluable when latency is assumed but not measured for the reviewed source. |
+| SIEM-TIME-04 | Lookback buffer | Query period exceeds query frequency by enough to cover p95/p99 latency plus clock skew for the detection objective. | Fail when the event-time window equals frequency despite known delay. |
+| SIEM-TIME-05 | Overlap deduplication | Overlapping lookbacks use alert keys, incident grouping, `arg_max`, `dedup`, or suppression to avoid duplicate alerts. | Fail when extended lookback creates repeated identical alerts. |
+| SIEM-TIME-06 | Clock skew and timezone normalization | Normalize source timestamps to UTC and define tolerated skew between hosts, identity providers, and collectors. | Not Evaluable when multi-source correlation lacks timestamp normalization evidence. |
+| SIEM-TIME-07 | Sequence preservation | For correlation rules, use event time for ordering and ingestion/index time only for arrival coverage or freshness filtering. | Fail when index time changes the attack sequence in the finding narrative. |
+| SIEM-TIME-08 | Backfill and outage handling | Define replay/backfill behavior for collector outages, delayed connectors, and restored data. | Keep rule in Testing/Needs Tuning until delayed-event behavior is verified. |
+
+**Example KQL latency-aware window pattern:**
+
+```kql
+let rule_frequency = 5m;
+let latency_buffer = 15m;
+let detection_window = 10m;
+SigninLogs
+| where ingestion_time() > ago(rule_frequency + latency_buffer)
+| where TimeGenerated > ago(detection_window + latency_buffer)
+| extend IngestionDelay = ingestion_time() - TimeGenerated
+| summarize
+    DistinctAccounts = dcount(UserPrincipalName),
+    FirstEventTime = min(TimeGenerated),
+    LastEventTime = max(TimeGenerated),
+    MaxIngestionDelay = max(IngestionDelay)
+    by IPAddress, bin(TimeGenerated, detection_window)
+| where DistinctAccounts >= 10
+```
+
+**Example SPL latency-aware window pattern:**
+
+```spl
+index=wineventlog sourcetype="WinEventLog:Security" EventCode=4625 earliest=-20m@m latest=now
+| eval ingestion_delay_sec = _indextime - _time
+| where _time >= relative_time(now(), "-15m")
+| bin _time span=10m
+| stats dc(TargetUserName) as distinct_accounts,
+    count as attempt_count,
+    max(ingestion_delay_sec) as max_ingestion_delay_sec
+    by IpAddress, _time
+| where distinct_accounts >= 10
+| eval alert_key = IpAddress . ":" . tostring(_time)
+| dedup alert_key
+```
+
 ### Step 5: Detection Rule Lifecycle Management
 
 **Lifecycle stages:**
@@ -509,7 +560,7 @@ Produce SIEM rule deliverables in this structure:
 ```markdown
 ## SIEM Detection Rule: [Rule Name]
 **Date:** [YYYY-MM-DD]
-**Skill:** siem-rules v1.0.0
+**Skill:** siem-rules v1.0.1
 **Framework:** MITRE ATT&CK v16
 **Platform:** [Microsoft Sentinel (KQL) | Splunk (SPL)]
 
@@ -533,6 +584,17 @@ Produce SIEM rule deliverables in this structure:
 | Time window | [Xm/h] | [Why this window] |
 | Frequency | [Xm/h] | [How often to run] |
 | Suppression | [Xh] | [Cooldown period] |
+
+### Time Semantics and Late-Arrival Handling
+| Field | Value | Evidence |
+|---|---|---|
+| Event-time field | [TimeGenerated / _time / source timestamp] | [Why this represents event occurrence] |
+| Ingestion/index-time field | [ingestion_time() / _indextime] | [How arrival time is measured] |
+| Latency distribution | [p50/p95/p99] | [Measurement source and date] |
+| Lookback buffer | [Duration] | [Why it covers latency and skew] |
+| Deduplication key | [Entity + event window + rule ID] | [How overlapping windows avoid duplicate alerts] |
+| Clock skew / timezone handling | [UTC normalization and tolerance] | [Evidence] |
+| Backfill behavior | [Replay / suppress / manual review] | [Procedure] |
 
 ### Entity Mapping
 | Entity Type | Source Field |
@@ -631,6 +693,10 @@ Deploying a rule without confirming it fires on known-malicious activity is depl
 ### Pitfall 5: Failing to Suppress Duplicate Alerts
 
 A detection rule that fires every 5 minutes on the same ongoing activity (e.g., a brute force attack lasting 2 hours) floods the alert queue with duplicates. Configure alert suppression or deduplication to prevent the same incident from generating hundreds of identical alerts. Use suppression windows and entity-based grouping to consolidate related alerts.
+
+### Pitfall 6: Treating Event Time and Ingestion Time as Interchangeable
+
+Event time describes when activity occurred; ingestion or index time describes when the SIEM received it. A rule that searches only the last 5 minutes of event time can miss events that arrive 8-12 minutes late. A rule rewritten entirely around ingestion time can preserve alert coverage but break sequence logic for detections such as failed logons followed by success. Use ingestion/index time to capture late arrivals, event time to reason about attacker behavior, and deduplication for overlapping lookbacks.
 
 ---
 

--- a/skills/secops/siem-rules/tests/benign/latency-aware-overlap-dedup.md
+++ b/skills/secops/siem-rules/tests/benign/latency-aware-overlap-dedup.md
@@ -1,0 +1,58 @@
+# Benign: Latency-Aware Window With Deduplication
+
+## Scenario
+
+A Sentinel password spray rule runs every 5 minutes and intentionally searches a 20 minute arrival window with event-time grouping.
+
+## Rule Fragment
+
+```kql
+let rule_frequency = 5m;
+let latency_buffer = 15m;
+let detection_window = 10m;
+SigninLogs
+| where ingestion_time() > ago(rule_frequency + latency_buffer)
+| where TimeGenerated > ago(detection_window + latency_buffer)
+| where ResultType == "50126"
+| extend IngestionDelay = ingestion_time() - TimeGenerated
+| summarize
+    DistinctAccounts = dcount(UserPrincipalName),
+    FirstEventTime = min(TimeGenerated),
+    LastEventTime = max(TimeGenerated),
+    MaxIngestionDelay = max(IngestionDelay)
+    by IPAddress, EventTimeBucket = bin(TimeGenerated, detection_window)
+| where DistinctAccounts >= 10
+| extend AlertKey = strcat(IPAddress, ":", tostring(EventTimeBucket))
+```
+
+## Evidence
+
+```text
+Event-time field: TimeGenerated
+Ingestion-time field: ingestion_time()
+Latency measurement date: 2026-06-01
+p50/p95/p99: 2m / 9m / 14m
+Clock skew tolerance: 2m, source timestamps normalized to UTC
+Lookback buffer: 15m
+Deduplication: IPAddress + 10m event-time bucket + rule ID
+Backfill: connector outage replay suppresses duplicate alert keys and sends replay summary to SOC lead
+```
+
+## Expected Skill Behavior
+
+The SIEM review should not flag this as a late-arrival blind spot.
+
+Required satisfied gates:
+
+- `SIEM-TIME-01` documents `TimeGenerated` as event time.
+- `SIEM-TIME-02` documents `ingestion_time()` as arrival time.
+- `SIEM-TIME-03` documents p50/p95/p99 latency.
+- `SIEM-TIME-04` uses a 15 minute buffer that covers measured p99 and skew.
+- `SIEM-TIME-05` defines a deduplication key for overlapping windows.
+- `SIEM-TIME-06` documents UTC normalization and clock skew.
+- `SIEM-TIME-07` uses event time for sequence/window grouping.
+- `SIEM-TIME-08` defines backfill/outage replay behavior.
+
+## Correct Classification
+
+Pass for late-arrival handling, subject to periodic latency remeasurement.

--- a/skills/secops/siem-rules/tests/vulnerable/event-window-misses-late-arrivals.md
+++ b/skills/secops/siem-rules/tests/vulnerable/event-window-misses-late-arrivals.md
@@ -1,0 +1,56 @@
+# Vulnerable: Event-Time Window Misses Late Arrivals
+
+## Scenario
+
+A password spray rule runs every 5 minutes with a 5 minute event-time query period.
+
+## Rule Fragment
+
+```kql
+let threshold_accounts = 10;
+SigninLogs
+| where TimeGenerated > ago(5m)
+| where ResultType == "50126"
+| summarize DistinctAccounts = dcount(UserPrincipalName) by IPAddress, bin(TimeGenerated, 5m)
+| where DistinctAccounts >= threshold_accounts
+```
+
+## Source Latency Evidence
+
+```text
+Connector: Azure AD SigninLogs
+Measured ingestion delay during peak load:
+  p50: 3m
+  p95: 11m
+  p99: 16m
+Clock skew tolerance: not documented
+Deduplication: none
+```
+
+## Late Events
+
+```text
+Event Time           Ingestion Time       IP
+2026-06-08 12:00:10  2026-06-08 12:10:40  203.0.113.10
+2026-06-08 12:01:02  2026-06-08 12:11:05  203.0.113.10
+2026-06-08 12:03:41  2026-06-08 12:13:12  203.0.113.10
+```
+
+## Expected Skill Behavior
+
+The SIEM review should flag this rule as likely to miss delayed password spray events.
+
+Required findings:
+
+- `SIEM-TIME-01` should identify `TimeGenerated` as the event-time field.
+- `SIEM-TIME-02` should fail because `ingestion_time()` is not used or measured in the rule.
+- `SIEM-TIME-03` should require p95/p99 latency evidence in the rule design.
+- `SIEM-TIME-04` should fail because the query period equals rule frequency despite p95 latency above 5 minutes.
+- `SIEM-TIME-05` should require deduplication before extending the lookback.
+- `SIEM-TIME-06` should require clock-skew and timezone normalization evidence.
+- `SIEM-TIME-07` should preserve event time for the spray sequence.
+- `SIEM-TIME-08` should require backfill behavior for delayed connector ingestion.
+
+## Correct Classification
+
+P2 High detection reliability gap until latency-aware lookback and deduplication are implemented.


### PR DESCRIPTION
/claim #1775

## Summary
- Adds a time semantics and late-arrival evidence gate for SIEM rules that distinguishes event time from ingestion/index time.
- Covers latency distribution, lookback buffers, overlapping-window deduplication, clock skew/timezone normalization, sequence preservation, and backfill/outage behavior.
- Adds vulnerable and benign fixtures for a 5 minute event-time rule missing delayed password spray events versus a latency-aware overlapping lookback with deduplication.

## Verification
- `git diff --cached --check`
- Markdown fence-balance check for changed Markdown files
- Added-line ASCII check
- Marker check for `SIEM-TIME-01` through `SIEM-TIME-08`
- Added-line sensitive-pattern scan
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`

## Bounty
Requesting Improver Moderate ($100) if accepted/merged. Preferred payout: PayPal or crypto after maintainer acceptance.