### PR TITLE
Improve HIPAA transmission security evidence gates

### DIFF
--- a/skills/compliance/hipaa-review/SKILL.md
+++ b/skills/compliance/hipaa-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [HIPAA-Security-Rule, 45-CFR-164-Subpart-C]
 difficulty: intermediate
 time_estimate: "60-120min"
-version: "1.0.1"
+version: "1.0.2"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -71,6 +71,7 @@ The HIPAA Security Rule (45 CFR Part 164, Subpart C) establishes national standa
 - Business Associate Agreements (BAAs) inventory
 - Incident response and breach notification procedures
 - Access control configurations and user provisioning processes
+- Transmission security evidence for ePHI paths (API, email, EDI, SFTP, backups, vendor portals, webhooks)
 - Backup and disaster recovery documentation
 - Workforce training records
 - Prior OCR audit findings or corrective action plans
@@ -334,6 +335,17 @@ Hybrid Entity: [Yes/No] — If yes, document healthcare component designation
 - Implement a mechanism to encrypt ePHI whenever deemed appropriate
 - Note: Encryption of ePHI in transit is strongly recommended by OCR. Unencrypted transmission of ePHI over the internet is a frequent enforcement target.
 
+Transmission security evidence review:
+- Build a transmission path register for every ePHI flow that crosses systems, networks, organizations, or support workflows.
+- Include primary and exception paths: EHR and patient portal APIs, claims/EDI, email, SFTP, backups, webhook callbacks, vendor portal exports, support attachments, and manual file transfers.
+- For each path, require evidence of:
+  - ePHI elements, source, destination, owner, and Business Associate or external recipient when applicable
+  - Transport protections such as TLS version, certificate validation, downgrade prevention, mTLS/VPN/SFTP/AS2 controls, or documented equivalent measures
+  - Integrity controls such as message authentication, signatures, checksums, EDI control totals, tamper-evident queues, or reconciliation that detects improper modification
+  - Exception handling for email, manual exports, legacy interfaces, or emergency workarounds, including documented risk rationale when encryption or integrity controls are not implemented
+- Do not mark 164.312(e) compliant solely because "TLS is enabled" or traffic is "internal" if the actual ePHI routes, protocol versions, certificate validation, and exception paths are not evidenced.
+- Flag high severity when ePHI is transmitted over the internet or to a third party without encryption, integrity protection, or a documented addressable-specification rationale.
+
 ---
 
 ### Step 5: Organizational Requirements (45 CFR 164.314)
@@ -460,6 +472,13 @@ Assess:
 ## Breach Notification Readiness
 [Assessment of breach response procedures, notification capability, HHS reporting readiness]
 
+## Transmission Security Assessment
+- ePHI Transmission Paths: [count, systems, recipients, external/BA flows]
+- Encryption Evidence: [implemented, alternative control, missing, or undocumented by path]
+- Integrity Evidence: [implemented, alternative control, missing, or undocumented by path]
+- Exception Paths: [email, manual exports, vendor portal downloads, emergency transfers, legacy protocols]
+- 164.312(e) Gaps: [missing route inventory, weak protocol, no certificate validation, no integrity control, undocumented addressable decision]
+
 ## Risk Analysis Gap Summary
 [Specific deficiencies in the organization's risk analysis per 164.308(a)(1)(ii)(A)]
 
@@ -570,6 +589,8 @@ Policies, Procedures, and Documentation — 164.316
 4. **Confusing HIPAA Security Rule with HIPAA Privacy Rule.** The Security Rule (Subpart C) applies only to ePHI and focuses on technical, physical, and administrative safeguards. The Privacy Rule (Subpart E) covers all PHI including paper records and addresses permitted uses and disclosures. A Security Rule review does not satisfy Privacy Rule obligations and vice versa.
 
 5. **Failing to document the "why" behind security decisions.** The Security Rule is designed to be flexible and scalable. But that flexibility requires documentation. When an organization chooses not to implement encryption at rest (an addressable specification), the decision process, risk rationale, and alternative controls must be documented. OCR auditors expect written justification, not verbal explanations.
+
+6. **Treating a TLS checkbox as complete transmission security.** 164.312(e) requires review of actual ePHI transmission paths, including exception workflows and third-party transfers. A generic "TLS enabled" statement does not prove certificate validation, downgrade resistance, integrity controls, encrypted email/file-transfer workflows, or documented addressable-specification rationale for legacy routes.
 
 ---
 

--- a/tests/benign/hipaa-transmission-security-documented-paths.yaml
+++ b/tests/benign/hipaa-transmission-security-documented-paths.yaml
@@ -1,0 +1,57 @@
+scenario: ephi_transmission_security_documented_paths
+skill: hipaa-review
+expected_result: do_not_flag_164_312e_gap
+entity:
+  type: business_associate
+  systems:
+    - ehr_integration_api
+    - edi_gateway
+    - secure_support_portal
+transmission_register:
+  api_exchange:
+    ephi_elements:
+      - patient_id
+      - appointment_status
+    source: ehr_integration_api
+    destination: covered_entity_api
+    encryption: tls_1_3
+    certificate_validation: enforced
+    downgrade_prevention: hsts_and_modern_cipher_policy
+    integrity_control: signed_payload_digest
+    evidence:
+      - api-gateway-tls-policy-2026-06
+      - integration-signature-runbook
+  edi_claims:
+    ephi_elements:
+      - subscriber_id
+      - diagnosis_code
+      - procedure_code
+    source: edi_gateway
+    destination: payer_clearinghouse
+    encryption: as2_tls_1_2_or_higher
+    integrity_control: edi_control_totals_and_mic
+    reconciliation: daily_exception_report_reviewed
+    evidence:
+      - edi-as2-config-export
+      - claims-reconciliation-sop
+  support_portal_exports:
+    ephi_elements:
+      - patient_name
+      - encounter_summary
+    destination: secure_support_portal
+    encryption: portal_tls_1_3
+    integrity_control: sha256_file_hash_logged
+    access_control: case_scoped_download_link_with_expiry
+    baa_reference: CE-BAA-2026-014
+addressable_decisions:
+  encryption:
+    status: implemented_for_all_external_paths
+    owner: security_official
+  integrity_controls:
+    status: implemented_or_reconciled_by_path
+    owner: compliance
+why_this_should_pass: >
+  Each ePHI transmission path has source, destination, encryption evidence,
+  integrity evidence, exception handling, and ownership, so the review has
+  sufficient evidence for 45 CFR 164.312(e) without relying on a generic TLS
+  assertion.

--- a/tests/vulnerable/hipaa-transmission-security-missing-exception-paths.yaml
+++ b/tests/vulnerable/hipaa-transmission-security-missing-exception-paths.yaml
@@ -1,0 +1,42 @@
+scenario: ephi_transmission_security_missing_exception_paths
+skill: hipaa-review
+expected_result: flag_164_312e_transmission_security_gap
+entity:
+  type: covered_entity
+  systems:
+    - ehr
+    - patient_portal
+    - claims_gateway
+    - support_vendor_portal
+transmission_evidence:
+  primary_api:
+    ephi_elements:
+      - patient_id
+      - lab_result
+      - diagnosis_code
+    protection: tls_enabled
+    tls_version: not_documented
+    certificate_validation: not_documented
+    integrity_control: not_documented
+  exception_workflows:
+    support_exports:
+      destination: external_vendor_portal
+      ephi_elements:
+        - patient_name
+        - encounter_notes
+      encryption: not_documented
+      integrity_control: missing
+      baa_reference: VND-443
+    claims_resubmission_email:
+      destination: billing_partner
+      ephi_elements:
+        - claim_id
+        - diagnosis_code
+      encryption: missing
+      integrity_control: missing
+      addressable_rationale: missing
+why_this_should_fail: >
+  The review cannot mark 45 CFR 164.312(e) compliant from a generic TLS
+  statement when exception paths transmit ePHI to vendors and billing partners
+  without documented encryption, certificate validation, integrity controls, or
+  an addressable-specification rationale.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `hipaa-review`
**Skill path:** `skills/compliance/hipaa-review/SKILL.md`

### What Was Wrong
The HIPAA review covered 45 CFR 164.312(e) Transmission Security but could still accept a generic "TLS enabled" assertion without requiring a path-by-path ePHI transmission inventory. That misses exception routes such as claims resubmission email, vendor portal exports, SFTP/EDI paths, support attachments, webhook callbacks, and manual/emergency transfers.

Related review issue: #2054

### What This PR Fixes
- Adds a 164.312(e) transmission security evidence review that requires primary and exception path coverage.
- Requires per-path ePHI elements, source, destination, owner, external/BA recipient, encryption evidence, certificate/downgrade controls, and integrity evidence.
- Clarifies that addressable encryption/integrity specifications need documented implementation, equivalent control, or risk rationale.
- Adds an output section for transmission path, encryption, integrity, exception-route, and 164.312(e) gap reporting.
- Adds a common pitfall warning against treating a TLS checkbox as complete transmission security.

### Evidence

**Before (skill could miss this):**
```yaml
primary_api:
  protection: tls_enabled
  tls_version: not_documented
  certificate_validation: not_documented
exception_workflows:
  claims_resubmission_email:
    encryption: missing
    integrity_control: missing
    addressable_rationale: missing
```

**After (now correctly handled):**
```yaml
transmission_register:
  api_exchange:
    encryption: tls_1_3
    certificate_validation: enforced
    integrity_control: signed_payload_digest
  edi_claims:
    encryption: as2_tls_1_2_or_higher
    integrity_control: edi_control_totals_and_mic
  support_portal_exports:
    encryption: portal_tls_1_3
    integrity_control: sha256_file_hash_logged
```

### Test Cases Added/Updated
- [x] Added vulnerable test case: `tests/vulnerable/hipaa-transmission-security-missing-exception-paths.yaml`
- [x] Added benign test case: `tests/benign/hipaa-transmission-security-documented-paths.yaml`
- [x] Existing tests still pass / no executable test harness exists in this repository; validated with `git diff --check`, `git diff --cached --check`, and key-field checks for the new YAML evidence files.

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** GitHub Sponsors