### PR TITLE
Improve CVE alias status normalization

### DIFF
--- a/skills/vuln-management/cve-triage/SKILL.md
+++ b/skills/vuln-management/cve-triage/SKILL.md
@@ -12,7 +12,7 @@ phase: [operate, respond]
 frameworks: [CVSS-4.0, SSVC-2.1, CISA-KEV, EPSS]
 difficulty: intermediate
 time_estimate: "10-20min per CVE"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob, WebFetch
@@ -47,6 +47,7 @@ Use this skill when a CVE identifier appears in conversation, when vulnerability
 Before starting, collect or confirm:
 
 - [ ] **CVE ID(s):** The specific CVE identifier(s) to triage (e.g., CVE-2024-3094)
+- [ ] **Canonical vulnerability identity:** Source status, aliases, and advisory IDs (NVD, CNA, GHSA, OSV, vendor advisory, distro advisory)
 - [ ] **Affected software/version:** Product name, version, and component (e.g., OpenSSL 3.0.2, xz-utils 5.6.0)
 - [ ] **Deployment context:** Where is this software running? (Internet-facing, internal, air-gapped)
 - [ ] **Business criticality:** What business function does the affected system support? (Revenue-generating, customer-facing, internal tooling, development)
@@ -69,11 +70,28 @@ Extract the CVE identifier and collect all available context about the vulnerabi
 4. Note the disclosure date and whether a patch/fix is available
 5. If the user provided scan output, extract the CVE ID, affected asset, and scanner-assigned severity
 
+#### 1.1 Canonical Status and Alias Normalization
+
+Before scoring or assigning an SLA, normalize vulnerability identity across NVD, CNA, GHSA, OSV, vendor advisories, and scanner output:
+
+- Resolve aliases such as GHSA IDs, OSV IDs, vendor advisory IDs, distro bug IDs, and common names to a single canonical CVE when a reliable mapping exists.
+- Track every alias in the report so duplicate scanner findings do not create duplicate remediation tickets or inflate backlog counts.
+- Verify source lifecycle status before scoring:
+  - `REJECTED`, `RESERVED`, withdrawn, or duplicate CVEs must not receive CVSS/EPSS/SSVC priority as if they were active vulnerabilities.
+  - `DISPUTED` CVEs may still require action, but must be flagged for human review and should not be escalated solely from one source's score.
+  - If NVD and CNA/vendor records conflict on affected products or severity, cite both sources and prefer the CNA/vendor affectedness statement for product applicability while keeping NVD scores as advisory context.
+- Require at least one authoritative source for active triage: CNA/vendor advisory, NVD record, GHSA/OSV advisory, CISA KEV, or vendor security bulletin.
+- When aliases point to the same issue, produce one consolidated recommendation with per-source evidence rather than separate recommendations per identifier.
+- If alias mappings are uncertain, mark identity confidence as low and keep the finding in review status rather than assigning an aggressive SLA.
+
 **Framework mapping:** NVD (National Vulnerability Database) for CVE metadata
 
 ```
 CVE Context Summary:
 - CVE ID:              [CVE-YYYY-NNNNN]
+- Source Status:       [Published | RESERVED | REJECTED | DISPUTED | Withdrawn | Unknown]
+- Identity Confidence: [High | Medium | Low]
+- Advisory Aliases:    [GHSA-..., OSV-..., vendor advisory IDs, distro advisory IDs]
 - Vulnerability Type:  [RCE | Privilege Escalation | Info Disclosure | DoS | XSS | SQLi | Auth Bypass | Other]
 - Affected Software:   [Product Name vX.Y.Z]
 - Affected Component:  [Library, module, or subsystem]
@@ -312,7 +330,7 @@ Produce a structured report with these exact sections:
 ```markdown
 ## CVE Triage Report: [CVE-YYYY-NNNNN]
 **Date:** [YYYY-MM-DD]
-**Skill:** cve-triage v1.0.0
+**Skill:** cve-triage v1.0.1
 **Frameworks:** CVSS 4.0, SSVC 2.1, EPSS, CISA KEV
 **Reviewer:** AI-assisted (human review required for Immediate/Out-of-Cycle findings)
 
@@ -324,6 +342,9 @@ recommended SLA tier. Lead with the most critical fact.]
 | Field | Value |
 |---|---|
 | CVE ID | [CVE-YYYY-NNNNN] |
+| Source Status | [Published/RESERVED/REJECTED/DISPUTED/Withdrawn/Unknown] |
+| Identity Confidence | [High/Medium/Low] |
+| Advisory Aliases | [GHSA/OSV/vendor/distro IDs] |
 | Vulnerability Type | [Type] |
 | Affected Software | [Product vX.Y.Z] |
 | Affected Component | [Component] |
@@ -369,6 +390,13 @@ recommended SLA tier. Lead with the most critical fact.]
 - **De-escalation Factors:** [List any compensating controls or mitigating factors]
 - **Assumptions Made:** [List any assumptions due to missing context]
 
+### Source and Alias Evidence
+| Source | Identifier | Status | Affectedness / Notes | Last Checked |
+|---|---|---|---|---|
+| NVD | [CVE-ID] | [status] | [summary] | [date] |
+| CNA/Vendor | [advisory ID] | [status] | [summary] | [date] |
+| GHSA/OSV | [alias] | [status] | [summary] | [date] |
+
 ### Risk Acceptance (If Deferring)
 [If the recommendation is Scheduled or Defer, include a risk acceptance template:]
 
@@ -395,12 +423,11 @@ When triaging multiple CVEs (e.g., from a scan report), produce a summary table 
 **Date:** [YYYY-MM-DD]
 **Total CVEs:** [N]
 
-| CVE ID | CVSS 4.0 | EPSS | KEV | SSVC Decision | SLA | Affected System |
-|---|---|---|---|---|---|---|
-| CVE-YYYY-NNNNN | 9.8 Critical | 0.95 | Yes | Immediate | 24h | [System] |
-| CVE-YYYY-NNNNN | 7.5 High | 0.15 | No | Out-of-Cycle | 72h | [System] |
-| CVE-YYYY-NNNNN | 5.3 Medium | 0.02 | No | Scheduled | 30d | [System] |
-| CVE-YYYY-NNNNN | 3.1 Low | 0.001 | No | Defer | 90d | [System] |
+| CVE ID | Status | Aliases | CVSS 4.0 | EPSS | KEV | SSVC Decision | SLA | Affected System |
+|---|---|---|---|---|---|---|---|---|
+| CVE-YYYY-NNNNN | Published | GHSA-... | 9.8 Critical | 0.95 | Yes | Immediate | 24h | [System] |
+| CVE-YYYY-NNNNN | DISPUTED | Vendor-... | 7.5 High | 0.15 | No | Review | Hold | [System] |
+| CVE-YYYY-NNNNN | REJECTED | GHSA-... | N/A | N/A | No | Not triaged | No SLA | [System] |
 
 ### Priority Order
 1. [CVE with Immediate SLA -- full assessment below]

--- a/tests/benign/cve-triage-canonical-alias-status-reviewed.yaml
+++ b/tests/benign/cve-triage-canonical-alias-status-reviewed.yaml
@@ -1,0 +1,38 @@
+scenario: canonical_alias_status_reviewed_before_triage
+skill: cve-triage
+expected_result: do_not_duplicate_or_overprioritize
+scan_input:
+  scanner: example-vuln-scanner
+  findings:
+    - id: GHSA-qwer-5678-asdf
+      aliases:
+        - CVE-2026-27777
+        - OSV-2026-27777
+      affected_package: acme-cache
+      installed_version: 1.8.0
+      scanner_severity: high
+    - id: CVE-2026-27777
+      source: nvd
+      source_status: DISPUTED
+      affected_package: acme-cache
+      installed_version: 1.8.0
+source_evidence:
+  canonical_id: CVE-2026-27777
+  advisory_aliases:
+    - GHSA-qwer-5678-asdf
+    - OSV-2026-27777
+  nvd_status: DISPUTED
+  vendor_advisory:
+    id: ACMESA-2026-11
+    affectedness: fixed_in_1_8_3
+    notes: vendor_confirms_affected_function_requires_optional_plugin
+  identity_confidence: medium
+triage_output:
+  consolidated_ticket: CVE-2026-27777
+  duplicate_tickets_created: false
+  ssvc_decision: human_review_required
+  sla: hold_pending_vendor_context
+why_this_should_pass: >
+  The finding keeps one canonical recommendation, records all aliases, flags
+  disputed source status for human review, and avoids duplicate urgent tickets
+  until authoritative affectedness and deployment context are confirmed.

--- a/tests/vulnerable/cve-triage-rejected-alias-duplicated-as-active.yaml
+++ b/tests/vulnerable/cve-triage-rejected-alias-duplicated-as-active.yaml
@@ -1,0 +1,35 @@
+scenario: rejected_cve_alias_duplicated_as_active_findings
+skill: cve-triage
+expected_result: flag_invalid_priority_assignment
+scan_input:
+  scanner: example-vuln-scanner
+  findings:
+    - id: CVE-2026-40404
+      source: nvd
+      source_status: REJECTED
+      aliases:
+        - GHSA-abcd-1234-wxyz
+        - OSV-2026-40404
+      affected_package: acme-auth
+      installed_version: 2.4.1
+      scanner_severity: critical
+      scanner_cvss: 9.8
+    - id: GHSA-abcd-1234-wxyz
+      source: github_advisory
+      aliases:
+        - CVE-2026-40404
+      affected_package: acme-auth
+      installed_version: 2.4.1
+      scanner_severity: high
+triage_output:
+  tickets_created:
+    - CVE-2026-40404-critical
+    - GHSA-abcd-1234-wxyz-high
+  sla: immediate
+  identity_confidence: not_documented
+  source_status_checked: false
+why_this_should_fail: >
+  A rejected CVE and its GHSA/OSV aliases were treated as separate active
+  vulnerabilities with urgent SLAs. The skill should normalize aliases, honor
+  source lifecycle status, and avoid CVSS/EPSS/SSVC priority for rejected or
+  withdrawn records.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `cve-triage`
**Skill path:** `skills/vuln-management/cve-triage/SKILL.md`

### What Was Wrong
The CVE triage flow parsed CVE IDs and then moved directly into CVSS, KEV, EPSS, SSVC, and SLA assignment. It did not explicitly normalize advisory aliases or check source lifecycle status before scoring. That can create duplicate remediation tickets for the same vulnerability (`CVE-*`, `GHSA-*`, OSV, vendor advisory, distro advisory) or over-prioritize `REJECTED`, `RESERVED`, withdrawn, duplicate, or `DISPUTED` records.

Related review issue: #2057

### What This PR Fixes
- Adds canonical vulnerability identity collection to prerequisites.
- Adds a pre-scoring alias/status normalization step across NVD, CNA, GHSA, OSV, vendor, distro, and scanner sources.
- Prevents `REJECTED`, `RESERVED`, withdrawn, or duplicate CVEs from receiving active CVSS/EPSS/SSVC priority as if they were live vulnerabilities.
- Requires human review for `DISPUTED` records and low-confidence alias mappings.
- Adds output fields for source status, identity confidence, advisory aliases, and source/alias evidence.
- Updates batch triage output so status and aliases are visible before prioritization.

### Evidence

**Before (skill could over-prioritize this):**
```yaml
findings:
  - id: CVE-2026-40404
    source_status: REJECTED
    aliases: [GHSA-abcd-1234-wxyz, OSV-2026-40404]
    scanner_severity: critical
  - id: GHSA-abcd-1234-wxyz
    aliases: [CVE-2026-40404]
triage_output:
  tickets_created:
    - CVE-2026-40404-critical
    - GHSA-abcd-1234-wxyz-high
  sla: immediate
```

**After (now correctly handled):**
```yaml
source_evidence:
  canonical_id: CVE-2026-27777
  advisory_aliases: [GHSA-qwer-5678-asdf, OSV-2026-27777]
  nvd_status: DISPUTED
  identity_confidence: medium
triage_output:
  consolidated_ticket: CVE-2026-27777
  duplicate_tickets_created: false
  ssvc_decision: human_review_required
```

### Test Cases Added/Updated
- [x] Added vulnerable test case: `tests/vulnerable/cve-triage-rejected-alias-duplicated-as-active.yaml`
- [x] Added benign test case: `tests/benign/cve-triage-canonical-alias-status-reviewed.yaml`
- [x] Existing tests still pass / no executable test harness exists in this repository; validated with `git diff --check`, `git diff --cached --check`, and key-field checks for the new YAML evidence files.

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** GitHub Sponsors