### PR TITLE
Improve pipeline workflow artifact handoff gates

### DIFF
--- a/skills/devsecops/pipeline-security/SKILL.md
+++ b/skills/devsecops/pipeline-security/SKILL.md
@@ -12,7 +12,7 @@ phase: [build, deploy]
 frameworks: [SLSA-v1.0, OWASP-CICD-Top-10]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -49,6 +49,7 @@ The assessment produces a formal report containing a SLSA build level determinat
 - Access to CI/CD configuration files (e.g., `.github/workflows/*.yml`, `.gitlab-ci.yml`, `Jenkinsfile`, `cloudbuild.yaml`).
 - Access to repository settings context (branch protection rules, environment configurations).
 - Read access to dependency manifests and lock files for supply-chain analysis.
+- Access to workflow artifact, cache, and promotion metadata when pipelines hand build outputs from one workflow to another.
 
 ---
 
@@ -251,6 +252,7 @@ on: pull_request_target
 ```
 
 - **Indirect PPE:** Workflows that execute scripts, Makefiles, or config files that exist in the repository and can be modified by a pull request.
+- **Workflow handoff PPE:** Privileged workflows triggered by `workflow_run` that download artifacts, caches, coverage reports, build outputs, or scripts from an untrusted PR or fork workflow and then execute, deploy, sign, publish, or upload them with elevated permissions.
 - **Public fork access:** Whether the repository allows workflows to run on pull requests from forks with access to secrets.
 - Injection of untrusted input into shell commands:
 
@@ -264,7 +266,33 @@ on: pull_request_target
     PR_TITLE: ${{ github.event.pull_request.title }}
 ```
 
-**Finding format:** Report any `pull_request_target` usage, direct expression injection in `run:` steps, fork workflow policies, and whether PR code can influence privileged pipelines.
+```yaml
+# DANGEROUS: privileged workflow_run consumes untrusted PR artifact
+on:
+  workflow_run:
+    workflows: ["PR build"]
+    types: [completed]
+
+permissions: write-all
+
+jobs:
+  publish:
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+      - run: ./dist/release.sh
+```
+
+For `workflow_run` or equivalent multi-stage pipelines, verify:
+
+- The upstream workflow cannot be triggered from untrusted forks or unreviewed branches when downstream jobs receive secrets, write tokens, signing keys, package publishing tokens, or deployment credentials.
+- The downstream workflow checks `github.event.workflow_run.conclusion == 'success'`, source repository, head branch, event type, and trusted actor/team before consuming outputs.
+- Downloaded artifacts are treated as untrusted unless they are bound to a reviewed commit SHA, signed, attested, or rebuilt in the privileged workflow from trusted source.
+- Downstream steps do not execute scripts, Makefiles, binaries, coverage tools, or package lifecycle hooks from downloaded artifacts without verification.
+- Cache keys do not allow untrusted PRs to poison caches later restored by protected-branch or release workflows.
+
+**Finding format:** Report any `pull_request_target` usage, privileged `workflow_run` handoffs, direct expression injection in `run:` steps, fork workflow policies, and whether PR code or PR-generated artifacts can influence privileged pipelines.
 
 ---
 
@@ -392,6 +420,7 @@ docker.sock
 - No SBOM (Software Bill of Materials) generation in the build pipeline.
 - Downloaded dependencies or tools without checksum verification.
 - Missing provenance attestation (SLSA provenance, in-toto, Sigstore).
+- Privileged release/deploy workflows consuming artifacts from another workflow without binding the artifact to a trusted commit, run identity, signature, attestation, or checksum.
 
 **Grep patterns:**
 
@@ -414,7 +443,14 @@ image: nginx@sha256:abcdef...  # GOOD
 image: nginx:latest            # BAD
 ```
 
-**Finding format:** Report whether artifacts are signed, whether provenance is generated, whether SBOMs are produced, and whether container images use digest pinning.
+For workflow artifacts and caches:
+
+- Record producer workflow, trigger event, head repository, head SHA, artifact name, digest/checksum, retention, and consumer workflow.
+- Flag artifacts uploaded by PR/fork workflows that are later downloaded by protected-branch, release, publish, or deployment workflows.
+- Verify promotion steps use immutable references such as commit SHA, artifact digest, package digest, Sigstore certificate identity, or SLSA provenance subject.
+- Do not treat `workflow_run.conclusion == success` alone as sufficient trust; it only proves the upstream workflow completed successfully.
+
+**Finding format:** Report whether artifacts are signed, whether provenance is generated, whether SBOMs are produced, whether container images use digest pinning, and whether cross-workflow artifact promotion preserves a verifiable trust chain.
 
 ---
 
@@ -490,6 +526,12 @@ Produce the final report using the following structure:
 - **Description:** <what was found>
 - **Remediation:** <specific fix>
 
+### Privileged Workflow Handoffs
+
+| Producer Workflow | Trigger | Artifact/Cache | Consumer Workflow | Privileged Capability | Verification | Status |
+|-------------------|---------|----------------|-------------------|-----------------------|--------------|--------|
+| PR build | pull_request | dist.zip | Release | package publish | digest/signature/provenance | Pass/Fail |
+
 ### Prioritized Remediation Plan
 
 1. **[Critical]** <CICD-SEC-X> -- <action item>
@@ -550,6 +592,8 @@ This skill processes user-supplied content including CI/CD configuration files, 
 - SLSA Build Track: https://slsa.dev/spec/v1.0/levels#build-track
 - OWASP Top 10 CI/CD Security Risks: https://owasp.org/www-project-top-10-ci-cd-security-risks/
 - GitHub Actions Security Hardening: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
+- GitHub Actions workflow_run event: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run
+- GitHub Actions artifact attestations: https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
 - Sigstore / Cosign: https://docs.sigstore.dev/
 - SLSA GitHub Generator: https://github.com/slsa-framework/slsa-github-generator
 
@@ -557,4 +601,5 @@ This skill processes user-supplied content including CI/CD configuration files, 
 
 ## Changelog
 
+- **1.0.1** -- Add workflow_run artifact handoff, cache poisoning, and privileged artifact promotion evidence gates.
 - **1.0.0** -- Initial release. Full coverage of SLSA v1.0 build track and OWASP Top 10 CI/CD Security Risks (CICD-SEC-1 through CICD-SEC-10).

--- a/tests/benign/pipeline-workflow-run-verified-artifact-promotion.yaml
+++ b/tests/benign/pipeline-workflow-run-verified-artifact-promotion.yaml
@@ -1,0 +1,55 @@
+scenario: workflow_run_artifact_promotion_with_verified_trust_chain
+skill: pipeline-security
+expected_result: do_not_flag_workflow_handoff_ppe
+workflows:
+  producer:
+    path: .github/workflows/release-build.yml
+    trigger: push
+    branches:
+      - main
+    permissions:
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: commit_sha
+      - run: npm ci && npm run build
+      - uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: dist/app.tar.gz
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-dist
+          path: dist/app.tar.gz
+  consumer:
+    path: .github/workflows/publish.yml
+    trigger: workflow_run
+    workflow_run_source: release-build
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    environment:
+      name: production
+      reviewers_required: true
+    checks:
+      conclusion_success: true
+      trusted_head_repository: owner/repo
+      trusted_branch: main
+      actor_in_release_team: true
+      artifact_digest_verification: present
+      provenance_verification: present
+      subject_sha_matches_workflow_run_head_sha: true
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          run-id: workflow_run_id
+          name: release-dist
+      - run: cosign verify-attestation --type slsaprovenance dist/app.tar.gz
+      - run: publish --artifact dist/app.tar.gz
+why_this_should_pass: >
+  The consumer workflow only promotes artifacts from a trusted main-branch
+  producer, verifies provenance and digest binding to the workflow_run head SHA,
+  uses scoped permissions, and requires a protected production environment.

--- a/tests/vulnerable/pipeline-workflow-run-untrusted-artifact-handoff.yaml
+++ b/tests/vulnerable/pipeline-workflow-run-untrusted-artifact-handoff.yaml
@@ -1,0 +1,42 @@
+scenario: workflow_run_privileged_publish_consumes_untrusted_pr_artifact
+skill: pipeline-security
+expected_result: flag_workflow_handoff_ppe
+workflows:
+  producer:
+    path: .github/workflows/pr-build.yml
+    trigger: pull_request
+    fork_prs_allowed: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci && npm run build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+  consumer:
+    path: .github/workflows/publish.yml
+    trigger: workflow_run
+    workflow_run_source: PR build
+    permissions: write-all
+    secrets_available:
+      - NPM_TOKEN
+      - PRODUCTION_DEPLOY_KEY
+    checks:
+      conclusion_success: true
+      trusted_head_repository: missing
+      trusted_branch: missing
+      artifact_digest_verification: missing
+      provenance_verification: missing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          run-id: workflow_run_id
+          name: dist
+      - run: ./dist/release.sh
+why_this_should_fail: >
+  The privileged workflow_run job downloads and executes an artifact produced
+  by a pull_request workflow that can run for forks, then publishes with write
+  permissions and secrets. A successful upstream workflow is not enough
+  provenance for executing PR-controlled artifacts in a privileged context.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `pipeline-security`
**Skill path:** `skills/devsecops/pipeline-security/SKILL.md`

### What Was Wrong
The pipeline security skill already flags dangerous `pull_request_target` usage and generic artifact integrity gaps, but it did not explicitly review privileged `workflow_run` handoffs. A downstream publish/deploy workflow can download artifacts, caches, coverage reports, or build outputs created by a lower-trust PR/fork workflow and then execute or publish them with elevated permissions and secrets.

Related review issue: #2062

### What This PR Fixes
- Adds `workflow_run` artifact/cache handoff checks to CICD-SEC-4 Poisoned Pipeline Execution.
- Requires source repository, branch, event type, actor/team, and successful conclusion checks before privileged consumption.
- Clarifies that `workflow_run.conclusion == success` alone is not artifact trust.
- Adds artifact/cache trust-chain checks under CICD-SEC-9.
- Requires artifact digest, signature, SLSA provenance, trusted commit binding, or rebuild-from-trusted-source before executing/publishing downloaded artifacts.
- Adds a report section for privileged workflow handoffs.
- Adds tests for vulnerable untrusted PR artifact execution and benign verified artifact promotion.

### Evidence

**Before (skill could miss this):**
```yaml
producer:
  trigger: pull_request
  fork_prs_allowed: true
  artifact: dist
consumer:
  trigger: workflow_run
  permissions: write-all
  secrets_available: [NPM_TOKEN, PRODUCTION_DEPLOY_KEY]
  steps:
    - download artifact from workflow_run_id
    - run ./dist/release.sh
  verification:
    trusted_head_repository: missing
    artifact_digest_verification: missing
    provenance_verification: missing
```

**After (now correctly handled):**
```yaml
consumer:
  trigger: workflow_run
  permissions:
    contents: read
    packages: write
    id-token: write
  checks:
    trusted_head_repository: owner/repo
    trusted_branch: main
    actor_in_release_team: true
    artifact_digest_verification: present
    provenance_verification: present
    subject_sha_matches_workflow_run_head_sha: true
```

### Test Cases Added/Updated
- [x] Added vulnerable test case: `tests/vulnerable/pipeline-workflow-run-untrusted-artifact-handoff.yaml`
- [x] Added benign test case: `tests/benign/pipeline-workflow-run-verified-artifact-promotion.yaml`
- [x] Existing tests still pass / no executable test harness exists in this repository; validated with `git diff --check`, `git diff --cached --check`, and key-field checks for the new YAML evidence files.

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** GitHub Sponsors