### PR TITLE
Improve DNS security evidence handling

### DIFF
--- a/skills/network/dns-security/SKILL.md
+++ b/skills/network/dns-security/SKILL.md
@@ -13,7 +13,7 @@ phase: [operate]
 frameworks: [NIST-SP-800-81-Rev2, CIS-Controls-v8]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -294,6 +294,27 @@ abcdef0123456789.dnscat.example.com TXT
 
 ---
 
+### Step 7: Control-Plane Evidence and Bypass Review
+
+Before final reporting, tie each DNS finding to the control-plane and data-plane evidence that proves it. DNSSEC, protective DNS, RPZ, encrypted transport, and exfiltration detection can all look present in configuration while failing in public validation, client path enforcement, feed freshness, or logging coverage.
+
+**DNS evidence gates:**
+
+| Gate | Requirement |
+|------|-------------|
+| `DNS-CTRL-01` | Record evidence source and confidence for each control: configuration, authoritative query, parent DS query, resolver query result, egress policy, RPZ feed export, log/SIEM sample, docs-only, or unknown. |
+| `DNS-CTRL-02` | For authoritative DNSSEC, verify signed zone records, algorithm/key size, DNSKEY/KSK fingerprint, matching DS in the parent, and external validation status. |
+| `DNS-CTRL-03` | For recursive DNSSEC, verify resolver validation setting, trust-anchor freshness, NTA inventory, and positive/negative validation query results. |
+| `DNS-CTRL-04` | For protective DNS/RPZ, verify feed source, update automation, last update time, block action, test-domain result, blocked-query logging, and SIEM forwarding. |
+| `DNS-CTRL-05` | For client path enforcement, verify DHCP/resolver settings, endpoint policy, direct UDP/TCP 53 egress controls, browser DoH policy, and known public DoH endpoint handling. |
+| `DNS-CTRL-06` | For exfiltration detection, verify resolver logs include source, qname, qtype, response code, response size, entropy/volume rules, and TCP/UDP 53 coverage. |
+| `DNS-CTRL-07` | Mark controls as Not Evaluable with a reason code when evidence is missing: `missing-parent-ds`, `missing-external-validation`, `missing-resolver-path`, `missing-egress-policy`, `missing-doh-policy`, `missing-rpz-feed`, `missing-query-logs`, `missing-siem-forwarding`, or `sample-only`. |
+| `DNS-CTRL-08` | Record split-horizon scope, exception owner, expiry, compensating controls, and retest trigger before downgrading or accepting risk. |
+
+**Classification guidance:** A locally signed zone without parent DS and external validation evidence is at least **High** and can be **Critical** when public clients rely on DNSSEC. Protective DNS configured on the resolver but bypassable through direct DNS or public DoH is **High**. RPZ/protective DNS without feed freshness or block logging is **Medium**. Exfiltration detection without source-attributed logs or TCP/UDP coverage is **Medium** to **High** depending on exposure.
+
+---
+
 ## Findings Classification
 
 | Severity | Definition |
@@ -333,6 +354,11 @@ abcdef0123456789.dnscat.example.com TXT
 #### [F-001] <Finding Title>
 - **Severity:** Critical / High / Medium / Low
 - **Control Reference:** NIST SP 800-81 Section X / CIS 9.2
+- **Asset Role:** authoritative / recursive / client / protective-dns / siem
+- **Evidence Source:** configuration / authoritative-query / parent-ds-query / resolver-query / egress-policy / rpz-feed / log-siem-sample / docs-only / unknown
+- **Evidence Confidence:** high / medium / low / unknown
+- **Not Evaluable Reason:** <reason code if applicable>
+- **Bypass Path:** <direct DNS, public DoH, split-horizon gap, or none>
 - **File:** <path to config file>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration snippet>
@@ -384,6 +410,14 @@ abcdef0123456789.dnscat.example.com TXT
 
 4. **Ignoring DNS over TCP.** DNS is not UDP-only. DNS over TCP (port 53) supports large responses and is required for zone transfers. Some tunneling tools prefer TCP for reliability. Firewall rules and monitoring must cover both UDP and TCP port 53.
 
+5. **Accepting signed zone files without parent-chain proof.** RRSIG and DNSKEY records in a local zone file do not prove public DNSSEC validation. Query the parent DS record and validate externally.
+
+6. **Treating resolver hardening as client enforcement.** DNSSEC-validating or RPZ-enabled resolvers do not protect endpoints that can use direct DNS or public browser DoH.
+
+7. **Accepting stale RPZ feeds.** RPZ configuration is not enough without feed source, automated update evidence, last update time, block behavior, and logging.
+
+8. **Logging without source attribution.** DNS exfiltration detection needs source identity, qname, qtype, response code, and response size. Aggregate-only counts are insufficient for triage.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -413,4 +447,5 @@ This skill processes DNS configuration files that may contain user-supplied zone
 
 ## Changelog
 
+- **1.0.1** -- Added DNS control-plane evidence gates, evidence confidence fields, DNSSEC parent-chain validation, client bypass review, RPZ freshness/logging requirements, and Not Evaluable reason codes.
 - **1.0.0** -- Initial release. Full coverage of NIST SP 800-81 Rev 2 and CIS Controls v8 Control 9.2 for DNS security review.

--- a/tests/benign/dns-security-control-plane-evidence-verified.yaml
+++ b/tests/benign/dns-security-control-plane-evidence-verified.yaml
@@ -1,0 +1,65 @@
+id: dns-security-control-plane-evidence-verified
+skill: dns-security
+expected: benign
+description: >
+  DNS review ties each finding to authoritative, recursive, client path, RPZ,
+  and SIEM evidence before assigning scoped Pass results.
+scenario:
+  evidence_inventory:
+    - name: authoritative_dnssec_validation
+      source_type: authoritative-query
+      captured: "2026-06-01T08:00:00Z"
+      coverage: "public zone example.test, DNSKEY/KSK fingerprint, parent DS query, external validation pass"
+    - name: recursive_validation_queries
+      source_type: resolver-query
+      captured: "2026-06-01T08:10:00Z"
+      coverage: "enterprise resolvers, valid and intentionally broken DNSSEC test domains"
+    - name: client_path_enforcement
+      source_type: egress-policy
+      captured: "2026-06-01T08:20:00Z"
+      coverage: "DHCP resolver assignment, endpoint policy, UDP/TCP 53 egress deny except resolvers, browser DoH disabled"
+    - name: rpz_feed_and_block_logs
+      source_type: rpz-feed
+      captured: "2026-06-01T08:30:00Z"
+      coverage: "feed source, automated transfer, last update, test domain blocked, blocked-query logs"
+    - name: dns_siem_detection_sample
+      source_type: log-siem-sample
+      captured: "2026-06-01T08:40:00Z"
+      coverage: "source, qname, qtype, rcode, response size, entropy and volume alerts, UDP/TCP 53"
+  reported_findings:
+    - title: "DNSSEC deployed for public zone"
+      status: Pass
+      severity: Low
+      asset_role: authoritative
+      evidence_source: authoritative-query
+      evidence_confidence: high
+      bypass_path: none
+      notes:
+        - "Parent DS matches KSK fingerprint and external validation passes."
+    - title: "Protective DNS enforced for endpoints"
+      status: Pass
+      severity: Low
+      asset_role: protective-dns
+      evidence_source: egress-policy
+      evidence_confidence: high
+      bypass_path: none
+      notes:
+        - "Direct UDP/TCP 53 and browser DoH bypass paths are controlled."
+        - "RPZ feed freshness and blocked-query logging are verified."
+    - title: "Split-horizon internal DNSSEC"
+      status: Not Evaluable
+      severity: Informational
+      asset_role: authoritative
+      evidence_source: unknown
+      not_evaluable_reason: sample-only
+      notes:
+        - "Internal split-horizon zone was outside the supplied sample."
+should_not_trigger:
+  - "signed zone accepted without parent DS"
+  - "resolver RPZ treated as client enforcement"
+  - "exfiltration detection accepted without source-attributed logs"
+expected_result: >
+  The skill should accept scoped Pass findings where control-plane and
+  data-plane evidence exists, preserve Not Evaluable reason codes for unsampled
+  split-horizon zones, and avoid overclaiming protective DNS when bypass evidence
+  is missing.

--- a/tests/vulnerable/dns-security-signed-zone-bypass-overclaim.yaml
+++ b/tests/vulnerable/dns-security-signed-zone-bypass-overclaim.yaml
@@ -1,0 +1,70 @@
+id: dns-security-signed-zone-bypass-overclaim
+skill: dns-security
+expected: vulnerable
+description: >
+  Local DNSSEC and RPZ configuration are overclaimed as effective DNS security
+  without parent-chain, resolver-path, egress, DoH, feed, or logging evidence.
+scenario:
+  authoritative_zone:
+    zone: example.test
+    local_zone_file: zones/example.test.signed
+    local_records:
+      - DNSKEY
+      - RRSIG
+      - NSEC3PARAM
+    missing_evidence:
+      - parent_ds_query
+      - external_dnssec_validation_result
+      - ksk_fingerprint_match
+      - registrar_or_parent_update_ticket
+  recursive_resolver:
+    software: BIND
+    config:
+      dnssec_validation: auto
+      response_policy_zone: malware-block.rpz
+    missing_evidence:
+      - trust_anchor_freshness
+      - validating_resolver_query_result
+      - negative_trust_anchor_inventory
+      - rpz_feed_source
+      - rpz_last_update_time
+      - rpz_test_block_result
+      - blocked_query_logs
+  client_path:
+    claimed_scope: "all enterprise endpoints"
+    missing_evidence:
+      - dhcp_resolver_assignment
+      - endpoint_dns_policy
+      - udp_53_egress_block
+      - tcp_53_egress_block
+      - browser_doh_policy
+      - public_doh_endpoint_policy
+  reported_findings:
+    - title: "DNSSEC deployed for public zone"
+      status: Pass
+      evidence_source: configuration
+      evidence_confidence: low
+      problem: "Local signed zone records are treated as public chain-of-trust validation."
+    - title: "Protective DNS enforced for endpoints"
+      status: Pass
+      evidence_source: configuration
+      evidence_confidence: low
+      problem: "Resolver RPZ exists, but clients can bypass through direct DNS or browser DoH."
+    - title: "DNS exfiltration detection ready"
+      status: Pass
+      evidence_source: docs-only
+      evidence_confidence: low
+      problem: "No source-attributed DNS query logs or TCP/UDP coverage evidence is supplied."
+should_trigger:
+  - DNS-CTRL-01
+  - DNS-CTRL-02
+  - DNS-CTRL-03
+  - DNS-CTRL-04
+  - DNS-CTRL-05
+  - DNS-CTRL-06
+  - DNS-CTRL-07
+expected_result: >
+  The skill should flag the assessment as overconfident. DNSSEC should remain
+  Fail or Not Evaluable until parent DS and external validation evidence exist,
+  protective DNS should be High risk when client bypass paths are not controlled,
+  and exfiltration readiness should require source-attributed DNS logs.


### PR DESCRIPTION
/claim #54

## Summary

Improves `dns-security` so DNSSEC, protective DNS, RPZ, client-path, and exfiltration findings are tied to concrete control-plane and data-plane evidence.

Changes include:

- Adds `DNS-CTRL-01` through `DNS-CTRL-08` gates for evidence source/confidence, authoritative parent-chain validation, recursive validation, RPZ freshness/logging, client bypass enforcement, exfiltration logging coverage, Not Evaluable reason codes, and split-horizon exception tracking.
- Extends finding output with asset role, evidence source, evidence confidence, Not Evaluable reason, and bypass path fields.
- Adds vulnerable and benign fixtures for signed-zone/RPZ overclaiming versus verified parent DS, resolver, egress, RPZ, and SIEM evidence.

## Why

Signed local zone files and resolver RPZ configuration do not prove public DNSSEC validation or endpoint enforcement. The review should distinguish configuration intent from parent DS evidence, external validation, resolver path controls, direct DNS/DoH bypass handling, feed freshness, and source-attributed logs.

## Validation

- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`
- Markdown fence-balance check for `skills/network/dns-security/SKILL.md`
- Marker check for `DNS-CTRL-01` through `DNS-CTRL-08`
- YAML parse check for both added fixtures
- Added-line sensitive/public-contact pattern scan

## Bounty Info

- I have read and agree to `CONTRIBUTING.md` bounty terms.
- Requested tier: Improver Moderate ($100) if accepted/merged.