### PR TITLE
Improve firewall rule evidence handling

### DIFF
--- a/skills/network/firewall-review/SKILL.md
+++ b/skills/network/firewall-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [operate]
 frameworks: [CIS-Controls-v8, NIST-SP-800-41-Rev1]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -254,7 +254,30 @@ Egress filtering prevents compromised internal hosts from establishing unrestric
 
 ---
 
-### Step 3: Compile Assessment Report
+### Step 3: Build Rule Evidence Matrix
+
+Before compiling findings, normalize each reviewed rule into an evidence matrix. Firewall rule severity depends on effective exposure, not just the literal rule text. Object groups, NAT, first-match order, cloud defaults, IPv6 parity, runtime counters, and flow logs can all change the conclusion.
+
+**Rule evidence gates:**
+
+| Gate | Requirement |
+|------|-------------|
+| `FW-EVID-01` | Record rule ID, platform, direction, source zone, destination zone, action, protocol/service, source, destination, owner, change ticket, and intended business flow. |
+| `FW-EVID-02` | Expand source/destination/service objects and groups before rating severity; record stale, broad, mixed-environment, or unexpanded members. |
+| `FW-EVID-03` | Record NAT stage and translated source/destination/service for pre-NAT and post-NAT policy evaluation. |
+| `FW-EVID-04` | Record first-match order, shadowing relationship, default policy, and whether the finding depends on rule order. |
+| `FW-EVID-05` | Record hit count, counter baseline timestamp, last-used timestamp, failover/reload resets, and corroborating flow/SIEM evidence before recommending removal. |
+| `FW-EVID-06` | Record logging state, log destination, log field completeness, and retention for deny rules and sensitive permits. |
+| `FW-EVID-07` | Record IPv4/IPv6 parity, cloud implicit defaults, egress path, management-plane scope, and out-of-scope policy sets. |
+| `FW-EVID-08` | Mark controls as Not Evaluable with a reason code when evidence is missing: `missing-object-expansion`, `missing-nat-stage`, `missing-rule-order`, `missing-counter-baseline`, `missing-flow-logs`, `missing-owner-ticket`, `missing-ipv6-policy`, `missing-egress-path`, or `stale-export`. |
+
+**Evidence confidence levels:** Use `high` for exported policy plus expanded objects plus current counters/flow evidence; `medium` for exported policy with partial runtime evidence; `low` for IaC or documentation only; `unknown` when rule text or runtime context is unavailable.
+
+**Classification guidance:** Any/any inbound remains **Critical**, but a broad-looking private east-west permit with owner, ticket, object expansion, NAT context, logging, and current flow evidence can be scoped lower. Zero-hit rules should not be removed solely from counters when the counter baseline is recent or reset by failover. Unexpanded broad objects, missing NAT stage, or missing IPv6/egress evidence should produce Not Evaluable or reduced-confidence findings instead of speculative conclusions.
+
+---
+
+### Step 4: Compile Assessment Report
 
 Produce the final report using the following structure.
 
@@ -294,6 +317,12 @@ Produce the final report using the following structure.
 #### [F-001] <Finding Title>
 - **Severity:** Critical / High / Medium / Low
 - **Control Reference:** CIS 4.4 / NIST SP 800-41 Section X.X
+- **Evidence Confidence:** high / medium / low / unknown
+- **Not Evaluable Reason:** <reason code if applicable>
+- **Owner / Ticket:** <business owner and change reference>
+- **Object Expansion:** <expanded source/destination/service members or gap>
+- **NAT Stage:** <pre-NAT/post-NAT/none/unknown>
+- **Counter Baseline:** <hit count, last used, reset timestamp, flow-log evidence>
 - **File:** <path to config file>
 - **Rule(s):** <rule number(s) or line(s)>
 - **Description:** <what was found>
@@ -361,6 +390,14 @@ Produce the final report using the following structure.
 
 5. **Conflating network ACLs with security groups in cloud environments.** In AWS, NACLs are stateless and operate at the subnet level; security groups are stateful and operate at the instance level. Both must be audited. A permissive NACL can undermine restrictive security group rules for responses.
 
+6. **Rating object names without expansion.** Friendly names such as `APP_PROD` can hide `0.0.0.0/0`, mixed environments, stale hosts, or nested groups. Expand members before severity assignment.
+
+7. **Ignoring NAT stage.** A rule that appears private pre-NAT can expose a public translated address post-NAT, and a post-NAT rule can miss the original source context.
+
+8. **Removing zero-hit rules after a reset.** Counter baselines can reset during failover, policy install, reboot, or HA sync. Require baseline age and flow evidence before removal.
+
+9. **Omitting management-plane and emergency rules.** Out-of-band management, break-glass, and emergency access policies often live in separate rule sets. Mark them Not Evaluable if they are not supplied.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -386,4 +423,5 @@ This skill processes firewall configurations that may contain user-supplied comm
 
 ## Changelog
 
+- **1.0.1** -- Added normalized rule evidence gates, object expansion/NAT/counter-baseline fields, evidence confidence, and Not Evaluable reason codes.
 - **1.0.0** -- Initial release. Full coverage of CIS Controls v8 (4.4, 4.5) and NIST SP 800-41 Rev 1 firewall audit methodology.

--- a/tests/benign/firewall-review-rule-evidence-matrix-verified.yaml
+++ b/tests/benign/firewall-review-rule-evidence-matrix-verified.yaml
@@ -1,0 +1,67 @@
+id: firewall-review-rule-evidence-matrix-verified
+skill: firewall-review
+expected: benign
+description: >
+  Firewall review uses a normalized rule evidence matrix with expanded objects,
+  NAT context, order, counters, logging, ownership, IPv6 parity, and flow logs.
+scenario:
+  platform: "Firewall manager export with runtime counters and SIEM flows"
+  evidence_inventory:
+    - name: policy_export
+      source_type: firewall-manager-export
+      captured: "2026-06-01T08:00:00Z"
+      coverage: "IPv4 and IPv6 security policy, NAT policy, rule order"
+    - name: object_expansion
+      source_type: firewall-manager-export
+      captured: "2026-06-01T08:05:00Z"
+      coverage: "nested address and service groups expanded"
+    - name: runtime_counters
+      source_type: runtime-counter
+      captured: "2026-06-01T08:10:00Z"
+      coverage: "90-day counter baseline with no failover reset"
+    - name: flow_logs
+      source_type: siem-flow-log
+      captured: "2026-06-01T08:20:00Z"
+      coverage: "source, destination, service, action, rule ID, 90-day lookback"
+  rule_evidence_matrix:
+    - rule_id: "120"
+      action: allow
+      direction: ingress
+      source_zone: untrust
+      destination_zone: dmz
+      source: "approved partner CIDRs"
+      expanded_source:
+        - 203.0.113.0/24
+      destination: "APP_PROD"
+      expanded_destination:
+        - 10.20.4.10
+        - 10.20.4.11
+      service: tcp/443
+      nat_stage: "post-NAT destination 10.20.4.10/31 from public VIP 198.51.100.20"
+      owner_ticket: "payments-platform / CHG-1842"
+      hit_count: 184233
+      counter_baseline: "90 days, no reset"
+      logging: enabled_to_siem
+      evidence_confidence: high
+      result: "scoped Pass with owner and logging"
+    - rule_id: "240"
+      action: allow
+      direction: egress
+      source_zone: app
+      destination_zone: internet
+      source: "legacy batch subnet"
+      destination: any
+      service: tcp/25
+      hit_count: 0
+      counter_baseline: "90 days"
+      flow_logs: "no matching flows"
+      owner_ticket: "mail migration / CHG-1901"
+      result: "candidate removal with rollback and owner approval"
+should_not_trigger:
+  - "object name rated without expansion"
+  - "zero-hit removal after recent counter reset"
+  - "NAT stage missing"
+expected_result: >
+  The skill should accept scoped findings because object expansion, NAT stage,
+  rule order, counters, flow logs, owner/ticket, logging, and IPv6 parity are
+  documented. Unused-rule removal advice is evidence-backed and owner-approved.

--- a/tests/vulnerable/firewall-review-object-nat-counter-overclaim.yaml
+++ b/tests/vulnerable/firewall-review-object-nat-counter-overclaim.yaml
@@ -1,0 +1,61 @@
+id: firewall-review-object-nat-counter-overclaim
+skill: firewall-review
+expected: vulnerable
+description: >
+  Firewall review rates rule severity and removal safety without object
+  expansion, NAT stage, counter baseline, IPv6, owner, or flow-log evidence.
+scenario:
+  platform: "Palo Alto export plus partial runtime counters"
+  supplied_evidence:
+    - source_type: exported-policy
+      captured: "2026-06-01"
+      coverage: "IPv4 security policy only"
+    - source_type: runtime-counter
+      captured: "2026-06-01T10:00:00Z"
+      coverage: "counter reset after HA failover two hours earlier"
+  missing_evidence:
+    - expanded_destination_object_members
+    - expanded_service_group_members
+    - post_nat_translation
+    - ipv6_policy_export
+    - owner_and_change_ticket
+    - flow_log_or_siem_corroboration
+    - management_plane_policy_set
+  rules:
+    - id: "120"
+      action: allow
+      direction: ingress
+      source_zone: untrust
+      destination_zone: dmz
+      source: any
+      destination: object-group:APP_PROD
+      service: service-group:WEB_EXT
+      logging: disabled
+      hit_count: 0
+      counter_baseline: "reset two hours ago during HA failover"
+      nat_stage: unknown
+      reported_status: "unused broad permit, safe to remove"
+    - id: "130"
+      action: deny
+      direction: ingress
+      source_zone: untrust
+      destination_zone: dmz
+      source: any
+      destination: host:10.5.10.20
+      service: tcp/22
+      reported_status: "effective deny"
+      problem: "Earlier unexpanded allow may shadow this deny after object/service expansion."
+should_trigger:
+  - FW-EVID-01
+  - FW-EVID-02
+  - FW-EVID-03
+  - FW-EVID-04
+  - FW-EVID-05
+  - FW-EVID-06
+  - FW-EVID-07
+  - FW-EVID-08
+expected_result: >
+  The skill should mark severity and removal advice as low-confidence or Not
+  Evaluable until object/service expansion, NAT stage, rule order, counter
+  baseline age, flow evidence, owner/ticket, IPv6 parity, and missing policy
+  sets are supplied.


### PR DESCRIPTION
/claim #59

## Summary

Improves `firewall-review` with a normalized rule evidence matrix so findings account for object expansion, NAT stage, rule order, counter baselines, logging, IPv6 parity, egress path, and ownership evidence.

Changes include:

- Adds `FW-EVID-01` through `FW-EVID-08` gates for rule metadata, object/service expansion, NAT translation, first-match/shadowing context, hit-count baselines, logging evidence, IPv4/IPv6/egress scope, and Not Evaluable reason codes.
- Extends finding output with evidence confidence, Not Evaluable reason, owner/ticket, object expansion, NAT stage, and counter-baseline fields.
- Adds vulnerable and benign fixtures for object/NAT/counter overclaiming versus a verified rule evidence matrix.

## Why

Firewall severity and removal safety depend on effective exposure. A friendly object name can hide a broad CIDR, NAT can change the real source or destination, and zero-hit counters can be meaningless after failover. The new gates force those evidence gaps into the report before severity or removal recommendations are made.

## Validation

- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`
- Markdown fence-balance check for `skills/network/firewall-review/SKILL.md`
- Marker check for `FW-EVID-01` through `FW-EVID-08`
- YAML parse check for both added fixtures
- Added-line sensitive/public-contact pattern scan

## Bounty Info

- I have read and agree to `CONTRIBUTING.md` bounty terms.
- Requested tier: Improver Moderate ($100) if accepted/merged.