### PR TITLE
Improve GCP review GKE posture gates

### DIFF
--- a/skills/cloud/gcp-review/SKILL.md
+++ b/skills/cloud/gcp-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-GCP-v2.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -25,7 +25,7 @@ argument-hint: "[target-file-or-directory]"
 
 ## Overview
 
-This skill performs a structured security assessment of Google Cloud Platform environments against the **CIS Google Cloud Platform Foundation Benchmark v2.0.0**. The benchmark is organized into seven sections covering identity and access management, logging and monitoring, networking, virtual machines, storage, Cloud SQL, and BigQuery. Each recommendation is evaluated by inspecting infrastructure-as-code definitions (Terraform, Deployment Manager), gcloud CLI output, or configuration files available in the repository.
+This skill performs a structured security assessment of Google Cloud Platform environments against the **CIS Google Cloud Platform Foundation Benchmark v2.0.0**. The benchmark is organized into seven sections covering identity and access management, logging and monitoring, networking, virtual machines, storage, Cloud SQL, and BigQuery. Each recommendation is evaluated by inspecting infrastructure-as-code definitions (Terraform, Deployment Manager), gcloud CLI output, or configuration files available in the repository. When GKE clusters are present, the review also collects supplemental GKE posture evidence so cluster-level Google Cloud controls are not lost between generic GCP checks and the separate container workload review.
 
 The CIS GCP Foundation Benchmark v2.0.0 provides prescriptive guidance for hardening GCP projects and organizations. This skill evaluates each applicable control and produces a findings report with CIS recommendation IDs, severity ratings, and actionable remediation steps.
 
@@ -88,7 +88,39 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
-### Step 9: Compile Assessment Report
+### Step 9: Supplemental GKE Cluster Posture Evidence
+
+When `google_container_cluster`, `google_container_node_pool`, or GKE configuration exports are present, evaluate cluster-level GCP controls before final scoring. This supplemental gate does not replace the `container-security` skill for Kubernetes manifests, RBAC, Pod Security, or workload YAML. It covers the Google Cloud control plane and node-pool settings that are visible in Terraform or GKE exports.
+
+Record a GKE evidence row for each cluster and node pool:
+
+| Evidence Field | Required Evidence | Risk If Missing |
+|---|---|---|
+| Cluster mode | Standard vs. Autopilot and provider-managed defaults | Standard-only requirements can be misapplied to Autopilot, or Autopilot defaults can be assumed without proof |
+| Control plane exposure | `private_cluster_config`, private endpoint status, and `master_authorized_networks_config` CIDRs | Public or broadly reachable cluster API endpoint |
+| Node identity | Node service account, OAuth scopes, default service-account usage, and node-pool IAM | Pods inherit broad node identity or `cloud-platform` access |
+| Workload Identity Federation for GKE | `workload_identity_config`, node-pool `workload_metadata_config`, namespace/KSA mapping, and IAM conditions where relevant | Pods fall back to node metadata, or same namespace/KSA names in the project share unintended Google Cloud access |
+| Metadata exception paths | Host-network workloads, Dataplane V2 metadata egress allowances, and compensating controls | Workloads bypass expected GKE metadata server behavior |
+| Node integrity | Shielded GKE Nodes status and node-pool override evidence | Node bootstrap identity and integrity are not verifiable |
+| Admission and network controls | Binary Authorization mode, NetworkPolicy enablement, and provider-managed equivalents | Unverified images or unrestricted pod-to-pod traffic in production clusters |
+
+**Finding triggers:**
+
+```
+GCP-GKE-01: GKE cluster evidence is missing while Terraform declares google_container_cluster resources
+GCP-GKE-02: Public control plane or authorized networks include 0.0.0.0/0 without documented compensating control
+GCP-GKE-03: Standard cluster node pool uses default service account or cloud-platform OAuth scope without workload-bound least privilege
+GCP-GKE-04: Workload Identity Federation for GKE is absent, disabled at the node pool, or not mapped to reviewed namespace/KSA bindings
+GCP-GKE-05: Host-network metadata exception paths are present without compensating controls
+GCP-GKE-06: Shielded GKE Nodes are disabled or not evidenced for Standard clusters
+GCP-GKE-07: Binary Authorization or NetworkPolicy is disabled for production clusters without documented exception
+```
+
+If GKE evidence is incomplete, mark the affected cluster as **Not Evaluable** rather than scoring it as pass. If the same environment includes Kubernetes manifests, route manifest-level findings to `skills/cloud/container-security/SKILL.md`.
+
+---
+
+### Step 10: Compile Assessment Report
 
 
 Produce the final report using the structure defined in the Output Format section.
@@ -137,6 +169,12 @@ Produce the final report using the structure defined in the Output Format sectio
 | 5 | Storage | X | Y | Z | nn% |
 | 6 | Cloud SQL | X | Y | Z | nn% |
 | 7 | BigQuery | X | Y | Z | nn% |
+
+### Supplemental GKE Evidence
+
+| Cluster/Node Pool | Mode | Control Plane Exposure | Node Identity | Workload Identity Evidence | Metadata Exceptions | Shielded Nodes | Binary Authorization | NetworkPolicy | Status |
+|---|---|---|---|---|---|---|---|---|---|
+| <cluster> | Standard/Autopilot | <private/public/CIDRs> | <service account/scopes> | <enabled/missing/N/A> | <hostNetwork/none/unknown> | <enabled/disabled/managed> | <enforced/disabled/N/A> | <enabled/disabled/N/A> | Pass/Fail/Not Evaluable |
 
 ### Detailed Findings
 
@@ -194,6 +232,7 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Cloud SQL authorized_networks vs. private IP.** CIS 6.5 flags `0.0.0.0/0` in authorized networks, but CIS 6.6 goes further and recommends disabling public IP entirely in favor of private networking.
 5. **BigQuery dataset-level vs. table-level CMEK.** CIS 7.2 checks table-level encryption, while CIS 7.3 checks the dataset default. Both should be evaluated independently.
 6. **Default compute service account identification.** The default SA follows the pattern `PROJECT_NUMBER-compute@developer.gserviceaccount.com`. Grep for this pattern, not just the string "default."
+7. **Letting GKE fall between skills.** Generic CIS GCP checks do not inspect cluster-only settings such as private endpoint, Workload Identity Federation for GKE, node metadata mode, Shielded GKE Nodes, Binary Authorization, or NetworkPolicy. Capture those controls here, then hand Kubernetes manifest findings to `container-security`.
 
 ---
 
@@ -218,6 +257,9 @@ Produce the final report using the structure defined in the Output Format sectio
 - Google Cloud IAM Documentation: https://cloud.google.com/iam/docs
 - Google Cloud Audit Logs: https://cloud.google.com/logging/docs/audit
 - Google Cloud VPC Documentation: https://cloud.google.com/vpc/docs
+- Google Cloud GKE Workload Identity Federation: https://docs.cloud.google.com/kubernetes-engine/docs/concepts/workload-identity
+- Google Cloud GKE network isolation: https://docs.cloud.google.com/kubernetes-engine/docs/concepts/network-isolation
+- Google Cloud Shielded GKE Nodes: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes
 - Google Cloud SQL Security: https://cloud.google.com/sql/docs/mysql/configure-ssl-instance
 - Terraform Google Provider Documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs
 
@@ -225,4 +267,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Adds supplemental GKE cluster posture evidence gates for private control plane, Workload Identity Federation for GKE, node identity, metadata exception paths, Shielded GKE Nodes, Binary Authorization, and NetworkPolicy.
 - **1.0.0** -- Initial release. Full coverage of CIS Google Cloud Platform Foundation Benchmark v2.0.0 sections 1 through 7.

--- a/skills/cloud/gcp-review/benchmark-checklist.md
+++ b/skills/cloud/gcp-review/benchmark-checklist.md
@@ -534,6 +534,132 @@ resource "google_compute_instance" {
 
 ---
 
+## Supplemental GKE Cluster Posture Review
+
+Evaluate `google_container_cluster`, `google_container_node_pool`, and GKE export evidence when a GCP environment runs Google Kubernetes Engine. These checks are supplemental to CIS GCP v2.0.0 because they focus on cluster-level Google Cloud controls; use `skills/cloud/container-security/SKILL.md` for Kubernetes workload manifests.
+
+### GCP-GKE-01 -- Ensure GKE Clusters Are Explicitly Inventoried
+
+**Grep patterns:**
+
+```
+resource "google_container_cluster"
+resource "google_container_node_pool"
+google_container_cluster
+google_container_node_pool
+```
+
+If any GKE resource is present, require a GKE evidence row in the final report. Missing cluster mode, node-pool identity, Workload Identity, or control-plane evidence is **Not Evaluable**.
+
+### GCP-GKE-02 -- Ensure Control Plane Exposure Is Private or Tightly Scoped
+
+```hcl
+# BAD: public endpoint with broad authorized network
+resource "google_container_cluster" "bad" {
+  private_cluster_config {
+    enable_private_nodes    = false
+    enable_private_endpoint = false
+  }
+
+  master_authorized_networks_config {
+    cidr_blocks {
+      cidr_block = "0.0.0.0/0"
+    }
+  }
+}
+```
+
+Require evidence for private nodes, private endpoint status, and authorized network CIDRs. A public endpoint can be acceptable only with narrow, documented networks and compensating controls.
+
+### GCP-GKE-03 -- Ensure Node Identity Is Least Privilege
+
+```hcl
+# BAD: default service account and broad OAuth scope
+resource "google_container_node_pool" "bad" {
+  node_config {
+    service_account = "default"
+    oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
+  }
+}
+```
+
+Look for:
+
+```
+service_account = "default"
+oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+roles/editor
+PROJECT_NUMBER-compute@developer.gserviceaccount.com
+```
+
+Node pools should use a dedicated service account with minimal IAM and minimal OAuth scopes where scopes still apply.
+
+### GCP-GKE-04 -- Ensure Workload Identity Federation for GKE Is Enabled and Evidenced
+
+```hcl
+resource "google_container_cluster" "good" {
+  workload_identity_config {
+    workload_pool = "example-prod.svc.id.goog"
+  }
+}
+
+resource "google_container_node_pool" "good" {
+  node_config {
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+  }
+}
+```
+
+Require cluster-level `workload_identity_config`, node-pool `workload_metadata_config`, namespace/Kubernetes ServiceAccount mapping, and IAM binding conditions where namespace or KSA names can collide across clusters in the same project.
+
+### GCP-GKE-05 -- Ensure Metadata Exception Paths Are Reviewed
+
+Workload Identity Federation for GKE changes metadata behavior, but host-network workloads and required metadata egress paths can be exceptions.
+
+**Grep patterns:**
+
+```
+hostNetwork: true
+169.254.169.254
+169.254.169.252
+workload_metadata_config
+mode = "GCE_METADATA"
+```
+
+Document any host-network workloads, Dataplane V2 metadata egress allowances, and compensating controls before marking Workload Identity evidence complete.
+
+### GCP-GKE-06 -- Ensure Shielded GKE Nodes Are Enabled or Provider-Managed
+
+```hcl
+# BAD for Standard clusters unless justified
+resource "google_container_cluster" "bad" {
+  enable_shielded_nodes = false
+}
+```
+
+For Standard clusters, require evidence that Shielded GKE Nodes are enabled or that a provider-managed mode such as Autopilot enforces the equivalent control.
+
+### GCP-GKE-07 -- Ensure Binary Authorization and NetworkPolicy Are Reviewed
+
+```hcl
+# BAD in production without a documented exception
+resource "google_container_cluster" "bad" {
+  network_policy {
+    enabled = false
+  }
+
+  binary_authorization {
+    evaluation_mode = "DISABLED"
+  }
+}
+```
+
+Record whether Binary Authorization is enforced, disabled, or not applicable, and whether NetworkPolicy is enabled or replaced by documented provider-managed controls. Disabled controls in production should be **High** unless an exception is documented.
+
+---
+
 ## Section 5 -- Storage
 
 Evaluate Cloud Storage configurations against CIS GCP v2.0.0 Section 5 recommendations.

--- a/skills/cloud/gcp-review/tests/benign/private-standard-gke-evidence.tf
+++ b/skills/cloud/gcp-review/tests/benign/private-standard-gke-evidence.tf
@@ -1,0 +1,50 @@
+resource "google_container_cluster" "payments" {
+  name     = "payments-prod"
+  location = "us-central1"
+
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  private_cluster_config {
+    enable_private_nodes    = true
+    enable_private_endpoint = true
+    master_ipv4_cidr_block  = "172.16.0.0/28"
+  }
+
+  master_authorized_networks_config {
+    cidr_blocks {
+      cidr_block   = "203.0.113.0/24"
+      display_name = "corp-vpn"
+    }
+  }
+
+  workload_identity_config {
+    workload_pool = "example-prod.svc.id.goog"
+  }
+
+  network_policy {
+    enabled  = true
+    provider = "CALICO"
+  }
+
+  binary_authorization {
+    evaluation_mode = "PROJECT_SINGLETON_POLICY_ENFORCE"
+  }
+
+  enable_shielded_nodes = true
+}
+
+resource "google_container_node_pool" "payments" {
+  name     = "payments-private"
+  cluster  = google_container_cluster.payments.name
+  location = "us-central1"
+
+  node_config {
+    service_account = "gke-nodes@example-prod.iam.gserviceaccount.com"
+    oauth_scopes    = ["https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/monitoring"]
+
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+  }
+}

--- a/skills/cloud/gcp-review/tests/vulnerable/public-gke-broad-node-metadata.tf
+++ b/skills/cloud/gcp-review/tests/vulnerable/public-gke-broad-node-metadata.tf
@@ -1,0 +1,41 @@
+resource "google_container_cluster" "admin" {
+  name     = "admin-prod"
+  location = "us-central1"
+
+  private_cluster_config {
+    enable_private_nodes    = false
+    enable_private_endpoint = false
+  }
+
+  master_authorized_networks_config {
+    cidr_blocks {
+      cidr_block   = "0.0.0.0/0"
+      display_name = "anywhere"
+    }
+  }
+
+  network_policy {
+    enabled = false
+  }
+
+  binary_authorization {
+    evaluation_mode = "DISABLED"
+  }
+
+  enable_shielded_nodes = false
+}
+
+resource "google_container_node_pool" "default" {
+  name     = "default-pool"
+  cluster  = google_container_cluster.admin.name
+  location = "us-central1"
+
+  node_config {
+    service_account = "default"
+    oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
+
+    workload_metadata_config {
+      mode = "GCE_METADATA"
+    }
+  }
+}


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `gcp-review`
**Skill path:** `skills/cloud/gcp-review/`

Closes #2088.

### What Was Wrong
The GCP review skill covered CIS GCP v2.0.0 sections for IAM, logging, networking, VMs, storage, Cloud SQL, and BigQuery, but it did not evaluate GKE cluster and node-pool posture. That can let GKE fall between generic GCP checks and the separate `container-security` skill: Terraform can declare risky `google_container_cluster` and `google_container_node_pool` settings without any GKE evidence row in the GCP posture report.

Missed cases included:

- Public or weakly restricted GKE control planes.
- Default node service accounts and broad `cloud-platform` OAuth scopes.
- Missing Workload Identity Federation for GKE or node pools still using `GCE_METADATA`.
- Missing review of host-network metadata exception paths.
- Disabled Shielded GKE Nodes, Binary Authorization, or NetworkPolicy in production clusters.

### What This PR Fixes
This PR adds a supplemental GKE posture gate to `gcp-review` while keeping manifest-level Kubernetes review delegated to `container-security`.

Changes include:

- Adds `Step 9: Supplemental GKE Cluster Posture Evidence` to `SKILL.md`.
- Adds a GKE evidence table to the report output.
- Adds `GCP-GKE-01` through `GCP-GKE-07` finding triggers.
- Extends `benchmark-checklist.md` with concrete Terraform review checks for `google_container_cluster` and `google_container_node_pool`.
- Adds a common pitfall warning for GKE cluster controls falling between skills.
- Adds official Google Cloud references for Workload Identity Federation for GKE, network isolation, and Shielded GKE Nodes.
- Adds benign and vulnerable Terraform fixtures.

### Evidence

**Before (skill misses this):**
```hcl
resource "google_container_cluster" "admin" {
  private_cluster_config {
    enable_private_nodes    = false
    enable_private_endpoint = false
  }

  master_authorized_networks_config {
    cidr_blocks {
      cidr_block = "0.0.0.0/0"
    }
  }
}

resource "google_container_node_pool" "default" {
  node_config {
    service_account = "default"
    oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
    workload_metadata_config {
      mode = "GCE_METADATA"
    }
  }
}
```

**After (now correctly handled):**
```text
GCP-GKE-02: Public control plane or authorized networks include 0.0.0.0/0 without documented compensating control
GCP-GKE-03: Standard cluster node pool uses default service account or cloud-platform OAuth scope without workload-bound least privilege
GCP-GKE-04: Workload Identity Federation for GKE is absent, disabled at the node pool, or not mapped to reviewed namespace/KSA bindings
```

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing checks still pass

Added fixtures:

- `skills/cloud/gcp-review/tests/vulnerable/public-gke-broad-node-metadata.tf`
- `skills/cloud/gcp-review/tests/benign/private-standard-gke-evidence.tf`

### Validation
- `git diff --cached --check`
- Workflow-equivalent frontmatter required-field check
- Index file-existence check
- Markdown fence balance check for changed markdown files
- Changed-file ASCII check
- Prompt-injection pattern scan equivalent to `.github/workflows/injection-scan.yml`
- Marker checks for `GCP-GKE-*`, `Supplemental GKE Evidence`, `Workload Identity Federation for GKE`, `enable_shielded_nodes`, `binary_authorization`, `GCE_METADATA`, and `GKE_METADATA`

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** GitHub Sponsors or private details after acceptance