### PR TITLE
Improve AWS review EKS posture gates

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-AWS-v3.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -25,7 +25,7 @@ argument-hint: "[target-file-or-directory]"
 
 ## Overview
 
-This skill performs a structured security assessment of AWS environments against the **CIS Amazon Web Services Foundations Benchmark v3.0.0**. The benchmark is organized into five sections covering identity management, storage, logging, monitoring, and networking. Each recommendation is evaluated by inspecting infrastructure-as-code definitions (Terraform, CloudFormation, CDK), AWS CLI output, or configuration files available in the repository.
+This skill performs a structured security assessment of AWS environments against the **CIS Amazon Web Services Foundations Benchmark v3.0.0**. The benchmark is organized into five sections covering identity management, storage, logging, monitoring, and networking. Each recommendation is evaluated by inspecting infrastructure-as-code definitions (Terraform, CloudFormation, CDK), AWS CLI output, or configuration files available in the repository. When EKS clusters are present, the review also collects supplemental EKS posture evidence so cluster-level AWS controls are not lost between generic AWS checks and the separate container workload review.
 
 The CIS AWS Foundations Benchmark v3.0.0 contains 62 recommendations across five domains. This skill evaluates each applicable control against the codebase and produces a findings report with CIS recommendation IDs, severity ratings, and actionable remediation steps.
 
@@ -99,7 +99,39 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
-### Step 7: Compile Assessment Report
+### Step 7: Supplemental EKS Cluster Posture Evidence
+
+When `aws_eks_cluster`, `aws_eks_node_group`, `aws_eks_pod_identity_association`, or EKS configuration exports are present, evaluate cluster-level AWS controls before final scoring. This supplemental gate does not replace the `container-security` skill for Kubernetes manifests, RBAC, Pod Security, or workload YAML. It covers the AWS control plane, IAM, endpoint, encryption, logging, and pod identity settings that are visible in Terraform, CloudFormation, CDK, or EKS exports.
+
+Record an EKS evidence row for each cluster and node group:
+
+| Evidence Field | Required Evidence | Risk If Missing |
+|---|---|---|
+| Cluster mode | Managed node group, Fargate, self-managed, or EKS Auto Mode evidence | Node identity and operational controls can be scored against the wrong runtime model |
+| API server endpoint | `endpoint_private_access`, `endpoint_public_access`, and `public_access_cidrs` | Public or broadly reachable Kubernetes API server |
+| Cluster access management | `access_config`, authentication mode, bootstrap creator admin status, and `aws-auth`/CAM evidence | Standing cluster-admin or legacy access paths remain unreviewed |
+| Pod AWS identity | EKS Pod Identity associations, IRSA/OIDC provider, namespace/service-account mapping, and IAM trust scope | Workloads inherit broad node roles or static AWS credentials |
+| Node identity | Node group IAM role, policies, launch template, and IMDSv2 evidence | Pods or nodes can use overbroad AWS permissions |
+| Secrets and audit | `encryption_config`, KMS key, and complete `enabled_cluster_log_types` | Kubernetes secrets or control-plane actions lack encryption/audit evidence |
+| Network add-ons | VPC CNI, security groups for pods, private subnets, and endpoint/VPC route evidence | Pod networking and egress paths are not reviewable from AWS posture data |
+
+**Finding triggers:**
+
+```
+AWS-EKS-01: EKS cluster evidence is missing while IaC declares aws_eks_cluster resources
+AWS-EKS-02: Public endpoint is enabled with 0.0.0.0/0 or ::/0 public access CIDRs without documented compensating control
+AWS-EKS-03: Bootstrap cluster creator admin is enabled or access mode evidence is missing
+AWS-EKS-04: Pod Identity or IRSA evidence is absent for workloads that need AWS API access
+AWS-EKS-05: Node IAM role is broad or node/launch-template IMDSv2 evidence is missing
+AWS-EKS-06: Secrets encryption or complete control-plane logging evidence is missing
+AWS-EKS-07: Network add-on, private subnet, or security-groups-for-pods evidence is missing or Not Evaluable
+```
+
+If EKS evidence is incomplete, mark the affected cluster as **Not Evaluable** rather than scoring it as pass. If the same environment includes Kubernetes manifests, route manifest-level findings to `skills/cloud/container-security/SKILL.md`.
+
+---
+
+### Step 8: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
 
@@ -145,6 +177,12 @@ Produce the final report using the structure defined in the Output Format sectio
 | 3 | Logging | X/11 | Y | Z | nn% |
 | 4 | Monitoring | X/16 | Y | Z | nn% |
 | 5 | Networking | X/6 | Y | Z | nn% |
+
+### Supplemental EKS Evidence
+
+| Cluster/Node Group | Mode | API Endpoint | Access Management | Pod AWS Identity | Node Identity | Secrets/Logging | Network Add-ons | Status |
+|---|---|---|---|---|---|---|---|---|
+| <cluster> | Managed/Fargate/Self-managed/Auto | <private/public/CIDRs> | <access mode/bootstrap/admin evidence> | <Pod Identity/IRSA/none> | <node role/IMDSv2> | <KMS/log types> | <CNI/SGP/private subnet> | Pass/Fail/Not Evaluable |
 
 ### Detailed Findings
 
@@ -200,6 +238,7 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
 5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
 6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
+7. **Letting EKS fall between skills.** Generic CIS AWS checks do not inspect cluster-only settings such as API endpoint access, public access CIDRs, bootstrap admin, access management mode, Pod Identity/IRSA, secrets encryption, control-plane logs, or node role scope. Capture those controls here, then hand Kubernetes manifest findings to `container-security`.
 
 ---
 
@@ -225,10 +264,14 @@ Produce the final report using the structure defined in the Output Format sectio
 - AWS CloudTrail Documentation: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/
 - AWS Security Hub: https://docs.aws.amazon.com/securityhub/latest/userguide/
 - AWS VPC Security: https://docs.aws.amazon.com/vpc/latest/userguide/security.html
+- Amazon EKS cluster endpoint access: https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html
+- Amazon EKS Pod Identity: https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html
+- Amazon EKS security best practices: https://docs.aws.amazon.com/eks/latest/best-practices/security.html
 - Terraform AWS Provider Documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 
 ---
 
 ## Changelog
 
+- **1.0.1** -- Adds supplemental EKS cluster posture evidence gates for API endpoint access, cluster access management, Pod Identity/IRSA, node identity, secrets encryption, control-plane logs, and network add-on evidence.
 - **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 (62 recommendations).

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -488,3 +488,120 @@ resource "aws_launch_template" {
   }
 }
 ```
+
+---
+
+## Supplemental EKS Cluster Posture Review
+
+Evaluate `aws_eks_cluster`, `aws_eks_node_group`, `aws_eks_fargate_profile`, `aws_eks_pod_identity_association`, OIDC provider resources, and EKS export evidence when an AWS environment runs Amazon EKS. These checks are supplemental to CIS AWS v3.0.0 because they focus on cluster-level AWS controls; use `skills/cloud/container-security/SKILL.md` for Kubernetes workload manifests.
+
+### AWS-EKS-01 -- Ensure EKS Clusters Are Explicitly Inventoried
+
+**Grep patterns:**
+
+```
+resource "aws_eks_cluster"
+resource "aws_eks_node_group"
+resource "aws_eks_fargate_profile"
+resource "aws_eks_pod_identity_association"
+aws_eks_cluster
+```
+
+If any EKS resource is present, require an EKS evidence row in the final report. Missing endpoint, access management, pod identity, node role, encryption, or logging evidence is **Not Evaluable**.
+
+### AWS-EKS-02 -- Ensure API Server Endpoint Access Is Private or Tightly Scoped
+
+```hcl
+# BAD: public endpoint open to the internet
+resource "aws_eks_cluster" "bad" {
+  vpc_config {
+    endpoint_private_access = false
+    endpoint_public_access  = true
+    public_access_cidrs     = ["0.0.0.0/0"]
+  }
+}
+```
+
+Require evidence for `endpoint_private_access`, `endpoint_public_access`, and `public_access_cidrs`. A public endpoint can be acceptable only with narrow CIDRs and documented admin source networks.
+
+### AWS-EKS-03 -- Ensure Cluster Access Management Is Reviewed
+
+```hcl
+# BAD: legacy config map only and bootstrap admin retained
+resource "aws_eks_cluster" "bad" {
+  access_config {
+    authentication_mode                         = "CONFIG_MAP"
+    bootstrap_cluster_creator_admin_permissions = true
+  }
+}
+```
+
+Look for:
+
+```
+access_config {
+authentication_mode
+bootstrap_cluster_creator_admin_permissions = true
+aws-auth
+```
+
+Record whether access uses the EKS access management API, the legacy `aws-auth` ConfigMap, or both. Bootstrap creator admin should be disabled or time-bound with explicit break-glass review.
+
+### AWS-EKS-04 -- Ensure Pod Identity or IRSA Evidence Exists
+
+```hcl
+resource "aws_eks_pod_identity_association" "app" {
+  cluster_name    = aws_eks_cluster.private.name
+  namespace       = "payments"
+  service_account = "api"
+  role_arn        = aws_iam_role.payments_pod.arn
+}
+```
+
+Accept either EKS Pod Identity or IRSA when namespace, service account, IAM role, and trust policy are scoped. Missing pod-level identity evidence should be **High** for workloads that access AWS APIs.
+
+### AWS-EKS-05 -- Ensure Node Role and IMDSv2 Evidence Exists
+
+```hcl
+resource "aws_eks_node_group" "good" {
+  node_role_arn = aws_iam_role.eks_nodes_minimal.arn
+
+  launch_template {
+    id      = aws_launch_template.eks_nodes.id
+    version = "$Latest"
+  }
+}
+```
+
+Cross-check node roles for broad policies and ensure launch templates enforce IMDSv2 where node metadata is exposed. If no node identity evidence exists, mark the node group **Not Evaluable**.
+
+### AWS-EKS-06 -- Ensure Secrets Encryption and Control-Plane Logging Are Enabled
+
+```hcl
+resource "aws_eks_cluster" "good" {
+  encryption_config {
+    provider {
+      key_arn = aws_kms_key.eks_secrets.arn
+    }
+    resources = ["secrets"]
+  }
+
+  enabled_cluster_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
+}
+```
+
+Require KMS-backed secrets encryption and complete control-plane logging for production clusters. Missing audit or authenticator logs should be **High**.
+
+### AWS-EKS-07 -- Ensure Network Add-on and Private Subnet Evidence Exists
+
+Check for:
+
+```
+aws_eks_addon
+vpc-cni
+aws_eks_fargate_profile
+subnet_ids = aws_subnet.private
+aws_security_group_policy
+```
+
+Record VPC CNI/add-on version evidence, private subnet placement, Fargate or managed node group mode, and security groups for pods where used. Missing network add-on or private routing evidence should be **Not Evaluable**.

--- a/skills/cloud/aws-review/tests/benign/private-eks-pod-identity.tf
+++ b/skills/cloud/aws-review/tests/benign/private-eks-pod-identity.tf
@@ -1,0 +1,44 @@
+resource "aws_eks_cluster" "payments" {
+  name     = "payments-prod"
+  role_arn = aws_iam_role.eks_control_plane.arn
+
+  vpc_config {
+    subnet_ids              = aws_subnet.private[*].id
+    endpoint_private_access = true
+    endpoint_public_access  = false
+    public_access_cidrs     = []
+  }
+
+  access_config {
+    authentication_mode                         = "API_AND_CONFIG_MAP"
+    bootstrap_cluster_creator_admin_permissions = false
+  }
+
+  encryption_config {
+    provider {
+      key_arn = aws_kms_key.eks_secrets.arn
+    }
+    resources = ["secrets"]
+  }
+
+  enabled_cluster_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
+}
+
+resource "aws_eks_node_group" "payments" {
+  cluster_name    = aws_eks_cluster.payments.name
+  node_group_name = "payments-private"
+  node_role_arn   = aws_iam_role.eks_nodes_minimal.arn
+  subnet_ids      = aws_subnet.private[*].id
+
+  launch_template {
+    id      = aws_launch_template.eks_nodes.id
+    version = "$Latest"
+  }
+}
+
+resource "aws_eks_pod_identity_association" "payments_api" {
+  cluster_name    = aws_eks_cluster.payments.name
+  namespace       = "payments"
+  service_account = "api"
+  role_arn        = aws_iam_role.payments_pod.arn
+}

--- a/skills/cloud/aws-review/tests/vulnerable/public-eks-bootstrap-admin.tf
+++ b/skills/cloud/aws-review/tests/vulnerable/public-eks-bootstrap-admin.tf
@@ -1,0 +1,25 @@
+resource "aws_eks_cluster" "admin" {
+  name     = "admin-prod"
+  role_arn = aws_iam_role.eks_control_plane.arn
+
+  vpc_config {
+    subnet_ids              = aws_subnet.public[*].id
+    endpoint_private_access = false
+    endpoint_public_access  = true
+    public_access_cidrs     = ["0.0.0.0/0"]
+  }
+
+  access_config {
+    authentication_mode                         = "CONFIG_MAP"
+    bootstrap_cluster_creator_admin_permissions = true
+  }
+
+  enabled_cluster_log_types = []
+}
+
+resource "aws_eks_node_group" "default" {
+  cluster_name    = aws_eks_cluster.admin.name
+  node_group_name = "default"
+  node_role_arn   = aws_iam_role.broad_node.arn
+  subnet_ids      = aws_subnet.public[*].id
+}


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `aws-review`
**Skill path:** `skills/cloud/aws-review/`

Closes #2093.

### What Was Wrong
The AWS review skill covered CIS AWS v3.0.0 sections for IAM, storage, logging, monitoring, and networking, but it did not evaluate EKS cluster posture. That can let EKS fall between generic AWS checks and the separate `container-security` skill: Terraform can declare risky `aws_eks_cluster` settings without any EKS evidence row in the AWS posture report.

Missed cases included:

- Public EKS API endpoints open to `0.0.0.0/0` or `::/0`.
- Bootstrap cluster creator admin and legacy access modes left unreviewed.
- Missing EKS Pod Identity or IRSA evidence for workloads that call AWS APIs.
- Broad node roles or missing launch-template IMDSv2 evidence.
- Missing KMS secrets encryption and control-plane logs.
- Missing VPC CNI/private subnet/security-groups-for-pods evidence.

### What This PR Fixes
This PR adds a supplemental EKS posture gate to `aws-review` while keeping manifest-level Kubernetes review delegated to `container-security`.

Changes include:

- Adds `Step 7: Supplemental EKS Cluster Posture Evidence` to `SKILL.md`.
- Adds an EKS evidence table to the report output.
- Adds `AWS-EKS-01` through `AWS-EKS-07` finding triggers.
- Extends `benchmark-checklist.md` with concrete Terraform review checks for EKS clusters, node groups, Pod Identity, endpoint access, secrets encryption, and control-plane logs.
- Adds a common pitfall warning for EKS cluster controls falling between skills.
- Adds AWS documentation references for EKS endpoint access, Pod Identity, and security best practices.
- Adds benign and vulnerable Terraform fixtures.

### Evidence

**Before (skill misses this):**
```hcl
resource "aws_eks_cluster" "admin" {
  vpc_config {
    endpoint_private_access = false
    endpoint_public_access  = true
    public_access_cidrs     = ["0.0.0.0/0"]
  }

  access_config {
    authentication_mode                         = "CONFIG_MAP"
    bootstrap_cluster_creator_admin_permissions = true
  }
}
```

**After (now correctly handled):**
```text
AWS-EKS-02: Public endpoint is enabled with 0.0.0.0/0 or ::/0 public access CIDRs without documented compensating control
AWS-EKS-03: Bootstrap cluster creator admin is enabled or access mode evidence is missing
AWS-EKS-04: Pod Identity or IRSA evidence is absent for workloads that need AWS API access
```

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing checks still pass

Added fixtures:

- `skills/cloud/aws-review/tests/vulnerable/public-eks-bootstrap-admin.tf`
- `skills/cloud/aws-review/tests/benign/private-eks-pod-identity.tf`

### Validation
- `git diff --cached --check`
- Workflow-equivalent frontmatter required-field check
- Index file-existence check
- Markdown fence balance check for changed markdown files
- Changed-file ASCII check
- Prompt-injection pattern scan equivalent to `.github/workflows/injection-scan.yml`
- Marker checks for `AWS-EKS-*`, `Supplemental EKS Evidence`, `endpoint_private_access`, `endpoint_public_access`, `public_access_cidrs`, `bootstrap_cluster_creator_admin_permissions`, `aws_eks_pod_identity_association`, `enabled_cluster_log_types`, and `encryption_config`

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** GitHub Sponsors or private details after acceptance