### PR TITLE
Improve AWS review RDS posture gates

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -4,16 +4,17 @@ description: >
   Performs an AWS security posture review against the CIS Amazon Web Services
   Foundations Benchmark v3.0.0. Auto-invoked when reviewing AWS infrastructure,
   IAM policies, S3 configurations, CloudTrail settings, VPC security groups, or
-  RDS encryption. Walks through all five benchmark sections, evaluates each
-  recommendation, and produces a prioritized findings report with remediation
-  guidance mapped to specific CIS control IDs.
+  RDS/Aurora database posture. Walks through all five benchmark sections,
+  evaluates each recommendation, and produces a prioritized findings report with
+  remediation guidance mapped to specific CIS control IDs plus supplemental
+  database evidence gates.
 tags: [cloud, aws, cis-benchmark]
 role: [cloud-security-engineer, security-engineer]
 phase: [assess, operate]
 frameworks: [CIS-AWS-v3.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -28,6 +29,8 @@ argument-hint: "[target-file-or-directory]"
 This skill performs a structured security assessment of AWS environments against the **CIS Amazon Web Services Foundations Benchmark v3.0.0**. The benchmark is organized into five sections covering identity management, storage, logging, monitoring, and networking. Each recommendation is evaluated by inspecting infrastructure-as-code definitions (Terraform, CloudFormation, CDK), AWS CLI output, or configuration files available in the repository.
 
 The CIS AWS Foundations Benchmark v3.0.0 contains 62 recommendations across five domains. This skill evaluates each applicable control against the codebase and produces a findings report with CIS recommendation IDs, severity ratings, and actionable remediation steps.
+
+For database workloads, the skill also performs supplemental RDS and Aurora posture checks that bind public reachability, subnet routing, security group ingress, encryption, backup retention, deletion protection, snapshot sharing, and database observability evidence. These gates are reported separately from CIS scoring so they improve coverage without changing the benchmark denominator.
 
 ---
 
@@ -54,6 +57,7 @@ The CIS Amazon Web Services Foundations Benchmark v3.0.0 is a consensus-driven s
 - IAM policy documents (JSON)
 - S3 bucket policies and ACL configurations
 - VPC, security group, and NACL definitions
+- RDS and Aurora DB instance, cluster, subnet group, parameter group, snapshot, backup, and log export definitions
 - CloudTrail and CloudWatch configuration files
 
 ---
@@ -99,7 +103,21 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
-### Step 7: Compile Assessment Report
+### Step 7: Supplemental RDS and Aurora Database Posture Evidence
+
+Evaluate database-specific posture beyond the CIS storage checks. For detailed supplemental checklist items, grep patterns, and Terraform examples, see [benchmark-checklist.md](benchmark-checklist.md).
+
+Reviewers should:
+
+1. Inventory `aws_db_instance`, `aws_rds_cluster`, `aws_rds_cluster_instance`, `aws_db_subnet_group`, `aws_db_snapshot`, `aws_db_cluster_snapshot`, AWS Backup plans, and related security groups.
+2. Join `publicly_accessible` values with subnet group routing, route tables, public subnet membership, and security group sources before declaring a database private or public.
+3. Verify encryption and KMS evidence for DB instances, clusters, read replicas, snapshots, snapshot copies, and Performance Insights when enabled.
+4. Review recovery controls including `backup_retention_period`, PITR expectations, final snapshot behavior, deletion protection, cross-Region restore strategy, and restore test evidence.
+5. Check auditability through engine log exports, audit/error/slow query logging where supported, CloudTrail control-plane monitoring, Performance Insights retention, and GuardDuty RDS Protection context where available.
+
+---
+
+### Step 8: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
 
@@ -158,6 +176,22 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Evidence:** <specific configuration or code snippet>
 - **Remediation:** <specific fix with code example>
 
+### Supplemental RDS and Aurora Findings
+
+| Control | Database | Engine | Exposure | Encryption/KMS | Backup/Deletion Protection | Logging/Audit | Status |
+|---------|----------|--------|----------|----------------|----------------------------|---------------|--------|
+| AWS-RDS-01 | <db id> | <engine> | <public/private/unknown> | <evidence> | <evidence> | <evidence> | Pass/Fail/Not Evaluable |
+
+#### [AWS-RDS-NN] <Database Posture Finding>
+- **Status:** Pass / Fail / Not Evaluable
+- **Severity:** Critical / High / Medium / Low
+- **File:** <path to relevant config>
+- **Line(s):** <line numbers if applicable>
+- **Description:** <what was found>
+- **Evidence:** <specific configuration, routing, SG, KMS, backup, or log evidence>
+- **Impact:** <why this matters for exposure, data protection, recovery, or investigation>
+- **Remediation:** <specific fix with code example or operational verification step>
+
 ### Prioritized Remediation Plan
 
 1. **[Critical]** CIS X.Y -- <action item>
@@ -200,6 +234,8 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
 5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
 6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
+7. **Checking only `publicly_accessible` for RDS exposure.** A database can still be reachable from broad internal networks, while a public flag needs subnet, route table, and security group evidence before severity is assigned.
+8. **Reviewing only DB instances and missing Aurora cluster-level settings.** Aurora splits encryption, backup retention, deletion protection, log exports, and public accessibility across cluster and cluster instance resources.
 
 ---
 
@@ -225,10 +261,14 @@ Produce the final report using the structure defined in the Output Format sectio
 - AWS CloudTrail Documentation: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/
 - AWS Security Hub: https://docs.aws.amazon.com/securityhub/latest/userguide/
 - AWS VPC Security: https://docs.aws.amazon.com/vpc/latest/userguide/security.html
+- AWS RDS Public and Private Access: https://docs.aws.amazon.com/AmazonRDS/latest/gettingstartedguide/security-public-private.html
+- AWS RDS Encryption: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Encryption.html
+- AWS Aurora Backup and Restore: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Managing.Backups.html
 - Terraform AWS Provider Documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 
 ---
 
 ## Changelog
 
+- **1.0.1** -- Added supplemental RDS and Aurora posture review gates for public exposure, encryption/KMS, backups, deletion protection, snapshot sharing, and database audit evidence.
 - **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 (62 recommendations).

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -488,3 +488,217 @@ resource "aws_launch_template" {
   }
 }
 ```
+
+---
+
+## Supplemental RDS and Aurora Database Posture Review
+
+The following checks extend CIS 2.3 RDS coverage with database-specific evidence gates. Report these as `AWS-RDS-*` supplemental findings so CIS benchmark scoring remains tied to the official 62 recommendations.
+
+### AWS-RDS-01 -- Inventory RDS and Aurora resources before scoring exposure
+
+Build a database inventory across Terraform, CloudFormation, CDK, and AWS inventory exports.
+
+**Grep patterns:**
+
+```hcl
+aws_db_instance
+aws_rds_cluster
+aws_rds_cluster_instance
+aws_db_subnet_group
+aws_db_snapshot
+aws_db_cluster_snapshot
+aws_backup_plan
+aws_backup_selection
+```
+
+**Review requirements:**
+
+- Record DB identifier, engine, environment, data classification, subnet group, security groups, KMS key, backup retention, deletion protection, log exports, and owner.
+- Join Aurora cluster settings with cluster instance settings. Do not evaluate `aws_rds_cluster` and `aws_rds_cluster_instance` in isolation.
+- Mark controls "Not Evaluable" when the repository lacks routing, security group, backup, or logging evidence rather than assuming a pass.
+
+### AWS-RDS-02 -- Verify public reachability with subnet, route, and security group evidence
+
+**Critical check:**
+
+```hcl
+# BAD: Public DB with internet-wide ingress
+resource "aws_db_instance" "customer" {
+  publicly_accessible = true
+  vpc_security_group_ids = [aws_security_group.db_public.id]
+}
+
+resource "aws_security_group_rule" "postgres_anywhere" {
+  type              = "ingress"
+  security_group_id = aws_security_group.db_public.id
+  protocol          = "tcp"
+  from_port         = 5432
+  to_port           = 5432
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+```
+
+Also check for IPv6 exposure:
+
+```hcl
+ipv6_cidr_blocks = ["::/0"]
+```
+
+**Review requirements:**
+
+- Treat `publicly_accessible = true` plus broad DB port ingress as High or Critical depending on data sensitivity and authentication controls.
+- Inspect DB subnet group subnets, route tables, internet gateway routes, NAT-only routes, and security group sources before declaring exposure.
+- For `publicly_accessible = false`, still check broad internal CIDRs such as `10.0.0.0/8`, peered VPC CIDRs, VPN ranges, and shared security groups.
+- Require explicit exception evidence for intentionally public partner, migration, demo, or allowlisted administrative access.
+
+### AWS-RDS-03 -- Verify RDS and Aurora encryption, KMS ownership, and replica coverage
+
+**What to look for:**
+
+```hcl
+resource "aws_db_instance" "orders" {
+  storage_encrypted = true
+  kms_key_id        = aws_kms_key.rds.arn
+}
+
+resource "aws_rds_cluster" "orders" {
+  storage_encrypted = true
+  kms_key_id        = aws_kms_key.rds.arn
+}
+```
+
+**Fail patterns:**
+
+```hcl
+storage_encrypted = false
+kms_key_id = null
+```
+
+**Review requirements:**
+
+- Confirm encryption for DB instances, Aurora clusters, read replicas, snapshots, snapshot copies, and cross-Region copies.
+- Note when a workload requires a customer-managed KMS key rather than an AWS-managed key.
+- Check KMS key policy, rotation expectations, alias clarity, and access path for backup and restore operations.
+- Flag unencrypted source databases because AWS cannot restore an unencrypted backup directly into an encrypted DB instance.
+
+### AWS-RDS-04 -- Verify backup retention, final snapshot behavior, and deletion protection
+
+**What to look for:**
+
+```hcl
+resource "aws_rds_cluster" "payments" {
+  backup_retention_period = 14
+  deletion_protection     = true
+  skip_final_snapshot     = false
+}
+```
+
+**Fail patterns:**
+
+```hcl
+backup_retention_period = 0
+backup_retention_period = 1
+deletion_protection = false
+skip_final_snapshot = true
+```
+
+**Review requirements:**
+
+- Compare backup retention with production recovery point objectives and PITR requirements.
+- Check final snapshot settings on destructive changes and deletion workflows.
+- Require deletion protection for production or regulated databases unless a documented breakglass process exists.
+- Look for AWS Backup plans, copy actions, vault lock, cross-account/cross-Region restore strategy, and restore test evidence where required.
+
+### AWS-RDS-05 -- Review snapshot sharing, backup copies, and restore access
+
+**Grep patterns:**
+
+```hcl
+aws_db_snapshot
+aws_db_cluster_snapshot
+aws_db_snapshot_copy
+aws_db_cluster_snapshot_copy
+aws_db_snapshot_attribute
+aws_rds_cluster_snapshot_copy
+```
+
+**Review requirements:**
+
+- Flag snapshots shared with `all`, unknown external accounts, or broad organization accounts without documented approval.
+- Verify encrypted snapshot copies use the intended KMS key in the destination Region/account.
+- Check whether manual snapshots outlive automated backup retention and whether ownership/expiry is documented.
+- Confirm restore roles and KMS permissions are least privilege.
+
+### AWS-RDS-06 -- Verify database audit logs, engine logs, and investigation readiness
+
+**What to look for:**
+
+```hcl
+resource "aws_db_instance" "app" {
+  enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
+  performance_insights_enabled    = true
+  performance_insights_kms_key_id = aws_kms_key.rds.arn
+}
+
+resource "aws_rds_cluster" "app" {
+  enabled_cloudwatch_logs_exports = ["postgresql"]
+}
+```
+
+**Review requirements:**
+
+- Check engine-specific exports for audit, error, general, slow query, PostgreSQL, MySQL, MariaDB, Oracle, or SQL Server logs as applicable.
+- Verify parameter group settings that enable database audit logging, SSL enforcement, and password/security controls where the engine supports them.
+- Review CloudTrail management events for RDS changes and monitoring for destructive actions such as `DeleteDBInstance`, `DeleteDBCluster`, `ModifyDBInstance`, and snapshot sharing.
+- Include GuardDuty RDS Protection or equivalent database threat monitoring context when available.
+
+### AWS-RDS-07 -- Review Performance Insights, monitoring retention, and KMS settings
+
+**What to look for:**
+
+```hcl
+performance_insights_enabled          = true
+performance_insights_retention_period = 731
+performance_insights_kms_key_id       = aws_kms_key.rds.arn
+monitoring_interval                   = 60
+monitoring_role_arn                   = aws_iam_role.rds_monitoring.arn
+```
+
+**Review requirements:**
+
+- Verify Performance Insights is enabled for production databases where supported and retained long enough for investigation needs.
+- Check that Performance Insights and Enhanced Monitoring use the expected KMS key and IAM role.
+- Record when monitoring is not supported by the selected engine or instance class rather than forcing a false failure.
+
+### AWS-RDS-08 -- Calibrate severity by data sensitivity and compensating controls
+
+**Severity guidance:**
+
+- Critical: public DB endpoint with `0.0.0.0/0` or `::/0` database port ingress, sensitive data, weak authentication evidence, or no audit trail.
+- High: unencrypted production database, weak backup/deletion posture for critical data, or broad internal reachability across many networks.
+- Medium: missing log exports, short retention, missing Performance Insights, or incomplete restore evidence.
+- Low: documentation gaps, tag/owner gaps, or non-production exception cleanup.
+
+**Benign example:**
+
+```hcl
+resource "aws_rds_cluster" "orders" {
+  cluster_identifier      = "orders-prod"
+  engine                  = "aurora-postgresql"
+  storage_encrypted       = true
+  kms_key_id              = aws_kms_key.rds.arn
+  backup_retention_period = 14
+  deletion_protection     = true
+  db_subnet_group_name    = aws_db_subnet_group.private.name
+  vpc_security_group_ids  = [aws_security_group.rds_private.id]
+  enabled_cloudwatch_logs_exports = ["postgresql"]
+}
+
+resource "aws_rds_cluster_instance" "orders" {
+  cluster_identifier  = aws_rds_cluster.orders.id
+  instance_class      = "db.r7g.large"
+  engine              = aws_rds_cluster.orders.engine
+  publicly_accessible = false
+}
+```

--- a/skills/cloud/aws-review/tests/benign/private-encrypted-aurora.tf
+++ b/skills/cloud/aws-review/tests/benign/private-encrypted-aurora.tf
@@ -1,0 +1,45 @@
+resource "aws_kms_key" "rds" {
+  description         = "Customer managed key for production RDS and Aurora data"
+  enable_key_rotation = true
+}
+
+resource "aws_security_group" "rds_private" {
+  name        = "orders-rds-private"
+  description = "Private application subnet access to Aurora"
+  vpc_id      = aws_vpc.main.id
+}
+
+resource "aws_security_group_rule" "postgres_from_app" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.rds_private.id
+  protocol                 = "tcp"
+  from_port                = 5432
+  to_port                  = 5432
+  source_security_group_id = aws_security_group.app.id
+}
+
+resource "aws_db_subnet_group" "private" {
+  name       = "orders-private"
+  subnet_ids = [aws_subnet.private_a.id, aws_subnet.private_b.id]
+}
+
+resource "aws_rds_cluster" "orders" {
+  cluster_identifier              = "orders-prod"
+  engine                          = "aurora-postgresql"
+  storage_encrypted               = true
+  kms_key_id                      = aws_kms_key.rds.arn
+  backup_retention_period         = 14
+  deletion_protection             = true
+  db_subnet_group_name            = aws_db_subnet_group.private.name
+  vpc_security_group_ids          = [aws_security_group.rds_private.id]
+  enabled_cloudwatch_logs_exports = ["postgresql"]
+}
+
+resource "aws_rds_cluster_instance" "orders" {
+  cluster_identifier              = aws_rds_cluster.orders.id
+  instance_class                  = "db.r7g.large"
+  engine                          = aws_rds_cluster.orders.engine
+  publicly_accessible             = false
+  performance_insights_enabled    = true
+  performance_insights_kms_key_id = aws_kms_key.rds.arn
+}

--- a/skills/cloud/aws-review/tests/vulnerable/public-rds-weak-recovery.tf
+++ b/skills/cloud/aws-review/tests/vulnerable/public-rds-weak-recovery.tf
@@ -1,0 +1,38 @@
+resource "aws_security_group" "db_public" {
+  name        = "customer-db-public"
+  description = "Public database access for a production RDS instance"
+  vpc_id      = aws_vpc.main.id
+}
+
+resource "aws_security_group_rule" "postgres_anywhere" {
+  type              = "ingress"
+  security_group_id = aws_security_group.db_public.id
+  protocol          = "tcp"
+  from_port         = 5432
+  to_port           = 5432
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_db_instance" "customer" {
+  identifier                      = "customer-prod"
+  engine                          = "postgres"
+  instance_class                  = "db.m7g.large"
+  allocated_storage               = 100
+  publicly_accessible             = true
+  vpc_security_group_ids          = [aws_security_group.db_public.id]
+  storage_encrypted               = false
+  backup_retention_period         = 1
+  deletion_protection             = false
+  skip_final_snapshot             = true
+  enabled_cloudwatch_logs_exports = []
+  performance_insights_enabled    = false
+}
+
+resource "aws_rds_cluster" "payments" {
+  cluster_identifier      = "payments-prod"
+  engine                  = "aurora-mysql"
+  storage_encrypted       = false
+  backup_retention_period = 1
+  deletion_protection     = false
+  skip_final_snapshot     = true
+}


### PR DESCRIPTION
## Summary

Closes #2096.

Adds supplemental RDS and Aurora database posture evidence gates to `aws-review` so reviewers can evaluate database exposure, encryption, backup/recovery, deletion protection, snapshot sharing, and database observability separately from the official CIS AWS v3.0.0 scoring denominator.

## What changed

- Bumped `aws-review` to `1.0.1` and added an explicit supplemental RDS/Aurora review step.
- Added `AWS-RDS-01` through `AWS-RDS-08` checklist coverage for:
  - RDS/Aurora inventory and cluster/instance joins
  - public reachability across `publicly_accessible`, DB subnet groups, route tables, and security groups
  - storage/snapshot/replica encryption and KMS evidence
  - backup retention, final snapshots, deletion protection, and restore evidence
  - snapshot sharing and backup copy posture
  - engine log exports, database audit readiness, CloudTrail monitoring, GuardDuty RDS context, and Performance Insights
- Added benign and vulnerable Terraform examples under `skills/cloud/aws-review/tests/`.

## Validation

- `git diff --cached --check`
- Frontmatter required-field check matching `.github/workflows/lint-skills.yml`
- `index.yaml` file-existence check matching `.github/workflows/validate-index.yml`
- Markdown code fence balance check for changed Markdown files
- ASCII-only check for changed files
- Prompt-injection scan matching `.github/workflows/injection-scan.yml`
- RDS marker check for `AWS-RDS-*`, `aws_db_instance`, `aws_rds_cluster`, `publicly_accessible`, `storage_encrypted`, `kms_key_id`, `backup_retention_period`, `deletion_protection`, `skip_final_snapshot`, log export, and Performance Insights coverage

Note: `terraform fmt` was not run because Terraform CLI is not installed in the local environment.

## Bounty

Requesting Improver - Moderate ($100). Preferred payment method: GitHub Sponsors if accepted, otherwise private payment details can be provided after acceptance.