### PR TITLE
Improve container runtime isolation gates

### DIFF
--- a/skills/cloud/container-security/SKILL.md
+++ b/skills/cloud/container-security/SKILL.md
@@ -6,14 +6,15 @@ description: >
   Auto-invoked when reviewing Dockerfiles, Kubernetes manifests, Helm charts,
   or container orchestration configurations. Evaluates image security, runtime
   hardening, RBAC, Pod Security Standards, network policies, and secrets
-  management. Produces a prioritized findings report with remediation guidance.
+  management, including supplemental runtime isolation evidence for high-risk
+  workloads. Produces a prioritized findings report with remediation guidance.
 tags: [cloud, containers, kubernetes, docker]
 role: [cloud-security-engineer, security-engineer]
 phase: [build, deploy, operate]
 frameworks: [CIS-Docker-v1.6.0, CIS-Kubernetes-v1.9.0, NIST-SP-800-190]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -32,6 +33,8 @@ This skill performs a structured security review of container images and Kuberne
 - **NIST SP 800-190** (Application Container Security Guide) -- Countermeasures for image, registry, orchestrator, container, and host OS risks.
 
 The review covers Dockerfiles, Kubernetes manifests, Helm charts, and supporting configurations. Each finding is mapped to specific CIS recommendation IDs or NIST SP 800-190 countermeasure categories.
+
+For untrusted, multi-tenant, plugin, CI/build, notebook, customer-supplied, or high-risk workloads, the skill also evaluates supplemental runtime isolation evidence. These checks cover `RuntimeClass`, sandbox runtime mapping, seccomp, AppArmor, SELinux, localhost profile distribution, node pool isolation, and exception evidence without requiring sandbox runtimes for ordinary trusted workloads that already satisfy Restricted Pod Security controls.
 
 ---
 
@@ -61,6 +64,7 @@ NIST SP 800-190 identifies five risk categories: image risks, registry risks, or
 - RBAC configuration files (Roles, ClusterRoles, RoleBindings)
 - NetworkPolicy definitions
 - Pod Security Standard configurations or OPA/Gatekeeper policies
+- RuntimeClass definitions, node pool labels/taints, and seccomp/AppArmor/SELinux profile evidence
 - Container registry configurations (if available)
 
 ---
@@ -115,7 +119,25 @@ For detailed CIS benchmark checklist items, NIST SP 800-190 countermeasure table
 
 ---
 
-### Step 7: Compile Assessment Report
+### Step 7: Supplemental Runtime Isolation Evidence
+
+Classify workloads by trust level before requiring sandbox runtime evidence:
+
+- **Standard trusted workloads:** may pass with Restricted Pod Security controls, `RuntimeDefault` seccomp/AppArmor, dropped capabilities, non-root execution, read-only root filesystem, and resource limits.
+- **High-risk workloads:** untrusted code execution, CI/build runners, customer plugins, notebooks, multi-tenant workloads, internet-exposed processing of hostile content, or workloads with broad secrets/network reach should have explicit runtime isolation evidence.
+
+For high-risk workloads, verify:
+
+1. `runtimeClassName` maps to a reviewed `RuntimeClass` handler such as gVisor, Kata Containers, or a documented organization sandbox runtime.
+2. RuntimeClass `overhead`, node labels, taints/tolerations, node selectors, and affinity constrain scheduling to the intended runtime-capable node pool.
+3. Pod, container, init container, sidecar, and ephemeral container seccomp/AppArmor settings are `RuntimeDefault` or reviewed `Localhost`, not `Unconfined`.
+4. `Localhost` profiles include profile distribution evidence across eligible nodes.
+5. SELinux options are reviewed when the Linux distribution and cluster policy use SELinux labels; mark non-Linux or Windows-only workloads not applicable.
+6. Exceptions to sandboxing or runtime profiles include owner, reason, namespace/workload scope, expiry, and compensating controls.
+
+---
+
+### Step 8: Compile Assessment Report
 
 
 Produce the final report using the structure defined in the Output Format section.
@@ -184,6 +206,25 @@ Produce the final report using the structure defined in the Output Format sectio
 |----------|-----------|-----------|------------|
 | deploy/app | production | Baseline (not Restricted) | runAsRoot, no seccomp |
 | deploy/worker | production | Privileged | privileged: true |
+
+### Runtime Isolation Evidence Matrix
+
+| Workload | Namespace | Trust Level | RuntimeClass | Handler | Seccomp | AppArmor | SELinux | Node Isolation | Status |
+|----------|-----------|-------------|--------------|---------|---------|----------|---------|----------------|--------|
+| job/plugin-runner | plugins | Untrusted code | <missing> | <none> | RuntimeDefault | <missing> | N/A | <missing> | Fail |
+
+#### [CONTAINER-RUNTIME-NN] <Runtime Isolation Finding>
+- **Status:** Pass / Fail / Not Applicable / Not Evaluable
+- **Severity:** Critical / High / Medium / Low
+- **Workload Trust Level:** Trusted / Sensitive / Untrusted / Multi-tenant / Build or CI
+- **RuntimeClass Evidence:** <runtimeClassName, handler, overhead, node scheduling evidence>
+- **Profile Evidence:** <seccomp/AppArmor/SELinux effective profile evidence>
+- **File:** <path>
+- **Line(s):** <line numbers>
+- **Resource:** <Deployment/StatefulSet/Job name>
+- **Container:** <container, initContainer, or ephemeralContainer name>
+- **Description:** <what was found>
+- **Remediation:** <fix with code example>
 
 ### Prioritized Remediation Plan
 
@@ -257,6 +298,9 @@ Produce the final report using the structure defined in the Output Format sectio
 5. **`readOnlyRootFilesystem` breaks many applications.** When recommending this control, also recommend adding writable `emptyDir` volume mounts for directories the application needs to write to (e.g., `/tmp`, `/var/cache`).
 6. **Network policies are additive, not subtractive.** A default-deny policy must be explicitly created. Without it, all pod-to-pod traffic is allowed regardless of other NetworkPolicy resources.
 7. **Distroless images have no shell.** While this is excellent for security, note that debugging requires ephemeral containers (`kubectl debug`). Flag this as a consideration, not a problem.
+8. **Sandbox runtime is risk-based, not universal.** Do not fail every trusted workload without `runtimeClassName`; require sandbox runtime evidence for untrusted, multi-tenant, plugin, CI/build, notebook, or high-risk workloads.
+9. **`Localhost` profiles are node-local.** A manifest that references a seccomp or AppArmor localhost profile needs evidence that the profile is loaded on every eligible node.
+10. **Missing profile fields differ from explicit `Unconfined`.** A missing seccomp/AppArmor field may inherit cluster defaults, but explicit `Unconfined` is a direct runtime isolation finding unless narrowly justified.
 
 ---
 
@@ -283,6 +327,10 @@ Produce the final report using the structure defined in the Output Format sectio
 - NIST SP 800-190 Application Container Security Guide: https://csrc.nist.gov/publications/detail/sp/800-190/final
 - Kubernetes Pod Security Standards: https://kubernetes.io/docs/concepts/security/pod-security-standards/
 - Kubernetes Pod Security Admission: https://kubernetes.io/docs/concepts/security/pod-security-admission/
+- Kubernetes RuntimeClass: https://kubernetes.io/docs/concepts/containers/runtime-class/
+- Kubernetes seccomp: https://kubernetes.io/docs/reference/node/seccomp/
+- Kubernetes AppArmor: https://kubernetes.io/docs/tutorials/security/apparmor/
+- Kubernetes Security Context: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 - Kubernetes Network Policies: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 - Kubernetes RBAC: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 - Docker Security Best Practices: https://docs.docker.com/develop/security-best-practices/
@@ -293,4 +341,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Added supplemental runtime isolation evidence gates for RuntimeClass, sandbox runtimes, seccomp, AppArmor, SELinux, node pool scheduling, localhost profile distribution, and risk-based exceptions.
 - **1.0.0** -- Initial release. Full coverage of CIS Docker Benchmark v1.6.0 Section 4-5, CIS Kubernetes Benchmark v1.9.0 Sections 1-5, and NIST SP 800-190 countermeasures across all five risk categories.

--- a/skills/cloud/container-security/cis-benchmarks.md
+++ b/skills/cloud/container-security/cis-benchmarks.md
@@ -690,3 +690,191 @@ spec:
 - Capabilities beyond the allowed set (only `NET_BIND_SERVICE` is permitted)
 - `procMount` other than `Default`
 - `appArmorProfile` of `unconfined`
+
+---
+
+## Supplemental Runtime Isolation Evidence Review
+
+These supplemental checks help reviewers decide when the container runtime boundary is sufficient and when a stronger sandbox runtime or profile evidence is required. Report these findings as `CONTAINER-RUNTIME-*` so CIS benchmark scoring remains mapped to the official Docker and Kubernetes controls.
+
+### CONTAINER-RUNTIME-01 -- Classify workload trust before requiring sandbox runtime
+
+Do not require `runtimeClassName` for every workload. First classify the workload.
+
+**Higher-risk workload indicators:**
+
+```yaml
+metadata:
+  namespace: plugins
+  labels:
+    workload.unitone.ai/trust-level: untrusted
+    workload.unitone.ai/code-origin: customer-supplied
+```
+
+Examples that usually require stronger isolation evidence:
+
+- Customer-supplied code, plugin runners, notebook execution, browser automation, CI/build workers, code interpreters, or test sandboxes.
+- Multi-tenant workloads where one customer or team can influence code executed next to another tenant.
+- Workloads with broad secret access, privileged network reach, sensitive host integrations, or hostile internet content parsing.
+
+Standard trusted application workloads can pass with Restricted Pod Security controls and `RuntimeDefault` profiles when other controls are present.
+
+### CONTAINER-RUNTIME-02 -- Verify RuntimeClass mapping for high-risk workloads
+
+**What to look for:**
+
+```yaml
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: kata
+handler: kata
+overhead:
+  podFixed:
+    cpu: "250m"
+    memory: "256Mi"
+scheduling:
+  nodeSelector:
+    runtime: kata
+  tolerations:
+    - key: runtime
+      operator: Equal
+      value: kata
+      effect: NoSchedule
+```
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: customer-plugin-runner
+  namespace: plugins
+spec:
+  template:
+    spec:
+      runtimeClassName: kata
+      nodeSelector:
+        runtime: kata
+```
+
+**Fail patterns:**
+
+```yaml
+# High-risk workload missing sandbox runtime evidence
+metadata:
+  name: customer-plugin-runner
+  namespace: plugins
+spec:
+  template:
+    spec:
+      containers:
+        - name: runner
+```
+
+**Review requirements:**
+
+- For high-risk workloads, verify `runtimeClassName` maps to a reviewed RuntimeClass handler such as gVisor, Kata Containers, or a documented organization sandbox runtime.
+- Confirm RuntimeClass `scheduling` and workload `nodeSelector`, affinity, and tolerations keep the pod on runtime-capable nodes.
+- Confirm RuntimeClass `overhead` is present or resource quotas account for sandbox overhead when the runtime requires it.
+- Record a pass for standard trusted workloads that do not need sandboxing but still meet Restricted Pod Security requirements.
+
+### CONTAINER-RUNTIME-03 -- Distinguish missing profiles from explicit Unconfined profiles
+
+**Critical fail patterns:**
+
+```yaml
+securityContext:
+  seccompProfile:
+    type: Unconfined
+```
+
+```yaml
+securityContext:
+  appArmorProfile:
+    type: Unconfined
+```
+
+**Review requirements:**
+
+- Check pod-level and container-level `securityContext` fields for containers, init containers, sidecars, and ephemeral containers.
+- Treat explicit `Unconfined` seccomp or AppArmor profiles as High or Critical depending on workload trust, privileges, and host access.
+- Treat missing fields as Not Evaluable or inherited when cluster-level default evidence exists; do not automatically equate missing YAML with `Unconfined`.
+- Prefer `RuntimeDefault` for standard workloads and reviewed `Localhost` profiles for workloads requiring custom syscall or MAC policies.
+
+### CONTAINER-RUNTIME-04 -- Require distribution evidence for Localhost profiles
+
+**What to look for:**
+
+```yaml
+securityContext:
+  seccompProfile:
+    type: Localhost
+    localhostProfile: profiles/audit-tight.json
+```
+
+```yaml
+securityContext:
+  appArmorProfile:
+    type: Localhost
+    localhostProfile: profiles/k8s-apparmor-example-deny-write
+```
+
+**Review requirements:**
+
+- Confirm the profile is loaded on every node where the workload can schedule.
+- Verify DaemonSet, node image, machine config, bootstrap script, or managed-node evidence that distributes the profile.
+- Check workload node selectors, affinity, and tolerations so pods do not land on nodes missing the profile.
+- If distribution evidence is unavailable, mark profile enforcement Not Evaluable rather than passing from manifest references alone.
+
+### CONTAINER-RUNTIME-05 -- Review SELinux applicability and options
+
+**What to look for:**
+
+```yaml
+securityContext:
+  seLinuxOptions:
+    type: container_t
+```
+
+**Review requirements:**
+
+- For Linux distributions and managed platforms that use SELinux labels, review `seLinuxOptions`, namespace/platform defaults, and volume label behavior.
+- Flag broad or privileged SELinux types for application workloads unless they are platform-required and narrowly scoped.
+- Mark SELinux controls Not Applicable for Windows containers and Not Evaluable when the node OS policy is unknown.
+
+### CONTAINER-RUNTIME-06 -- Verify node pool isolation for sandboxed workloads
+
+**Review requirements:**
+
+- Check RuntimeClass scheduling, workload selectors, taints/tolerations, and node affinity together.
+- Verify sandbox node pools do not co-host sensitive trusted workloads unless that is the documented design.
+- Confirm system DaemonSets needed by the runtime are present and limited to sandbox-capable nodes.
+- Include cluster autoscaler or node provisioner labels when they determine which node class is created.
+
+### CONTAINER-RUNTIME-07 -- Calibrate severity by trust level and host interaction
+
+**Severity guidance:**
+
+- Critical: untrusted code runs without sandbox runtime evidence and also has host namespace, hostPath, privileged mode, broad secrets, or broad network reach.
+- High: untrusted or multi-tenant workload lacks sandbox RuntimeClass or uses explicit `Unconfined` seccomp/AppArmor.
+- Medium: localhost profile references lack distribution evidence, sandbox RuntimeClass lacks scheduling/overhead evidence, or cluster default profile evidence is missing.
+- Low: trusted workload lacks optional sandboxing but meets Restricted Pod Security controls.
+
+### CONTAINER-RUNTIME-08 -- Use risk-based exceptions
+
+Exceptions to sandbox runtime or runtime profiles should include:
+
+- owner
+- reason
+- namespace and workload scope
+- expiry date or review cadence
+- compensating controls
+- evidence that the exception is enforced narrowly
+
+```yaml
+metadata:
+  annotations:
+    security.unitone.ai/runtime-exception-owner: "platform-security"
+    security.unitone.ai/runtime-exception-ticket: "SEC-1234"
+    security.unitone.ai/runtime-exception-expiry: "2026-09-30"
+```

--- a/skills/cloud/container-security/tests/benign/restricted-runtime-default-workload.yaml
+++ b/skills/cloud/container-security/tests/benign/restricted-runtime-default-workload.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payments-api
+  namespace: production
+  labels:
+    workload.unitone.ai/trust-level: trusted
+spec:
+  selector:
+    matchLabels:
+      app: payments-api
+  template:
+    metadata:
+      labels:
+        app: payments-api
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: app
+          image: registry.example.com/payments@sha256:abc123
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            appArmorProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+---
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: kata
+handler: kata
+overhead:
+  podFixed:
+    cpu: "250m"
+    memory: "256Mi"
+scheduling:
+  nodeSelector:
+    runtime: kata
+  tolerations:
+    - key: runtime
+      operator: Equal
+      value: kata
+      effect: NoSchedule
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: customer-plugin-runner
+  namespace: plugins
+  labels:
+    workload.unitone.ai/trust-level: untrusted
+spec:
+  template:
+    spec:
+      runtimeClassName: kata
+      nodeSelector:
+        runtime: kata
+      tolerations:
+        - key: runtime
+          operator: Equal
+          value: kata
+          effect: NoSchedule
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: runner
+          image: registry.example.com/plugin-runner@sha256:def456
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            capabilities:
+              drop: ["ALL"]
+      restartPolicy: Never

--- a/skills/cloud/container-security/tests/vulnerable/untrusted-runtime-with-unconfined-profiles.yaml
+++ b/skills/cloud/container-security/tests/vulnerable/untrusted-runtime-with-unconfined-profiles.yaml
@@ -1,0 +1,54 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: customer-plugin-runner
+  namespace: plugins
+  labels:
+    workload.unitone.ai/trust-level: untrusted
+    workload.unitone.ai/code-origin: customer-supplied
+spec:
+  template:
+    spec:
+      securityContext:
+        seccompProfile:
+          type: Unconfined
+      containers:
+        - name: runner
+          image: registry.example.com/plugin-runner:latest
+          securityContext:
+            allowPrivilegeEscalation: false
+            appArmorProfile:
+              type: Unconfined
+            capabilities:
+              drop: ["ALL"]
+      restartPolicy: Never
+---
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: kata
+handler: kata
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: customer-code
+  namespace: plugins
+spec:
+  selector:
+    matchLabels:
+      app: customer-code
+  template:
+    metadata:
+      labels:
+        app: customer-code
+        workload.unitone.ai/trust-level: untrusted
+    spec:
+      runtimeClassName: kata
+      containers:
+        - name: app
+          image: registry.example.com/customer-code@sha256:deadbeef
+          securityContext:
+            seccompProfile:
+              type: Localhost
+              localhostProfile: profiles/customer-code.json


### PR DESCRIPTION
## Summary

Closes #2099.

Adds supplemental runtime isolation evidence gates to `container-security` so Kubernetes reviews can distinguish ordinary trusted workloads that pass Restricted Pod Security from high-risk workloads that need sandbox runtime, runtime profile, and node pool isolation evidence.

## What changed

- Bumped `container-security` to `1.0.1` and added `Step 7: Supplemental Runtime Isolation Evidence`.
- Added a runtime isolation evidence matrix to the report template.
- Added `CONTAINER-RUNTIME-01` through `CONTAINER-RUNTIME-08` checks covering:
  - workload trust classification
  - RuntimeClass handler, overhead, and scheduling evidence
  - explicit `Unconfined` seccomp/AppArmor handling
  - `Localhost` profile distribution evidence
  - SELinux applicability and options
  - sandbox node pool isolation
  - severity calibration and risk-based exceptions
- Added benign and vulnerable Kubernetes fixtures under `skills/cloud/container-security/tests/`.

## Validation

- `git diff --cached --check`
- Frontmatter required-field check matching `.github/workflows/lint-skills.yml`
- `index.yaml` file-existence check matching `.github/workflows/validate-index.yml`
- Markdown code fence balance check for changed Markdown files
- ASCII-only check for changed files
- Prompt-injection scan matching `.github/workflows/injection-scan.yml`
- Runtime isolation marker check for `CONTAINER-RUNTIME-*`, `RuntimeClass`, `runtimeClassName`, `handler`, `overhead`, `nodeSelector`, `tolerations`, `seccompProfile`, `RuntimeDefault`, `Unconfined`, `appArmorProfile`, `seLinuxOptions`, `Localhost`, `localhostProfile`, and trust-level evidence

Note: YAML parser validation was attempted, but PyYAML is not installed in the local environment.

## Bounty

Requesting Improver - Moderate ($100). Preferred payment method: GitHub Sponsors if accepted, otherwise private payment details can be provided after acceptance.