### PR TITLE
Add DAST API route coverage fixtures

### DIFF
--- a/skills/devsecops/dast-config/SKILL.md
+++ b/skills/devsecops/dast-config/SKILL.md
@@ -12,7 +12,7 @@ phase: [build, deploy]
 frameworks: [OWASP-Top-10-2021, OWASP-Testing-Guide-v4.2]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -247,6 +247,33 @@ jobs:
 - API authentication is configured (Bearer tokens, API keys injected via ZAP headers).
 - Content-Type is set correctly for API requests (`application/json` for REST).
 - Rate limiting considerations: API scans should respect rate limits to avoid triggering WAF blocks.
+
+#### 3.1A API Route Coverage Evidence
+
+Do not treat a successful OpenAPI import as proof that the deployed API was scanned. Reconcile the API specification, runtime route inventory, scanner import output, and request evidence at the method/path level.
+
+**Route coverage evidence gates:**
+
+| Code | Gate | Evidence Required |
+|------|------|-------------------|
+| DAST-ROUTE-01 | Runtime route inventory | Framework route dump, API gateway export, service mesh inventory, or access-log inventory tied to the deployed build. |
+| DAST-ROUTE-02 | OpenAPI build binding | Spec commit, generated timestamp, build ID, artifact digest, or release ID that matches the deployed target. |
+| DAST-ROUTE-03 | Import completeness | ZAP/Burp import log with imported, skipped, failed, and warning counts per operation. |
+| DAST-ROUTE-04 | Request execution proof | HAR, proxy log, scanner request log, or server access log proving each covered route received a request. |
+| DAST-ROUTE-05 | Auth role coverage | Route-to-role matrix showing which user context exercised user, admin, service, tenant, and lower-privilege paths. |
+| DAST-ROUTE-06 | Sensitive route handling | Destructive or high-risk routes have passive-only, manual-test, mock, dry-run, or intentionally-untested evidence with owner approval. |
+| DAST-ROUTE-07 | Blocked route diagnosis | WAF, rate-limit, 401/403, CSRF, missing role, or parser-blocked routes are recorded as coverage gaps instead of passing silently. |
+| DAST-ROUTE-08 | Owner and remediation | Each missing, skipped, or unexercised runtime route has an owner, risk rating, and remediation or alternate-test plan. |
+
+**Coverage matrix template:**
+
+| Runtime Method/Path | In OpenAPI | Imported | Request Evidence | Auth Context | Gap Reason | Owner | Status |
+|---------------------|------------|----------|------------------|--------------|------------|-------|--------|
+| GET /api/orders/{id} | Yes | Yes | HAR + access log | user | None | API team | Covered |
+| POST /api/admin/reindex | No | No | None | admin | Runtime-only route missing from spec | Platform team | Gap |
+| POST /api/orders/{id}/refund | Yes | Yes | None | finance | Role missing in scanner session | Payments team | Gap |
+
+**Finding classification:** Sensitive runtime routes missing from the spec are **High**. OpenAPI import failures, skipped operations without owner, or routes marked covered without request evidence are **Medium**. DAST route coverage below the organization's minimum threshold is **Medium**, or **High** when admin, payment, tenant, identity, or destructive routes are affected. Mark route coverage **Not Evaluable** when runtime inventory or request evidence is unavailable.
 
 #### 3.2 GraphQL Scanning
 
@@ -483,7 +510,7 @@ DAST tools report findings per-URL, producing hundreds of duplicate alerts for t
 |----------|-----------|
 | **Critical** | No authenticated scanning; active scanning targeting production; injection scan rules disabled; no scope restrictions. |
 | **High** | No DAST in CI/CD; no API scanning for API endpoints; active scanning disabled entirely; hardcoded credentials in config; destructive endpoints not excluded; authentication verification absent. |
-| **Medium** | No passive scanning on PRs; no scheduled full scan; OpenAPI spec out of date; no triage workflow; no deduplication; ZAP action unpinned; missing GraphQL scanning; missing security header rules. |
+| **Medium** | No passive scanning on PRs; no scheduled full scan; OpenAPI spec out of date; OpenAPI import or request evidence is incomplete; no triage workflow; no deduplication; ZAP action unpinned; missing GraphQL scanning; missing security header rules. |
 | **Low** | Suboptimal scan duration settings; cosmetic report formatting; non-critical passive rules disabled. |
 
 ---
@@ -519,6 +546,12 @@ DAST tools report findings per-URL, producing hundreds of duplicate alerts for t
 | Active scanning (staging) | Yes/No | <workflow file> |
 | API scanning | Yes/No | <OpenAPI/GraphQL import> |
 | Results deduplication | Yes/No | <dedup method> |
+
+### API Route Coverage Evidence
+
+| Runtime Method/Path | In Spec | Imported | Exercised | Auth Context | Evidence | Gap Reason | Owner |
+|---------------------|---------|----------|-----------|--------------|----------|------------|-------|
+| <method path> | Yes/No | Yes/No | Yes/No | <role/user> | <HAR/log/import record> | <none/skipped/missing/blocker> | <team> |
 
 ### Findings
 
@@ -584,6 +617,8 @@ DAST tools report findings per-URL, producing hundreds of duplicate alerts for t
 
 5. **Running only scheduled weekly scans instead of integrating into CI.** Weekly scans create a feedback loop measured in days. Passive baseline scans in CI (on every PR) give developers immediate feedback on security header regressions and configuration issues, while weekly full scans provide comprehensive active testing coverage.
 
+6. **Counting OpenAPI import success as route coverage.** A green import job can still miss runtime-only routes, admin endpoints, partially imported operations, endpoints blocked by auth, or routes suppressed by WAF/rate limits. Require route-level request evidence before marking API coverage complete.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -614,4 +649,5 @@ This skill processes DAST configuration files that may contain target URLs, auth
 
 ## Changelog
 
+- **1.0.1** -- Added API route coverage evidence gates, route-level output fields, and classification guidance for OpenAPI/runtime/import/request-log gaps.
 - **1.0.0** -- Initial release. Full coverage of DAST configuration review against OWASP Top 10:2021 and OWASP Testing Guide v4.2, with ZAP-specific patterns.

--- a/skills/devsecops/dast-config/tests/benign/api-route-coverage-evidence-complete.yaml
+++ b/skills/devsecops/dast-config/tests/benign/api-route-coverage-evidence-complete.yaml
@@ -1,0 +1,49 @@
+case: api-route-coverage-evidence-complete
+skill: dast-config
+expected_result: covered
+target:
+  environment: staging
+  build_id: webapi-2026-06-08.42
+openapi:
+  source: generated-from-deployed-build
+  commit: 8f4b2c7
+  generated_at: "2026-06-08T09:10:00Z"
+zap_import:
+  imported_operations: 64
+  failed_operations: 0
+  warnings: []
+runtime_inventory:
+  source: api-gateway-export
+  build_id: webapi-2026-06-08.42
+  total_routes: 64
+route_coverage:
+  - method: GET
+    path: /api/orders/{id}
+    in_openapi: true
+    imported: true
+    request_evidence: har-and-access-log
+    auth_context: user
+    status: covered
+  - method: POST
+    path: /api/orders/{id}/refund
+    in_openapi: true
+    imported: true
+    request_evidence: har-and-access-log
+    auth_context: finance
+    status: covered
+  - method: POST
+    path: /api/admin/reindex
+    in_openapi: true
+    imported: true
+    request_evidence: passive-manual-test-log
+    auth_context: admin
+    status: covered-with-approved-passive-test
+controls:
+  destructive_routes:
+    dry_run_or_manual_evidence: true
+    owner_approval: platform-security
+  waf_blocks_recorded_as_gaps: true
+  coverage_threshold_met: true
+finding_expectation:
+  - no_dast_route_coverage_gap
+  - no_false_positive_for_approved_passive_destructive_route

--- a/skills/devsecops/dast-config/tests/vulnerable/openapi-import-with-runtime-route-gaps.yaml
+++ b/skills/devsecops/dast-config/tests/vulnerable/openapi-import-with-runtime-route-gaps.yaml
@@ -1,0 +1,57 @@
+case: openapi-import-with-runtime-route-gaps
+skill: dast-config
+expected_result: finding
+target:
+  environment: staging
+  build_id: webapi-2026-06-08.43
+openapi:
+  source: checked-in-spec
+  commit: 3a91d0e
+  generated_at: "2026-05-01T12:00:00Z"
+zap_import:
+  imported_operations: 42
+  failed_operations: 5
+  warnings:
+    - unsupported auth scheme for /api/billing/*
+scan_summary:
+  high_findings: 0
+  status: pass
+runtime_inventory:
+  source: framework-route-dump
+  build_id: webapi-2026-06-08.43
+  total_routes: 64
+  routes_missing_from_openapi:
+    - POST /api/admin/reindex
+    - DELETE /api/users/{id}
+route_coverage:
+  - method: POST
+    path: /api/admin/reindex
+    in_openapi: false
+    imported: false
+    request_evidence: none
+    auth_context: admin
+    gap_reason: runtime-only route missing from OpenAPI
+  - method: DELETE
+    path: /api/users/{id}
+    in_openapi: false
+    imported: false
+    request_evidence: none
+    auth_context: admin
+    gap_reason: destructive runtime route missing from OpenAPI
+  - method: POST
+    path: /api/orders/{id}/refund
+    in_openapi: true
+    imported: true
+    request_evidence: none
+    auth_context: user
+    gap_reason: scanner session lacks finance role
+controls:
+  route_owner_assigned: false
+  waf_blocks_recorded_as_gaps: false
+  coverage_claim: openapi-import-success-equals-pass
+finding_expectation:
+  - DAST-ROUTE-01
+  - DAST-ROUTE-03
+  - DAST-ROUTE-04
+  - DAST-ROUTE-05
+  - DAST-ROUTE-08


### PR DESCRIPTION
/claim #1708

## Summary

Adds fixture-backed API route coverage evidence gates to `dast-config` so OpenAPI import success is not treated as complete API DAST coverage.

Changes include:

- adds `DAST-ROUTE-01` through `DAST-ROUTE-08` for runtime route inventory, OpenAPI build binding, import completeness, request execution proof, auth role coverage, sensitive route handling, blocked-route diagnosis, and owner remediation
- adds a method/path coverage matrix to reconcile runtime routes, spec presence, scanner import status, HAR/access-log evidence, auth context, gap reason, and owner
- updates finding severity guidance and output format for runtime-only routes, partial imports, and routes marked covered without request evidence
- adds benign/vulnerable fixtures for complete route-level coverage versus a green OpenAPI import that misses admin/destructive routes and role-protected operations

## Why

The existing #1709 PR adds useful single-file guidance, but it has no local regression fixtures. This PR keeps the change scoped and adds concrete benign and vulnerable evidence examples so future edits preserve the distinction between imported operations and actually exercised routes.

## Validation

- `git diff --check origin/main...HEAD`
- Markdown fence-balance check for modified and added files
- YAML parse check for both added fixtures
- Marker check for `DAST-ROUTE-01` through `DAST-ROUTE-08`, `API Route Coverage Evidence`, `Coverage matrix template`, and `version: "1.0.1"`
- Added-line ASCII scan
- Added-line sensitive/public-contact pattern scan
- `git merge-tree --write-tree origin/main HEAD`

## Bounty

I have read and agree to the CONTRIBUTING.md bounty terms. Requested Improver Moderate tier if accepted.