### PR TITLE
Improve API OpenAPI contract drift gates

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -4,14 +4,15 @@ description: >
   Reviews REST and GraphQL APIs against the OWASP API Security Top 10:2023.
   Auto-invoked when reviewing OpenAPI/Swagger specs, API endpoint code, or
   GraphQL schemas. Covers BOLA, BFLA, authentication, rate limiting, and
-  SSRF. Produces findings mapped to API1-API10 with remediation guidance.
+  SSRF, including OpenAPI contract and authorization drift. Produces findings
+  mapped to API1-API10 with remediation guidance.
 tags: [appsec, api, rest, graphql]
 role: [appsec-engineer, security-engineer]
 phase: [design, build, review]
 frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -22,6 +23,8 @@ argument-hint: "[target-file-or-directory]"
 # API Security Review -- OWASP API Security Top 10:2023
 
 A structured, repeatable process for reviewing REST and GraphQL APIs against the OWASP API Security Top 10:2023. This skill produces findings mapped to API1 through API10 with associated CWE identifiers, severity ratings, and actionable remediation guidance. It applies to OpenAPI/Swagger specifications, API endpoint source code, GraphQL schemas, and API gateway configurations.
+
+The review also compares documented OpenAPI operations against implemented routes and gateway policies. This contract drift check catches shadow routes, stale documented operations, `security: []` overrides, auth scheme downgrades, and missing operation or response evidence that can make API9 inventory findings materially affect API2, API5, and API1 risk.
 
 ---
 
@@ -38,6 +41,7 @@ Before analyzing any endpoint, establish a complete inventory of the API surface
 5. **Catalog data objects** -- List the resources/entities exposed by the API and their sensitivity classification (PII, financial, internal, public).
 6. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, or cost-control mechanisms at the gateway or application layer.
 7. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
+8. **Build a contract drift inventory** -- Normalize OpenAPI paths, methods, operationIds, security requirements, code routes, route middleware, and gateway policies into a single route/auth matrix.
 
 > **Gate:** Do not proceed until the API style, authentication model, authorization model, and endpoint inventory are documented. Incomplete scope leads to missed findings.
 
@@ -48,6 +52,22 @@ Before analyzing any endpoint, establish a complete inventory of the API surface
 Evaluate the API against all ten OWASP API Security Top 10:2023 risk categories: Broken Object Level Authorization (BOLA), Broken Authentication, Broken Object Property Level Authorization, Unrestricted Resource Consumption, Broken Function Level Authorization (BFLA), Unrestricted Access to Sensitive Business Flows, Server Side Request Forgery (SSRF), Security Misconfiguration, Improper Inventory Management, and Unsafe Consumption of APIs.
 
 For detailed checklist items with vulnerable code patterns, remediation examples, and review checklists for all ten API risk categories (API1:2023 through API10:2023), see [api-top10-checklist.md](api-top10-checklist.md) in this skill directory.
+
+---
+
+## Step 12: OpenAPI Contract and Authorization Drift Evidence
+
+When OpenAPI/Swagger specs and route code are both available, compare them before finalizing API9, API2, API5, and API1 findings.
+
+Reviewers should:
+
+1. Normalize OpenAPI path templates (`/users/{id}`) and framework route templates (`/users/:id`, `/users/{id:int}`) before comparing.
+2. Compare every documented path/method/operationId against implemented routes and gateway policy evidence.
+3. Compare every implemented route against OpenAPI paths to find shadow, debug, test, internal, or admin endpoints.
+4. Identify top-level OpenAPI `security` requirements and operation-level overrides, especially `security: []`.
+5. Compare documented security schemes and scopes with code middleware, route policies, gateway auth, and direct-origin exposure controls.
+6. Record public endpoint allowlist evidence for unauthenticated routes.
+7. Mark gateway-only authentication as Not Evaluable or Partial unless direct access to the origin is blocked and gateway policy evidence is available.
 
 ---
 
@@ -64,6 +84,7 @@ Each finding produced by this review must include the following fields:
 | **CWE** | Applicable CWE identifier (e.g., CWE-639) |
 | **API Style** | REST, GraphQL, gRPC, or General |
 | **Location** | File path and line number(s), or OpenAPI spec path |
+| **Contract Drift Evidence** | Spec route, code route, operationId, documented security, implemented auth, gateway policy, and drift decision |
 | **Description** | What the vulnerability is and why it matters |
 | **Evidence** | Relevant code snippet or spec excerpt demonstrating the issue |
 | **Remediation** | Specific fix with code example where possible |
@@ -113,6 +134,24 @@ The final review output must be structured as follows:
 **Critical:** [count] | **High:** [count] | **Medium:** [count] | **Low:** [count] | **Info:** [count]
 
 ### Findings
+
+### OpenAPI Contract Drift Matrix
+
+| Spec Path | Code Route | Method | OperationId | Documented Security | Implemented Auth | Gateway Evidence | Decision |
+|---|---|---|---|---|---|---|---|
+| /api/v1/orders/{orderId} | /api/v1/orders/:orderId | GET | getOrder | bearerAuth | requireAuth + owner filter | direct origin blocked | Match |
+| /api/v1/admin/users/{userId} | /api/v1/admin/users/:userId | DELETE | deleteUser | bearerAuth | missing | none | Drift |
+
+#### API-CONTRACT-001: [Title]
+- **OWASP API Risk:** API9:2023 -- Improper Inventory Management; also map to API2/API5/API1 where applicable
+- **Severity:** [Critical|High|Medium|Low|Informational]
+- **API Style:** REST / GraphQL / gRPC / Hybrid
+- **Spec Evidence:** [OpenAPI path, method, operationId, security requirement]
+- **Implementation Evidence:** [route path, handler, middleware, policy, gateway rule]
+- **Drift Type:** Shadow Route / Stale Spec / Auth Mismatch / Public Override / Auth Downgrade / Missing Schema
+- **Description:** [explanation]
+- **Remediation:** [specific fix with code or spec example]
+- **Status:** Open
 
 #### API-SEC-001: [Title]
 - **OWASP API Risk:** API[N]:2023 -- [Name]
@@ -215,6 +254,10 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 6. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
 
+7. **Trusting OpenAPI `security` without implementation evidence.** A spec can claim `bearerAuth` while the route lacks middleware, accepts a weaker scheme, or is reachable by direct origin bypass.
+
+8. **Missing operation-level security overrides.** In OpenAPI, operation-level `security: []` can intentionally make a route public, but sensitive operations need explicit allowlist and business justification evidence.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -239,3 +282,10 @@ This skill is hardened against prompt injection. When reviewing API code and spe
 - **OWASP GraphQL Cheat Sheet:** https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html
 - **OWASP Testing Guide -- API Testing:** https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/12-API_Testing/
 - **NIST SP 800-204 -- Security Strategies for Microservices-based Application Systems:** https://csrc.nist.gov/publications/detail/sp/800-204/final
+- **OpenAPI Specification 3.1.0:** https://spec.openapis.org/oas/v3.1.0.html
+
+---
+
+## Changelog
+
+- **1.0.1** -- Added OpenAPI contract and authorization drift evidence gates for route/spec diffing, operationId uniqueness, security overrides, public endpoint allowlists, auth scheme downgrade checks, and gateway policy evidence.

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -518,6 +518,196 @@ Document doc = builder.parse(request.getInputStream());
 
 ---
 
+## Supplemental OpenAPI Contract and Authorization Drift Review
+
+Report these checks as `API-CONTRACT-*` evidence. Map each finding back to API9 and also to API2, API5, API1, API3, or API4 when the drift changes authentication, authorization, object access, response schemas, or rate limits.
+
+### API-CONTRACT-01 -- Normalize and inventory OpenAPI operations and code routes
+
+Build a route/auth matrix from:
+
+- OpenAPI or Swagger paths, methods, operationIds, parameters, request bodies, responses, and `security` requirements.
+- Code route registrations, controller attributes, Minimal API groups, Express routers, FastAPI decorators, GraphQL resolvers, or gateway routes.
+- API gateway policies, direct-origin access controls, route rewrites, and environment-specific feature flags.
+
+**Route normalization examples:**
+
+```text
+OpenAPI: /api/v1/orders/{orderId}
+Express: /api/v1/orders/:orderId
+ASP.NET: /api/v1/orders/{orderId:int}
+FastAPI: /api/v1/orders/{order_id}
+```
+
+Treat these as the same route only after normalizing parameter syntax and method.
+
+### API-CONTRACT-02 -- Detect shadow routes missing from OpenAPI
+
+**Fail pattern:**
+
+```javascript
+app.post("/api/v1/debug/impersonate", requireAuth, async (req, res) => {
+  await impersonate(req.body.userId);
+  res.json({ ok: true });
+});
+```
+
+**Review requirements:**
+
+- Flag undocumented debug, test, internal, admin, export, billing, impersonation, and support routes.
+- Check whether missing routes also bypass gateway policy, rate limits, client SDK review, or formal authorization review.
+- Require owner, environment, exposure, retirement, and monitoring evidence for any intentionally undocumented route.
+
+### API-CONTRACT-03 -- Detect stale OpenAPI operations with no implementation
+
+**Fail pattern:**
+
+```yaml
+paths:
+  /api/v1/legacy/reset-password:
+    post:
+      operationId: legacyResetPassword
+      security: []
+```
+
+**Review requirements:**
+
+- Determine whether the stale operation is only documentation drift or still reachable through an older deployment, gateway route, or versioned host.
+- For deprecated operations, require sunset date, owner, equivalent security controls, and monitoring.
+- Mark unresolved stale operations as API9 risk because consumers and security tooling may rely on inaccurate docs.
+
+### API-CONTRACT-04 -- Compare documented security with implemented route auth
+
+**Fail pattern:**
+
+```yaml
+paths:
+  /api/v1/admin/users/{userId}:
+    delete:
+      operationId: deleteUser
+      security:
+        - bearerAuth: []
+```
+
+```javascript
+app.delete("/api/v1/admin/users/:userId", async (req, res) => {
+  await Users.delete(req.params.userId);
+  res.sendStatus(204);
+});
+```
+
+**Review requirements:**
+
+- Verify code middleware or controller attributes enforce the documented auth scheme.
+- Verify role, permission, tenant, and ownership checks for admin or object-specific routes.
+- If auth is enforced only at the gateway, require gateway policy evidence and direct-origin blocking evidence.
+
+### API-CONTRACT-05 -- Review operation-level `security: []` overrides
+
+**Fail pattern:**
+
+```yaml
+security:
+  - bearerAuth: []
+paths:
+  /api/v1/reports/export:
+    post:
+      operationId: exportReports
+      security: []
+```
+
+**Review requirements:**
+
+- Treat `security: []` as an explicit public override of top-level security.
+- Allow only documented public endpoints such as health checks, public docs, or public catalog reads.
+- Require business justification, data classification, rate limiting, and monitoring evidence for public endpoints.
+- Flag public overrides on admin, billing, export, user-data, mutation, or support operations as High or Critical.
+
+### API-CONTRACT-06 -- Detect auth scheme downgrades
+
+**Fail pattern:**
+
+```yaml
+components:
+  securitySchemes:
+    oauth2:
+      type: oauth2
+paths:
+  /api/v1/billing:
+    get:
+      security:
+        - oauth2: ["billing:read"]
+```
+
+```javascript
+router.get("/api/v1/billing", optionalApiKeyOrBearer, billingHandler);
+```
+
+**Review requirements:**
+
+- Compare documented OAuth scopes, mTLS, API key, session, or JWT requirements against route middleware.
+- Flag routes that accept query tokens, legacy API keys, optional auth, weaker schemes, or broader scopes than the spec documents.
+- Verify scope checks are enforced in the application or gateway, not only named in OpenAPI.
+
+### API-CONTRACT-07 -- Check operationId uniqueness and security traceability
+
+**Review requirements:**
+
+- Ensure each operation has a stable, unique `operationId` so findings, tests, SDK methods, and gateway policies can reference the same operation.
+- Flag duplicate or missing operationIds on sensitive routes because they weaken traceability and CI policy mapping.
+- Require operationIds to appear in route tests, contract tests, or generated SDK metadata where those systems exist.
+
+### API-CONTRACT-08 -- Verify request and response schema drift for sensitive fields
+
+**Review requirements:**
+
+- Compare documented request schemas with accepted body fields to catch mass-assignment drift.
+- Compare documented response schemas with actual serializers/DTOs to catch excessive data exposure.
+- Flag undocumented sensitive fields such as `passwordHash`, `internalRole`, `tenantId`, `billingStatus`, `ssn`, or support notes.
+- Map request drift to API3 mass assignment and response drift to API3 excessive data exposure.
+
+### API-CONTRACT-09 -- Require CI or review evidence for contract drift prevention
+
+**Review requirements:**
+
+- Look for CI checks that compare route inventory to OpenAPI, such as contract tests, generated specs, spectral/openapi linting, or gateway export comparison.
+- Verify CI fails on undocumented sensitive routes, missing security requirements, duplicate operationIds, and public overrides outside an allowlist.
+- If no automated check exists, record manual review evidence and residual risk.
+
+### API-CONTRACT-10 -- Calibrate severity by exposure and sensitivity
+
+**Severity guidance:**
+
+- Critical: unauthenticated implemented route for admin, account takeover, export, billing, or sensitive object access where the spec claims authentication.
+- High: shadow admin/debug/internal route externally reachable, `security: []` on sensitive mutation, or auth scheme downgrade to weaker credentials.
+- Medium: stale spec with unclear deployment status, missing operationId on sensitive route, or missing gateway evidence.
+- Low: documentation mismatch on public low-risk read endpoints with no sensitive data.
+
+**Benign matching example:**
+
+```yaml
+paths:
+  /api/v1/orders/{orderId}:
+    get:
+      operationId: getOrder
+      security:
+        - bearerAuth: []
+```
+
+```javascript
+router.get("/api/v1/orders/:orderId", requireAuth, async (req, res) => {
+  const order = await Orders.findOne({
+    id: req.params.orderId,
+    tenantId: req.user.tenantId,
+    userId: req.user.id,
+  });
+  if (!order) return res.sendStatus(404);
+  res.json(toOrderResponse(order));
+});
+```
+
+---
+
 ## API10:2023 -- Unsafe Consumption of APIs
 
 **CWE:** CWE-20 (Improper Input Validation), CWE-295 (Improper Certificate Validation), CWE-319 (Cleartext Transmission of Sensitive Information)

--- a/skills/appsec/api-security/tests/benign/openapi-auth-matrix.yaml
+++ b/skills/appsec/api-security/tests/benign/openapi-auth-matrix.yaml
@@ -1,0 +1,70 @@
+openapi: 3.1.0
+info:
+  title: Benign Contract Matched API
+  version: "1.0.0"
+security:
+  - bearerAuth: []
+paths:
+  /api/v1/orders/{orderId}:
+    get:
+      operationId: getOrder
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Order visible to the caller
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OrderResponse"
+  /healthz:
+    get:
+      operationId: healthCheck
+      security: []
+      x-public-allowlist-reason: unauthenticated load balancer health check
+      responses:
+        "200":
+          description: Health check response
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    OrderResponse:
+      type: object
+      required:
+        - id
+        - status
+      properties:
+        id:
+          type: string
+        status:
+          type: string
+---
+implementedRoutes:
+  - method: GET
+    route: /api/v1/orders/:orderId
+    operationId: getOrder
+    middleware:
+      - requireAuth
+      - requireTenant
+    objectAuthorization:
+      ownershipFilter:
+        - tenantId
+        - userId
+    gateway:
+      directOriginBlocked: true
+      policy: bearerAuth
+  - method: GET
+    route: /healthz
+    operationId: healthCheck
+    middleware: []
+    publicAllowlistReason: unauthenticated load balancer health check

--- a/skills/appsec/api-security/tests/vulnerable/openapi-auth-drift.yaml
+++ b/skills/appsec/api-security/tests/vulnerable/openapi-auth-drift.yaml
@@ -1,0 +1,69 @@
+openapi: 3.1.0
+info:
+  title: Vulnerable Contract Drift API
+  version: "1.0.0"
+security:
+  - bearerAuth: []
+paths:
+  /api/v1/admin/users/{userId}:
+    delete:
+      operationId: deleteUser
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Deleted
+  /api/v1/reports/export:
+    post:
+      operationId: exportReports
+      security: []
+      responses:
+        "202":
+          description: Export started
+  /api/v1/billing:
+    get:
+      operationId: getBilling
+      security:
+        - oauth2:
+            - billing:read
+      responses:
+        "200":
+          description: Billing data
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+    oauth2:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://auth.example.com/oauth/token
+          scopes:
+            billing:read: Read billing data
+---
+implementedRoutes:
+  - method: DELETE
+    route: /api/v1/admin/users/:userId
+    operationId: deleteUser
+    middleware: []
+    finding: spec requires bearerAuth but the route has no auth middleware
+  - method: POST
+    route: /api/v1/debug/impersonate
+    operationId: null
+    middleware:
+      - requireAuth
+    finding: shadow debug route is missing from OpenAPI
+  - method: GET
+    route: /api/v1/billing
+    operationId: getBilling
+    middleware:
+      - optionalApiKeyOrBearer
+    finding: spec requires OAuth scope but implementation accepts weaker optional API key path


### PR DESCRIPTION
## Summary

Closes #2102.

Adds OpenAPI contract and authorization drift evidence gates to `api-security` so reviewers can compare documented paths, methods, operationIds, security requirements, code routes, route middleware, and gateway policies before finalizing API9/API2/API5/API1 findings.

## What changed

- Bumped `api-security` to `1.0.1` and added `Step 12: OpenAPI Contract and Authorization Drift Evidence`.
- Added an OpenAPI contract drift matrix to the report template.
- Added `API-CONTRACT-01` through `API-CONTRACT-10` checks covering:
  - OpenAPI/code route normalization and inventory
  - shadow routes and stale documented operations
  - documented security vs implemented route auth
  - operation-level `security: []` public overrides
  - auth scheme downgrades
  - operationId uniqueness and traceability
  - request/response schema drift
  - CI/review evidence for contract drift prevention
  - severity calibration by exposure and data sensitivity
- Added benign and vulnerable OpenAPI/route inventory fixtures under `skills/appsec/api-security/tests/`.

## Validation

- `git diff --cached --check`
- Frontmatter required-field check matching `.github/workflows/lint-skills.yml`
- `index.yaml` file-existence check matching `.github/workflows/validate-index.yml`
- Markdown code fence balance check for changed Markdown files
- ASCII-only check for changed files
- Prompt-injection scan matching `.github/workflows/injection-scan.yml`
- OpenAPI contract marker check for `API-CONTRACT-*`, `OpenAPI Contract Drift Matrix`, `operationId`, `security: []`, `bearerAuth`, `oauth2`, `optionalApiKeyOrBearer`, `directOriginBlocked`, shadow route, auth downgrade, and public override evidence

Note: YAML parser validation was attempted, but Ruby is not installed in the local environment. PyYAML is also unavailable locally.

## Bounty

Requesting Improver - Moderate ($100). Preferred payment method: GitHub Sponsors if accepted, otherwise private payment details can be provided after acceptance.