### PR TITLE
Add Azure disk export evidence fixtures

### DIFF
--- a/skills/cloud/azure-review/SKILL.md
+++ b/skills/cloud/azure-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-Azure-v2.1.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -88,6 +88,23 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, Bic
 
 ---
 
+### Step 10A: Supplemental Managed Disk and Snapshot Export Evidence
+
+Managed disk encryption and VM network posture do not prove that disk or snapshot export is controlled. Review managed disks, snapshots, Disk Access resources, private endpoints, RBAC export permissions, and export SAS usage separately from normal VM access.
+
+| Code | Gate | Evidence Required |
+|------|------|-------------------|
+| AZ-DISK-EXPORT-01 | Disk and snapshot inventory | In-scope managed disk and snapshot denominator with subscription, resource group, data sensitivity, owner, and workload mapping. |
+| AZ-DISK-EXPORT-02 | Network export policy | `networkAccessPolicy`, `publicNetworkAccess`, and `diskAccessId` for each managed disk and snapshot. |
+| AZ-DISK-EXPORT-03 | Disk Access private endpoint | Disk Access resource, private endpoint connection state, DNS evidence, and coverage for every exportable disk or snapshot. |
+| AZ-DISK-EXPORT-04 | Export-capable RBAC | Principals with `Microsoft.Compute/disks/beginGetAccess/action`, `Microsoft.Compute/disks/endGetAccess/action`, `Microsoft.Compute/snapshots/beginGetAccess/action`, or `Microsoft.Compute/snapshots/endGetAccess/action`. |
+| AZ-DISK-EXPORT-05 | SAS duration and revocation | Approved `grant-access` duration, ticket or justification, `revoke-access` evidence, and stale export URL handling. |
+| AZ-DISK-EXPORT-06 | Snapshot parity | Snapshot export controls reviewed independently from source VM and managed disk controls. |
+| AZ-DISK-EXPORT-07 | Audit and monitoring | Activity Log or diagnostic evidence for disk/snapshot grant and revoke operations with alert owner. |
+| AZ-DISK-EXPORT-08 | Exception governance | Business justification, approved principal, expiry, compensating monitoring, and residual data-exfiltration risk for export exceptions. |
+
+Mark this section **Not Evaluable** when live inventory, Resource Graph export, or IaC evidence does not include managed disk and snapshot export settings. Do not infer a pass from a private VM, encrypted OS/data disk, or CMK setting alone.
+
 
 ---
 
@@ -102,7 +119,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | Severity | Definition | Examples |
 |----------|-----------|----------|
 | **Critical** | Immediate risk of data breach or unauthorized access | NSGs open to 0.0.0.0/0 on RDP/SSH, SQL databases publicly accessible, Defender for Cloud disabled |
-| **High** | Significant security gap that materially weakens posture | Missing MFA enforcement, storage accounts with public access, Key Vault without purge protection |
+| **High** | Significant security gap that materially weakens posture | Missing MFA enforcement, storage accounts with public access, Key Vault without purge protection, production disk/snapshot export allowed publicly with broad export-capable RBAC |
 | **Medium** | Control gap that should be addressed in normal cycle | Missing activity log alerts, soft delete not enabled, TLS below 1.2 |
 | **Low** | Hardening recommendation or defense-in-depth measure | HTTP/2 not enabled, FTP not fully disabled, missing CMK on non-sensitive storage |
 | **Informational** | Best practice observation, no direct security impact | Naming conventions, tag policies, documentation gaps |
@@ -141,6 +158,12 @@ Produce the final report using the structure defined in the Output Format sectio
 | 7 | Virtual Machines | X | Y | Z | nn% |
 | 8 | Key Vault | X | Y | Z | nn% |
 | 9 | App Service | X | Y | Z | nn% |
+
+### Supplemental Managed Disk and Snapshot Export Evidence
+
+| Artifact Type | Resource | Sensitivity | NetworkAccessPolicy | PublicNetworkAccess | Disk Access / Private Endpoint | Export-Capable Principals | SAS Duration / Revocation | Audit Evidence | Status |
+|---------------|----------|-------------|---------------------|---------------------|-------------------------------|---------------------------|---------------------------|----------------|--------|
+| disk/snapshot | <name> | <level> | <policy> | <enabled/disabled> | <resource/state> | <principal list> | <duration/revoked> | <log query/ref> | Pass/Fail/Not Evaluable |
 
 ### Detailed Findings
 
@@ -200,6 +223,7 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **NSG rules using service tags.** A rule with `source_address_prefix = "Internet"` is equivalent to `0.0.0.0/0`. Both must be flagged for CIS 6.1 and 6.2.
 5. **Key Vault purge protection is irreversible.** CIS 8.5 requires `purge_protection_enabled = true`. Note this cannot be disabled once enabled -- flag this for awareness during remediation.
 6. **App Service TLS version on both Linux and Windows.** Check `azurerm_linux_web_app` and `azurerm_windows_web_app` resources separately.
+7. **Treating private VMs or encrypted disks as proof that disk export is private.** Managed disk and snapshot import/export use separate network controls, Disk Access resources, export SAS operations, and RBAC actions. Review these paths directly.
 
 ---
 
@@ -225,10 +249,13 @@ Produce the final report using the structure defined in the Output Format sectio
 - Azure Storage Security: https://learn.microsoft.com/en-us/azure/storage/common/storage-security-guide
 - Azure Key Vault Best Practices: https://learn.microsoft.com/en-us/azure/key-vault/general/best-practices
 - Azure App Service Security: https://learn.microsoft.com/en-us/azure/app-service/overview-security
+- Restrict managed disks from being imported or exported: https://learn.microsoft.com/en-us/azure/virtual-machines/disks-restrict-import-export-overview
+- Restrict import/export access for managed disks using Azure Private Link: https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-private-links-for-import-export-portal
 - Terraform AzureRM Provider Documentation: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
 
 ---
 
 ## Changelog
 
+- **1.0.1** -- Added supplemental managed disk and snapshot export evidence gates covering network export policy, Disk Access private endpoints, export-capable RBAC, SAS duration/revocation, audit evidence, and exception governance.
 - **1.0.0** -- Initial release. Full coverage of CIS Microsoft Azure Foundations Benchmark v2.1.0 sections 1 through 9.

--- a/skills/cloud/azure-review/benchmark-checklist.md
+++ b/skills/cloud/azure-review/benchmark-checklist.md
@@ -568,6 +568,69 @@ Check for anti-malware extension deployment.
 
 Verify encryption for any legacy VHD-based disks.
 
+### Supplemental -- Managed Disk and Snapshot Export Evidence
+
+This supplemental checklist is reported separately from CIS scoring. It verifies whether managed disks and snapshots can be exported through public SAS URLs or unrestricted principals even when the VM itself is private and encrypted.
+
+**Azure CLI / Resource Graph evidence to request:**
+
+```bash
+az disk show --resource-group <rg> --name <disk> \
+  --query '{networkAccessPolicy:networkAccessPolicy, publicNetworkAccess:publicNetworkAccess, diskAccessId:diskAccessId}'
+
+az snapshot show --resource-group <rg> --name <snapshot> \
+  --query '{networkAccessPolicy:networkAccessPolicy, publicNetworkAccess:publicNetworkAccess, diskAccessId:diskAccessId}'
+
+az role assignment list --all --include-inherited \
+  --query "[?contains(roleDefinitionName, 'Disk') || contains(roleDefinitionName, 'Contributor')]"
+
+az disk grant-access --resource-group <rg> --name <disk> --access-level Read --duration-in-seconds <duration>
+az disk revoke-access --resource-group <rg> --name <disk>
+```
+
+**Terraform patterns to review:**
+
+```hcl
+resource "azurerm_managed_disk" "example" {
+  network_access_policy = "AllowPrivate"
+  public_network_access_enabled = false
+  disk_access_id = azurerm_disk_access.example.id
+}
+
+resource "azurerm_snapshot" "example" {
+  network_access_policy = "AllowPrivate"
+  public_network_access_enabled = false
+  disk_access_id = azurerm_disk_access.example.id
+}
+
+resource "azurerm_private_endpoint" "disk_access" {
+  private_service_connection {
+    private_connection_resource_id = azurerm_disk_access.example.id
+    subresource_names = ["disks"]
+  }
+}
+```
+
+**Review checks:**
+
+| Code | Check | Evidence |
+|------|-------|----------|
+| AZ-DISK-EXPORT-01 | Managed disk and snapshot inventory is complete | Disk/snapshot list from IaC, Resource Graph, or Azure CLI with owner and sensitivity. |
+| AZ-DISK-EXPORT-02 | Public export is disabled or private-only | `networkAccessPolicy`, `publicNetworkAccess`, and `diskAccessId` values for every artifact. |
+| AZ-DISK-EXPORT-03 | Disk Access private endpoint is connected | Disk Access ID, private endpoint state, and DNS/private-link evidence. |
+| AZ-DISK-EXPORT-04 | Export-capable RBAC is least privilege | Role definitions and assignments containing begin/end get access actions are limited and approved. |
+| AZ-DISK-EXPORT-05 | SAS generation is time-bound and revoked | Grant duration, approval ticket, revoke evidence, and stale URL handling. |
+| AZ-DISK-EXPORT-06 | Snapshots are reviewed independently | Snapshot export settings are not inferred from the source disk or VM. |
+| AZ-DISK-EXPORT-07 | Export operations are monitored | Activity Log or diagnostic evidence for grant/revoke access operations. |
+| AZ-DISK-EXPORT-08 | Exceptions are governed | Owner, justification, expiry, monitoring, and residual risk are documented. |
+
+**Severity guidance:**
+
+- **High:** production or regulated managed disk/snapshot allows public export and broad principals can generate SAS URLs.
+- **Medium:** export is allowed for named roles but duration, revocation, owner, audit, or sensitivity evidence is incomplete.
+- **Low:** private endpoint or Disk Access exists but inventory coverage, snapshot parity, or monitoring evidence is incomplete.
+- **Informational:** export is disabled or restricted through private endpoint and RBAC evidence across all in-scope disks/snapshots.
+
 ---
 
 ## Section 8 -- Key Vault

--- a/skills/cloud/azure-review/tests/benign/private-disk-access-export-controlled.tf
+++ b/skills/cloud/azure-review/tests/benign/private-disk-access-export-controlled.tf
@@ -1,0 +1,73 @@
+resource "azurerm_resource_group" "prod" {
+  name     = "rg-prod-disk-evidence"
+  location = "eastus"
+}
+
+resource "azurerm_virtual_network" "prod" {
+  name                = "vnet-prod"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  address_space       = ["10.20.0.0/16"]
+}
+
+resource "azurerm_subnet" "private_link" {
+  name                 = "snet-private-link"
+  resource_group_name  = azurerm_resource_group.prod.name
+  virtual_network_name = azurerm_virtual_network.prod.name
+  address_prefixes     = ["10.20.10.0/24"]
+}
+
+resource "azurerm_disk_access" "prod" {
+  name                = "da-prod-export"
+  resource_group_name = azurerm_resource_group.prod.name
+  location            = azurerm_resource_group.prod.location
+}
+
+resource "azurerm_private_endpoint" "disk_access" {
+  name                = "pe-disk-access"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  subnet_id           = azurerm_subnet.private_link.id
+
+  private_service_connection {
+    name                           = "disk-access"
+    private_connection_resource_id = azurerm_disk_access.prod.id
+    is_manual_connection           = false
+    subresource_names              = ["disks"]
+  }
+}
+
+resource "azurerm_managed_disk" "orders" {
+  name                          = "orders-prod-osdisk"
+  location                      = azurerm_resource_group.prod.location
+  resource_group_name           = azurerm_resource_group.prod.name
+  storage_account_type          = "Premium_LRS"
+  create_option                 = "Empty"
+  disk_size_gb                  = 256
+  network_access_policy         = "AllowPrivate"
+  public_network_access_enabled = false
+  disk_access_id                = azurerm_disk_access.prod.id
+}
+
+resource "azurerm_snapshot" "orders_backup" {
+  name                          = "orders-prod-validated-snapshot"
+  location                      = azurerm_resource_group.prod.location
+  resource_group_name           = azurerm_resource_group.prod.name
+  create_option                 = "Copy"
+  source_resource_id            = azurerm_managed_disk.orders.id
+  network_access_policy         = "AllowPrivate"
+  public_network_access_enabled = false
+  disk_access_id                = azurerm_disk_access.prod.id
+}
+
+locals {
+  disk_export_evidence = {
+    inventory_complete              = true
+    disk_access_private_endpoint    = azurerm_private_endpoint.disk_access.name
+    export_capable_principals       = ["breakglass-disk-export-operators"]
+    approval_required               = true
+    max_sas_duration_seconds        = 3600
+    revoke_access_evidence_required = true
+    activity_log_alert              = "Microsoft.Compute/disks/beginGetAccess/action"
+  }
+}

--- a/skills/cloud/azure-review/tests/vulnerable/public-disk-snapshot-export-broad-rbac.tf
+++ b/skills/cloud/azure-review/tests/vulnerable/public-disk-snapshot-export-broad-rbac.tf
@@ -1,0 +1,62 @@
+resource "azurerm_resource_group" "prod" {
+  name     = "rg-prod-disk-export-risk"
+  location = "eastus"
+}
+
+resource "azurerm_managed_disk" "payments" {
+  name                          = "payments-prod-osdisk"
+  location                      = azurerm_resource_group.prod.location
+  resource_group_name           = azurerm_resource_group.prod.name
+  storage_account_type          = "Premium_LRS"
+  create_option                 = "Empty"
+  disk_size_gb                  = 512
+  network_access_policy         = "AllowAll"
+  public_network_access_enabled = true
+}
+
+resource "azurerm_snapshot" "payments_backup" {
+  name                          = "payments-prod-snapshot"
+  location                      = azurerm_resource_group.prod.location
+  resource_group_name           = azurerm_resource_group.prod.name
+  create_option                 = "Copy"
+  source_resource_id            = azurerm_managed_disk.payments.id
+  network_access_policy         = "AllowAll"
+  public_network_access_enabled = true
+}
+
+resource "azurerm_role_definition" "disk_export_operator" {
+  name        = "Broad Disk Export Operator"
+  scope       = azurerm_resource_group.prod.id
+  description = "Allows disk and snapshot SAS export for a broad operations group."
+
+  permissions {
+    actions = [
+      "Microsoft.Compute/disks/read",
+      "Microsoft.Compute/disks/beginGetAccess/action",
+      "Microsoft.Compute/disks/endGetAccess/action",
+      "Microsoft.Compute/snapshots/read",
+      "Microsoft.Compute/snapshots/beginGetAccess/action",
+      "Microsoft.Compute/snapshots/endGetAccess/action"
+    ]
+    not_actions = []
+  }
+
+  assignable_scopes = [azurerm_resource_group.prod.id]
+}
+
+resource "azurerm_role_assignment" "broad_export" {
+  scope              = azurerm_resource_group.prod.id
+  role_definition_id = azurerm_role_definition.disk_export_operator.role_definition_resource_id
+  principal_id       = var.all_operations_group_object_id
+}
+
+locals {
+  disk_export_gaps = {
+    missing_disk_access_private_endpoint = true
+    sas_duration_seconds                 = 86400
+    revoke_access_evidence               = "missing"
+    activity_log_alert                   = "missing"
+    approval_ticket                      = "missing"
+    snapshot_reviewed_separately         = false
+  }
+}


### PR DESCRIPTION
/claim #1741

## Summary

Adds fixture-backed managed disk and snapshot export evidence handling to `azure-review`.

Changes include:

- adds `AZ-DISK-EXPORT-01` through `AZ-DISK-EXPORT-08` for disk/snapshot inventory, network export policy, Disk Access private endpoint coverage, export-capable RBAC, SAS duration/revocation, snapshot parity, audit monitoring, and exception governance
- adds a supplemental Managed Disk and Snapshot Export Evidence output table
- extends the Azure benchmark checklist with CLI/Resource Graph evidence, Terraform fields, review checks, and severity guidance for disk and snapshot import/export controls
- adds benign/vulnerable Terraform fixtures for private Disk Access export control versus public disk/snapshot export with broad `beginGetAccess` RBAC and missing revoke/audit evidence

## Why

The existing #1743 PR adds useful skill/checklist guidance, but it has no local regression fixtures. This PR keeps the fix skill-local and adds concrete benign and vulnerable Terraform examples so future reviews distinguish private encrypted VM posture from disk and snapshot export exposure.

## Validation

- `git diff --check origin/main...HEAD`
- Markdown fence-balance check for modified and added files
- Marker check for `AZ-DISK-EXPORT-01` through `AZ-DISK-EXPORT-08`, `Managed Disk and Snapshot Export Evidence`, `networkAccessPolicy`, `publicNetworkAccess`, `diskAccessId`, `beginGetAccess/action`, `az disk grant-access`, and `az disk revoke-access`
- Terraform fixture marker check for `AllowPrivate`, `AllowAll`, Disk Access private endpoint, broad `beginGetAccess/action`, and missing revoke evidence
- Added-line ASCII scan
- Added-line sensitive/public-contact pattern scan
- `git merge-tree --write-tree origin/main HEAD`

## Bounty

I have read and agree to the CONTRIBUTING.md bounty terms. Requested Improver Moderate tier if accepted.