### PR TITLE
Add GCP image snapshot sharing fixtures

### DIFF
--- a/skills/cloud/gcp-review/SKILL.md
+++ b/skills/cloud/gcp-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-GCP-v2.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -88,6 +88,25 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
+### Step 8A: Supplemental Custom Image and Snapshot Sharing Evidence
+
+Private VMs, Shielded VM, and CMEK disks do not prove that the underlying custom image or disk snapshot is private. Review Compute Engine custom images, snapshots, project-level discoverability, artifact sensitivity, and IAM sharing separately from VM posture.
+
+| Code | Gate | Evidence Required |
+|------|------|-------------------|
+| GCP-IMAGE-SHARE-01 | Image and snapshot inventory | In-scope custom image and snapshot denominator with project, artifact ID, source workload, sensitivity, owner, and review date. |
+| GCP-IMAGE-SHARE-02 | Image IAM policy | `roles/compute.imageUser` bindings, including `allAuthenticatedUsers`, external principals, inherited IAM, and conditional expiry. |
+| GCP-IMAGE-SHARE-03 | Snapshot IAM policy | Snapshot IAM bindings and approved principal inventory reviewed independently from disk encryption and VM network controls. |
+| GCP-IMAGE-SHARE-04 | Project Viewer discoverability | Project-level `roles/viewer` or equivalent bindings that let principals discover shared images in the image project. |
+| GCP-IMAGE-SHARE-05 | Public and cross-org sharing | `allAuthenticatedUsers`, partner groups, external domains, and cross-organization access mapped to business approval and expiry. |
+| GCP-IMAGE-SHARE-06 | Data sanitization | Evidence that shared images or snapshots were generalized, scrubbed, rebuilt from golden source, or classified safe to share. |
+| GCP-IMAGE-SHARE-07 | Audit and monitoring | Cloud Asset Inventory, IAM policy export, and audit-log evidence for image/snapshot policy changes. |
+| GCP-IMAGE-SHARE-08 | Not Evaluable and exception handling | Missing inventory, missing artifact IAM, missing sensitivity, or approved exception with owner, expiry, and residual risk. |
+
+Mark this supplemental section **Not Evaluable** when the review lacks artifact-level image/snapshot inventory or IAM policy evidence. Do not infer a pass from a private instance, encrypted disk, or absence of `allUsers`.
+
+---
+
 ### Step 9: Compile Assessment Report
 
 
@@ -100,7 +119,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | Severity | Definition | Examples |
 |----------|-----------|----------|
 | **Critical** | Immediate risk of data breach or unauthorized access | Public GCS buckets, firewall rules allowing 0.0.0.0/0 on SSH/RDP, Cloud SQL with public IP and no SSL, user-managed SA keys with admin roles |
-| **High** | Significant security gap that materially weakens posture | Default service accounts with broad scopes, missing Cloud Audit Logs, no VPC flow logs, instances with public IPs |
+| **High** | Significant security gap that materially weakens posture | Default service accounts with broad scopes, missing Cloud Audit Logs, no VPC flow logs, instances with public IPs, sensitive custom image or snapshot shared with `allAuthenticatedUsers` or unapproved external principals |
 | **Medium** | Control gap that should be addressed in normal cycle | Missing log metric filters, DNSSEC not enabled, Shielded VM not enabled, uniform bucket access not set |
 | **Low** | Hardening recommendation or defense-in-depth measure | OS Login not enabled, serial port access not explicitly disabled, BigQuery tables without CMEK |
 | **Informational** | Best practice observation, no direct security impact | Default network still exists (non-production), naming conventions, documentation gaps |
@@ -137,6 +156,12 @@ Produce the final report using the structure defined in the Output Format sectio
 | 5 | Storage | X | Y | Z | nn% |
 | 6 | Cloud SQL | X | Y | Z | nn% |
 | 7 | BigQuery | X | Y | Z | nn% |
+
+### Supplemental Custom Image and Snapshot Sharing Evidence
+
+| Artifact Type | Project | Artifact ID | IAM Scope | Shared Principals | Project Viewer Discoverability | Sensitivity / Sanitization | Audit Evidence | Status |
+|---------------|---------|-------------|-----------|-------------------|--------------------------------|----------------------------|----------------|--------|
+| image/snapshot | <project> | <name> | <artifact/project/inherited> | <principal list> | <yes/no> | <classification/evidence> | <asset/log ref> | Pass/Fail/Not Evaluable |
 
 ### Detailed Findings
 
@@ -194,6 +219,7 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Cloud SQL authorized_networks vs. private IP.** CIS 6.5 flags `0.0.0.0/0` in authorized networks, but CIS 6.6 goes further and recommends disabling public IP entirely in favor of private networking.
 5. **BigQuery dataset-level vs. table-level CMEK.** CIS 7.2 checks table-level encryption, while CIS 7.3 checks the dataset default. Both should be evaluated independently.
 6. **Default compute service account identification.** The default SA follows the pattern `PROJECT_NUMBER-compute@developer.gserviceaccount.com`. Grep for this pattern, not just the string "default."
+7. **Treating private VM posture as image or snapshot privacy.** Custom images and snapshots have separate IAM policies. `allUsers` may be absent while `allAuthenticatedUsers` or project-level discoverability still exposes sensitive artifacts.
 
 ---
 
@@ -219,10 +245,13 @@ Produce the final report using the structure defined in the Output Format sectio
 - Google Cloud Audit Logs: https://cloud.google.com/logging/docs/audit
 - Google Cloud VPC Documentation: https://cloud.google.com/vpc/docs
 - Google Cloud SQL Security: https://cloud.google.com/sql/docs/mysql/configure-ssl-instance
+- Manage access to custom images: https://cloud.google.com/compute/docs/images/managing-access-custom-images
+- Compute Engine snapshots: https://cloud.google.com/compute/docs/disks/snapshots
 - Terraform Google Provider Documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs
 
 ---
 
 ## Changelog
 
+- **1.0.1** -- Added supplemental custom image and snapshot sharing evidence gates covering image/snapshot IAM policy, `allAuthenticatedUsers`, project Viewer discoverability, sanitization, audit evidence, and exception governance.
 - **1.0.0** -- Initial release. Full coverage of CIS Google Cloud Platform Foundation Benchmark v2.0.0 sections 1 through 7.

--- a/skills/cloud/gcp-review/benchmark-checklist.md
+++ b/skills/cloud/gcp-review/benchmark-checklist.md
@@ -532,6 +532,63 @@ resource "google_compute_instance" {
 }
 ```
 
+### Supplemental -- Custom Image and Snapshot Sharing Evidence
+
+This supplemental checklist is reported separately from CIS scoring. It verifies whether Compute Engine custom images and snapshots can expose disk-derived data even when the VM is private, Shielded, and CMEK-encrypted.
+
+**gcloud / Cloud Asset evidence to request:**
+
+```bash
+gcloud compute images get-iam-policy <image> --project <image-project>
+gcloud compute snapshots get-iam-policy <snapshot> --project <snapshot-project>
+
+gcloud projects get-iam-policy <image-project> \
+  --flatten="bindings[].members" \
+  --filter="bindings.role:roles/viewer OR bindings.role:roles/compute.imageUser"
+
+gcloud asset search-all-iam-policies \
+  --scope=organizations/<org-id> \
+  --query='policy:roles/compute.imageUser OR policy:allAuthenticatedUsers'
+```
+
+**Terraform patterns to review:**
+
+```hcl
+resource "google_compute_image_iam_member" "image_user" {
+  project = google_compute_image.hardened.project
+  image   = google_compute_image.hardened.name
+  role    = "roles/compute.imageUser"
+  member  = var.approved_image_user_group
+}
+
+resource "google_compute_snapshot_iam_member" "snapshot_user" {
+  project  = var.project_id
+  snapshot = google_compute_snapshot.sanitized.name
+  role     = "roles/compute.storageAdmin"
+  member   = var.approved_snapshot_admin_group
+}
+```
+
+**Review checks:**
+
+| Code | Check | Evidence |
+|------|-------|----------|
+| GCP-IMAGE-SHARE-01 | Custom image and snapshot inventory is complete | Artifact list from IaC, Cloud Asset Inventory, or gcloud with project, owner, source workload, and sensitivity. |
+| GCP-IMAGE-SHARE-02 | Custom image IAM is restricted | `roles/compute.imageUser` bindings exclude `allAuthenticatedUsers` and unapproved external principals. |
+| GCP-IMAGE-SHARE-03 | Snapshot IAM is restricted | Snapshot IAM policy is reviewed independently from the source disk and VM. |
+| GCP-IMAGE-SHARE-04 | Project Viewer discoverability is understood | Project-level Viewer bindings for image projects are approved and bounded. |
+| GCP-IMAGE-SHARE-05 | Cross-org sharing is approved | External groups/domains have owner, ticket, expiry, and business justification. |
+| GCP-IMAGE-SHARE-06 | Shared artifact data is sanitized | Evidence shows generalized image, scrubbed secrets, clean golden image, or approved data classification. |
+| GCP-IMAGE-SHARE-07 | Sharing changes are monitored | Audit logs or Cloud Asset Inventory exports cover image/snapshot IAM changes. |
+| GCP-IMAGE-SHARE-08 | Exceptions are governed | Missing evidence, approved exceptions, and residual risk are explicit in the report. |
+
+**Severity guidance:**
+
+- **High:** production-derived or sensitive image/snapshot is shared with `allAuthenticatedUsers` or unapproved external principals.
+- **Medium:** image/snapshot is shared with named external groups but owner, expiry, sanitization, or review evidence is incomplete.
+- **Low:** artifact inventory, project Viewer discoverability, or audit evidence is incomplete.
+- **Informational:** image/snapshot IAM is restricted to approved principals with review cadence and sanitization evidence.
+
 ---
 
 ## Section 5 -- Storage

--- a/skills/cloud/gcp-review/tests/benign/restricted-custom-image-snapshot-sharing.tf
+++ b/skills/cloud/gcp-review/tests/benign/restricted-custom-image-snapshot-sharing.tf
@@ -1,0 +1,53 @@
+resource "google_compute_image" "hardened_app" {
+  project     = "private-images"
+  name        = "hardened-app-20260608"
+  source_disk = google_compute_disk.golden.self_link
+
+  labels = {
+    data_classification = "sanitized"
+    owner               = "platform-security"
+  }
+}
+
+resource "google_compute_image_iam_member" "approved_builders" {
+  project = google_compute_image.hardened_app.project
+  image   = google_compute_image.hardened_app.name
+  role    = "roles/compute.imageUser"
+  member  = var.approved_builders_group_member
+
+  condition {
+    title       = "expires_after_build_window"
+    expression  = "request.time < timestamp('2026-07-01T00:00:00Z')"
+    description = "Temporary access for approved image consumers."
+  }
+}
+
+resource "google_compute_snapshot" "orders_dr" {
+  project     = "private-images"
+  name        = "orders-dr-sanitized-20260608"
+  source_disk = google_compute_disk.golden.name
+
+  labels = {
+    data_classification = "sanitized"
+    owner               = "platform-security"
+  }
+}
+
+resource "google_compute_snapshot_iam_member" "approved_dr" {
+  project  = google_compute_snapshot.orders_dr.project
+  snapshot = google_compute_snapshot.orders_dr.name
+  role     = "roles/compute.storageAdmin"
+  member   = var.approved_dr_group_member
+}
+
+locals {
+  image_snapshot_sharing_evidence = {
+    inventory_complete          = true
+    project_viewer_principals   = [var.approved_builders_group_member]
+    all_authenticated_users     = false
+    external_principals_reviewed = true
+    sanitization_evidence       = "golden-image-build-log-and-secret-scan"
+    audit_log_monitoring        = "SetIamPolicy alert for images and snapshots"
+    review_cadence_days         = 30
+  }
+}

--- a/skills/cloud/gcp-review/tests/vulnerable/public-custom-image-snapshot-sharing.tf
+++ b/skills/cloud/gcp-review/tests/vulnerable/public-custom-image-snapshot-sharing.tf
@@ -1,0 +1,53 @@
+resource "google_compute_image" "prod_clone" {
+  project     = "private-images"
+  name        = "prod-payments-clone"
+  source_disk = google_compute_disk.payments.self_link
+
+  labels = {
+    data_classification = "regulated"
+    owner               = "unknown"
+  }
+}
+
+resource "google_compute_image_iam_member" "public_image_user" {
+  project = google_compute_image.prod_clone.project
+  image   = google_compute_image.prod_clone.name
+  role    = "roles/compute.imageUser"
+  member  = "allAuthenticatedUsers"
+}
+
+resource "google_project_iam_member" "image_project_viewer" {
+  project = google_compute_image.prod_clone.project
+  role    = "roles/viewer"
+  member  = var.contractor_group_member
+}
+
+resource "google_compute_snapshot" "payments_snapshot" {
+  project     = "private-images"
+  name        = "payments-prod-snapshot-20260608"
+  source_disk = google_compute_disk.payments.name
+
+  labels = {
+    data_classification = "regulated"
+    owner               = "unknown"
+  }
+}
+
+resource "google_compute_snapshot_iam_member" "external_snapshot_user" {
+  project  = google_compute_snapshot.payments_snapshot.project
+  snapshot = google_compute_snapshot.payments_snapshot.name
+  role     = "roles/compute.storageAdmin"
+  member   = var.external_ops_group_member
+}
+
+locals {
+  image_snapshot_sharing_gaps = {
+    all_authenticated_users      = true
+    unapproved_external_group    = var.external_ops_group_member
+    project_viewer_discoverable  = true
+    sanitization_evidence        = "missing"
+    approval_ticket              = "missing"
+    expiry                       = "missing"
+    audit_log_monitoring         = "missing"
+  }
+}


### PR DESCRIPTION
/claim #1746

## Summary

Adds fixture-backed custom image and snapshot sharing evidence handling to `gcp-review`.

Changes include:

- adds `GCP-IMAGE-SHARE-01` through `GCP-IMAGE-SHARE-08` for custom image/snapshot inventory, image IAM, snapshot IAM, project Viewer discoverability, public/cross-org sharing, data sanitization, audit monitoring, and exception governance
- adds a supplemental Custom Image and Snapshot Sharing Evidence output table
- extends the GCP benchmark checklist with `gcloud` and Cloud Asset Inventory evidence commands, Terraform review patterns, review checks, and severity guidance
- adds benign/vulnerable Terraform fixtures for restricted sanitized image/snapshot sharing versus `allAuthenticatedUsers`, project Viewer discoverability, unapproved external snapshot access, and missing sanitization/audit evidence

## Why

The existing #1748 PR adds useful skill/checklist guidance, but it has no local regression fixtures. This PR keeps the fix skill-local and adds concrete benign and vulnerable Terraform examples so future reviews distinguish private VM/CMEK posture from custom image and snapshot IAM exposure.

## Validation

- `git diff --check origin/main...HEAD`
- Markdown fence-balance check for modified and added files
- Marker check for `GCP-IMAGE-SHARE-01` through `GCP-IMAGE-SHARE-08`, `Custom Image and Snapshot Sharing Evidence`, `roles/compute.imageUser`, `allAuthenticatedUsers`, `gcloud compute images get-iam-policy`, `gcloud compute snapshots get-iam-policy`, and `Project Viewer`
- Terraform fixture marker check for restricted image user, sanitization evidence, `allAuthenticatedUsers`, `roles/viewer`, and missing audit evidence
- Added-line ASCII scan
- Added-line sensitive/public-contact pattern scan
- `git merge-tree --write-tree origin/main HEAD`

## Bounty

I have read and agree to the CONTRIBUTING.md bounty terms. Requested Improver Moderate tier if accepted.