### PR TITLE
Add GCP IAM conditions fixtures

### DIFF
--- a/skills/cloud/gcp-review/SKILL.md
+++ b/skills/cloud/gcp-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-GCP-v2.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -88,6 +88,31 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
+### Step 8.1: IAM Conditions and Time-Bound Access Evidence
+
+For temporary, partner, contractor, emergency, and scoped access, verify the IAM binding itself enforces the boundary. Tickets, comments, expiration dates in a spreadsheet, or manual reminders are not sufficient if the deployed IAM policy is still permanent.
+
+Apply these gates before crediting a grant as time-bound or scoped:
+
+- **GCP-IAM-COND-01 -- Binding inventory:** enumerate project, folder, organization, service account, KMS, bucket, and BigQuery IAM bindings that grant elevated, external, emergency, or temporary access.
+- **GCP-IAM-COND-02 -- CEL condition evidence:** require a condition `title`, `description`, and CEL `expression` on the deployed binding, not only in a ticket or design note.
+- **GCP-IAM-COND-03 -- Enforceable expiry:** for temporary access, require `request.time < timestamp(...)` or an equivalent JIT mechanism with activation and expiry evidence.
+- **GCP-IAM-COND-04 -- Scoped condition:** for scoped access, verify resource name, resource type, tag, Access Context Manager, IP/device, or service-specific attributes are actually referenced by the CEL expression where supported.
+- **GCP-IAM-COND-05 -- Unsupported basic/public grants:** do not credit IAM Conditions for basic roles (`roles/owner`, `roles/editor`, `roles/viewer`) or public principals (`allUsers`, `allAuthenticatedUsers`) when the platform does not enforce the claimed conditional boundary.
+- **GCP-IAM-COND-06 -- Break-glass governance:** require activation reason, approver, ticket, monitoring, expiry, and post-use review evidence for emergency access.
+- **GCP-IAM-COND-07 -- Drift and expiry monitoring:** verify IAM policy exports, Cloud Asset Inventory, Policy Analyzer, or scheduled checks detect missing, expired, weakened, or removed conditions.
+- **GCP-IAM-COND-08 -- Evidence confidence:** mark grants **Not Evaluable** when the review only has comments, screenshots, or intended Terraform without a deployed IAM policy export or equivalent IaC evidence.
+
+Use this supplemental output table for IAM Conditions evidence:
+
+| Principal | Role | Resource Scope | Condition Title | Expiry / Scope Expression | Unsupported Basic/Public Grant | Evidence Source | Review Status |
+|-----------|------|----------------|-----------------|---------------------------|--------------------------------|-----------------|---------------|
+| `<principal>` | `<role>` | Project / Folder / Org / Resource | Present / Missing | `request.time < timestamp(...)` / scoped CEL / Missing | Yes / No | Terraform / IAM export / Cloud Asset / Policy Analyzer | Pass / Fail / Not Evaluable |
+
+Treat permanent external or emergency grants with privileged roles as **High** severity. Treat missing condition evidence for lower-privilege temporary access as **Medium**. Treat unsupported basic/public grants with claimed conditional safeguards as **High** when they expose broad project or organization access.
+
+---
+
 ### Step 9: Compile Assessment Report
 
 
@@ -137,6 +162,12 @@ Produce the final report using the structure defined in the Output Format sectio
 | 5 | Storage | X | Y | Z | nn% |
 | 6 | Cloud SQL | X | Y | Z | nn% |
 | 7 | BigQuery | X | Y | Z | nn% |
+
+### Supplemental IAM Conditions Evidence
+
+| Principal | Role | Resource Scope | Condition Title | Expiry / Scope Expression | Unsupported Basic/Public Grant | Evidence Source | Review Status |
+|-----------|------|----------------|-----------------|---------------------------|--------------------------------|-----------------|---------------|
+| <principal> | <role> | <scope> | Present / Missing | <expression> | Yes / No | <source> | Pass / Fail / Not Evaluable |
 
 ### Detailed Findings
 
@@ -194,6 +225,8 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Cloud SQL authorized_networks vs. private IP.** CIS 6.5 flags `0.0.0.0/0` in authorized networks, but CIS 6.6 goes further and recommends disabling public IP entirely in favor of private networking.
 5. **BigQuery dataset-level vs. table-level CMEK.** CIS 7.2 checks table-level encryption, while CIS 7.3 checks the dataset default. Both should be evaluated independently.
 6. **Default compute service account identification.** The default SA follows the pattern `PROJECT_NUMBER-compute@developer.gserviceaccount.com`. Grep for this pattern, not just the string "default."
+7. **Temporary access comments are not IAM Conditions.** Do not credit manual reminders, ticket due dates, or comments as scoped access unless the IAM binding includes an enforceable CEL condition or the JIT system has activation/expiry evidence.
+8. **Basic and public principals cannot be treated as safely conditional by assertion.** Flag `roles/owner`, `roles/editor`, `roles/viewer`, `allUsers`, and `allAuthenticatedUsers` grants when the claimed IAM Condition is unsupported, absent, or not visible in the deployed policy export.
 
 ---
 
@@ -219,10 +252,14 @@ Produce the final report using the structure defined in the Output Format sectio
 - Google Cloud Audit Logs: https://cloud.google.com/logging/docs/audit
 - Google Cloud VPC Documentation: https://cloud.google.com/vpc/docs
 - Google Cloud SQL Security: https://cloud.google.com/sql/docs/mysql/configure-ssl-instance
+- Google Cloud IAM Conditions: https://cloud.google.com/iam/docs/conditions-overview
+- Configure temporary access with IAM Conditions: https://cloud.google.com/iam/docs/configuring-temporary-access
+- IAM Policy Analyzer: https://cloud.google.com/policy-intelligence/docs/analyze-iam-policies
 - Terraform Google Provider Documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs
 
 ---
 
 ## Changelog
 
+- **1.0.1** -- Adds IAM Conditions and time-bound access evidence gates, output fields, severity guidance, and validation expectations.
 - **1.0.0** -- Initial release. Full coverage of CIS Google Cloud Platform Foundation Benchmark v2.0.0 sections 1 through 7.

--- a/skills/cloud/gcp-review/benchmark-checklist.md
+++ b/skills/cloud/gcp-review/benchmark-checklist.md
@@ -146,6 +146,86 @@ resource "google_essential_contacts_contact" {
 }
 ```
 
+### Supplemental -- IAM Conditions and Time-Bound Access
+
+Review temporary, scoped, emergency, contractor, and partner access by inspecting the deployed IAM binding condition. Do not accept comments, ticket due dates, or intended access-review dates as evidence when the IAM policy grants permanent access.
+
+Required evidence:
+
+- IAM binding export for project, folder, organization, service account, KMS, Cloud Storage, or BigQuery resources.
+- Terraform `condition` block or IAM policy JSON with `title`, `description`, and CEL `expression`.
+- Expiry expression such as `request.time < timestamp("2026-07-01T00:00:00Z")` for temporary access.
+- Scope expression using supported CEL attributes, such as `resource.name`, `resource.type`, tags, Access Context Manager attributes, IP/device context, or service-specific attributes.
+- Explicit unsupported-status review for basic roles (`roles/owner`, `roles/editor`, `roles/viewer`) and public principals (`allUsers`, `allAuthenticatedUsers`).
+- Break-glass evidence with activation reason, approver, ticket, monitoring, expiry, and post-use review.
+- Drift monitoring through Cloud Asset Inventory, Policy Analyzer, scheduled IAM exports, or equivalent controls.
+
+Terraform conditional project grant example:
+
+```hcl
+resource "google_project_iam_member" "temporary_image_builder" {
+  project = var.project_id
+  role    = "roles/compute.imageUser"
+  member  = var.approved_builder_group_member
+
+  condition {
+    title       = "temporary_image_build_access"
+    description = "Expires after the approved image build window."
+    expression  = "request.time < timestamp(\"2026-07-01T00:00:00Z\")"
+  }
+}
+```
+
+Terraform scoped resource grant example:
+
+```hcl
+resource "google_service_account_iam_member" "scoped_deployer" {
+  service_account_id = google_service_account.deploy.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = var.deployer_group_member
+
+  condition {
+    title       = "deploy_only_prod_service_account"
+    description = "Restricts impersonation to the approved deployment service account."
+    expression  = "resource.name.endsWith(\"/serviceAccounts/prod-deploy\")"
+  }
+}
+```
+
+Unsupported basic/public grant example:
+
+```hcl
+resource "google_project_iam_binding" "viewer_public" {
+  project = var.project_id
+  role    = "roles/viewer"
+  members = ["allAuthenticatedUsers"]
+
+  condition {
+    title       = "claimed_temporary_public_viewer"
+    description = "This must not be credited as a safe conditional boundary."
+    expression  = "request.time < timestamp(\"2026-07-01T00:00:00Z\")"
+  }
+}
+```
+
+Evidence commands:
+
+```bash
+gcloud projects get-iam-policy <project-id> --format=json
+gcloud folders get-iam-policy <folder-id> --format=json
+gcloud organizations get-iam-policy <organization-id> --format=json
+gcloud asset search-all-iam-policies --scope=organizations/<org-id> --query='policy:condition'
+```
+
+Review checks:
+
+- Pass only when the deployed IAM policy or source IaC includes the expected CEL `condition` block.
+- Fail temporary grants without `request.time < timestamp(...)` or an equivalent JIT activation/expiry record.
+- Fail scoped grants whose CEL expression does not reference supported resource, tag, access-level, or service-specific attributes.
+- Fail unsupported conditional claims on basic roles or public principals unless platform documentation proves the exact grant is enforceable.
+- Mark Not Evaluable when only comments, screenshots, planned expiry dates, or reviewer notes are available.
+- Verify monitoring detects condition removal, condition weakening, expired access that remains active, and reintroduced permanent grants.
+
 ### CIS 1.17 -- Ensure that Dataproc Cluster Is Encrypted Using Customer-Managed Encryption Key
 
 Check Dataproc clusters for CMEK configuration.

--- a/skills/cloud/gcp-review/tests/benign/iam-conditions-time-bound-access.tf
+++ b/skills/cloud/gcp-review/tests/benign/iam-conditions-time-bound-access.tf
@@ -1,0 +1,96 @@
+# Benign: temporary and scoped access is enforced by IAM Conditions, with drift
+# monitoring and break-glass evidence.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.30"
+    }
+  }
+}
+
+variable "project_id" {
+  type = string
+}
+
+variable "approved_builder_group_member" {
+  type = string
+}
+
+variable "deployer_group_member" {
+  type = string
+}
+
+variable "breakglass_group_member" {
+  type = string
+}
+
+resource "google_service_account" "deploy" {
+  project      = var.project_id
+  account_id   = "prod-deploy"
+  display_name = "Production deployment service account"
+}
+
+resource "google_project_iam_member" "temporary_image_builder" {
+  project = var.project_id
+  role    = "roles/compute.imageUser"
+  member  = var.approved_builder_group_member
+
+  condition {
+    title       = "temporary_image_build_access"
+    description = "Expires after approved image build window ticket CHG-2026-0701."
+    expression  = "request.time < timestamp(\"2026-07-01T00:00:00Z\")"
+  }
+}
+
+resource "google_service_account_iam_member" "scoped_deployer" {
+  service_account_id = google_service_account.deploy.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = var.deployer_group_member
+
+  condition {
+    title       = "deploy_only_prod_service_account"
+    description = "Restricts impersonation to the approved deployment service account."
+    expression  = "resource.name.endsWith(\"/serviceAccounts/prod-deploy\")"
+  }
+}
+
+resource "google_project_iam_member" "breakglass_observer" {
+  project = var.project_id
+  role    = "roles/logging.viewer"
+  member  = var.breakglass_group_member
+
+  condition {
+    title       = "breakglass_incident_window"
+    description = "Emergency observer access approved for incident INC-2026-0042 with post-use review."
+    expression  = "request.time < timestamp(\"2026-06-15T12:00:00Z\")"
+  }
+}
+
+resource "google_project_service" "cloudasset" {
+  project = var.project_id
+  service = "cloudasset.googleapis.com"
+}
+
+resource "google_logging_metric" "iam_condition_removed" {
+  project = var.project_id
+  name    = "iam-condition-removed-or-weakened"
+  filter  = "protoPayload.methodName=\"SetIamPolicy\" AND protoPayload.serviceData.policyDelta.bindingDeltas:*"
+}
+
+resource "google_monitoring_alert_policy" "iam_condition_drift" {
+  project      = var.project_id
+  display_name = "IAM condition removed or weakened"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "SetIamPolicy changed IAM bindings"
+    condition_threshold {
+      filter          = "metric.type=\"logging.googleapis.com/user/iam-condition-removed-or-weakened\""
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      duration        = "0s"
+    }
+  }
+}

--- a/skills/cloud/gcp-review/tests/vulnerable/permanent-iam-access-with-claimed-conditions.tf
+++ b/skills/cloud/gcp-review/tests/vulnerable/permanent-iam-access-with-claimed-conditions.tf
@@ -1,0 +1,63 @@
+# Vulnerable: comments and planned dates claim temporary access, but deployed IAM
+# bindings are permanent or use unsupported basic/public grants.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.30"
+    }
+  }
+}
+
+variable "project_id" {
+  type = string
+}
+
+variable "contractor_group_member" {
+  type = string
+}
+
+variable "external_partner_member" {
+  type = string
+}
+
+resource "google_project_iam_member" "contractor_editor" {
+  project = var.project_id
+  role    = "roles/editor"
+  member  = var.contractor_group_member
+
+  # Ticket says this expires on 2026-07-01, but there is no CEL condition.
+}
+
+resource "google_project_iam_member" "partner_token_creator" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = var.external_partner_member
+
+  # Manual reminder is not enforceable time-bound access.
+}
+
+resource "google_project_iam_binding" "public_viewer_claimed_temporary" {
+  project = var.project_id
+  role    = "roles/viewer"
+  members = ["allAuthenticatedUsers"]
+
+  condition {
+    title       = "claimed_temporary_public_viewer"
+    description = "Public/basic grant must not be credited as a safe conditional boundary."
+    expression  = "request.time < timestamp(\"2026-07-01T00:00:00Z\")"
+  }
+}
+
+resource "google_service_account_iam_member" "weak_scope" {
+  service_account_id = "projects/${var.project_id}/serviceAccounts/prod-deploy@${var.project_id}.iam.gserviceaccount.com"
+  role               = "roles/iam.serviceAccountUser"
+  member             = var.contractor_group_member
+
+  condition {
+    title       = "claimed_scoped_deployment"
+    description = "Condition has an expiry but no resource or access-context scope."
+    expression  = "request.time < timestamp(\"2026-07-01T00:00:00Z\")"
+  }
+}


### PR DESCRIPTION
/claim #1727

## Summary

Adds fixture-backed IAM Conditions and time-bound access evidence handling to `gcp-review`.

Changes include:

- adds `GCP-IAM-COND-01` through `GCP-IAM-COND-08` for binding inventory, CEL condition evidence, enforceable expiry, scoped conditions, unsupported basic/public grants, break-glass governance, drift/expiry monitoring, and evidence confidence
- adds a supplemental IAM Conditions evidence output table
- extends the GCP benchmark checklist with Terraform examples, `gcloud`/Cloud Asset evidence commands, review checks, and unsupported basic/public grant guidance
- adds benign/vulnerable Terraform fixtures for enforceable temporary/scoped/break-glass IAM Conditions versus permanent comments, manual reminders, basic/public grants, and weak scope conditions

## Why

The existing #1728 and #1729 PRs add useful skill/checklist guidance, but neither adds local regression fixtures. This PR keeps the fix skill-local and adds concrete benign and vulnerable Terraform examples so future reviews distinguish deployed IAM Conditions from ticket-only or unsupported conditional-access claims.

## Validation

- `git diff --check origin/main...HEAD`
- Markdown fence-balance check for modified files
- Marker check for `GCP-IAM-COND-01` through `GCP-IAM-COND-08`, `IAM Conditions and Time-Bound Access Evidence`, `request.time < timestamp`, `allAuthenticatedUsers`, `roles/owner`, `roles/editor`, `roles/viewer`, `configuring-temporary-access`, and `version: "1.0.1"`
- Terraform fixture marker check for temporary/scoped/break-glass conditions, drift monitoring, permanent editor access, service account token creator access, public viewer access, and weak scope conditions
- Added-line ASCII scan
- Added-line sensitive/public-contact pattern scan
- `git merge-tree --write-tree origin/main HEAD`

## Bounty

I have read and agree to the CONTRIBUTING.md bounty terms. Requested Improver Moderate tier if accepted.