### PR TITLE
Add container provenance evidence fixtures

### DIFF
--- a/skills/cloud/container-security/SKILL.md
+++ b/skills/cloud/container-security/SKILL.md
@@ -13,7 +13,7 @@ phase: [build, deploy, operate]
 frameworks: [CIS-Docker-v1.6.0, CIS-Kubernetes-v1.9.0, NIST-SP-800-190]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -62,6 +62,8 @@ NIST SP 800-190 identifies five risk categories: image risks, registry risks, or
 - NetworkPolicy definitions
 - Pod Security Standard configurations or OPA/Gatekeeper policies
 - Container registry configurations (if available)
+- Rendered production manifests, image digests, build provenance, signatures,
+  SBOMs, admission policy mode, and exception records for deployed images
 
 ---
 
@@ -115,7 +117,39 @@ For detailed CIS benchmark checklist items, NIST SP 800-190 countermeasure table
 
 ---
 
-### Step 7: Compile Assessment Report
+### Step 7: Verify Image Provenance and Admission Evidence Chain
+
+For every production workload image, verify an end-to-end evidence chain proving
+the deployed artifact is the same artifact that was built, scanned, signed,
+attested, and admitted by policy. Use rendered manifests rather than only
+Dockerfiles, Helm defaults, or Kustomize bases.
+
+Required checks:
+
+- **CONT-PROV-01:** Production workload uses a mutable tag without recording the
+  resolved digest.
+- **CONT-PROV-02:** Signature verification is performed against a tag or stale
+  digest instead of the deployed digest.
+- **CONT-PROV-03:** SBOM, vulnerability scan, or provenance attestation subject
+  digest does not match the deployed digest.
+- **CONT-PROV-04:** Admission policy is in `audit` or `warn` mode only for a
+  production namespace.
+- **CONT-PROV-05:** Trusted signer identity, issuer, workflow, or repository
+  constraint is missing or too broad.
+- **CONT-PROV-06:** Rendered Helm/Kustomize output differs from the reviewed
+  pinned image or admission policy.
+- **CONT-PROV-07:** Production exception lacks an owner, expiry, compensating
+  control, or retest trigger.
+- **CONT-PROV-08:** Registry retention or lifecycle policy can delete the
+  signed/SBOM-linked digest before the workload is retired.
+
+Treat `imagePullPolicy: Always` as pull behavior only. It is not provenance and
+does not prove digest pinning, signature verification, SBOM linkage, or trusted
+build origin.
+
+---
+
+### Step 8: Compile Assessment Report
 
 
 Produce the final report using the structure defined in the Output Format section.
@@ -161,6 +195,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | RBAC | CIS K8s 5.1.x | X | X | X | X | X |
 | Network Policies | CIS K8s 5.3.x | X | X | X | X | X |
 | Secrets Management | CIS K8s 5.4.x | X | X | X | X | X |
+| Image Provenance | NIST 800-190 Image/Registry | X | X | X | X | X |
 | Runtime Hardening | NIST 800-190 | X | X | X | X | X |
 | Control Plane | CIS K8s 1.x-4.x | X | X | X | X | X |
 
@@ -177,6 +212,12 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Description:** <what was found>
 - **Evidence:** <specific configuration>
 - **Remediation:** <fix with code example>
+
+### Image Provenance Evidence
+
+| Workload | Rendered Image | Resolved Digest | Signature / Attestation | SBOM / Scan Digest | Admission Mode | Exception |
+|----------|----------------|-----------------|-------------------------|--------------------|----------------|-----------|
+| deploy/api | registry/app@sha256:<digest> | sha256:<digest> | cosign pass, trusted workflow | matches deployed digest | enforce | none |
 
 ### Pod Security Standards Compliance Matrix
 
@@ -226,8 +267,8 @@ Produce the final report using the structure defined in the Output Format sectio
 
 | Risk Category | Key Risks | Countermeasure Focus |
 |--------------|-----------|---------------------|
-| Image Risks | Vulnerabilities, malware, embedded secrets, unpatched software | Minimal base images, scanning, signing, immutable references |
-| Registry Risks | Unauthorized access, stale images, insufficient authentication | Registry authentication, image lifecycle policies |
+| Image Risks | Vulnerabilities, malware, embedded secrets, unpatched software, unsigned or untraceable artifacts | Minimal base images, scanning, signing, immutable references, deployed-digest provenance |
+| Registry Risks | Unauthorized access, stale images, insufficient authentication, deleted evidence artifacts | Registry authentication, image lifecycle policies, signature/SBOM retention |
 | Orchestrator Risks | Unrestricted access, mixed sensitivity workloads, insufficient logging | RBAC, namespaces, network policies, audit logging |
 | Container Risks | Runtime privilege escalation, unbounded resources, writable filesystems | Non-root, capabilities, resource limits, read-only FS |
 | Host OS Risks | Shared kernel, large attack surface, unpatched hosts | Minimal host OS, regular patching, immutable infrastructure |
@@ -257,6 +298,8 @@ Produce the final report using the structure defined in the Output Format sectio
 5. **`readOnlyRootFilesystem` breaks many applications.** When recommending this control, also recommend adding writable `emptyDir` volume mounts for directories the application needs to write to (e.g., `/tmp`, `/var/cache`).
 6. **Network policies are additive, not subtractive.** A default-deny policy must be explicitly created. Without it, all pod-to-pod traffic is allowed regardless of other NetworkPolicy resources.
 7. **Distroless images have no shell.** While this is excellent for security, note that debugging requires ephemeral containers (`kubectl debug`). Flag this as a consideration, not a problem.
+8. **`imagePullPolicy: Always` is not image provenance.** It does not prove the image is signed, digest-pinned, linked to an SBOM, or admitted by an enforcing production policy.
+9. **A signed tag is not enough.** Signatures, SBOMs, vulnerability scans, and attestations must match the digest actually rendered and running in the workload.
 
 ---
 
@@ -285,6 +328,9 @@ Produce the final report using the structure defined in the Output Format sectio
 - Kubernetes Pod Security Admission: https://kubernetes.io/docs/concepts/security/pod-security-admission/
 - Kubernetes Network Policies: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 - Kubernetes RBAC: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Kubernetes Dynamic Admission Control: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/
+- Sigstore Cosign Verification: https://docs.sigstore.dev/cosign/verifying/verify/
+- SLSA Provenance: https://slsa.dev/spec/v1.0/provenance
 - Docker Security Best Practices: https://docs.docker.com/develop/security-best-practices/
 - Dockerfile Best Practices: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
 - NSA/CISA Kubernetes Hardening Guide: https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF
@@ -293,4 +339,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Added image provenance and admission evidence-chain review gates, output evidence table, and deployed-digest matching requirements for signatures, SBOMs, scans, and attestations.
 - **1.0.0** -- Initial release. Full coverage of CIS Docker Benchmark v1.6.0 Section 4-5, CIS Kubernetes Benchmark v1.9.0 Sections 1-5, and NIST SP 800-190 countermeasures across all five risk categories.

--- a/skills/cloud/container-security/cis-benchmarks.md
+++ b/skills/cloud/container-security/cis-benchmarks.md
@@ -592,9 +592,71 @@ Evaluate container runtime configurations against NIST SP 800-190 countermeasure
 |---------------|---------------|
 | **CM-1:** Use minimal base images | Verify Alpine, Distroless, or slim variants in FROM |
 | **CM-2:** Scan images for vulnerabilities | Check for Trivy, Grype, Snyk in CI pipeline |
-| **CM-3:** Sign and verify images | Check for Cosign signatures, Notary, or admission webhooks |
-| **CM-4:** Use immutable tags or digests | `image: nginx@sha256:...` preferred over `image: nginx:1.25` |
+| **CM-3:** Sign and verify images | Check for Cosign signatures, Notary, or admission webhooks that verify the deployed digest |
+| **CM-4:** Use immutable tags or digests | `image: nginx@sha256:...` preferred over `image: nginx:1.25`; record the runtime-resolved digest for approved tag exceptions |
 | **CM-5:** Remove unnecessary packages | No curl, wget, netcat, or shells in production images |
+
+### NIST 800-190: Image Provenance Evidence Chain
+
+Apply these checks to rendered production manifests and admission policy evidence,
+not just source templates. Record `Not Evaluable` if any required artifact is
+unavailable and explain the missing evidence.
+
+| ID | Evidence Gate | Passing Evidence | Failure Pattern |
+|----|---------------|------------------|-----------------|
+| **CONT-PROV-01** | Rendered workload image is immutable or has a captured resolved digest | `image: registry/app@sha256:<digest>` or runtime digest captured for a tag exception | `image: registry/app:latest` or `:1.4.2` with no resolved digest |
+| **CONT-PROV-02** | Signature verification targets the deployed digest | `cosign verify registry/app@sha256:<digest>` with matching subject | Signature checked against a tag while the runtime digest differs |
+| **CONT-PROV-03** | SBOM, vulnerability scan, and provenance attestation subject match the deployed digest | SBOM `subject.digest`, scan artifact digest, and SLSA/cosign attestation all match | SBOM file exists but references an older digest |
+| **CONT-PROV-04** | Production admission policy enforces trusted image requirements | Kyverno/Gatekeeper/registry policy mode is `enforce` for production namespaces | Admission policy is `audit` or `warn` only |
+| **CONT-PROV-05** | Signer identity is constrained to an approved issuer, repository, and release workflow | Fulcio/Sigstore identity, OIDC issuer, repository, and workflow path are checked | Any trusted certificate or broad organization signer is accepted |
+| **CONT-PROV-06** | Rendered Helm/Kustomize output matches the reviewed pinned image and policy | `helm template` or `kustomize build` output contains the signed digest and enforcement policy | Base template is pinned but production values override to a mutable tag |
+| **CONT-PROV-07** | Exceptions have owner, expiry, compensating control, and retest trigger | Exception record references workload, digest, owner, expiry, risk acceptance, and planned removal | Permanent exception or missing owner/expiry |
+| **CONT-PROV-08** | Registry lifecycle retains the deployed digest, signature, SBOM, and attestations while in use | Retention policy protects active production digests and attached artifacts | Lifecycle policy can garbage-collect the digest or attached evidence |
+
+**Benign example: production digest with matching provenance**
+
+```yaml
+workload: deploy/api
+namespace: production
+rendered_image: registry.internal.invalid/payments/api@sha256:1111111111111111111111111111111111111111111111111111111111111111
+build:
+  commit: 4f2c18a
+  workflow: .github/workflows/release.yml
+signature:
+  verifier: cosign
+  result: pass
+  subject_digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+  trusted_identity: repo:org/payments-api:ref:refs/heads/main
+sbom:
+  format: spdx-json
+  subject_digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+admission_policy:
+  engine: kyverno
+  mode: enforce
+  namespaces:
+    - production
+```
+
+**Vulnerable example: signed tag but different deployed digest**
+
+```yaml
+workload: deploy/api
+namespace: production
+rendered_image: registry.internal.invalid/payments/api:1.4.2
+runtime_resolved_digest: sha256:2222222222222222222222222222222222222222222222222222222222222222
+review_evidence:
+  signed_image: registry.internal.invalid/payments/api:1.4.2
+  signed_digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+  sbom_subject_digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+admission_policy:
+  engine: kyverno
+  mode: audit
+```
+
+The vulnerable example must be reported because the signature and SBOM prove a
+different digest than the one running, and audit-only admission does not block
+untrusted production images. `imagePullPolicy: Always` would not change that
+result because it only controls pull behavior.
 
 ### NIST 800-190: Orchestrator Countermeasures
 

--- a/skills/cloud/container-security/tests/benign/image-provenance-admission-enforced.yaml
+++ b/skills/cloud/container-security/tests/benign/image-provenance-admission-enforced.yaml
@@ -1,0 +1,51 @@
+---
+case: image-provenance-admission-enforced
+expected_result: pass
+description: Production workload uses a rendered digest with matching signature, SBOM, provenance, and enforce-mode admission.
+workload:
+  kind: Deployment
+  name: payments-api
+  namespace: production
+  rendered_image: registry.internal.invalid/payments/api@sha256:1111111111111111111111111111111111111111111111111111111111111111
+  runtime_resolved_digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+  imagePullPolicy: IfNotPresent
+build_provenance:
+  source_commit: 4f2c18a
+  builder: repo:org/payments-api:ref:refs/heads/main
+  workflow: .github/workflows/release.yml
+  subject_digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+signature:
+  verifier: cosign
+  result: pass
+  subject_digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+  oidc_issuer: https://token.actions.githubusercontent.com
+  trusted_identity: repo:org/payments-api:ref:refs/heads/main
+  trusted_workflow: .github/workflows/release.yml
+sbom:
+  format: spdx-json
+  subject_digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+vulnerability_scan:
+  scanner: trivy
+  artifact_digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+  critical: 0
+  high: 0
+admission_policy:
+  engine: kyverno
+  policy: verify-production-images
+  mode: enforce
+  namespaces:
+    - production
+  allow_tagless_digest_only: true
+registry_retention:
+  protects_active_digests: true
+  protects_attached_artifacts: true
+exceptions: []
+evidence_gates:
+  CONT-PROV-01: pass
+  CONT-PROV-02: pass
+  CONT-PROV-03: pass
+  CONT-PROV-04: pass
+  CONT-PROV-05: pass
+  CONT-PROV-06: pass
+  CONT-PROV-07: pass
+  CONT-PROV-08: pass

--- a/skills/cloud/container-security/tests/vulnerable/mutable-tag-audit-only-admission.yaml
+++ b/skills/cloud/container-security/tests/vulnerable/mutable-tag-audit-only-admission.yaml
@@ -1,0 +1,51 @@
+---
+case: mutable-tag-audit-only-admission
+expected_result: fail
+description: Production workload uses a mutable tag, evidence for a different digest, and audit-only admission policy.
+workload:
+  kind: Deployment
+  name: payments-api
+  namespace: production
+  rendered_image: registry.internal.invalid/payments/api:1.4.2
+  runtime_resolved_digest: sha256:2222222222222222222222222222222222222222222222222222222222222222
+  imagePullPolicy: Always
+helm_rendering:
+  template_default: registry.internal.invalid/payments/api@sha256:1111111111111111111111111111111111111111111111111111111111111111
+  production_values_override: tag:1.4.2
+build_provenance:
+  source_commit: 4f2c18a
+  workflow: .github/workflows/release.yml
+  subject_digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+signature:
+  verifier: cosign
+  result: pass
+  verified_reference: registry.internal.invalid/payments/api:1.4.2
+  subject_digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+  trusted_identity: repo:org/payments-api:ref:refs/heads/main
+sbom:
+  format: spdx-json
+  subject_digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+vulnerability_scan:
+  scanner: trivy
+  artifact_digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+admission_policy:
+  engine: kyverno
+  policy: verify-production-images
+  mode: audit
+  namespaces:
+    - production
+exception:
+  owner: ""
+  expiry: ""
+  compensating_control: ""
+registry_retention:
+  protects_active_digests: false
+  protects_attached_artifacts: false
+expected_findings:
+  - CONT-PROV-01
+  - CONT-PROV-02
+  - CONT-PROV-03
+  - CONT-PROV-04
+  - CONT-PROV-06
+  - CONT-PROV-07
+  - CONT-PROV-08


### PR DESCRIPTION
/claim #1659

## What changed

Adds a fixture-backed image provenance evidence chain to `container-security` so reviews verify the deployed production image digest, not only template defaults or tag-level evidence.

- Adds `CONT-PROV-01` through `CONT-PROV-08` for mutable tags, signature/SBOM/provenance digest mismatch, audit-only admission, weak signer identity constraints, rendered Helm/Kustomize drift, stale exceptions, and registry evidence-retention gaps.
- Extends the report output with an Image Provenance Evidence table.
- Expands the NIST 800-190 image countermeasure checklist with concrete deployed-digest evidence gates.
- Adds benign and vulnerable YAML fixtures covering enforce-mode admission with matching cosign/SBOM evidence versus mutable tag, mismatched digest evidence, `imagePullPolicy: Always`, and audit-only admission.

## Validation

- `git diff --check origin/main...HEAD`
- Markdown fence balance for edited docs
- Marker checks for `CONT-PROV-01` through `CONT-PROV-08`, `Image Provenance Evidence`, `imagePullPolicy: Always`, `cosign`, `SBOM`, `enforce`, `audit`, and `version: "1.0.1"`
- Fixture marker checks for pass/fail cases and provenance/admission fields
- Added-line ASCII scan
- Added-line sensitive/public-contact pattern scan
- `git merge-tree --write-tree origin/main HEAD`

## Bounty tier

Requesting Improver Moderate ($100) if accepted. This is more than a Markdown-only update because it adds skill-local benign/vulnerable fixtures for the false-positive and missed-variant cases described in the issue.