### PR TITLE
Improve IAM session token continuity gates

### DIFF
--- a/skills/identity/iam-review/SKILL.md
+++ b/skills/identity/iam-review/SKILL.md
@@ -366,6 +366,70 @@ IAM-ZT-10: Implicit trust for internal service-to-service communication
 
 ---
 
+### Step 8: Session Revocation and Token Continuity
+
+**Objective:** Verify that logout, account risk changes, credential resets, and explicit revocation events actually terminate usable access instead of only clearing the visible browser session.
+
+**NIST SP 800-63B Reference:** Session management, reauthentication, and authenticator lifecycle requirements
+**NIST SP 800-207 Reference:** Dynamic authentication and authorization enforcement
+**OAuth 2.0 Security BCP Reference:** Refresh-token rotation or sender-constrained refresh tokens for public clients
+
+#### Review Checklist
+
+```
+IAM-SESS-01: Logout clears only the browser cookie; refresh tokens remain valid
+IAM-SESS-02: Refresh tokens are bearer tokens without rotation, sender constraint, or reuse detection
+IAM-SESS-03: Critical risk events do not revoke refresh tokens or terminate active sessions
+IAM-SESS-04: CAE / continuous evaluation coverage is claimed but not mapped to resources and clients
+IAM-SESS-05: Relying-party session caches continue accepting access after IdP revocation
+IAM-SESS-06: Remember-me / trusted-device controls extend sessions without reauthentication limits
+IAM-SESS-07: Offline/mobile refresh-token flows lack absolute lifetime and device-loss handling
+IAM-SESS-08: Session termination has not been tested for disablement, password reset, MFA change, device noncompliance, risk change, logout, and admin revoke
+```
+
+#### Evidence Gate
+
+Treat missing evidence as **Not Evaluable** for low-risk systems and as a finding for sensitive systems, privileged access, regulated data, or internet-facing administration. Do not flag long-lived access tokens by lifetime alone when the design proves continuous evaluation and fail-closed revocation.
+
+| Evidence Area | Required Evidence | Acceptable Benign Pattern | Finding Pattern |
+|---|---|---|---|
+| Access-token lifetime | Token TTLs by client/resource, reauthentication policy, CAE or equivalent event support | Longer access tokens only for CAE-capable clients/resources with documented critical-event enforcement | Long token lifetime with no reauth, no CAE, or unknown resource coverage |
+| Refresh-token controls | Rotation settings, sender constraint, reuse detection, absolute lifetime, revocation API evidence | Public clients use rotation or sender-constrained refresh tokens with reuse detection and explicit revoke support | Bearer refresh tokens survive password reset, logout, or device loss |
+| Logout propagation | RP-initiated logout behavior, IdP session handling, app-session destruction, token revocation scope | Report distinguishes app session, IdP session, other device sessions, and refresh-token revocation | Logout deletes only a local cookie while background clients continue minting tokens |
+| Critical-event enforcement | Test results for user disablement, password reset, MFA reset, high user risk, device noncompliance, and admin revoke | Events terminate or block active sessions near real time for covered clients/resources; gaps are documented | Sessions remain usable until natural expiry after critical identity events |
+| Session caches | RP/API cache invalidation design, token introspection or denylist TTL, gateway/session-store invalidation | Caches fail closed or expire quickly enough to honor revocation SLAs | Relying-party cache accepts revoked tokens longer than policy permits |
+| Remembered devices | Trusted-device duration, idle timeout, overall timeout, step-up triggers for sensitive actions | Remember-me is bounded and does not bypass required reauthentication or step-up | Remembered device bypasses AAL2/AAL3 reauthentication expectations |
+
+#### Platform-specific checks
+
+| Platform | Mechanism | What to verify |
+|---|---|---|
+| **AWS** | STS session duration, IAM Identity Center sessions, Cognito refresh-token settings | Max session duration, global sign-out, refresh-token revocation, device remembering, and API cache behavior |
+| **Azure / Entra ID** | Continuous Access Evaluation, token lifetime policy, sign-in logs, refresh-token revoke events | CAE-capable clients/resources, critical-event propagation, revoke refresh sessions, and Conditional Access session controls |
+| **GCP** | Google Workspace session controls, OAuth app access, BeyondCorp signals | Session length, OAuth app token revocation, device trust, context-aware access, and revocation audit evidence |
+| **OIDC / OAuth apps** | RP-Initiated Logout, back-channel/front-channel logout, token endpoint, refresh-token rotation | RP session destruction, IdP session handling, refresh-token replay detection, and explicit revocation endpoint behavior |
+
+**Severity Classification:**
+
+| Finding | Severity | Rationale |
+|---|---|---|
+| Privileged or admin refresh token remains valid after account disablement or admin revoke | **Critical** | Compromised privileged access can persist after emergency containment |
+| Public-client refresh tokens are bearer tokens with no rotation or sender constraint | **High** | Copied tokens can continue minting access tokens without possession proof |
+| Logout only clears app cookie while refresh tokens remain usable | **High** | Users and auditors believe access ended when it did not |
+| CAE / critical-event coverage undocumented for sensitive resources | **Medium** | Continuous enforcement cannot be trusted without mapped coverage and tests |
+| Remember-me duration exceeds reauthentication policy without step-up | **Medium** | Convenience control bypasses session assurance requirements |
+
+**False positive guardrails:**
+
+- Do not flag a CAE-aware design solely because access tokens last longer than a static TTL baseline; require evidence that critical events are enforced for the relevant clients and resource providers.
+- Do not require IdP global logout for every application if the report documents RP session destruction, token revocation behavior, and the residual risk of IdP session persistence.
+- Do not flag offline/mobile clients merely for using refresh tokens; flag them when rotation, sender constraint, reuse detection, absolute lifetime, explicit revoke, or device-loss handling is missing.
+- If evidence is incomplete, label the item **Not Evaluable** unless the system is sensitive enough that missing proof is itself a risk.
+
+**Output:** Add a session/token continuity table with columns: Flow, Token Type, Lifetime, Revocation Trigger Tested, RP Session Result, Refresh Token Result, CAE/Critical Event Coverage, Evidence Source, Assessment.
+
+---
+
 ## Output Format
 
 ### Findings Table
@@ -410,9 +474,15 @@ For each finding, produce a row with:
 - Stale Accounts (Step 5): [count]
 - JIT Access (Step 6): [count]
 - Zero Trust (Step 7): [count]
+- Session Revocation / Token Continuity (Step 8): [count]
 
 ### Detailed Findings
 [Findings table — see above]
+
+### Session and Token Continuity
+| Flow | Token Type | Lifetime | Revocation Trigger Tested | RP Session Result | Refresh Token Result | CAE/Critical Event Coverage | Evidence Source | Assessment |
+|---|---|---|---|---|---|---|---|---|
+| [Login / refresh / logout / risk event] | [access / refresh / session cookie] | [duration] | [event tested] | [terminated / persisted / unknown] | [revoked / rotated / persisted / unknown] | [covered / partial / none] | [log / config / test] | [Pass / Finding / Not Evaluable] |
 
 ### Remediation Roadmap
 [Prioritized actions: immediate (0-7 days), short-term (30 days), medium-term (90 days)]
@@ -428,9 +498,9 @@ For each finding, produce a row with:
 | Priority | Timeframe | Example Findings |
 |---|---|---|
 | **P0 — Immediate** | 0-7 days | Root/global admin without MFA, former employee with active access, wildcard admin policies |
-| **P1 — Urgent** | 8-30 days | No JIT for admin access, service account keys > 1 year old, no stale account process |
+| **P1 — Urgent** | 8-30 days | No JIT for admin access, refresh tokens remain valid after disablement/revoke, service account keys > 1 year old, no stale account process |
 | **P2 — Important** | 31-90 days | No phishing-resistant MFA, incomplete identity inventory, no access review cadence |
-| **P3 — Planned** | 91-180 days | Zero trust maturity gaps, device trust integration, continuous access evaluation |
+| **P3 — Planned** | 91-180 days | Zero trust maturity gaps, device trust integration, continuous access evaluation coverage documentation |
 
 ---
 
@@ -472,7 +542,7 @@ This skill processes user-supplied content including IAM policies, access config
 | **5.3** | Disable Dormant Accounts | Step 5 |
 | **5.4** | Restrict Administrator Privileges to Dedicated Administrator Accounts | Steps 3, 6 |
 | **5.5** | Establish and Maintain an Inventory of Service Accounts | Steps 1, 4 |
-| **5.6** | Centralize Account Management | Steps 1, 7 |
+| **5.6** | Centralize Account Management | Steps 1, 7, 8 |
 
 ### Control 6 — Access Control Management
 
@@ -484,7 +554,7 @@ This skill processes user-supplied content including IAM policies, access config
 | **6.4** | Require MFA for Remote Network Access | Step 2 |
 | **6.5** | Require MFA for Administrative Access | Step 2 |
 | **6.6** | Establish and Maintain an Inventory of Authentication and Authorization Systems | Step 1 |
-| **6.7** | Centralize Access Control | Step 7 |
+| **6.7** | Centralize Access Control | Steps 7, 8 |
 | **6.8** | Define and Maintain Role-Based Access Control | Step 3 |
 
 ---
@@ -502,6 +572,14 @@ This skill processes user-supplied content including IAM policies, access config
 | **5.1.7** | Multi-Factor Crypto Device | Hardware token; meets AAL3 requirements |
 | **5.2.3** | Reauthentication | AAL2 requires reauth every 12 hours or 30 minutes idle; AAL3 every 12 hours or 15 minutes idle |
 
+### Appendix: Session Continuity References
+
+| Source | Topic | Key Requirement |
+|---|---|---|
+| [OAuth 2.0 Security BCP / RFC 9700](https://www.rfc-editor.org/rfc/rfc9700) | Refresh-token protection | Public-client refresh tokens should be sender-constrained or rotated; replay should be detectable |
+| [OpenID Connect RP-Initiated Logout 1.0](https://openid.net/specs/openid-connect-rpinitiated-1_0.html) | Logout propagation | Relying parties can initiate logout with the OpenID Provider, but app, IdP, and token sessions still need separate evidence |
+| [Microsoft Entra Continuous Access Evaluation](https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-continuous-access-evaluation) | Critical-event enforcement | CAE-capable clients and resources can react to user, session, and policy events without waiting for static token expiry |
+
 ---
 
 ## Version History
@@ -509,3 +587,4 @@ This skill processes user-supplied content including IAM policies, access config
 | Version | Date | Changes |
 |---|---|---|
 | 1.0.0 | 2025-03-06 | Initial release |
+| 1.1.0 | 2026-06-09 | Added session revocation and refresh-token continuity evidence gates |

--- a/skills/identity/iam-review/SKILL.md
+++ b/skills/identity/iam-review/SKILL.md
@@ -428,6 +428,8 @@ Treat missing evidence as **Not Evaluable** for low-risk systems and as a findin
 
 **Output:** Add a session/token continuity table with columns: Flow, Token Type, Lifetime, Revocation Trigger Tested, RP Session Result, Refresh Token Result, CAE/Critical Event Coverage, Evidence Source, Assessment.
 
+**Test fixtures:** Use `tests/vulnerable/refresh-token-survives-logout.yaml` to verify the skill catches refresh-token continuity after logout/revocation, and `tests/benign/cae-aware-session-revocation.yaml` to verify the false-positive guardrail for CAE-aware, fail-closed session designs.
+
 ---
 
 ## Output Format
@@ -587,4 +589,4 @@ This skill processes user-supplied content including IAM policies, access config
 | Version | Date | Changes |
 |---|---|---|
 | 1.0.0 | 2025-03-06 | Initial release |
-| 1.1.0 | 2026-06-09 | Added session revocation and refresh-token continuity evidence gates |
+| 1.1.0 | 2026-06-09 | Added session revocation and refresh-token continuity evidence gates with vulnerable and benign fixtures |

--- a/skills/identity/iam-review/tests/benign/cae-aware-session-revocation.yaml
+++ b/skills/identity/iam-review/tests/benign/cae-aware-session-revocation.yaml
@@ -1,0 +1,44 @@
+name: cae-aware-session-revocation
+description: >
+  Longer-lived access tokens are acceptable because CAE-capable clients and
+  resource providers enforce critical events, refresh tokens are protected,
+  and logout/session revocation behavior is tested.
+environment:
+  identity_provider: Microsoft Entra ID
+  access_token_lifetime: 28h_cae_session
+  cae_capable_clients: true
+  resource_provider_coverage:
+    exchange_online: cae_supported
+    sharepoint_online: cae_supported
+    custom_api_gateway: token_introspection_with_5m_cache_ttl
+  refresh_token:
+    rotation: enabled
+    sender_constrained: true
+    reuse_detection: enabled
+    absolute_lifetime: 30d
+    revoked_on_password_reset: true
+    revoked_on_admin_revoke: true
+  logout:
+    rp_initiated_logout: implemented
+    app_session_destroyed: true
+    idp_session_handled: documented
+    refresh_token_revoked: true
+    other_device_sessions_policy: documented
+  critical_event_enforcement:
+    user_disabled: near_real_time
+    password_reset: near_real_time
+    mfa_reset: near_real_time
+    high_user_risk: near_real_time
+    device_noncompliance: near_real_time
+    admin_revoke: near_real_time
+  remembered_device:
+    duration: 14d
+    idle_timeout: 30m
+    overall_timeout: 12h
+    step_up_for_sensitive_actions: true
+expected_assessment:
+  session_continuity: Pass
+  false_positive_guardrail: >
+    Do not flag access-token lifetime by itself; require evidence that CAE,
+    refresh-token protection, logout propagation, and critical-event tests are
+    missing before reporting a finding.

--- a/skills/identity/iam-review/tests/vulnerable/refresh-token-survives-logout.yaml
+++ b/skills/identity/iam-review/tests/vulnerable/refresh-token-survives-logout.yaml
@@ -1,0 +1,45 @@
+name: refresh-token-survives-logout
+description: >
+  Logout only clears the local application cookie while bearer refresh tokens
+  remain valid and can continue minting access tokens after user logout,
+  password reset, or administrative revoke.
+environment:
+  identity_provider: generic_oidc
+  client_type: public_mobile_app
+  access_token_lifetime: 1h
+  refresh_token:
+    token_type: bearer
+    rotation: disabled
+    sender_constrained: false
+    reuse_detection: missing
+    absolute_lifetime: 90d
+    revoked_on_password_reset: false
+    revoked_on_admin_revoke: manual_only
+  logout:
+    app_cookie_deleted: true
+    rp_initiated_logout: missing
+    idp_session_handled: unknown
+    refresh_token_revoked: false
+    other_device_sessions_revoked: false
+  critical_event_enforcement:
+    user_disabled: access_tokens_valid_until_expiry
+    password_reset: refresh_tokens_still_valid
+    mfa_reset: not_tested
+    device_noncompliance: not_tested
+  relying_party_cache:
+    revoked_token_cache_invalidation: missing
+    accepts_until_cache_ttl: 24h
+expected_findings:
+  - id: IAM-SESS-01
+    title: Logout does not revoke refresh-token continuity
+    severity: High
+  - id: IAM-SESS-02
+    title: Public-client refresh tokens lack rotation or sender constraint
+    severity: High
+  - id: IAM-SESS-03
+    title: Critical risk events do not terminate active token continuity
+    severity: Critical
+  - id: IAM-SESS-05
+    title: Relying-party cache accepts access after IdP revocation
+    severity: Medium
+

--- a/skills/identity/iam-review/tests/vulnerable/refresh-token-survives-logout.yaml
+++ b/skills/identity/iam-review/tests/vulnerable/refresh-token-survives-logout.yaml
@@ -42,4 +42,3 @@ expected_findings:
   - id: IAM-SESS-05
     title: Relying-party cache accepts access after IdP revocation
     severity: Medium
-


### PR DESCRIPTION
/claim #2125

## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** iam-review
**Skill path:** `skills/identity/iam-review/SKILL.md`

### What Was Wrong
The skill already flagged excessive token lifetime and missing continuous access evaluation at a high level, but it did not require concrete evidence that sessions and refresh tokens actually stop working after logout, account disablement, password reset, MFA/risk changes, or explicit admin revoke events. That can create false positives for CAE-aware longer-lived access tokens, while missing the more dangerous case where refresh tokens or relying-party sessions remain usable after revocation.

### What This PR Fixes
- Adds a dedicated **Session Revocation and Token Continuity** review step.
- Adds `IAM-SESS-*` findings for logout gaps, bearer refresh tokens without rotation/sender constraint, missing critical-event enforcement, stale relying-party caches, remember-me bypasses, and missing revocation tests.
- Adds an evidence gate and session/token continuity report table.
- Adds false-positive guardrails so CAE-aware, fail-closed designs are not flagged solely because access tokens are longer lived.
- Adds vulnerable and benign fixtures for the requested session-continuity cases.
- Adds primary references for RFC 9700, OIDC RP-Initiated Logout, and Microsoft Entra CAE.

### Evidence

**Before (skill misses this / false positive on this):**
```yaml
logout:
  app_cookie_deleted: true
  refresh_token_revoked: false
  rp_initiated_logout: missing
  other_sessions_revoked: false

refresh_token:
  rotation: disabled
  sender_constrained: false
  reuse_detection: missing
  absolute_lifetime: 90d
```

**After (now correctly handled):**
The IAM review now requires explicit evidence for access-token lifetime, refresh-token rotation/sender constraint, logout propagation, CAE/critical-event coverage, relying-party cache invalidation, remembered-device limits, and revocation test results. Missing evidence becomes `Not Evaluable` or a finding depending on system sensitivity.

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing validation checks pass

Fixtures added:
- `skills/identity/iam-review/tests/vulnerable/refresh-token-survives-logout.yaml`
- `skills/identity/iam-review/tests/benign/cae-aware-session-revocation.yaml`

### Validation
- `git diff --check`
- Frontmatter required-field check for `skills/identity/iam-review/SKILL.md`
- Markdown fence-balance check: 22 fences, balanced
- Required marker checks for `Session Revocation and Token Continuity`, `IAM-SESS-01`, `IAM-SESS-08`, `Session and Token Continuity`, both fixture names, `RFC 9700`, and `RP-Initiated Logout`
- Prompt-injection scan reviewed against repository workflow rules; only the pre-existing defensive safety notice contains example attack wording and is excluded by the workflow context filters

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** GitHub Sponsors if accepted; otherwise private payment details can be provided after maintainer acceptance.

Fixes #2125