### PR TITLE
Add Kubernetes audit log fixtures

### DIFF
--- a/skills/secops/log-analysis/SKILL.md
+++ b/skills/secops/log-analysis/SKILL.md
@@ -13,7 +13,7 @@ phase: [operate]
 frameworks: [MITRE-ATT&CK-v16, NIST-SP-800-92]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -119,6 +119,7 @@ Understand what each log source provides and which ATT&CK data sources it maps t
 | AWS CloudTrail | AWS | API calls -- CreateUser, AttachUserPolicy, RunInstances, PutBucketPolicy | Cloud Service (DS0025) |
 | Azure Activity Log | Azure | Resource operations -- create, delete, modify at the control plane | Cloud Service (DS0025) |
 | GCP Cloud Audit Logs | GCP | Admin activity, data access, system events | Cloud Service (DS0025) |
+| Kubernetes audit log | Kubernetes | API server requests -- pods/exec, pods/attach, pods/portforward, secrets access, RBAC changes, impersonation | Cloud Service (DS0025), Command (DS0017), User Account (DS0002) |
 | Microsoft 365 Unified Audit Log | SaaS | Exchange, SharePoint, Teams, Azure AD activity | Application Log (DS0015) |
 
 ### Step 2: Critical Windows Event IDs
@@ -249,6 +250,42 @@ Identify deviations from established baselines that may indicate malicious activ
 | **Relational** | Normal user-to-resource access patterns | Access to resources outside normal scope | Finance user accessing engineering source code repository |
 | **Protocol** | Expected protocols on network segments | Unexpected protocol usage | DNS over HTTPS (DoH) from a workstation, or SMB on an internet-facing interface |
 
+#### Kubernetes Audit Event Evidence
+
+When Kubernetes audit logs are in scope, do not collapse events into generic JSON write/read activity. Preserve the API-server fields that define security meaning:
+
+| Field | Why it matters |
+|-------|----------------|
+| `verb` | Distinguishes `get/list/watch` from `create/update/patch/delete` and interactive subresource access. |
+| `stage` | `ResponseComplete` usually proves final outcome; `ResponseStarted` is expected for long-running `exec`, `attach`, and `portforward` streams. |
+| `user.username` and `user.groups` | Separates human admins, service accounts, controllers, and node identities. |
+| `impersonatedUser` | Shows delegated identity and must be attributed separately from the caller. |
+| `sourceIPs` and `userAgent` | Supports source and tool baselining for `kubectl`, controllers, CI bots, and provider agents. |
+| `objectRef.resource`, `namespace`, `name`, and `subresource` | Preserves high-risk resources such as `secrets`, `rolebindings`, `clusterrolebindings`, `pods/exec`, `pods/attach`, and `pods/portforward`. |
+| `requestURI` | Confirms exact API path, query parameters, and subresource when `objectRef` is incomplete. |
+| `responseStatus.code` | Separates allowed access from denied probing; repeated 401/403 against sensitive resources is suspicious but different from successful access. |
+| Audit policy level | `Metadata` may be sufficient for identity and object access, while `RequestResponse` may include sensitive values and requires redaction handling. |
+
+Use these finding IDs when analyzing Kubernetes audit logs:
+
+| Finding ID | Condition | ATT&CK mapping |
+|------------|-----------|----------------|
+| LOG-K8S-01 | `pods/exec`, `pods/attach`, or `pods/portforward` is used by an unexpected human, source IP, namespace, or tool | T1609 -- Container Administration Command |
+| LOG-K8S-02 | Human or workload identity reads `secrets` or `configmaps` outside its baseline or namespace scope | T1552 -- Unsecured Credentials |
+| LOG-K8S-03 | `impersonatedUser` is present without expected delegated-admin context or approval evidence | T1098 -- Account Manipulation |
+| LOG-K8S-04 | RBAC objects such as roles, rolebindings, clusterroles, or clusterrolebindings are created, patched, or deleted outside change context | T1098 -- Account Manipulation |
+| LOG-K8S-05 | Repeated 401/403 responses against sensitive resources indicate RBAC probing or token misuse | T1087 -- Account Discovery |
+| LOG-K8S-06 | Privileged pod, hostPath, hostNetwork, or node-level object changes occur outside expected controller activity | T1611 -- Escape to Host |
+| LOG-K8S-07 | Audit stage or policy level is insufficient to determine final outcome, requiring a visibility-gap finding instead of confirmed abuse | N/A |
+| LOG-K8S-08 | Managed Kubernetes provider field mappings are not normalized before analysis, causing loss of user, objectRef, or responseStatus semantics | N/A |
+
+False-positive guardrails:
+
+- Baseline controllers and operators by `user.username`, groups, `userAgent`, namespace, objectRef, and recurring cadence before escalating write verbs.
+- Treat denied events as reconnaissance or policy-noise until a matching successful event or broader pattern is found.
+- Prefer `ResponseComplete` for outcome analysis, but preserve `ResponseStarted` for streaming subresources such as exec, attach, and portforward.
+- Redact request and response bodies when audit policy level includes sensitive data.
+
 ### Step 6: Baseline Establishment
 
 **NIST SP 800-92 alignment:** NIST SP 800-92, Section 4.2, recommends establishing baselines for log data to enable anomaly detection. Baselines should be built from a minimum of 30 days of clean (non-compromised) data.
@@ -337,7 +374,7 @@ Produce log analysis findings in this structure:
 ```markdown
 ## Security Log Analysis Report
 **Date:** [YYYY-MM-DD]
-**Skill:** log-analysis v1.0.0
+**Skill:** log-analysis v1.0.1
 **Frameworks:** MITRE ATT&CK v16, NIST SP 800-92
 **Analyst:** [Name or AI-assisted]
 
@@ -376,6 +413,11 @@ Produce log analysis findings in this structure:
 
 ### Baseline Observations
 [Any baseline deviations noted, with comparison to established norms]
+
+### Kubernetes Audit Evidence
+| Timestamp | Verb | Stage | User / impersonated user | Source IP / userAgent | Object reference | Response | Assessment | Finding ID |
+|-----------|------|-------|--------------------------|-----------------------|------------------|----------|------------|------------|
+| [UTC] | [verb] | [stage] | [caller -> impersonated] | [source / userAgent] | [namespace/resource/name/subresource] | [code] | [Benign / Suspicious / Visibility gap] | [LOG-K8S-## or N/A] |
 
 ### Visibility Gaps
 [Log sources that were not available but would have provided relevant data]
@@ -478,3 +520,7 @@ This skill processes user-supplied content that may include raw log data, event 
 9. **AWS CloudTrail Event Reference** -- https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference.html
 10. **Azure Activity Log Schema** -- https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log-schema
 11. **NIST SP 800-61 Rev 2 -- Incident Handling Guide** -- https://csrc.nist.gov/publications/detail/sp/800-61/rev-2/final
+12. **Kubernetes Auditing** -- https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/
+13. **Kubernetes Audit Configuration v1** -- https://kubernetes.io/docs/reference/config-api/apiserver-audit.v1/
+14. **Kubernetes User Impersonation** -- https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation
+15. **MITRE ATT&CK T1609 -- Container Administration Command** -- https://attack.mitre.org/techniques/T1609/

--- a/skills/secops/log-analysis/tests/benign/kubernetes-controller-reconciliation.json
+++ b/skills/secops/log-analysis/tests/benign/kubernetes-controller-reconciliation.json
@@ -1,0 +1,32 @@
+{
+  "scenario": "benign_kubernetes_controller_reconciliation",
+  "log_source": "kubernetes_audit",
+  "expected_result": {
+    "assessment": "benign_baselined_controller_activity",
+    "finding_ids": [],
+    "notes": "Controller-manager lease updates are normal when user, userAgent, namespace, objectRef, stage, and responseStatus match baseline."
+  },
+  "event": {
+    "kind": "Event",
+    "apiVersion": "audit.k8s.io/v1",
+    "verb": "update",
+    "stage": "ResponseComplete",
+    "user": {
+      "username": "system:kube-controller-manager",
+      "groups": ["system:authenticated"]
+    },
+    "userAgent": "kube-controller-manager/v1.30.0",
+    "sourceIPs": ["10.0.0.12"],
+    "objectRef": {
+      "resource": "leases",
+      "namespace": "kube-system",
+      "name": "kube-controller-manager"
+    },
+    "requestURI": "/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-controller-manager",
+    "responseStatus": {
+      "code": 200
+    },
+    "auditID": "11111111-2222-3333-4444-555555555555",
+    "level": "Metadata"
+  }
+}

--- a/skills/secops/log-analysis/tests/vulnerable/kubernetes-exec-impersonation-rbac-probing.json
+++ b/skills/secops/log-analysis/tests/vulnerable/kubernetes-exec-impersonation-rbac-probing.json
@@ -1,0 +1,85 @@
+{
+  "scenario": "suspicious_kubernetes_exec_impersonation_and_rbac_probing",
+  "log_source": "kubernetes_audit",
+  "expected_result": {
+    "assessment": "suspicious",
+    "finding_ids": ["LOG-K8S-01", "LOG-K8S-03", "LOG-K8S-05"],
+    "notes": "Human kubectl exec, delegated service-account impersonation, and repeated denied secrets listing require separate triage instead of generic create/get handling."
+  },
+  "events": [
+    {
+      "kind": "Event",
+      "apiVersion": "audit.k8s.io/v1",
+      "verb": "create",
+      "stage": "ResponseStarted",
+      "user": {
+        "username": "alice",
+        "groups": ["dev-team", "system:authenticated"]
+      },
+      "userAgent": "kubectl/v1.30.0",
+      "sourceIPs": ["203.0.113.10"],
+      "objectRef": {
+        "resource": "pods",
+        "namespace": "prod",
+        "name": "api-7f9",
+        "subresource": "exec"
+      },
+      "requestURI": "/api/v1/namespaces/prod/pods/api-7f9/exec?command=sh&stdin=true&stdout=true&tty=true",
+      "responseStatus": {
+        "code": 101
+      },
+      "auditID": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "level": "Metadata"
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "audit.k8s.io/v1",
+      "verb": "get",
+      "stage": "ResponseComplete",
+      "user": {
+        "username": "bob",
+        "groups": ["platform-admins", "system:authenticated"]
+      },
+      "impersonatedUser": {
+        "username": "system:serviceaccount:prod:deploy-bot",
+        "groups": ["system:serviceaccounts", "system:serviceaccounts:prod"]
+      },
+      "userAgent": "kubectl/v1.30.0",
+      "sourceIPs": ["198.51.100.25"],
+      "objectRef": {
+        "resource": "secrets",
+        "namespace": "prod",
+        "name": "payment-api-env"
+      },
+      "requestURI": "/api/v1/namespaces/prod/secrets/payment-api-env",
+      "responseStatus": {
+        "code": 200
+      },
+      "auditID": "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+      "level": "Metadata"
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "audit.k8s.io/v1",
+      "verb": "list",
+      "stage": "ResponseComplete",
+      "user": {
+        "username": "carol",
+        "groups": ["contractor", "system:authenticated"]
+      },
+      "userAgent": "kubectl/v1.30.0",
+      "sourceIPs": ["203.0.113.77"],
+      "objectRef": {
+        "resource": "secrets",
+        "namespace": "prod"
+      },
+      "requestURI": "/api/v1/namespaces/prod/secrets",
+      "responseStatus": {
+        "code": 403,
+        "reason": "Forbidden"
+      },
+      "auditID": "cccccccc-dddd-eeee-ffff-000000000000",
+      "level": "Metadata"
+    }
+  ]
+}


### PR DESCRIPTION
/claim #1557

## What changed

Adds fixture-backed Kubernetes audit event evidence to `log-analysis` so analysts preserve API-server semantics instead of treating events as generic JSON.

- Adds Kubernetes audit logs to the log source taxonomy.
- Adds a Kubernetes Audit Event Evidence section for `verb`, `stage`, `user`, `impersonatedUser`, `sourceIPs`, `userAgent`, `objectRef`, `requestURI`, `responseStatus.code`, and audit policy level.
- Adds `LOG-K8S-01` through `LOG-K8S-08` for exec/attach/portforward, secrets access, impersonation, RBAC changes, denied probing, privileged pod changes, insufficient audit stages, and managed-provider field mapping gaps.
- Adds a Kubernetes Audit Evidence output table.
- Adds benign/vulnerable JSON fixtures for controller reconciliation versus human `pods/exec`, service-account impersonation, and denied secrets probing.

## Why this PR

Existing PR #1558 is a useful single-file documentation update. This PR is intentionally fixture-backed and adds concrete local audit events so future changes can distinguish normal controller reconciliation from high-signal Kubernetes audit activity.

## Validation

- `git diff --check origin/main...HEAD`
- JSON parse check for both added fixtures
- Markdown fence balance for `log-analysis/SKILL.md`
- Marker checks for `version: "1.0.1"`, `Kubernetes Audit Event Evidence`, `LOG-K8S-01` through `LOG-K8S-08`, `pods/exec`, `impersonatedUser`, `responseStatus.code`, `Kubernetes Audit Evidence`, and `T1609`
- Added-line ASCII scan
- Added-line sensitive/public-contact pattern scan
- `git merge-tree --write-tree origin/main HEAD`

## Bounty tier

Requesting Improver Moderate ($100) if accepted. This adds local benign/vulnerable fixtures in addition to the skill guidance requested by the issue.