### PR TITLE
Improve AI data privacy telemetry gates

### DIFF
--- a/skills/ai-security/ai-data-privacy/SKILL.md
+++ b/skills/ai-security/ai-data-privacy/SKILL.md
@@ -80,6 +80,7 @@ Before beginning the assessment, gather the following. If any item is unavailabl
 | Training/fine-tuning data documentation | Data pipeline docs, dataset cards | Identifies personal data in training corpus |
 | Consent management implementation | Frontend code, API code, database schemas | Shows how user consent is captured and enforced |
 | Data classification scheme | Governance documentation | Defines sensitivity levels applied to AI data flows |
+| AI telemetry and analytics schema | Product analytics, model quality dashboards, event schemas | Identifies prompt categories, user/account identifiers, and aggregate exports that may still be privacy-sensitive |
 | Regulatory requirements | Compliance documentation, legal counsel input | Identifies applicable data protection obligations |
 
 ---
@@ -145,6 +146,7 @@ Assess whether personal data is exposed, leaked, or inadequately protected in th
 - System prompts that contain PII (customer names, account numbers, internal user data hardcoded for testing or personalization).
 - Model completions returned to users without PII scanning -- the model may reproduce PII from its context or generate plausible PII from memorized training data.
 - PII transmitted to third-party LLM APIs where the provider's data handling terms are unclear or insufficient.
+- AI telemetry that stores prompt categories, model outputs, account identifiers, or user attributes in analytics systems without small-cohort suppression or purpose-scoped pseudonymous identifiers.
 
 **Detection methods using allowed tools:**
 
@@ -162,6 +164,10 @@ Grep: "openai|anthropic|api.key|azure.openai|bedrock|vertex.ai|cohere|mistral" i
 
 # Check for access control in RAG retrieval
 Grep: "metadata_filter|access_control|permission|authorization|tenant" in **/*.{py,ts,js}
+
+# Check AI telemetry and pseudonymous identifiers
+Grep: "prompt_category|completion_category|ai_event|model_event|telemetry|analytics|dashboard|cohort" in **/*.{py,ts,js,yaml,yml,json}
+Grep: "sha256|sha1|md5|hash|digest|pseudonym|anonymous_id|subject_id|hmac" in **/*.{py,ts,js}
 ```
 
 **Model memorization risk:** LLMs can memorize and reproduce training data, including PII. Research by Carlini et al. (2021, 2023) demonstrated that GPT-2 and GPT-3 could be prompted to emit memorized training data including names, phone numbers, email addresses, and physical addresses. The risk is proportional to data frequency in training (repeated PII is more likely to be memorized) and inversely proportional to model size diversity (smaller fine-tuned models on narrow datasets memorize more). For fine-tuned models, this risk is especially acute -- the fine-tuning data is typically smaller and more repetitive than pre-training data, increasing memorization likelihood.
@@ -175,6 +181,8 @@ Grep: "metadata_filter|access_control|permission|authorization|tenant" in **/*.{
 | No PII detection on model completions before returning to users | High |
 | RAG retrieval returns documents across tenant or authorization boundaries | High |
 | User prompts containing PII are sent to the model without redaction | High |
+| AI usage analytics expose small cohorts or unique users after filters are applied | High |
+| Stable unsalted hashes of emails, phone numbers, or account IDs are reused across AI logs, vector events, support records, or evaluation datasets | High |
 | System prompts contain hardcoded PII (even test data) | Medium |
 | No assessment of model memorization risk for fine-tuned models trained on PII-containing data | Medium |
 
@@ -226,6 +234,20 @@ Grep: "backup|snapshot|archive" in **/*.{yaml,yml,json,toml}
 | RAG source documents | Original documents with full content including PII | Align retention with document source system; propagate deletions to vector store |
 | Evaluation/test datasets | May contain real user data used for testing | Anonymize or use synthetic data; apply same retention as production data |
 
+### AI Telemetry and Aggregate Analytics
+
+AI telemetry can remain privacy-sensitive even after raw prompts and completions are removed. Prompt categories, model names, account identifiers, geography, industry, plan tier, timestamps, and model-quality labels can disclose sensitive facts when exported in small cohorts or joined across systems.
+
+**What to verify:**
+
+- Aggregate dashboards enforce minimum cohort thresholds after every filter, including time range, geography, plan, industry, model version, tenant, and prompt category.
+- Near-real-time analytics buffers or delays release until thresholds are met; a single new event must not reveal membership in a sensitive prompt category.
+- Repeated analytics queries are controlled with rate limits, query auditing, or a differential-privacy budget when users can difference exports over the same dataset.
+- Pseudonymous identifiers are purpose-scoped and not dictionary-attackable. Use keyed HMAC or managed surrogate IDs rather than unsalted hashes of emails, phone numbers, or account IDs.
+- Identifier reuse across prompt telemetry, vector retrieval logs, support tickets, billing, and evaluation datasets has a documented legal basis and retention boundary.
+
+**False-positive guidance:** Ephemeral local prompt classification is not the same as prompt/completion logging when no raw text, no user identifier, and no linkable redacted payload is persisted, and only k-thresholded aggregate metrics are exported.
+
 **What constitutes a finding:**
 
 | Condition | Severity |
@@ -235,6 +257,8 @@ Grep: "backup|snapshot|archive" in **/*.{yaml,yml,json,toml}
 | Deletion requests cannot be propagated to vector stores (embeddings persist after source deletion) | High |
 | Fine-tuning datasets with PII retained without justification or retention period | Medium |
 | Backup systems retain AI data beyond primary retention period | Medium |
+| AI telemetry uses no small-cohort suppression for sensitive prompt or model-output categories | High |
+| Pseudonymous identifiers are stable, unsalted, or reused across AI lifecycle stores without purpose separation | High |
 | No automated purge mechanism for expired AI data | Medium |
 | Audit logs contain full prompt/completion text with no redaction | Low |
 
@@ -471,6 +495,8 @@ user input -> prompt assembly -> LLM API -> completion -> output -> logging/stor
 4. **Conflating data minimization with data deletion.** Data minimization (collecting only what is necessary) is a design-time principle. Data deletion (removing data when it is no longer needed or when a subject requests erasure) is an operational requirement. Both are needed. Many teams implement minimization at the application layer but fail to propagate deletion to downstream AI data stores (vector databases, training dataset snapshots, model checkpoints, conversation logs, analytics pipelines).
 
 5. **Ignoring model memorization as a privacy risk.** Organizations that use pre-trained or fine-tuned models often do not test for memorization of personal data. A model that has memorized PII from its training corpus is effectively a data store containing personal data -- it can reproduce that data on specific prompts. This has regulatory implications: if the model contains memorized PII of EU residents, GDPR obligations apply to the model weights themselves, not just the training dataset.
+
+6. **Treating aggregate AI telemetry as automatically anonymous.** Prompt categories, model-quality labels, and account attributes can still reveal sensitive facts when a dashboard exposes small cohorts or allows repeated filtered exports. Apply minimum cell-size thresholds after all filters, avoid stable cross-domain identifiers, and treat pseudonymous telemetry as personal data when it can be linked back to a person or account.
 
 ---
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] Skill follows the format specification in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] At least one real framework is cited with correct control IDs
- [x] All framework references verified against primary sources (not blogs or AI output)
- [x] Prompt Injection Safety Notice section included
- [x] `injection-hardened: true` set in frontmatter
- [x] `allowed-tools` scoped to minimum necessary permissions (`Read`, `Grep`, `Glob`)
- [x] Tested with at least one AI coding agent (which one: Codex CLI / GPT-5 Codex)
- [x] No prohibited patterns per [SECURITY.md](../SECURITY.md)
- [x] `index.yaml` updated with new skill entry (not applicable; this updates an existing skill)

## What This PR Does

This updates `skills/ai-security/ai-data-privacy/SKILL.md` to cover two privacy review gaps that appear in modern AI telemetry systems:

- small-cohort leakage in AI usage analytics, dashboards, model-quality reports, and prompt-category exports;
- reversible or cross-domain pseudonymous identifiers, including stable unsalted hashes or reused user/account IDs across AI lifecycle stores.

It also adds false-positive guidance so reviewers do not report safe ephemeral local prompt classification when no raw text, user identifier, or linkable redacted payload is persisted and only k-thresholded aggregate metrics are exported.

Refs #2128.

## Framework References

- NIST AI RMF 1.0: MAP 5.1, MEASURE 2.9, MANAGE 2.4, GOVERN 1.1
- OWASP Top 10 for LLM Applications 2025: LLM02 Sensitive Information Disclosure
- GDPR: Articles 5, 6, 13, 17, 25, 35
- EU AI Act: Articles 10, 11, 13
- CCPA/CPRA: California Civil Code Sec. 1798.100-199

## Testing

Tested with Codex CLI / GPT-5 Codex against a real public AI observability repository:

- Target: `langfuse/langfuse`
- Target commit: `53433e881d2c8aeaf948eccfe4bc0dd89444ce85`
- Method: applied the updated skill's read-only `Grep` checks for AI telemetry, dashboard aggregation, user/session identifiers, retention controls, and small-cohort suppression language.

Evidence from the skill run:

1. AI telemetry dashboards expose reviewer-relevant small-cohort questions.
   - `worker/src/constants/langfuse-dashboards.json:62` describes aggregated model cost by `trace.userId`.
   - `worker/src/constants/langfuse-dashboards.json:64` sets `dimensions: [{ field: "userId" }]`.
   - `worker/src/constants/langfuse-dashboards.json:129-132` defines `Max Latency by User Id (Traces)` with `userId` as the dimension.
   - Follow-up grep for `cohort`, `k-anonym`, `minimum cell`, `small cell`, `suppression`, and `threshold` across dashboard seeds, Mixpanel/PostHog transformers, and DashboardService paths returned no matches. This is not a confirmed vulnerability by itself, but it is exactly the review prompt this PR adds: reviewers should verify minimum-cell suppression after filters and exports.

2. Pseudonymous/linkable identifier checks produced concrete review evidence.
   - `worker/src/services/IngestionService/index.ts:292-293` stores ingested `userId` and `sessionId` as `user_id` and `session_id`.
   - `packages/shared/src/domain/traces.ts:27-28` and `packages/shared/src/domain/observations.ts:117-118` model trace/observation user and session identifiers.
   - `worker/src/features/mixpanel/transformers.ts:64-78` uses `trace.langfuse_user_id` as Mixpanel `distinct_id` / `$user_id` and exports session identifiers.
   - `worker/src/features/posthog/transformers.ts:31-39` uses `trace.langfuse_user_id` as PostHog `distinctId` and maps `posthog_session_id` to `$session_id`.
   - The updated skill turns this into a structured question: are these identifiers purpose-scoped, non-dictionary-attackable, retention-bounded, and not reused across AI telemetry, support, billing, and evaluation domains without legal basis?

3. The run also produced a useful non-finding.
   - Retention controls are present: `worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts` re-fetches current project retention and deletes ClickHouse/S3 data older than the current setting; tests cover trace, observation, score, media, and disabled-retention cases.
   - This supports the PR's false-positive guidance: the new telemetry gates should not over-report when there is evidence of bounded retention or ephemeral-only processing.

Representative commands used:

```bash
rg -n -i "prompt_category|completion_category|ai_event|model_event|telemetry|analytics|dashboard|cohort|trace|observation" web worker packages ee --glob "*.{ts,tsx,js,jsx,py,yaml,yml,json,md}"
rg -n -i "sha256|sha1|md5|hash|digest|pseudonym|anonymous_id|subject_id|hmac|userId|user_id|sessionId|session_id" web worker packages ee --glob "*.{ts,tsx,js,jsx,py,yaml,yml,json,md}"
rg -n -i "cohort|k-anonym|minimum cell|small cell|suppression|threshold" worker/src/constants/langfuse-dashboards.json worker/src/features/mixpanel worker/src/features/posthog packages/shared/src/server/services/DashboardService
```

## Bounty Info

- Preferred payment method: Crypto, preferably Base USDC; payout details can be provided privately after acceptance.