### PR TITLE
Add agent browser boundary fixtures

### DIFF
--- a/skills/ai-security/agent-security/SKILL.md
+++ b/skills/ai-security/agent-security/SKILL.md
@@ -14,7 +14,7 @@ phase: [design, build, review]
 frameworks: [OWASP-Agentic-AI, NIST-AI-RMF-1.0]
 difficulty: advanced
 time_estimate: "60-120min"
-version: "1.0.2"
+version: "1.0.3"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -78,6 +78,7 @@ Before beginning the assessment, gather the following. If any item is unavailabl
 |---|---|---|
 | Agent architecture diagram | Design docs, README, infrastructure code | Maps trust boundaries, delegation chains, tool surface |
 | Tool/function definitions | Code files defining tool schemas, OpenAPI specs, MCP server configs | Determines what each agent can do and with what parameters |
+| Browser automation configuration | Playwright/Selenium/browser-use setup, storage state, profile directories, permissions, download/upload handlers | Determines whether UI agents inherit ambient web authority or leak DOM/screenshot/clipboard data |
 | Permission/IAM configuration | Cloud IAM, role definitions, service account configs, .env files | Reveals whether least-privilege is enforced |
 | Human approval gate implementation | Workflow code, UI code, approval service configs | Determines if HITL is architecturally sound or bypassable |
 | Agent identity and credential management | Auth middleware, secret managers, token configs | Exposes credential scope and rotation practices |
@@ -205,6 +206,66 @@ Evaluate whether the agent architecture is designed from the ground up around le
 | No token budget or execution time limit enforced | High |
 | Agent can query any database table regardless of task scope | Medium |
 | No resource limits at container/infrastructure level | Medium |
+
+---
+
+### Step 2.1 -- Browser Agent and UI Automation Boundary
+
+Browser-control agents are a distinct tool boundary because UI automation can act through authenticated web sessions even when no explicit API tool exists for that site. Review browser agents separately from generic network or file-system tools.
+
+**What to look for in code and configuration:**
+
+- **Profile ownership and lifetime:** Does the agent launch an ephemeral context, a dedicated service-account profile, or a human user's persistent browser profile?
+- **Storage-state handling:** Are cookies, local storage, IndexedDB, password-manager state, and extensions discarded or scoped after each task?
+- **Origin allowlists:** Are browser navigation and form submissions restricted to expected domains?
+- **Browser permissions:** Are clipboard, geolocation, camera, microphone, notifications, and downloads denied by default or explicitly justified?
+- **Model-ingestion redaction:** Are DOM text, accessibility trees, screenshots, console logs, network traces, and browser traces redacted before model ingestion and audit persistence?
+- **Downloads and uploads:** Are downloads quarantined, canonicalized, type-checked, and scanned when needed? Is local-file upload blocked or gated by human approval?
+- **High-impact UI actions:** Are payment, transfer, deletion, account-setting, OAuth consent, public posting, and file upload actions gated before click/submit execution?
+
+**Detection methods using allowed tools:**
+
+```
+# Find persistent browser profiles and storage state reuse
+Grep: "launchPersistentContext|userDataDir|user_data_dir|storageState|storage_state|Default/Profile" in **/*.{py,ts,js}
+
+# Find browser permission grants and downloads/uploads
+Grep: "grantPermissions|permissions|clipboard|geolocation|camera|microphone|acceptDownloads|setInputFiles|upload" in **/*.{py,ts,js}
+
+# Find page capture paths that may feed model context or logs
+Grep: "screenshot|accessibility.snapshot|innerText|textContent|content\\(|trace|console|network" in **/*.{py,ts,js}
+
+# Find approval gates around high-impact browser actions
+Grep: "click|submit|approve|require_approval|payment|transfer|delete|oauth|consent" in **/*.{py,ts,js}
+```
+
+**Browser agent evidence matrix:**
+
+| Evidence field | Secure state | Finding if absent |
+|---|---|---|
+| Profile isolation | Ephemeral or dedicated service-account profile | Agent reuses a human user's authenticated browser profile |
+| Storage lifetime | Cookies/storage discarded or task-scoped | Persistent ambient sessions survive across tasks |
+| Origin scope | Navigation and submit actions allowlisted | Agent can browse or submit to arbitrary origins |
+| Permission grants | Clipboard/geolocation/camera/mic denied unless justified | Browser permissions granted broadly |
+| DOM/screenshot redaction | Sensitive fields masked before model/log ingestion | Page captures can expose tokens, PII, payment data, or one-time codes |
+| Downloads | Quarantined path, canonical filename, type validation, scan when needed | Untrusted downloads saved into workspace or executable paths |
+| Uploads | Explicit approval and file allowlist | Agent can upload arbitrary local files through file inputs |
+| High-impact actions | HITL gate before payment, deletion, account changes, OAuth consent, or public posting | Browser click/submit can cause irreversible external actions |
+
+**Finding IDs:**
+
+| Finding ID | Condition | Severity |
+|---|---|---|
+| AGENT-BROWSER-01 | Agent runs in a human user's persistent browser profile or default profile | Critical |
+| AGENT-BROWSER-02 | Cookies, local storage, IndexedDB, extensions, or password-manager state persist across unrelated tasks without scope control | High |
+| AGENT-BROWSER-03 | Browser navigation or form submission lacks origin allowlisting | High |
+| AGENT-BROWSER-04 | Clipboard, geolocation, camera, microphone, or notification permissions are granted without task-specific justification | High |
+| AGENT-BROWSER-05 | DOM, accessibility tree, screenshot, console, network, or trace data reaches the model or logs without pre-ingestion redaction | High |
+| AGENT-BROWSER-06 | Downloads from untrusted pages are saved outside quarantine or without filename/type validation | Medium |
+| AGENT-BROWSER-07 | Agent can upload local files without explicit human approval and file allowlist | High |
+| AGENT-BROWSER-08 | High-impact browser actions can be clicked or submitted without HITL approval | Critical |
+
+False-positive guardrail: unauthenticated public browsing in an ephemeral context with denied permissions, origin scope, redacted captures, quarantined downloads, blocked uploads, and approval gates for side effects should not be reported as Critical solely because it uses a browser.
 
 ---
 
@@ -515,6 +576,7 @@ Glob: **/security_architecture*
 |---|---|---|---|
 | Permission Model | [rating] | [one-line summary] | [priority] |
 | Least-Privilege Design | [rating] | [one-line summary] | [priority] |
+| Browser Agent Boundary | [rating] | [profile isolation, storage lifetime, permission grants, redaction, downloads/uploads, high-impact actions] | [priority] |
 | HITL Gate Placement | [rating] | [one-line summary] | [priority] |
 | Blast Radius Containment | [rating] | [one-line summary] | [priority] |
 | Audit Trail Completeness | [rating] | [one-line summary] | [priority] |
@@ -587,3 +649,4 @@ Glob: **/security_architecture*
 12. Sequential Tool Attack Chains and Context Amnesia in Agentic AI (2026) -- arXiv:2603.12644
 13. Confused-Deputy Attacks and Cascading Failures in Long-Horizon Agent Workflows (2026) -- arXiv:2603.12230
 14. fabraix/playground -- Open-source AI agent red-team exploit library for validating agent permission boundaries and tool-use attack surface -- https://github.com/fabraix/playground
+15. Playwright BrowserContext API -- https://playwright.dev/docs/api/class-browsercontext

--- a/skills/ai-security/agent-security/tests/benign/ephemeral-browser-agent-boundary.yaml
+++ b/skills/ai-security/agent-security/tests/benign/ephemeral-browser-agent-boundary.yaml
@@ -1,0 +1,44 @@
+scenario: ephemeral_browser_agent_boundary
+agent: travel-research-browser-agent
+expected_result:
+  posture: acceptable_with_monitoring
+  finding_ids: []
+  notes: Ephemeral public-browsing context has scoped origins, denied browser permissions, redacted captures, quarantined downloads, blocked uploads, and approval gates for high-impact actions.
+browser:
+  engine: chromium
+  context: ephemeral
+  user_profile: none
+  storage_state: discarded_after_task
+  persistent_profile_path: null
+  extensions_enabled: false
+  password_manager_enabled: false
+  allowed_origins:
+    - https://airline.example
+    - https://hotel.example
+permissions:
+  clipboard_read: denied
+  clipboard_write: denied
+  geolocation: denied
+  camera: denied
+  microphone: denied
+  downloads: quarantine_directory
+redaction:
+  dom_text: strip_hidden_inputs_tokens_and_cookies
+  accessibility_tree: mask_entered_values
+  screenshots: mask_password_inputs_payment_fields_and_one_time_codes
+  network_traces: redact_authorization_cookie_and_set_cookie_headers
+downloads:
+  quarantine_path: /tmp/agent-downloads
+  filename_canonicalization: enabled
+  mime_signature_validation: enabled
+uploads:
+  local_file_uploads: blocked_by_default
+approval:
+  required_before:
+    - submitting_payment_forms
+    - changing_account_settings
+    - uploading_local_files
+    - approving_oauth_consent
+audit:
+  browser_trace_retention_days: 7
+  sensitive_capture_redaction_before_persistence: true

--- a/skills/ai-security/agent-security/tests/vulnerable/persistent-human-browser-profile.yaml
+++ b/skills/ai-security/agent-security/tests/vulnerable/persistent-human-browser-profile.yaml
@@ -1,0 +1,53 @@
+scenario: persistent_human_browser_profile_reuse
+agent: shopping-assistant-browser-agent
+expected_result:
+  posture: critical
+  finding_ids:
+    - AGENT-BROWSER-01
+    - AGENT-BROWSER-02
+    - AGENT-BROWSER-03
+    - AGENT-BROWSER-04
+    - AGENT-BROWSER-05
+    - AGENT-BROWSER-06
+    - AGENT-BROWSER-07
+    - AGENT-BROWSER-08
+  notes: Agent inherits a human browser profile, reads page captures and clipboard into model context, writes downloads into the workspace, can upload local files, and can submit high-impact forms without approval.
+browser:
+  engine: chromium
+  context: persistent
+  user_profile: human_default_profile
+  storage_state: retained_across_tasks
+  persistent_profile_path: ${HOME}/.config/google-chrome/Default
+  extensions_enabled: true
+  password_manager_enabled: true
+  allowed_origins: []
+permissions:
+  clipboard_read: granted
+  clipboard_write: granted
+  geolocation: granted
+  camera: not_reviewed
+  microphone: not_reviewed
+  downloads: workspace_directory
+capture_to_model:
+  dom_text: full_body_inner_text
+  accessibility_tree: full_snapshot
+  screenshots: full_page_unredacted
+  console_logs: persisted_unredacted
+  network_traces: persisted_with_headers
+downloads:
+  quarantine_path: null
+  filename_canonicalization: missing
+  mime_signature_validation: missing
+  save_path: /workspace
+uploads:
+  local_file_uploads: allowed
+  file_allowlist: missing
+approval:
+  required_before: []
+  high_impact_actions_without_gate:
+    - submitting_payment_forms
+    - changing_account_settings
+    - approving_oauth_consent
+audit:
+  browser_trace_retention_days: 90
+  sensitive_capture_redaction_before_persistence: false


### PR DESCRIPTION
/claim #1257

## What changed

Adds fixture-backed browser-agent and UI automation boundary evidence to `agent-security`.

- Adds browser automation configuration to the review context inventory.
- Adds `Step 2.1 -- Browser Agent and UI Automation Boundary` for profile ownership, storage-state lifetime, origin allowlists, browser permissions, DOM/screenshot/clipboard redaction, downloads/uploads, and high-impact UI action approvals.
- Adds `AGENT-BROWSER-01` through `AGENT-BROWSER-08` for human browser profile reuse, persistent ambient sessions, missing origin scope, broad permissions, unredacted model/log ingestion, unsafe downloads, unapproved uploads, and ungated high-impact clicks/submits.
- Adds a Browser Agent Boundary row to the posture summary and a Playwright BrowserContext reference.
- Adds benign and vulnerable YAML fixtures for an ephemeral public-browsing context versus a persistent human browser profile with unredacted captures, workspace downloads, local uploads, and no approval gate.

## Why this PR

Existing PR #1258 is a useful single-file documentation update. This PR is intentionally fixture-backed and adds concrete skill-local examples so future reviews distinguish controlled ephemeral browsing from agents inheriting a human user's authenticated browser session.

## Validation

- `git diff --check origin/main...HEAD`
- Markdown fence balance for `agent-security/SKILL.md`
- Marker checks for `version: "1.0.3"`, `Browser Agent and UI Automation Boundary`, `Browser agent evidence matrix`, `AGENT-BROWSER-01` through `AGENT-BROWSER-08`, `storage_state`, `launchPersistentContext`, and `Playwright BrowserContext API`
- Fixture marker checks for benign and vulnerable browser-boundary cases
- Added-file ASCII scan
- Added-file sensitive/public-contact pattern scan
- `git merge-tree --write-tree origin/main HEAD`

## Bounty tier

Requesting Improver Moderate ($100) if accepted. This adds local benign/vulnerable fixtures in addition to the browser-boundary guidance requested by the issue.