### PR TITLE
Add PAM session recording assurance fixtures

### DIFF
--- a/skills/identity/privileged-access/SKILL.md
+++ b/skills/identity/privileged-access/SKILL.md
@@ -12,7 +12,7 @@ phase: [operate]
 frameworks: [CIS-Controls-v8, NIST-SP-800-53-AC-6]
 difficulty: intermediate
 time_estimate: "45-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -283,6 +283,10 @@ PAM-REC-09: No video/screenshot recording for GUI-based sessions (RDP, web conso
 PAM-REC-10: Session metadata not indexed or searchable for investigation
 PAM-REC-11: No automated alerting on high-risk commands during privileged sessions
 PAM-REC-12: Privileged database queries not recorded (data exfiltration blind spot)
+PAM-REC-13: Recordings lack tamper-evident integrity evidence or immutable retention
+PAM-REC-14: Playback or export access is not separated from the privileged session actors being reviewed
+PAM-REC-15: Session recording stores secrets, tokens, or regulated data without masking and restricted playback
+PAM-REC-16: Recording coverage is counted by protocol but omits high-risk privileged paths such as cloud consoles, databases, Kubernetes exec, vendor portals, or break-glass sessions
 ```
 
 **Session recording capability matrix:**
@@ -294,6 +298,39 @@ PAM-REC-12: Privileged database queries not recorded (data exfiltration blind sp
 | **Storage** | None | Local to PAM | Forwarded to secure storage | Immutable storage with integrity verification |
 | **Monitoring** | None | Post-hoc review | Near-real-time alerts on keywords | Real-time behavioral analytics with auto-termination |
 | **Retention** | None | < 90 days | 12 months | Policy-driven, aligned with regulatory requirements |
+
+#### Session Recording Assurance Matrix
+
+Do not score session management maturity from replay availability alone. Recordings are privileged evidence repositories, so the review must separately evaluate integrity, playback access, privacy controls, and path coverage.
+
+| Evidence field | Required proof |
+|---|---|
+| Privileged path | SSH, RDP, web/cloud console, database console, Kubernetes exec, vendor portal, break-glass, or PAM-outage path |
+| Recording type | Metadata, keystroke/command log, video replay, database query log, API audit event, or compensating evidence |
+| Command/query extraction | Whether high-risk commands, SQL queries, file transfers, and admin console actions are searchable |
+| Storage location | PAM server, external archive, SIEM, object storage, or WORM/object-lock destination |
+| Integrity evidence | Hash, signature, chain of custody, object lock, WORM retention, append-only audit, or verification procedure |
+| Reviewer independence | Reviewer role is separate from the session actor and PAM administrator for sensitive sessions |
+| Playback/export audit | Who viewed, exported, annotated, deleted, or shared recordings, with timestamps and ticket/incident links |
+| Redaction and masking | Tested masking for secrets, tokens, PII, regulated data, one-time codes, and password reset flows |
+| Coverage denominator | Critical privileged paths covered versus total privileged paths in inventory |
+| Evidence confidence | High / Medium / Low / Not Evaluable, with reason for missing or partial proof |
+
+**Assurance guidance:**
+
+- Treat local replay on the PAM server as partial evidence until immutable retention and integrity verification are proven.
+- Require dual-control or independent security review for playback of sessions involving PAM admins, database admins, break-glass users, or incident responders.
+- Prefer command/query logs or database activity monitoring over full video replay when full replay would expose sensitive result rows.
+- For break-glass and PAM-outage sessions, require compensating evidence and post-use reconciliation if the normal recorder cannot capture the session.
+- Redaction must be tested with examples that preserve command/action evidence while masking secrets and regulated data.
+
+**Recording assurance maturity:**
+
+| Level | Description |
+|---|---|
+| Basic | Metadata or partial replay for some privileged paths; integrity and playback controls are limited. |
+| Mature | Critical paths have retained replay or command/query evidence with indexed metadata and review workflow. |
+| Advanced | Critical paths have tamper-evident retention, independent reviewer access, playback/export audit, tested redaction, high-risk command alerting, and compensating evidence for unrecordable paths. |
 
 ---
 
@@ -388,6 +425,7 @@ PAM-VAULT-12: No secrets scanning in code repositories to detect credential leak
 |---|---|---|
 | Credential Vaulting | [Not Present/Basic/Mature/Advanced] | [Target] |
 | Session Management | [Not Present/Basic/Mature/Advanced] | [Target] |
+| Session Recording Assurance | [Basic/Mature/Advanced/Not Evaluable] | [Target] |
 | JIT Access | [Not Present/Basic/Mature/Advanced] | [Target] |
 | Break-Glass | [Not Present/Basic/Mature/Advanced] | [Target] |
 | Analytics | [Not Present/Basic/Mature/Advanced] | [Target] |

--- a/skills/identity/privileged-access/tests/benign/tamper-evident-session-recording.yaml
+++ b/skills/identity/privileged-access/tests/benign/tamper-evident-session-recording.yaml
@@ -1,0 +1,48 @@
+scenario: tamper_evident_session_recording
+expected_result:
+  posture: advanced
+  finding_ids: []
+  notes: Critical privileged paths have retained command or replay evidence, immutable storage, integrity checks, independent review, playback audit, and tested redaction.
+recording_assurance:
+  privileged_paths:
+    - path: pam_brokered_ssh
+      protocol: ssh
+      recording_type: keystroke_and_command_log
+      command_extraction: enabled
+      storage_location: object_storage_worm
+      immutable_retention_days: 365
+      integrity:
+        hash: sha256_recorded
+        signature: pam_archive_signing_key
+        verification_run_id: verify-2026-06-01
+      external_forwarding:
+        siem_metadata: enabled
+        archive_event: enabled
+      reviewer_independence:
+        reviewer_role: security-reviewer
+        session_actor_can_review_own_session: false
+        pam_admin_can_delete_recording: false
+      playback_export_audit:
+        enabled: true
+        fields:
+          - viewer
+          - timestamp
+          - ticket_id
+          - export_reason
+      redaction:
+        tested: true
+        masks:
+          - password_prompts
+          - api_tokens
+          - regulated_identifiers
+    - path: database_admin_console
+      protocol: sql
+      recording_type: database_activity_monitoring
+      command_extraction: enabled
+      sensitive_result_rows_recorded: false
+      storage_location: immutable_siem_archive
+coverage:
+  critical_paths_total: 6
+  critical_paths_recorded: 6
+  compensating_evidence_for_unrecordable_paths: []
+evidence_confidence: high

--- a/skills/identity/privileged-access/tests/vulnerable/local-recording-self-review-no-redaction.yaml
+++ b/skills/identity/privileged-access/tests/vulnerable/local-recording-self-review-no-redaction.yaml
@@ -1,0 +1,46 @@
+scenario: local_recording_self_review_no_redaction
+expected_result:
+  posture: fail
+  finding_ids:
+    - PAM-REC-13
+    - PAM-REC-14
+    - PAM-REC-15
+    - PAM-REC-16
+  notes: Session replay exists, but the evidence is mutable, self-reviewable, privacy-unsafe, and missing high-risk privileged paths.
+recording_assurance:
+  privileged_paths:
+    - path: pam_brokered_ssh
+      protocol: ssh
+      recording_type: video_replay
+      command_extraction: disabled
+      storage_location: pam_server_local_disk
+      immutable_retention_days: 0
+      integrity:
+        hash: missing
+        signature: missing
+        verification_run_id: null
+      external_forwarding:
+        siem_metadata: partial
+        archive_event: missing
+      reviewer_independence:
+        reviewer_role: pam_admins
+        session_actor_can_review_own_session: true
+        pam_admin_can_delete_recording: true
+      playback_export_audit:
+        enabled: false
+      redaction:
+        tested: false
+        masks: []
+        recorded_sensitive_examples:
+          - production_api_token_pasted_into_shell
+          - customer_identifier_visible_in_database_console
+coverage:
+  critical_paths_total: 7
+  critical_paths_recorded: 2
+  missing_paths:
+    - cloud_console_admin
+    - database_console
+    - kubernetes_exec
+    - vendor_support_portal
+    - break_glass_console
+evidence_confidence: low


### PR DESCRIPTION
/claim #1302

## What changed

Adds fixture-backed session-recording assurance gates to `privileged-access`.

- Adds `PAM-REC-13` through `PAM-REC-16` for tamper-evident recording integrity, independent reviewer/playback access, redaction/privacy controls, and privileged-path coverage gaps.
- Adds a Session Recording Assurance Matrix with evidence fields for privileged path, recording type, command/query extraction, storage location, integrity evidence, reviewer independence, playback/export audit, redaction, coverage denominator, and confidence.
- Adds recording assurance maturity guidance so replay availability is not over-scored without integrity, independent review, redaction, and coverage evidence.
- Adds a Session Recording Assurance row to the PAM maturity scorecard.
- Adds benign/vulnerable YAML fixtures for tamper-evident recording evidence versus local mutable recordings with self-review, no redaction, and missing high-risk privileged paths.

## Why this PR

Existing PR #1307 is a useful single-file documentation update. This PR is intentionally fixture-backed and adds concrete skill-local examples so future reviews distinguish replay availability from audit-reliable, privacy-safe session evidence.

## Validation

- `git diff --check origin/main...HEAD`
- Markdown fence balance for `privileged-access/SKILL.md`
- Marker checks for `version: "1.0.1"`, `PAM-REC-13` through `PAM-REC-16`, `Session Recording Assurance Matrix`, `Recording assurance maturity`, `Session Recording Assurance`, `Reviewer independence`, `Playback/export audit`, and `Redaction and masking`
- Fixture marker checks for tamper-evident and vulnerable local-recording cases
- Added-line ASCII scan
- Added-line sensitive/public-contact pattern scan
- `git merge-tree --write-tree origin/main HEAD`

## Bounty tier

Requesting Improver Moderate ($100) if accepted. This adds local benign/vulnerable fixtures in addition to the session-recording assurance guidance requested by the issue.