### PR TITLE
Add secrets exposure response fixtures

### DIFF
--- a/skills/devsecops/secrets-management/SKILL.md
+++ b/skills/devsecops/secrets-management/SKILL.md
@@ -13,7 +13,7 @@ phase: [build, operate]
 frameworks: [OWASP-Secrets-Management, NIST-SP-800-57-Part1-Rev5]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.1"
+version: "1.0.2"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -240,6 +240,55 @@ Secrets removed from current files may still exist in git history. Verify:
 
 ---
 
+#### 3.3 Secret Exposure Response Assurance
+
+When a suspected secret is found, do not treat file deletion or replacement-key creation as closure. Prove whether the exposed credential is still valid, whether old trust paths have stopped accepting it, and whether the exposure replicated beyond the first repository location.
+
+**Safe validation rule:** Do not test a detected secret by using it against production APIs unless an approved incident-response runbook explicitly authorizes that action. Prefer provider metadata, scanner validity state, key IDs, owner confirmation, revocation APIs, and provider audit logs. Never paste suspected secret values into shell commands, tickets, screenshots, chat, terminal output, or report evidence.
+
+**Secret Exposure Response Ledger:**
+
+| Field | Evidence to Record |
+|-------|--------------------|
+| Detector and confidence | Tool, rule ID, provider-specific match, entropy-only match, verification source, and scan timestamp |
+| Safe validation method | Provider metadata, scanner validity status, owner confirmation, audit log, revocation API, or `not_safely_verifiable` |
+| Validity state | `detected`, `provider_verified`, `unknown_validity`, `not_safely_verifiable`, or `revoked` |
+| Secret identity | Provider key ID, alias, or non-reversible fingerprint; never the secret value |
+| Owner and affected system | Owning team, application, environment, integration, supplier, and data/action scope |
+| First exposure | Commit, artifact, CI log, image digest, package version, ticket, or other first-known location |
+| Public exposure status | Private repo, internal artifact, public repo, fork, package registry, public image, issue, chat, or unknown |
+| Revocation proof | Old credential disabled, expired, deleted, rotated by provider, revoked by vault, or compensating reason |
+| Replacement deployment | New credential version deployed, rollout window, redeploy time, rollback key status, and dual-key overlap |
+| Post-rotation last-use check | Provider audit log, access log, SIEM query, or reason why last-use evidence is unavailable |
+| Downstream integrations checked | CI/CD, workers, cron, webhooks, vendor integrations, mobile apps, serverless jobs, and break-glass paths |
+| Residual exposure locations | Git history, public forks, CI logs, build artifacts, container layers, package archives, tickets, PR comments, chatops logs |
+| Evidence confidence | `Verified`, `Partial`, `Missing`, or `Not Evaluable` with owner and date |
+
+**Response assurance gates:**
+
+```
+SM-EXP-01: Detected secret was live-tested against a production API without approved runbook
+SM-EXP-02: Finding was closed because the file was deleted but exposed credential revocation was not proven
+SM-EXP-03: Replacement credential was created but old credential disabled state or last-use evidence is unknown
+SM-EXP-04: Downstream consumers, rollback keys, webhooks, or integrations may still trust the old credential
+SM-EXP-05: Exposure scope omits forks, CI logs, build artifacts, container layers, packages, tickets, or chatops logs
+SM-EXP-06: Scanner validity state is reported without source, date, provider support, or safe-validation method
+SM-EXP-07: Secret value was copied into shell history, tickets, screenshots, chat, or findings output during validation
+SM-EXP-08: Entropy-only or generic detector match is overstated as provider-verified active credential
+```
+
+**Closure criteria:**
+
+1. File deletion alone is not closure.
+2. New secret creation alone is not closure.
+3. Closure requires exposed credential revocation or expiry, redeployment where needed, downstream consumer migration, and post-rotation last-use evidence.
+4. If validity cannot be safely checked, mark `not_safely_verifiable`, revoke or expire the credential anyway, and document residual exposure scope.
+5. If public forks or immutable artifacts remain, document why history rewrite, package takedown, image rebuild, or consumer notification is or is not appropriate after revocation.
+
+**Finding classification:** Unsafe live validation with production credentials is **High**; raise to **Critical** if it creates unauthorized access, data exposure, or provider-side state changes. Unrevoked provider-verified credentials in current code, history, public forks, logs, artifacts, images, or packages are **Critical**. Missing revocation proof, last-use evidence, or downstream consumer validation is **High** for production or privileged credentials and **Medium** otherwise.
+
+---
+
 ### Step 4: Vault and Cloud Secrets Manager Integration (NIST SP 800-57, Section 5)
 
 Evaluate the secrets management architecture against NIST SP 800-57 key management lifecycle requirements.
@@ -357,8 +406,8 @@ spec:
 | Severity | Definition |
 |----------|-----------|
 | **Critical** | Committed secrets in current codebase or git history (unrotated); no secret detection tooling; .env with production credentials committed. |
-| **High** | No centralized secrets manager; no rotation automation; long-lived static credentials for agents; secrets in CI logs; no git history scanning; audit logging disabled on vault. |
-| **Medium** | Detection in CI only (no pre-commit); manual rotation process; excessive detection allowlists; token TTL mismatch; rotation not monitored; plaintext secrets in environment variables (vs. vault injection). |
+| **High** | No centralized secrets manager; no rotation automation; long-lived static credentials for agents; secrets in CI logs; no git history scanning; audit logging disabled on vault; unsafe live validation; missing revocation or downstream-consumer proof after exposure. |
+| **Medium** | Detection in CI only (no pre-commit); manual rotation process; excessive detection allowlists; token TTL mismatch; rotation not monitored; plaintext secrets in environment variables (vs. vault injection); unknown scanner validity without source/date. |
 | **Low** | Missing secret type documentation; secret naming convention inconsistencies; development-only secrets in non-.gitignored example files. |
 
 ---
@@ -388,6 +437,12 @@ spec:
 | DB credentials | Vault dynamic | On-demand | Yes | N/A (dynamic) |
 | API key (Stripe) | AWS SM | 90 days | Yes | 2024-01-15 |
 | TLS cert | cert-manager | 60 days | Yes | Auto |
+
+### Secret Exposure Response Ledger
+
+| Finding | Validity State | Safe Validation Method | Secret Identity (No Value) | Revocation Proof | Replacement Deployed | Post-Rotation Last Use | Downstream Consumers | Residual Exposure | Evidence Status |
+|---------|----------------|------------------------|-----------------------------|------------------|----------------------|------------------------|----------------------|-------------------|-----------------|
+| F-001 | provider_verified / unknown_validity / revoked / not_safely_verifiable | provider metadata / scanner status / owner confirmation / revocation API | key ID or non-reversible fingerprint | disabled/deleted/expired event | app/version/time | clean / observed / unavailable | checked / partial / missing | forks/logs/artifacts/images/packages/tickets | Verified/Partial/Not Evaluable |
 
 ### Findings
 
@@ -442,6 +497,12 @@ spec:
 
 4. **Ignoring secret sprawl across multiple secrets managers.** Large organizations often have Vault, AWS Secrets Manager, Azure Key Vault, and application-specific secret stores running simultaneously. Without a unified inventory, secrets expire unmonitored and rotation gaps emerge. Maintain a single source of truth for secret metadata (type, owner, rotation schedule, storage location).
 
+5. **Live-testing leaked credentials.** Using a suspected secret against a production API can create new access events, leak the secret into shell history or logs, and violate provider rules. Use safe validation metadata or revoke first.
+
+6. **Treating deletion as remediation.** Removing a token from a file does not invalidate the historical credential. Track revocation proof, replacement deployment, downstream consumer migration, and last-use evidence.
+
+7. **Stopping exposure scope at the repository.** Secrets frequently replicate into public forks, CI logs, build artifacts, image layers, package archives, issue comments, PR reviews, and chatops logs.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -461,6 +522,7 @@ This skill processes configuration files and code that may contain secret values
 - OWASP Secrets Management Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
 - NIST SP 800-57 Part 1 Rev 5: https://csrc.nist.gov/publications/detail/sp/800-57-part-1/rev-5/final
 - NIST SP 800-57 Part 1 Rev 5 (PDF): https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57pt1r5.pdf
+- GitHub Secret Scanning and validity checks: https://docs.github.com/en/code-security/secret-scanning
 - Gitleaks: https://github.com/gitleaks/gitleaks
 - TruffleHog: https://github.com/trufflesecurity/trufflehog
 - detect-secrets: https://github.com/Yelp/detect-secrets
@@ -471,5 +533,6 @@ This skill processes configuration files and code that may contain secret values
 
 ## Changelog
 
+- **1.0.2** -- Add safe-validation guardrails, secret exposure response ledger, validity states, revocation proof, post-rotation last-use checks, downstream integration review, and residual exposure scoping.
 - **1.0.1** -- Add false positive filtering guidance: distinguish real secrets from placeholders/examples, verify entropy, scope findings to actual secrets (not architectural gaps).
 - **1.0.0** -- Initial release. Full coverage of OWASP Secrets Management Cheat Sheet and NIST SP 800-57 Part 1 Rev 5 for secrets management review.

--- a/skills/devsecops/secrets-management/tests/benign/revoked-secret-exposure-ledger.yaml
+++ b/skills/devsecops/secrets-management/tests/benign/revoked-secret-exposure-ledger.yaml
@@ -1,0 +1,42 @@
+case_id: SM-EXP-BENIGN-001
+description: Exposed repository token was handled through safe validation, revocation, redeploy, and residual exposure scoping.
+detector:
+  tool: github_secret_scanning
+  rule_id: github_pat
+  confidence: provider_specific
+  validity_state: revoked
+  safe_validation_method: provider_validity_status_and_revocation_event
+secret_identity:
+  provider_key_id: github_pat_key_2026_06_support_bot
+  secret_value_recorded: false
+  fingerprint_type: non_reversible_prefix
+exposure:
+  first_location: commit_7c91e2_workflow_yaml
+  public_exposure_status: private_repo
+  residual_locations_checked:
+    git_history: true
+    public_forks: true
+    ci_logs: true
+    build_artifacts: true
+    container_layers: true
+    package_archives: true
+    tickets_and_comments: true
+closure:
+  old_credential_revoked_at: "2026-06-06T03:10:00Z"
+  replacement_deployed_at: "2026-06-06T03:25:00Z"
+  rollback_key_disabled: true
+  downstream_integrations_checked:
+    - github_actions
+    - deployment_webhook
+    - support_bot_worker
+  post_rotation_last_use_check: no_use_after_revocation
+  provider_audit_evidence: audit_event_revoked_and_no_post_rotation_access
+expected_assessment:
+  result: no_finding
+  satisfied_gates:
+    - SM-EXP-02
+    - SM-EXP-03
+    - SM-EXP-04
+    - SM-EXP-05
+    - SM-EXP-06
+  reason: The report never used the secret value, revoked the exposed credential, redeployed consumers, checked last use, and scoped residual exposure.

--- a/skills/devsecops/secrets-management/tests/vulnerable/deleted-file-live-tested-secret.yaml
+++ b/skills/devsecops/secrets-management/tests/vulnerable/deleted-file-live-tested-secret.yaml
@@ -1,0 +1,45 @@
+case_id: SM-EXP-VULN-001
+description: File deletion and replacement-key creation are incorrectly treated as closure while the old credential may remain valid.
+detector:
+  tool: generic_entropy_scanner
+  rule_id: generic_api_key
+  confidence: high_entropy_only
+  validity_state: unknown_validity
+  safe_validation_method: none
+unsafe_validation:
+  live_tested_against_production_api: true
+  approved_runbook: false
+  copied_to_shell_history: true
+  provider_audit_side_effect: new_profile_read_event
+remediation_record:
+  file_deleted: true
+  pull_request_merged: true
+  replacement_secret_created_at: "2026-06-06T02:10:00Z"
+  application_redeployed_at: "2026-06-06T02:35:00Z"
+  old_credential_disabled_at: null
+  old_credential_last_use_after_rotation: unknown
+  provider_audit_log_checked: false
+  rollback_secret_still_enabled: true
+exposure_scope:
+  public_forks_checked: false
+  ci_logs_checked: false
+  build_artifacts_checked: false
+  container_layers_checked: false
+  package_archives_checked: false
+  tickets_and_comments_checked: false
+expected_findings:
+  - gate: SM-EXP-01
+    severity: High
+    reason: The detected value was live-tested against production without an approved incident-response runbook.
+  - gate: SM-EXP-02
+    severity: High
+    reason: The finding was closed after file deletion without proving old credential revocation.
+  - gate: SM-EXP-03
+    severity: High
+    reason: Replacement credential creation did not prove old credential disabled state or post-rotation last use.
+  - gate: SM-EXP-05
+    severity: High
+    reason: Exposure scope omits forks, logs, artifacts, image layers, package archives, tickets, and comments.
+  - gate: SM-EXP-08
+    severity: Medium
+    reason: A generic entropy-only detector result is overstated as a valid provider credential.


### PR DESCRIPTION
/claim #1308

## What changed

Adds fixture-backed secret exposure response assurance gates to `secrets-management`.

- Adds `SM-EXP-01` through `SM-EXP-08` for unsafe live validation, deletion-only closure, missing old-credential revocation, stale downstream consumers, incomplete exposure scoping, scanner validity overclaiming, secret-value handling during validation, and generic detector overstatement.
- Adds a Secret Exposure Response Ledger with validity state, safe validation method, non-secret identity, revocation proof, replacement deployment, post-rotation last-use, downstream consumer checks, residual exposure, and evidence confidence.
- Adds closure criteria clarifying that file deletion and replacement secret creation are not enough without exposed-credential revocation/expiry, redeployment, downstream migration, and last-use evidence.
- Adds benign/vulnerable YAML fixtures for a fully revoked and scoped exposure versus deletion-only remediation with unsafe live production validation.

## Why this PR

Existing PR #1310 is a useful `SKILL.md`-only implementation. This PR is intentionally fixture-backed and adds concrete skill-local examples so future reviews can distinguish real remediation closure from deletion-only cleanup, unsafe validation, and unbounded residual exposure.

## Validation

- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`
- Markdown fence balance for `secrets-management/SKILL.md`
- YAML parse check for both added fixtures
- Marker checks for `version: "1.0.2"`, `Secret Exposure Response Assurance`, `Safe validation rule`, `Secret Exposure Response Ledger`, `SM-EXP-01` through `SM-EXP-08`, `Validity state`, `Post-rotation last-use check`, `Residual exposure locations`, and `not_safely_verifiable`
- Fixture marker checks for benign and vulnerable exposure-response cases
- Added-line ASCII scan
- Added-line sensitive/public-contact pattern scan

## Bounty tier

Requesting Improver Moderate ($100) if accepted. This adds local benign/vulnerable fixtures in addition to the safe-validation and exposure-response guidance requested by the issue.