### PR TITLE
Add SBOM artifact binding fixtures

### DIFF
--- a/skills/vuln-management/sbom-analysis/SKILL.md
+++ b/skills/vuln-management/sbom-analysis/SKILL.md
@@ -13,7 +13,7 @@ phase: [build, operate]
 frameworks: [CycloneDX-1.5, SPDX-2.3, VEX-CSAF, NTIA-SBOM-Minimum-Elements]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -48,6 +48,8 @@ Before starting, collect or confirm:
 - [ ] **SBOM format and version:** CycloneDX 1.5, SPDX 2.3, or other (identify version explicitly)
 - [ ] **VEX document(s):** Associated VEX statements, if available (CSAF 2.0 format, CycloneDX VEX, or OpenVEX)
 - [ ] **Software identity:** Name, version, and vendor of the software the SBOM describes
+- [ ] **Released artifact identity:** Package filename, container image digest, binary checksum, deployment artifact, or commit/release tag the SBOM is meant to describe
+- [ ] **SBOM generation context:** Tool name/version, source revision, build run, build timestamp, and declared scope (source, build, runtime, container, or deployed artifact)
 - [ ] **Intended use context:** Is this SBOM for procurement evaluation, compliance audit, incident response, or continuous monitoring?
 - [ ] **Compliance requirements:** Applicable mandates (EO 14028 for US federal suppliers, EU Cyber Resilience Act, FDA premarket guidance for medical devices)
 - [ ] **License policy:** Organization's approved/prohibited license list, if applicable
@@ -89,7 +91,53 @@ SBOM Format Assessment:
 - File Size:           [Size]
 ```
 
-### Step 2: NTIA Minimum Elements Completeness Check
+### Step 2: Bind SBOM to Released Artifact and Generation Scope
+
+Before scoring NTIA completeness, verify that the SBOM is actually bound to the released artifact, package, binary, image digest, or deployment artifact being assessed. A structurally valid SBOM generated from a different source revision, a previous build, or only a source manifest can mislead procurement, incident response, VEX interpretation, and vulnerability triage.
+
+**Framework mapping:** CycloneDX 1.5 `metadata.component`, `metadata.tools`, `metadata.timestamp`, `component.hashes`, `formulation`; SPDX 2.3 `DocumentName`, `DocumentNamespace`, `PackageChecksum`, `ExternalRef`; SLSA and in-toto provenance concepts.
+
+**Artifact binding evidence gates:**
+
+```
+SBOM-BIND-01: SBOM has no released artifact identity (package filename, image digest, binary hash, or release tag)
+SBOM-BIND-02: SBOM timestamp predates the release/build without documented regeneration
+SBOM-BIND-03: SBOM was generated only from source manifests but used as built/runtime/container evidence
+SBOM-BIND-04: Container image SBOM omits base image, OS packages, generated files, or layered runtime components
+SBOM-BIND-05: Source, build, test, runtime, and container dependency scopes are mixed without labels or compositions
+SBOM-BIND-06: Component identity lacks strong locator evidence (purl/CPE/SPDXID plus checksum where available)
+SBOM-BIND-07: Generator/tool name, version, and generation timestamp are missing or not repeatable
+SBOM-BIND-08: No source revision, CI run, release tag, provenance attestation, or signer connects the SBOM to the build
+SBOM-BIND-09: VEX product/version/digest does not match the SBOM subject and deployed artifact identity
+SBOM-BIND-10: Multiple SBOMs exist for one product but no serial number, namespace, or relationship explains their scope
+```
+
+**Artifact Binding Assessment output:**
+
+| Field | Description |
+|---|---|
+| Subject artifact | Package, image, binary, release tag, or deployed artifact being assessed |
+| Artifact digest/hash | Image digest, binary checksum, package hash, or reason unavailable |
+| Source revision | Commit, tag, source archive digest, or source attestation |
+| Build/run evidence | CI run, SLSA provenance, in-toto attestation, build signer, or release job |
+| SBOM generator | Tool name, version, command context, and generation timestamp |
+| Declared scope | `source`, `build`, `runtime`, `container`, `deployed`, or `mixed` |
+| Scope relationship | Relationship to other SBOMs when multiple scopes exist |
+| VEX subject match | `Matches`, `Mismatch`, `No VEX`, or `Not Evaluable` |
+| Binding confidence | `Strong`, `Partial`, `Weak`, or `Not Bound` |
+
+**Binding confidence guidance:**
+
+| Rating | Criteria | Risk |
+|---|---|---|
+| **Strong** | Artifact digest or immutable image reference, source revision, generator, timestamp, scope, and VEX subject all align | SBOM can support incident response and procurement decisions |
+| **Partial** | Product/version and timestamp align, but digest/provenance or scope is incomplete | Use with caution; request stronger release evidence |
+| **Weak** | SBOM is valid but tied only to a name/version or source manifest | Vulnerability and VEX conclusions may be wrong for the shipped artifact |
+| **Not Bound** | Subject artifact cannot be identified or conflicts with supplied release/VEX data | Treat as unsuitable for assurance decisions |
+
+---
+
+### Step 3: NTIA Minimum Elements Completeness Check
 
 Evaluate the SBOM against all seven NTIA "minimum elements for an SBOM" as defined in the July 2021 NTIA publication "The Minimum Elements for a Software Bill of Materials."
 
@@ -133,7 +181,7 @@ NTIA Completeness Assessment:
 | **Partial** | 5-6 elements present for majority of components; significant gaps in supplier or dependency data |
 | **Incomplete** | Fewer than 5 elements consistently present; SBOM not suitable for compliance or risk assessment |
 
-### Step 3: VEX Status Interpretation
+### Step 4: VEX Status Interpretation
 
 If VEX (Vulnerability Exploitability eXchange) documents are provided, interpret the status for each vulnerability-product pair.
 
@@ -164,13 +212,14 @@ When a VEX status is "Not Affected," the document must include one of these just
 VEX Assessment:
 - VEX Format:          [CSAF 2.0 | CycloneDX VEX | OpenVEX]
 - Total VEX Entries:   [N]
+- Subject Match:       [Matches SBOM/artifact | Mismatch | Not Evaluable]
 - Not Affected:        [N] (justifications: [list categories used])
 - Affected:            [N] (require remediation)
 - Fixed:               [N] (verify deployment)
 - Under Investigation: [N] (monitor for updates)
 ```
 
-### Step 4: Transitive Dependency Analysis
+### Step 5: Transitive Dependency Analysis
 
 Analyze the dependency tree to identify risk concentration in transitive (indirect) dependencies.
 
@@ -203,7 +252,7 @@ Transitive Dependency Analysis:
 - Stale Dependencies:       [N] components with no update in >= 18 months
 ```
 
-### Step 5: License Conflict Detection
+### Step 6: License Conflict Detection
 
 Analyze component licenses for conflicts, compliance risks, and policy violations.
 
@@ -245,8 +294,8 @@ Classify the overall SBOM analysis into one of the following states:
 
 | Classification | Definition | Criteria |
 |---|---|---|
-| **Critical Supply Chain Risk** | SBOM reveals high-risk supply chain exposure | Known exploited CVEs in dependencies, incomplete SBOM with missing critical elements, or license conflicts blocking distribution |
-| **Elevated Risk** | SBOM has notable gaps or concerning findings | NTIA completeness < 90%, multiple stale transitive dependencies, or VEX "Under Investigation" for critical components |
+| **Critical Supply Chain Risk** | SBOM reveals high-risk supply chain exposure | Known exploited CVEs in dependencies, unbound SBOM used for assurance decisions, incomplete SBOM with missing critical elements, or license conflicts blocking distribution |
+| **Elevated Risk** | SBOM has notable gaps or concerning findings | Weak/partial artifact binding, NTIA completeness < 90%, multiple stale transitive dependencies, or VEX "Under Investigation" for critical components |
 | **Acceptable** | SBOM meets minimum requirements with minor gaps | NTIA completeness >= 90%, no critical/high CVEs in dependencies, minor license issues documented |
 | **Strong** | SBOM is comprehensive and low-risk | NTIA 100% complete, all VEX statuses resolved, no critical dependency risks, clean license posture |
 
@@ -278,6 +327,20 @@ conflicts), and overall classification.]
 | Total Components | [N] (direct: [N], transitive: [N]) |
 | SBOM Author | [Author name] |
 | SBOM Timestamp | [ISO 8601] |
+
+### Artifact Binding and Provenance
+
+| Evidence | Status | Details |
+|---|---|---|
+| Subject Artifact | [Pass/Fail/Partial] | [Package/image/binary/release tag] |
+| Artifact Digest / Hash | [Pass/Fail/Partial] | [sha256/image digest/checksum] |
+| Source Revision | [Pass/Fail/Partial] | [Commit/tag/source attestation] |
+| Build / CI Evidence | [Pass/Fail/Partial] | [Run URL, provenance attestation, signer] |
+| SBOM Generator | [Pass/Fail/Partial] | [Tool and version] |
+| Declared Scope | [Pass/Fail/Partial] | [Source/build/runtime/container/deployed] |
+| VEX Subject Match | [Pass/Fail/N/A] | [Product/version/digest alignment] |
+
+**Binding Confidence:** [Strong / Partial / Weak / Not Bound]
 
 ### NTIA Minimum Elements Compliance
 
@@ -337,6 +400,8 @@ conflicts), and overall classification.]
 - CycloneDX 1.5 Specification: https://cyclonedx.org/docs/1.5/
 - SPDX 2.3 Specification: https://spdx.github.io/spdx-spec/v2.3/
 - VEX (CSAF): https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html
+- SLSA Provenance: https://slsa.dev/spec/v1.0/provenance
+- in-toto Attestation Framework: https://github.com/in-toto/attestation
 - Vendor advisory: [URL if applicable]
 ```
 
@@ -373,13 +438,15 @@ Published by NTIA in July 2021 as part of Executive Order 14028 implementation. 
 
 1. **Confusing SBOM presence with SBOM completeness.** Receiving an SBOM file does not mean it contains useful data. Many auto-generated SBOMs are missing supplier names, dependency relationships, or unique identifiers (purls). Always validate against the NTIA seven minimum elements before relying on the SBOM for security decisions.
 
-2. **Ignoring transitive dependencies.** Direct dependencies are typically well-managed, but transitive dependencies (dependencies of dependencies) account for the majority of supply chain vulnerabilities. The xz-utils backdoor (CVE-2024-3094) and Log4Shell (CVE-2021-44228) both demonstrated how deeply nested dependencies create organization-wide exposure. Analyze the full dependency tree, not just the top level.
+2. **Accepting an unbound SBOM as release evidence.** An SBOM generated from source manifests, a local workspace, or a previous build may not describe the binary, container image, or deployment artifact actually shipped. Require artifact digest, release tag, source revision, build evidence, and declared scope before treating the SBOM as authoritative.
 
-3. **Treating VEX "Not Affected" as automatic clearance.** A VEX "Not Affected" status is only as trustworthy as its justification. "Component not present" is verifiable against the SBOM; "vulnerable code not in execute path" requires code-level analysis that should be validated independently for critical systems. Always review the justification category and assess its credibility.
+3. **Ignoring transitive dependencies.** Direct dependencies are typically well-managed, but transitive dependencies (dependencies of dependencies) account for the majority of supply chain vulnerabilities. The xz-utils backdoor (CVE-2024-3094) and Log4Shell (CVE-2021-44228) both demonstrated how deeply nested dependencies create organization-wide exposure. Analyze the full dependency tree, not just the top level.
 
-4. **Overlooking license implications in SaaS deployments.** AGPL-3.0 triggers copyleft obligations for network use (SaaS), unlike GPL which only triggers on distribution. Organizations running AGPL-licensed components in SaaS products may have unrecognized compliance obligations. Always flag AGPL components regardless of distribution model.
+4. **Treating VEX "Not Affected" as automatic clearance.** A VEX "Not Affected" status is only as trustworthy as its justification and subject match. "Component not present" is verifiable against the SBOM only when the VEX product/version/digest matches the SBOM subject and deployed artifact. Always review the justification category and assess its credibility.
 
-5. **Failing to track SBOM freshness.** An SBOM is a point-in-time snapshot. Software composition changes with every dependency update, build, or deployment. SBOMs older than the most recent build/release are potentially inaccurate. Check the SBOM timestamp against the software's actual release date and flag stale SBOMs.
+5. **Overlooking license implications in SaaS deployments.** AGPL-3.0 triggers copyleft obligations for network use (SaaS), unlike GPL which only triggers on distribution. Organizations running AGPL-licensed components in SaaS products may have unrecognized compliance obligations. Always flag AGPL components regardless of distribution model.
+
+6. **Failing to track SBOM freshness.** An SBOM is a point-in-time snapshot. Software composition changes with every dependency update, build, or deployment. SBOMs older than the most recent build/release are potentially inaccurate. Check the SBOM timestamp against the software's actual release date and flag stale SBOMs.
 
 ---
 
@@ -404,6 +471,8 @@ Published by NTIA in July 2021 as part of Executive Order 14028 implementation. 
 - CSAF 2.0 (OASIS): https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html
 - CISA VEX Minimum Requirements: https://www.cisa.gov/sites/default/files/2023-04/minimum-requirements-for-vex-508c.pdf
 - OpenVEX Specification: https://github.com/openvex/spec
+- SLSA Provenance: https://slsa.dev/spec/v1.0/provenance
+- in-toto Attestation Framework: https://github.com/in-toto/attestation
 - Executive Order 14028: https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/
 - EU Cyber Resilience Act: https://digital-strategy.ec.europa.eu/en/policies/cyber-resilience-act
 - OSV (Open Source Vulnerability Database): https://osv.dev/

--- a/skills/vuln-management/sbom-analysis/tests/benign/bound-cyclonedx-release-artifact.json
+++ b/skills/vuln-management/sbom-analysis/tests/benign/bound-cyclonedx-release-artifact.json
@@ -1,0 +1,76 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:7f8f8c34-1ad7-4a5a-9e0f-1290-benign",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2026-06-06T08:42:00Z",
+    "tools": [
+      {
+        "vendor": "CycloneDX",
+        "name": "cdxgen",
+        "version": "10.1.0"
+      }
+    ],
+    "component": {
+      "type": "container",
+      "name": "api",
+      "version": "1.4.2",
+      "bom-ref": "pkg:oci/registry.example.com/app/api@sha256:prod123",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "prod123boundartifact0000000000000000000000000000000000000000000000"
+        }
+      ]
+    }
+  },
+  "formulation": [
+    {
+      "components": [
+        {
+          "type": "application",
+          "name": "api-source",
+          "version": "1.4.2",
+          "bom-ref": "git:app-api@release-1.4.2"
+        }
+      ],
+      "properties": [
+        {
+          "name": "slsa.buildRun",
+          "value": "ci/run/8842"
+        },
+        {
+          "name": "source.revision",
+          "value": "release-1.4.2"
+        },
+        {
+          "name": "declared.scope",
+          "value": "container"
+        }
+      ]
+    }
+  ],
+  "components": [
+    {
+      "type": "library",
+      "name": "express",
+      "version": "4.18.3",
+      "purl": "pkg:npm/express@4.18.3"
+    }
+  ],
+  "properties": [
+    {
+      "name": "SBOM-BIND-01",
+      "value": "pass"
+    },
+    {
+      "name": "binding.confidence",
+      "value": "Strong"
+    },
+    {
+      "name": "vex.subject.match",
+      "value": "Matches"
+    }
+  ]
+}

--- a/skills/vuln-management/sbom-analysis/tests/vulnerable/source-sbom-vex-mismatch.json
+++ b/skills/vuln-management/sbom-analysis/tests/vulnerable/source-sbom-vex-mismatch.json
@@ -1,0 +1,56 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:7f8f8c34-1ad7-4a5a-9e0f-1290-vulnerable",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2026-06-06T01:00:00Z",
+    "tools": [
+      {
+        "vendor": "Example",
+        "name": "manifest-sbom",
+        "version": "0.9.0"
+      }
+    ],
+    "component": {
+      "type": "application",
+      "name": "app-api",
+      "version": "1.4.2",
+      "bom-ref": "pkg:generic/app-api@1.4.2"
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "package-lock-only-dependency",
+      "version": "2.0.0",
+      "purl": "pkg:npm/package-lock-only-dependency@2.0.0"
+    }
+  ],
+  "properties": [
+    {
+      "name": "release.artifact",
+      "value": "registry.example.com/app/api@sha256:prod123"
+    },
+    {
+      "name": "sbom.subject",
+      "value": "app-api 1.4.2 source manifest"
+    },
+    {
+      "name": "declared.scope",
+      "value": "source"
+    },
+    {
+      "name": "vex.subject",
+      "value": "app-api 1.4.1"
+    },
+    {
+      "name": "expected.findings",
+      "value": "SBOM-BIND-01,SBOM-BIND-03,SBOM-BIND-04,SBOM-BIND-08,SBOM-BIND-09"
+    },
+    {
+      "name": "binding.confidence",
+      "value": "Weak"
+    }
+  ]
+}


### PR DESCRIPTION
/claim #1290

## What changed

Adds fixture-backed artifact binding and provenance gates to `sbom-analysis`.

- Adds `SBOM-BIND-01` through `SBOM-BIND-10` for released artifact identity, timestamp freshness, source-only SBOM misuse, container/runtime omissions, mixed scope labeling, component locator evidence, generator repeatability, source/build provenance, VEX subject matching, and multi-SBOM relationship clarity.
- Adds an Artifact Binding Assessment output table with subject artifact, digest/hash, source revision, build/run evidence, generator, declared scope, scope relationship, VEX subject match, and binding confidence.
- Updates VEX interpretation and classification so `Not Affected` or `Fixed` conclusions are not accepted when VEX product/version/digest does not match the SBOM subject and deployed artifact.
- Adds benign/vulnerable CycloneDX fixtures for a strongly bound release artifact versus a source-only SBOM with mismatched VEX and no deployed artifact binding.

## Why this PR

Existing PR #1292 is a useful `SKILL.md`-only implementation. This PR is intentionally fixture-backed and adds concrete skill-local examples so future reviews can distinguish structurally valid SBOMs from SBOMs that are not bound to the shipped artifact or matching VEX subject.

## Validation

- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`
- Markdown fence balance for `sbom-analysis/SKILL.md`
- JSON parse check for both added fixtures
- Marker checks for `version: 1.0.1`, `Bind SBOM to Released Artifact and Generation Scope`, `Artifact binding evidence gates`, `SBOM-BIND-01` through `SBOM-BIND-10`, `Artifact Binding Assessment`, `Binding confidence`, `VEX Subject Match`, and `Accepting an unbound SBOM as release evidence`
- Fixture marker checks for strongly bound and vulnerable SBOM/VEX mismatch cases
- Added-line ASCII scan
- Added-line sensitive/public-contact pattern scan
- Remote compare verification before PR creation

## Bounty tier

Requesting Improver Moderate ($100) if accepted. This adds local benign/vulnerable fixtures in addition to the artifact-binding and provenance guidance requested by the issue.