### PR TITLE
Add AWS Organizations guardrail fixtures

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-AWS-v3.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -55,6 +55,7 @@ The CIS Amazon Web Services Foundations Benchmark v3.0.0 is a consensus-driven s
 - S3 bucket policies and ACL configurations
 - VPC, security group, and NACL definitions
 - CloudTrail and CloudWatch configuration files
+- AWS Organizations exports for SCP/RCP policy types, policy attachments, OU/account placement, and effective-deny evidence when reviewing resource policies in multi-account environments
 
 ---
 
@@ -99,7 +100,77 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
-### Step 7: Compile Assessment Report
+### Step 7: Supplemental AWS Organizations Authorization Guardrails
+
+When the review includes cross-account access, public or external-principal resource policies, delegated administration, or multi-account guardrail claims, evaluate AWS Organizations authorization policies before final severity assignment.
+
+SCPs and RCPs set maximum available permissions; they never grant access. Do not treat the presence of an Organizations policy as a generic mitigation. Record which side of authorization the policy constrains:
+
+- **Service Control Policy (SCP):** principal-side guardrail for principals in member accounts.
+- **Resource Control Policy (RCP):** resource-side guardrail for resources in member accounts.
+
+#### Artifact discovery patterns
+
+Search for Organizations policy definitions and attachments:
+
+```
+aws_organizations_policy
+aws_organizations_policy_attachment
+SERVICE_CONTROL_POLICY
+RESOURCE_CONTROL_POLICY
+aws:PrincipalOrgID
+aws:ResourceOrgID
+organizations:AttachPolicy
+organizations:EnablePolicyType
+```
+
+Also review exported AWS CLI evidence when available:
+
+```
+aws organizations list-roots
+aws organizations list-policies --filter SERVICE_CONTROL_POLICY
+aws organizations list-policies --filter RESOURCE_CONTROL_POLICY
+aws organizations list-targets-for-policy --policy-id <policy-id>
+aws organizations list-policies-for-target --target-id <root-ou-or-account-id> --filter RESOURCE_CONTROL_POLICY
+aws iam get-account-authorization-details
+aws accessanalyzer list-findings
+```
+
+#### Evidence gates
+
+For each external-principal or public resource-policy finding, capture:
+
+| Gate | Required evidence | Fail / Not Evaluable condition |
+|------|-------------------|--------------------------------|
+| `AWS-ORG-GUARD-01` | Policy type is explicitly identified as SCP or RCP. | Report says "Organizations policy" without side or type. |
+| `AWS-ORG-GUARD-02` | Policy type is enabled for the organization root or target. | RCP/SCP mitigation claimed without enabled policy-type evidence. |
+| `AWS-ORG-GUARD-03` | Attachment path is mapped to root, OU, or account. | Policy exists but no target attachment is evidenced. |
+| `AWS-ORG-GUARD-04` | Covered accounts/OUs include the reviewed principal or resource account. | Attachment is to a different OU/account, or account placement is unknown. |
+| `AWS-ORG-GUARD-05` | SCP/RCP side matches the risk. | Principal-side SCP is used to claim a resource-side external-access deny, or vice versa. |
+| `AWS-ORG-GUARD-06` | RCP service/action/resource applicability is confirmed for the reviewed resource path. | RCP is claimed for an unsupported service/action or without service applicability evidence. |
+| `AWS-ORG-GUARD-07` | Exceptions are checked: management account resources, service-linked roles, AWS managed KMS keys, and required AWS service principals. | A broad "RCP blocks it" claim ignores documented exception paths. |
+| `AWS-ORG-GUARD-08` | Effective-deny evidence exists from Access Analyzer, IAM policy simulation, CloudTrail `AccessDenied`, or controlled test evidence. | Guardrail is accepted solely from policy text without live/exported effective-behavior evidence. |
+
+#### Severity calibration
+
+- **High:** public or external-principal access to sensitive resources with no applicable RCP/effective-access evidence.
+- **Medium:** an RCP/SCP exists, but attachment scope, enabled policy type, account/OU coverage, supported-service applicability, or effective-deny evidence is incomplete.
+- **Low:** broad-looking local policy is constrained by evidenced, applicable SCP/RCP layers, but documentation, coverage denominator, or test cadence is incomplete.
+- **Informational:** SCP/RCP guardrail is enabled, attached to the correct scope, applicable to the resource/action path, tested, and exception-reviewed.
+
+#### Common false positive guardrail
+
+Do not automatically mark every external-principal S3, KMS, SQS, SNS, ECR, or Secrets Manager resource policy as High when an applicable RCP is enabled, attached to the resource account/OU, covers the service/action, and has effective-deny evidence. Conversely, do not downgrade a resource-policy exposure because a region-deny SCP or root-user SCP exists; those constrain member-account principals and may not constrain the external principal or resource-side access path.
+
+#### Output addendum
+
+Include a guardrail table when Organizations evidence affects any finding:
+
+| Resource | Principal/Access path | Local policy risk | Policy type | Attachment path | Covered account/OU | Supported service/action? | Exception path checked? | Effective-deny evidence | Guardrail confidence |
+|----------|-----------------------|-------------------|-------------|-----------------|--------------------|---------------------------|-------------------------|-------------------------|---------------------|
+| `<arn>` | `<principal/action>` | `<risk>` | `SCP/RCP/None` | `<root/ou/account>` | `<scope>` | `Yes/No/Unknown` | `Yes/No` | `<artifact>` | `High/Medium/Low/Not Evaluable` |
+
+### Step 8: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
 
@@ -156,6 +227,7 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration or code snippet>
+- **Organizations guardrail evidence:** <SCP/RCP type, attachment path, account/OU coverage, applicability, exceptions, and effective-deny evidence if relevant>
 - **Remediation:** <specific fix with code example>
 
 ### Prioritized Remediation Plan
@@ -200,6 +272,8 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
 5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
 6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
+7. **Treating SCPs and RCPs as interchangeable.** SCPs constrain principals in member accounts. RCPs constrain resources in member accounts. Neither grants permissions, and neither replaces identity-based and resource-based policy review.
+8. **Accepting untested RCP claims.** RCPs do not apply to every service/action path and have exception boundaries. Require enabled policy type, attachment scope, covered account/OU, supported-service applicability, exception review, and effective-deny evidence before lowering severity.
 
 ---
 
@@ -226,9 +300,14 @@ Produce the final report using the structure defined in the Output Format sectio
 - AWS Security Hub: https://docs.aws.amazon.com/securityhub/latest/userguide/
 - AWS VPC Security: https://docs.aws.amazon.com/vpc/latest/userguide/security.html
 - Terraform AWS Provider Documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
+- AWS Organizations authorization policies: https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_authorization_policies.html
+- AWS Organizations resource control policies: https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_rcps.html
+- AWS Organizations RCP syntax: https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_rcps_syntax.html
+- Terraform `aws_organizations_policy`: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy
 
 ---
 
 ## Changelog
 
+- **1.0.1** -- Added AWS Organizations SCP/RCP authorization guardrail evidence gates, output fields, severity calibration, pitfalls, and fixture-backed examples for RCP-constrained versus overclaimed resource-policy exposure.
 - **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 (62 recommendations).

--- a/skills/cloud/aws-review/tests/benign/rcp-constrained-external-s3-policy.tf
+++ b/skills/cloud/aws-review/tests/benign/rcp-constrained-external-s3-policy.tf
@@ -1,0 +1,83 @@
+# Benign fixture: an external-looking S3 bucket policy is constrained by an
+# attached, enabled RCP with evidence that the reviewed resource path is denied.
+
+locals {
+  organization_id       = "o-exampleorg"
+  member_account_id     = "111111111111"
+  production_ou_id      = "ou-abcd-12345678"
+  reviewed_resource     = "arn:aws:s3:::example-reports/*"
+  effective_deny_signal = "cloudtrail AccessDenied for s3:GetObject by arn:aws:iam::222222222222:role/partner-reader"
+
+  expected_aws_review_result = {
+    finding_state        = "informational"
+    guardrail_confidence = "high"
+    rationale            = "RCP is enabled, attached to the production OU, covers the member account resource, targets S3 object access, and has effective-deny evidence."
+  }
+}
+
+resource "aws_organizations_organization" "org" {
+  feature_set = "ALL"
+
+  aws_service_access_principals = [
+    "access-analyzer.amazonaws.com"
+  ]
+
+  enabled_policy_types = [
+    "SERVICE_CONTROL_POLICY",
+    "RESOURCE_CONTROL_POLICY"
+  ]
+}
+
+resource "aws_organizations_policy" "deny_external_s3_resource_access" {
+  name = "deny-external-s3-resource-access"
+  type = "RESOURCE_CONTROL_POLICY"
+
+  content = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyExternalS3ObjectAccess"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = [
+          "s3:GetObject",
+          "s3:PutObject"
+        ]
+        Resource = "arn:aws:s3:::example-reports/*"
+        Condition = {
+          StringNotEquals = {
+            "aws:PrincipalOrgID" = local.organization_id
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_organizations_policy_attachment" "prod_ou_rcp" {
+  policy_id = aws_organizations_policy.deny_external_s3_resource_access.id
+  target_id = local.production_ou_id
+}
+
+resource "aws_s3_bucket" "reports" {
+  bucket = "example-reports"
+}
+
+resource "aws_s3_bucket_policy" "reports_partner_read" {
+  bucket = aws_s3_bucket.reports.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowPartnerReadIfNotConstrained"
+        Effect    = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::222222222222:role/partner-reader"
+        }
+        Action   = "s3:GetObject"
+        Resource = local.reviewed_resource
+      }
+    ]
+  })
+}

--- a/skills/cloud/aws-review/tests/vulnerable/scp-overclaimed-as-resource-guardrail.tf
+++ b/skills/cloud/aws-review/tests/vulnerable/scp-overclaimed-as-resource-guardrail.tf
@@ -1,0 +1,82 @@
+# Vulnerable fixture: a resource policy allows an external principal while the
+# only Organizations evidence is a principal-side SCP that does not prove
+# resource-side denial for the external access path.
+
+locals {
+  organization_id   = "o-exampleorg"
+  member_account_id = "111111111111"
+  reviewed_resource = "arn:aws:s3:::customer-exports/*"
+
+  expected_aws_review_result = {
+    finding_state        = "high"
+    guardrail_confidence = "not_evaluable"
+    rationale            = "The SCP constrains principals in member accounts, but no enabled, attached, applicable RCP or effective-deny evidence constrains the external principal reading the resource policy."
+  }
+}
+
+resource "aws_organizations_organization" "org" {
+  feature_set = "ALL"
+
+  enabled_policy_types = [
+    "SERVICE_CONTROL_POLICY"
+  ]
+}
+
+resource "aws_organizations_policy" "deny_unapproved_regions" {
+  name = "deny-unapproved-regions"
+  type = "SERVICE_CONTROL_POLICY"
+
+  content = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "DenyOutsideApprovedRegions"
+        Effect   = "Deny"
+        Action   = "*"
+        Resource = "*"
+        Condition = {
+          StringNotEquals = {
+            "aws:RequestedRegion" = [
+              "us-east-1",
+              "us-west-2"
+            ]
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_organizations_policy_attachment" "prod_account_scp" {
+  policy_id = aws_organizations_policy.deny_unapproved_regions.id
+  target_id = local.member_account_id
+}
+
+resource "aws_s3_bucket" "customer_exports" {
+  bucket = "customer-exports"
+}
+
+resource "aws_s3_bucket_policy" "external_export_reader" {
+  bucket = aws_s3_bucket.customer_exports.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowExternalExportReader"
+        Effect    = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::222222222222:role/external-export-reader"
+        }
+        Action = [
+          "s3:GetObject",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          "arn:aws:s3:::customer-exports",
+          local.reviewed_resource
+        ]
+      }
+    ]
+  })
+}


### PR DESCRIPTION
/claim #1261

## What changed

Adds fixture-backed AWS Organizations SCP/RCP guardrail evidence handling to `aws-review`.

- Adds `AWS-ORG-GUARD-01` through `AWS-ORG-GUARD-08` for policy type, enabled policy type, attachment path, covered account/OU, SCP-vs-RCP side matching, RCP service/action applicability, documented exception paths, and effective-deny evidence.
- Adds an Organizations guardrail output addendum with local policy risk, policy type, attachment path, covered account/OU, supported service/action, exception checks, effective-deny evidence, and guardrail confidence.
- Adds severity calibration so external-principal resource policies are not overreported when an applicable tested RCP exists, and not underreported when a principal-side SCP is incorrectly used as a resource-side mitigation.
- Adds benign/vulnerable Terraform fixtures for an RCP-constrained external-looking S3 policy versus an external S3 policy where a region-deny SCP is overclaimed as resource-side protection.

## Why this PR

Existing PR #1262 is a useful `SKILL.md`-only implementation. This PR is intentionally fixture-backed and adds concrete skill-local examples so future reviewers can distinguish an evidenced RCP constraint from an SCP/RCP mix-up or untested guardrail claim.

## Validation

- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`
- Markdown fence balance for `aws-review/SKILL.md`
- Marker checks for `version: 1.0.1`, `AWS Organizations Authorization Guardrails`, `AWS-ORG-GUARD-01` through `AWS-ORG-GUARD-08`, `RESOURCE_CONTROL_POLICY`, `SERVICE_CONTROL_POLICY`, `aws:PrincipalOrgID`, `Guardrail confidence`, `Treating SCPs and RCPs as interchangeable`, and `Accepting untested RCP claims`
- Fixture marker checks for `aws_organizations_policy`, `aws_organizations_policy_attachment`, `aws_s3_bucket_policy`, `expected_aws_review_result`, `finding_state`, and `guardrail_confidence`
- Added-line ASCII scan
- Added-line sensitive/public-contact pattern scan
- Remote compare verification before PR creation

`terraform` is not installed in my local environment, so the Terraform fixtures were validated by structure/marker checks rather than `terraform fmt` or `terraform validate`.

## Bounty tier

Requesting Improver Moderate ($100) if accepted. This adds local benign/vulnerable fixtures in addition to the SCP/RCP guidance requested by the issue.