### PR TITLE
Add detection telemetry health fixtures

### DIFF
--- a/skills/secops/detection-engineering/SKILL.md
+++ b/skills/secops/detection-engineering/SKILL.md
@@ -13,7 +13,7 @@ phase: [operate]
 frameworks: [MITRE-ATT&CK-v16, Sigma, Palantir-ADS]
 difficulty: advanced
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -58,6 +58,7 @@ Before beginning, gather or confirm:
 - [ ] **Existing detection coverage:** Current rules, known gaps, previous false positive history for similar detections.
 - [ ] **Detection priority:** Is this for a known active threat, proactive coverage expansion, or compliance requirement?
 - [ ] **Organizational naming conventions:** Rule ID format, severity taxonomy, and tagging standards used by the detection engineering team.
+- [ ] **Telemetry and rule-health evidence:** Current collector health, most recent event timestamp, parser field mapping, deployed rule status, suppression scope, and retention window for the claimed ATT&CK coverage.
 
 If the ATT&CK technique is provided but other context is missing, proceed with conservative assumptions (Windows enterprise environment, Sysmon + Windows Security logs available) and note assumptions in the output.
 
@@ -85,6 +86,25 @@ ATT&CK Technique Analysis:
 - Sub-techniques:     [.001 PowerShell, .002 AppleScript, .003 Windows Command Shell, ...]
 - Detection Scope:    [Sub-technique specific | Parent technique broad]
 ```
+
+### Step 1.5: Telemetry Readiness and Rule Health Evidence
+
+Do not count a Sigma rule as operational ATT&CK coverage until the required telemetry path and deployed rule health are proven. A rule that exists in version control but has stale logs, broken field mappings, disabled analytics, failing scheduled runs, overbroad suppressions, or insufficient retention provides only theoretical coverage.
+
+For every claimed detection coverage row, capture:
+
+| Gate | Required evidence | Fail / Not Evaluable condition |
+|------|-------------------|--------------------------------|
+| `DET-HEALTH-01` | ATT&CK data component and Sigma `logsource` are mapped to the backend table/index. | Technique is marked covered without a concrete telemetry source. |
+| `DET-HEALTH-02` | Collector/connector health includes enabled state, last successful fetch, and most recent event timestamp. | Required telemetry is stale, disabled, or has unknown `last_seen`. |
+| `DET-HEALTH-03` | Parser and field mapping proves every field used by the rule exists in current normalized events. | Sigma conversion targets fields that no longer exist or are empty after parser drift. |
+| `DET-HEALTH-04` | Deployed SIEM rule ID, enabled status, version/hash, schedule, and last-run result are recorded. | Rule exists only in source control, is disabled, test-only, or failing scheduled runs. |
+| `DET-HEALTH-05` | Suppressions/exceptions have owner, reason, expiry, affected entities, and volume impact. | Exceptions are ownerless, expired, or suppress all matching events. |
+| `DET-HEALTH-06` | Positive and negative samples prove the rule fires and does not fire as expected after backend conversion. | Only Sigma syntax validation exists; no backend sample/replay evidence. |
+| `DET-HEALTH-07` | Retention and searchable lookback meet the detection and investigation window. | Retention is shorter than schedule/lookback or archive is not searchable. |
+| `DET-HEALTH-08` | Coverage decision is explicit: Operational, Theoretical, Partial, Broken, or Not Evaluable. | Coverage dashboard shows covered without evidence status or owner. |
+
+**Classification rule:** Mark coverage **Theoretical** when a rule exists but telemetry or deployment health is not verified. Mark it **Not Evaluable** when the required data component, parser mapping, rule status, suppression effect, or retention cannot be proven. Escalate to **High** when a high-priority ATT&CK technique is claimed as covered but the log source is stale, the rule is disabled, parser drift breaks all matching fields, or suppressions hide all matching events.
 
 ### Step 2: Detection Logic Design
 
@@ -389,6 +409,11 @@ Produce detection engineering deliverables in this structure:
 | Target Coverage | [Operational / Robust] |
 | Validation Method | [Atomic Red Team test ID / manual test procedure] |
 
+### Telemetry and Rule Health Matrix
+| Technique | Data Component | Sigma Logsource | Backend Target | Last Event | Parser Fields Proven | Rule Status / Last Run | Suppression Scope | Retention | Coverage Decision |
+|-----------|----------------|-----------------|----------------|------------|----------------------|------------------------|-------------------|-----------|-------------------|
+| [T1059.001] | [Command Execution] | [windows/process_creation] | [Sentinel SecurityEvent / Splunk index] | [timestamp] | [CommandLine, Image, ParentImage] | [enabled/success/failure] | [owner/expiry/effect] | [days] | [Operational/Theoretical/Not Evaluable] |
+
 ### Deployment Notes
 - **Target SIEM:** [Platform]
 - **Converted Query:** [KQL/SPL/EQL equivalent if requested]
@@ -494,6 +519,10 @@ Detection rules are not write-once artifacts. Log sources change, environments e
 
 Overly broad or incorrect ATT&CK mappings undermine coverage analysis. A rule that detects a specific PowerShell obfuscation technique should map to T1059.001 (PowerShell) and potentially T1027 (Obfuscated Files or Information), not to the parent T1059 alone. Use sub-technique IDs when the detection is specific to a sub-technique. Validate mappings against the ATT&CK technique definition and procedure examples.
 
+### Pitfall 6: Counting Rules Without Live Telemetry or Rule Health
+
+A rule in a repository is not the same as deployed detection coverage. Connector failures, parser drift, renamed fields, disabled analytics rules, short retention, or broad suppressions can make a correct Sigma rule silent in production. Require current telemetry and rule-health evidence before reporting coverage as Operational or Robust.
+
 ---
 
 ## 8. Prompt Injection Safety Notice
@@ -522,3 +551,12 @@ This skill processes user-supplied content that may include log samples, detecti
 10. **MITRE Cyber Analytics Repository (CAR)** -- https://car.mitre.org/
 11. **Detection Engineering Maturity Model** -- Kyle Bailey, https://kyle-bailey.medium.com/detection-engineering-maturity-matrix-f4f3181a5cc7
 12. **Sigma Rule Creation Guide (SigmaHQ)** -- https://sigmahq.io/docs/guide/rules.html
+13. **MITRE ATT&CK Data Components** -- https://attack.mitre.org/datacomponents/
+14. **Sigma Rules Specification** -- https://sigmahq.io/sigma-specification/specification/sigma-rules-specification.html
+15. **Microsoft Sentinel Health Tables Reference** -- https://learn.microsoft.com/en-us/azure/sentinel/health-table-reference
+
+---
+
+## Changelog
+
+- **1.0.1** -- Added telemetry readiness and deployed rule-health evidence gates, coverage output fields, parser/suppression/retention checks, and fixture-backed healthy versus broken telemetry examples.

--- a/skills/secops/detection-engineering/tests/benign/healthy-telemetry-rule-path.json
+++ b/skills/secops/detection-engineering/tests/benign/healthy-telemetry-rule-path.json
@@ -1,0 +1,71 @@
+{
+  "fixture": "healthy-telemetry-rule-path",
+  "technique": {
+    "id": "T1059.001",
+    "name": "PowerShell",
+    "data_component": "Command Execution"
+  },
+  "expected_skill_decision": {
+    "coverage_decision": "Operational",
+    "finding_state": "healthy",
+    "reason": "Telemetry, parser fields, deployed rule health, suppression scope, validation samples, and retention are all evidenced."
+  },
+  "sigma_mapping": {
+    "product": "windows",
+    "category": "process_creation",
+    "backend": "microsoft_sentinel",
+    "target_table": "SecurityEvent",
+    "converted_rule_hash": "sha256:1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff"
+  },
+  "telemetry_health": {
+    "connector": "WindowsSecurityEvents",
+    "enabled": true,
+    "last_successful_fetch": "2026-06-08T23:58:00Z",
+    "most_recent_event": "2026-06-08T23:57:35Z",
+    "last_seen_within_minutes": 5
+  },
+  "parser_mapping": {
+    "parser_version": "2026.06.08",
+    "fields_used_by_rule": {
+      "CommandLine": "ProcessCommandLine",
+      "Image": "NewProcessName",
+      "ParentImage": "ParentProcessName",
+      "User": "SubjectUserName"
+    },
+    "positive_sample_has_all_fields": true,
+    "negative_sample_has_all_fields": true
+  },
+  "rule_deployment": {
+    "rule_id": "sentinel-t1059-001-encoded-powershell",
+    "enabled": true,
+    "mode": "production",
+    "schedule": "PT5M",
+    "last_run": "2026-06-08T23:55:00Z",
+    "last_run_status": "Succeeded",
+    "alert_destination": "soc-tier1-queue"
+  },
+  "suppression_scope": {
+    "exceptions": [
+      {
+        "owner": "endpoint-platform",
+        "reason": "SCCM client maintenance scripts",
+        "expiry": "2026-07-01",
+        "affected_entities": [
+          "sccm-prod-01"
+        ],
+        "suppressed_volume_percent": 4
+      }
+    ],
+    "hides_all_matching_events": false
+  },
+  "validation_samples": {
+    "positive_replay_alerted": true,
+    "negative_replay_suppressed": true,
+    "last_validation": "2026-06-08T22:10:00Z"
+  },
+  "retention": {
+    "hot_searchable_days": 45,
+    "investigation_window_days": 30,
+    "meets_window": true
+  }
+}

--- a/skills/secops/detection-engineering/tests/vulnerable/rule-exists-broken-telemetry.json
+++ b/skills/secops/detection-engineering/tests/vulnerable/rule-exists-broken-telemetry.json
@@ -1,0 +1,71 @@
+{
+  "fixture": "rule-exists-broken-telemetry",
+  "technique": {
+    "id": "T1059.001",
+    "name": "PowerShell",
+    "data_component": "Command Execution"
+  },
+  "expected_skill_decision": {
+    "coverage_decision": "Not Evaluable",
+    "finding_state": "high_detection_gap",
+    "reason": "The Sigma rule exists, but required telemetry is stale, parser fields drifted, the deployed rule is disabled, suppressions hide all matching test events, and retention is shorter than the investigation window."
+  },
+  "sigma_mapping": {
+    "product": "windows",
+    "category": "process_creation",
+    "backend": "microsoft_sentinel",
+    "target_table": "SecurityEvent",
+    "converted_rule_hash": "sha256:aaaabbbbccccddddeeeeffff1111222233334444555566667777888899990000"
+  },
+  "telemetry_health": {
+    "connector": "WindowsSecurityEvents",
+    "enabled": true,
+    "last_successful_fetch": "2026-05-27T02:00:00Z",
+    "most_recent_event": "2026-05-27T01:58:20Z",
+    "last_seen_within_minutes": 17280
+  },
+  "parser_mapping": {
+    "parser_version": "2026.06.08",
+    "fields_used_by_rule": {
+      "CommandLine": "missing_after_parser_change",
+      "Image": "process.executable",
+      "ParentImage": "missing_after_parser_change",
+      "User": "user.name"
+    },
+    "positive_sample_has_all_fields": false,
+    "negative_sample_has_all_fields": false
+  },
+  "rule_deployment": {
+    "rule_id": "sentinel-t1059-001-encoded-powershell",
+    "enabled": false,
+    "mode": "test_only",
+    "schedule": "PT5M",
+    "last_run": "2026-06-01T12:00:00Z",
+    "last_run_status": "Failed",
+    "alert_destination": null
+  },
+  "suppression_scope": {
+    "exceptions": [
+      {
+        "owner": null,
+        "reason": "temporary noise reduction",
+        "expiry": null,
+        "affected_entities": [
+          "endpoint-management-*"
+        ],
+        "suppressed_volume_percent": 100
+      }
+    ],
+    "hides_all_matching_events": true
+  },
+  "validation_samples": {
+    "positive_replay_alerted": false,
+    "negative_replay_suppressed": true,
+    "last_validation": null
+  },
+  "retention": {
+    "hot_searchable_days": 7,
+    "investigation_window_days": 30,
+    "meets_window": false
+  }
+}


### PR DESCRIPTION
/claim #1417

## What changed

Adds fixture-backed telemetry readiness and deployed rule-health gates to `detection-engineering`.

- Adds `DET-HEALTH-01` through `DET-HEALTH-08` for ATT&CK data component/logsource mapping, collector health, parser field mapping, deployed SIEM rule status, suppression scope, validation samples, retention, and explicit coverage decision.
- Adds a Telemetry and Rule Health Matrix so coverage dashboards distinguish rule-in-repo from operational detection coverage.
- Adds classification guidance for Theoretical, Broken, and Not Evaluable coverage when telemetry, parser mappings, suppressions, or rule run health are missing.
- Adds benign/vulnerable JSON fixtures for a healthy Sentinel rule path versus a Sigma rule that exists while telemetry is stale, parser fields drifted, the deployed rule is disabled, suppressions hide all matching events, and retention is too short.

## Why this PR

Existing PR #1418 is a useful Markdown edge-case implementation. This PR is intentionally fixture-backed with rule-health export style JSON so future reviews can distinguish live operational coverage from source-control-only or broken telemetry claims.

## Validation

- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`
- JSON parse check for both added fixtures
- Markdown fence balance for `detection-engineering/SKILL.md`
- Marker checks for `version: 1.0.1`, `Telemetry Readiness and Rule Health Evidence`, `DET-HEALTH-01` through `DET-HEALTH-08`, `Telemetry and Rule Health Matrix`, `Not Evaluable`, `Parser Fields Proven`, and `Counting Rules Without Live Telemetry or Rule Health`
- Fixture marker checks for `expected_skill_decision`, `telemetry_health`, `parser_mapping`, `rule_deployment`, `suppression_scope`, `validation_samples`, `retention`, and `coverage_decision`
- Added-line ASCII scan
- Added-line sensitive/public-contact pattern scan
- Remote compare verification before PR creation

## Bounty tier

Requesting Improver Moderate ($100) if accepted. This adds structured local fixtures in addition to the telemetry readiness guidance requested by the issue.