### PR TITLE
Add segmentation validation fixtures

### DIFF
--- a/skills/network/segmentation/SKILL.md
+++ b/skills/network/segmentation/SKILL.md
@@ -13,7 +13,7 @@ phase: [design, operate]
 frameworks: [NIST-SP-800-207, CIS-Controls-v8]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -243,6 +243,23 @@ Document or verify the existence of a segmentation testing process:
 4. **Test VLAN hopping** via double-tagging from user VLANs. Expected result: traffic dropped.
 5. **Validate that segmentation controls survive failover** (HA firewall failover should not open transit paths).
 
+#### 6.1 Segmentation Validation Evidence Gate
+
+Do not accept diagrams, intended ACLs, or "application still works" tests as proof that segmentation is effective. Require explicit test evidence for both denied and allowed paths from representative source locations, including failover and exception paths.
+
+| Gate | Required evidence | Fail / Not Evaluable condition |
+|------|-------------------|--------------------------------|
+| `SEG-VAL-01` | Test matrix includes source zone, destination zone, protocol, port, expected result, and actual result. | Boundary is asserted but no test matrix exists. |
+| `SEG-VAL-02` | Test source identity is representative: host/pod/subnet, route table, security group, namespace, workload role, or user zone. | Tests run only from admin/jump networks that bypass real paths. |
+| `SEG-VAL-03` | Denied-path proof includes firewall deny logs, flow-log rejects, packet capture, service-mesh decision logs, or command output. | Only allowed paths are tested; blocked paths have no evidence reference. |
+| `SEG-VAL-04` | Allowed-path proof covers required business flows and owner approval. | Required flows are assumed from policy text with no application or flow evidence. |
+| `SEG-VAL-05` | Exceptions have owner, expiry, business reason, compensating control, review date, and removal retest plan. | Temporary migration or incident routes are ownerless, expiry-less, or permanent. |
+| `SEG-VAL-06` | Alternate paths are tested: failover firewall, transit gateway, peering, VPN, Direct Connect, service mesh bypass, and HA routes. | Steady-state path is tested but failover or bypass path is not. |
+| `SEG-VAL-07` | PCI CDE/crown-jewel boundaries have independent validation evidence and last-tested date. | Critical boundary relies on diagrams or self-attestation only. |
+| `SEG-VAL-08` | Post-change retest proves route table/security group/network-policy updates did not weaken the boundary. | Segmentation changed after approval with no retest or stale evidence. |
+
+**Classification rule:** Mark CDE or crown-jewel boundaries **High** when denied-path proof, representative source context, or independent validation is missing. Mark segmentation **Not Evaluable** when actual result, evidence reference, exception scope, or alternate-path status cannot be proven.
+
 ---
 
 ## Findings Classification
@@ -283,6 +300,11 @@ Document or verify the existence of a segmentation testing process:
 | DMZ         | App       | Firewall    | Restricted | Pass |
 | App         | Data      | SG only     | Overly permissive | F-002 |
 | User        | Data      | None        | No control | F-001 |
+
+### Segmentation Validation Evidence
+| Source Zone | Destination Zone | Protocol/Port | Test Source Context | Expected | Actual | Evidence Reference | Last Tested | Exception / Expiry | Alternate Path Tested? | Decision |
+|-------------|------------------|---------------|---------------------|----------|--------|--------------------|-------------|--------------------|------------------------|----------|
+| User | Data | TCP/5432 | subnet/sg/route-table | Deny | Deny | flow-log/reject-id | YYYY-MM-DD | None | Yes/No | Pass/Fail/Not Evaluable |
 
 ### Findings
 
@@ -345,6 +367,12 @@ Document or verify the existence of a segmentation testing process:
 
 5. **Assuming Kubernetes namespaces provide network isolation.** Namespaces are a logical organizational boundary. Without a NetworkPolicy or CNI-level enforcement (Calico, Cilium), all pods across all namespaces can communicate freely by default.
 
+6. **Testing only permitted paths.** Verifying that applications still work does not prove segmentation. A valid test must also prove unauthorized paths are denied and logged from representative source zones.
+
+7. **Letting temporary exceptions become architecture.** Emergency routes, peering links, or firewall permits created for migration or incident response need owners, expiry dates, compensating controls, and re-test evidence after removal.
+
+8. **Ignoring failover and alternate routing paths.** HA firewalls, transit gateways, service mesh bypass, VPN failover, and direct connect routes can create paths that are absent from steady-state diagrams. Include failover scenarios in validation.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -372,4 +400,5 @@ This skill processes network configurations that may contain user-supplied comme
 
 ## Changelog
 
+- **1.0.1** -- Added segmentation validation evidence gates, denied/allowed path proof, exception and failover checks, output fields, and fixture-backed examples for validated versus diagram-only segmentation.
 - **1.0.0** -- Initial release. Full coverage of NIST SP 800-207 and CIS Controls v8 Control 12 for network segmentation review.

--- a/skills/network/segmentation/tests/benign/validated-cde-boundary.json
+++ b/skills/network/segmentation/tests/benign/validated-cde-boundary.json
@@ -1,0 +1,74 @@
+{
+  "fixture": "validated-cde-boundary",
+  "expected_skill_decision": {
+    "segmentation_decision": "Pass",
+    "risk_level": "low",
+    "reason": "Denied and allowed paths were tested from representative workload and user zones, failover was validated, and no open exceptions bypass the CDE boundary."
+  },
+  "boundary": {
+    "name": "pci-cde",
+    "criticality": "cde",
+    "source_zones": [
+      "user",
+      "app",
+      "dmz"
+    ],
+    "destination_zone": "cde-data"
+  },
+  "test_matrix": [
+    {
+      "source_zone": "user",
+      "destination_zone": "cde-data",
+      "protocol": "tcp",
+      "port": 5432,
+      "test_source_context": {
+        "subnet": "10.10.12.0/24",
+        "security_group": "sg-user-standard",
+        "route_table": "rtb-user-prod",
+        "identity": "corp-user-vdi"
+      },
+      "expected": "deny",
+      "actual": "deny",
+      "evidence_reference": "vpc-flow-log-reject-20260608-001",
+      "last_tested": "2026-06-08",
+      "exception": null
+    },
+    {
+      "source_zone": "app",
+      "destination_zone": "cde-data",
+      "protocol": "tcp",
+      "port": 5432,
+      "test_source_context": {
+        "subnet": "10.20.4.0/24",
+        "security_group": "sg-payment-app",
+        "route_table": "rtb-app-prod",
+        "identity": "payment-api-service"
+      },
+      "expected": "allow",
+      "actual": "allow",
+      "evidence_reference": "flow-log-accept-payment-api-20260608",
+      "last_tested": "2026-06-08",
+      "exception": null
+    }
+  ],
+  "alternate_path_tests": [
+    {
+      "path": "firewall-ha-failover",
+      "expected": "deny unauthorized tcp/5432 from user to cde-data",
+      "actual": "deny",
+      "evidence_reference": "packet-capture-fw-failover-20260608"
+    },
+    {
+      "path": "transit-gateway-backup-route",
+      "expected": "deny unauthorized tcp/5432 from dmz to cde-data",
+      "actual": "deny",
+      "evidence_reference": "tgw-flow-log-reject-20260608"
+    }
+  ],
+  "exceptions": [],
+  "independent_validation": {
+    "validator": "security-assurance",
+    "last_validated": "2026-06-08",
+    "report_id": "SEG-CDE-2026-06"
+  }
+}

--- a/skills/network/segmentation/tests/vulnerable/diagram-only-exception-failover-gap.json
+++ b/skills/network/segmentation/tests/vulnerable/diagram-only-exception-failover-gap.json
@@ -1,0 +1,80 @@
+{
+  "fixture": "diagram-only-exception-failover-gap",
+  "expected_skill_decision": {
+    "segmentation_decision": "Not Evaluable",
+    "risk_level": "high",
+    "reason": "The CDE boundary relies on diagrams, lacks denied-path evidence from representative sources, has an ownerless migration exception, and did not test failover transit routes."
+  },
+  "boundary": {
+    "name": "pci-cde",
+    "criticality": "cde",
+    "source_zones": [
+      "user",
+      "app",
+      "dmz"
+    ],
+    "destination_zone": "cde-data"
+  },
+  "test_matrix": [
+    {
+      "source_zone": "admin",
+      "destination_zone": "cde-data",
+      "protocol": "tcp",
+      "port": 443,
+      "test_source_context": {
+        "subnet": "10.99.0.0/24",
+        "security_group": "sg-admin-jump",
+        "route_table": "rtb-admin",
+        "identity": "jump-host"
+      },
+      "expected": "allow",
+      "actual": "allow",
+      "evidence_reference": "curl-output-admin-20260608",
+      "last_tested": "2026-06-08",
+      "exception": null
+    }
+  ],
+  "missing_denied_path_tests": [
+    {
+      "source_zone": "user",
+      "destination_zone": "cde-data",
+      "protocol": "tcp",
+      "port": 5432,
+      "expected": "deny"
+    },
+    {
+      "source_zone": "dmz",
+      "destination_zone": "cde-data",
+      "protocol": "tcp",
+      "port": 3306,
+      "expected": "deny"
+    }
+  ],
+  "alternate_path_tests": [
+    {
+      "path": "transit-gateway-backup-route",
+      "expected": "deny unauthorized access during firewall failover",
+      "actual": "not_tested",
+      "evidence_reference": null
+    }
+  ],
+  "exceptions": [
+    {
+      "source_zone": "app",
+      "destination_zone": "cde-data",
+      "protocol": "tcp",
+      "port": 1433,
+      "business_reason": "migration_cutover",
+      "owner": null,
+      "expiry": null,
+      "compensating_control": null,
+      "review_date": null,
+      "removal_retest_plan": null
+    }
+  ],
+  "independent_validation": {
+    "validator": null,
+    "last_validated": null,
+    "report_id": null
+  }
+}


### PR DESCRIPTION
/claim #1349

## What changed

Adds fixture-backed segmentation validation evidence gates to `segmentation`.

- Adds `SEG-VAL-01` through `SEG-VAL-08` for test matrix completeness, representative source context, denied-path proof, allowed-path proof, exception governance, alternate/failover path testing, CDE/crown-jewel independent validation, and post-change retesting.
- Adds a Segmentation Validation Evidence table with source/destination zone, protocol/port, test source context, expected/actual result, evidence reference, exception expiry, alternate-path status, and decision.
- Adds classification guidance so CDE/crown-jewel boundaries become High or Not Evaluable when denied-path proof, representative source context, exception scope, or alternate-path testing is missing.
- Adds benign/vulnerable JSON fixtures for a fully validated CDE boundary versus diagram-only segmentation with admin-only testing, missing denied-path evidence, ownerless migration exception, and untested transit-gateway failover route.

## Why this PR

Existing PR #1350 is a useful Markdown edge-case implementation. This PR is intentionally fixture-backed with structured validation matrices so future reviews can distinguish proven segmentation from diagram-only or steady-state-only claims.

## Validation

- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`
- JSON parse check for both added fixtures
- Markdown fence balance for `segmentation/SKILL.md`
- Marker checks for `version: 1.0.1`, `Segmentation Validation Evidence Gate`, `SEG-VAL-01` through `SEG-VAL-08`, `Segmentation Validation Evidence`, and `Alternate Path Tested`
- Fixture marker checks for `expected_skill_decision`, `test_matrix`, `alternate_path_tests`, `exceptions`, `independent_validation`, `segmentation_decision`, and `risk_level`
- Added-line ASCII scan
- Added-line sensitive/public-contact pattern scan
- Remote compare verification before PR creation

## Bounty tier

Requesting Improver Moderate ($100) if accepted. This adds structured local fixtures in addition to the validation/exception evidence guidance requested by the issue.