### PR TITLE
Add AWS organization coverage fixtures

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-AWS-v3.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -99,6 +99,25 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
+### Step 6A: AWS Organizations Coverage Evidence
+
+Before describing results as organization-wide, collect evidence that the review covered the AWS Organization and not only a single account export. If the evidence is unavailable, keep the status for organization-wide claims as **Not Evaluable**.
+
+| Gate | Evidence Required | Fail / Not Evaluable When |
+|------|-------------------|---------------------------|
+| `AWS-ORG-COV-01` Account inventory | Management account, account IDs, OU path, account status, environment, owner, and delegated-admin role for every in-scope account | Only one account export is provided, suspended accounts are omitted, or production OUs lack owners |
+| `AWS-ORG-COV-02` OU and SCP attachment map | SCP names, policy IDs, attachment targets, affected OUs/accounts, exception paths, and last effectiveness test | SCPs exist but are unattached, attached to the wrong OU, or untested against representative accounts |
+| `AWS-ORG-COV-03` Organization CloudTrail | Organization trail flag, all regions, opt-in regions, management events, log validation, KMS key, log bucket account, and covered accounts | Trail is account-local, opt-in regions are missing, management events are disabled, or log validation/KMS evidence is absent |
+| `AWS-ORG-COV-04` AWS Config aggregator | Aggregator account, all-account authorization, covered accounts, covered regions, global resource recording, and stale-account handling | Aggregator misses production accounts, opt-in regions, or global resources |
+| `AWS-ORG-COV-05` Delegated security services | Delegated admin, account list, region list, and last verified date for Security Hub, GuardDuty, IAM Access Analyzer, Macie, and Inspector | A service is enabled only in the audit account or has inconsistent delegated-admin scope |
+| `AWS-ORG-COV-06` Control Tower / landing zone drift | Enrolled account list, enabled controls, disabled controls, drift status, excluded OUs, and last drift check | Control Tower is assumed to cover unenrolled or drifted accounts |
+| `AWS-ORG-COV-07` Exception and break-glass accounts | Account ID, OU, owner, reason, approval, expiry/review date, monitoring coverage, and compensating controls | Break-glass, sandbox, acquisition, or excluded accounts bypass guardrails without expiry and monitoring |
+| `AWS-ORG-COV-08` Organization claim decision | Scope label: Single Account, OU-scoped, Organization-wide, or Not Evaluable, with evidence date and reviewer confidence | Report claims organization-wide coverage while any required organization evidence gate is missing |
+
+When the review input lacks live AWS exports, require structured evidence files or screenshots from approved commands such as `organizations list-accounts`, `list-policies-for-target`, `cloudtrail describe-trails`, `configservice describe-configuration-aggregators`, and the delegated admin APIs for each security service. Do not infer coverage from Terraform module names alone.
+
+---
+
 ### Step 7: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
@@ -115,6 +134,12 @@ Produce the final report using the structure defined in the Output Format sectio
 | **Low** | Hardening recommendation or defense-in-depth measure | Missing Macie classification, no hardware MFA on root (when virtual MFA exists), missing access analyzer in non-primary regions |
 | **Informational** | Best practice observation, no direct security impact | Naming conventions, tag hygiene, documentation gaps |
 
+**Organization coverage classification:**
+
+- **High:** Organization-wide claim is made while organization CloudTrail, Config aggregator, SCP attachment, delegated security services, or exception-account evidence is incomplete for production accounts.
+- **Medium:** Coverage is OU-scoped or service-specific, but the report labels limitations clearly and identifies missing accounts/regions.
+- **Low:** All organization evidence gates pass, but review cadence or stale suspended-account handling needs improvement.
+
 ---
 
 ## Output Format
@@ -127,6 +152,8 @@ Produce the final report using the structure defined in the Output Format sectio
 - Date: <assessment date>
 - Framework: CIS Amazon Web Services Foundations Benchmark v3.0.0
 - Files reviewed: <list of IaC files>
+- Scope decision: <Single Account / OU-scoped / Organization-wide / Not Evaluable>
+- Organization evidence date: <YYYY-MM-DD or Not Provided>
 
 ### Executive Summary
 - Total CIS recommendations evaluated: <N>/62
@@ -145,6 +172,18 @@ Produce the final report using the structure defined in the Output Format sectio
 | 3 | Logging | X/11 | Y | Z | nn% |
 | 4 | Monitoring | X/16 | Y | Z | nn% |
 | 5 | Networking | X/6 | Y | Z | nn% |
+
+### Organization Coverage Evidence
+
+| Evidence Area | Status | Covered Accounts / Regions | Owner | Last Verified | Limitations |
+|---------------|--------|----------------------------|-------|---------------|-------------|
+| Account Inventory | Pass / Fail / Not Evaluable | <count and OU scope> | <team> | <date> | <gaps> |
+| SCP Attachments | Pass / Fail / Not Evaluable | <targets> | <team> | <date> | <gaps> |
+| Organization CloudTrail | Pass / Fail / Not Evaluable | <accounts/regions> | <team> | <date> | <gaps> |
+| AWS Config Aggregator | Pass / Fail / Not Evaluable | <accounts/regions> | <team> | <date> | <gaps> |
+| Delegated Security Services | Pass / Fail / Not Evaluable | <service/account/region matrix> | <team> | <date> | <gaps> |
+| Control Tower / Landing Zone Drift | Pass / Fail / Not Evaluable | <enrolled accounts/OUs> | <team> | <date> | <gaps> |
+| Exception / Break-glass Accounts | Pass / Fail / Not Evaluable | <accounts> | <team> | <date> | <gaps> |
 
 ### Detailed Findings
 
@@ -200,6 +239,8 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
 5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
 6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
+7. **Treating one account as the organization.** A hardened audit or workload account does not prove organization governance. Require account inventory, OU scope, SCP attachment, organization CloudTrail, Config aggregator, delegated security service, and exception-account evidence before claiming organization-wide coverage.
+8. **Assuming delegated admin means full coverage.** Security Hub, GuardDuty, Access Analyzer, Macie, and Inspector can have different delegated administrators, regions, and member-account enrollment. Verify each service independently.
 
 ---
 
@@ -231,4 +272,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Added AWS Organizations coverage evidence gates, organization scope decision output, delegated security service coverage checks, and exception-account evidence requirements.
 - **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 (62 recommendations).

--- a/skills/cloud/aws-review/tests/benign/organization-wide-coverage-evidence.json
+++ b/skills/cloud/aws-review/tests/benign/organization-wide-coverage-evidence.json
@@ -1,0 +1,68 @@
+{
+  "fixture": "organization-wide-coverage-evidence",
+  "expected_skill_decision": {
+    "decision": "Organization-wide",
+    "risk_level": "low",
+    "reason": "All production accounts, regions, organization trails, Config aggregator scope, delegated security services, and exception accounts have fresh evidence."
+  },
+  "organization_evidence": {
+    "evidence_date": "2026-06-08",
+    "management_account": "111111111111",
+    "log_archive_account": "222222222222",
+    "security_tooling_account": "333333333333",
+    "scope_decision": "Organization-wide",
+    "reviewer_confidence": "high"
+  },
+  "account_inventory": [
+    {
+      "account_id": "444444444444",
+      "ou_path": "/Root/Production/Payments",
+      "status": "ACTIVE",
+      "environment": "production",
+      "owner": "payments-platform"
+    },
+    {
+      "account_id": "555555555555",
+      "ou_path": "/Root/Production/Identity",
+      "status": "ACTIVE",
+      "environment": "production",
+      "owner": "identity-platform"
+    }
+  ],
+  "scp_attachment_map": {
+    "policies": [
+      {
+        "policy_id": "p-deny-root-user",
+        "attached_to": "/Root/Production",
+        "last_effectiveness_test": "2026-06-07",
+        "exceptions": []
+      }
+    ]
+  },
+  "organization_trail": {
+    "is_organization_trail": true,
+    "multi_region": true,
+    "management_events": "all",
+    "opt_in_regions_included": true,
+    "log_file_validation": true,
+    "kms_encrypted": true,
+    "covered_accounts": [
+      "444444444444",
+      "555555555555"
+    ]
+  },
+  "config_aggregator": {
+    "all_accounts": true,
+    "all_regions": true,
+    "global_resources_recorded": true,
+    "stale_accounts": []
+  },
+  "delegated_admin_services": {
+    "security_hub": "all_accounts_all_regions",
+    "guardduty": "all_accounts_all_regions",
+    "access_analyzer": "all_accounts_all_regions",
+    "macie": "production_accounts_all_regions",
+    "inspector": "all_accounts_all_regions"
+  },
+  "exception_register": []
+}

--- a/skills/cloud/aws-review/tests/vulnerable/single-account-claimed-organization.json
+++ b/skills/cloud/aws-review/tests/vulnerable/single-account-claimed-organization.json
@@ -1,0 +1,72 @@
+{
+  "fixture": "single-account-claimed-organization",
+  "expected_skill_decision": {
+    "decision": "Not Evaluable",
+    "risk_level": "high",
+    "reason": "The report claims organization-wide governance from a single account export while SCP, CloudTrail, Config, delegated admin, and exception-account evidence is missing."
+  },
+  "organization_evidence": {
+    "evidence_date": "2026-06-08",
+    "management_account": null,
+    "log_archive_account": null,
+    "security_tooling_account": null,
+    "scope_decision": "Not Evaluable",
+    "reviewer_confidence": "low"
+  },
+  "account_inventory": [
+    {
+      "account_id": "444444444444",
+      "ou_path": null,
+      "status": "ACTIVE",
+      "environment": "production",
+      "owner": null
+    }
+  ],
+  "scp_attachment_map": {
+    "policies": [
+      {
+        "policy_id": "p-deny-root-user",
+        "attached_to": null,
+        "last_effectiveness_test": null,
+        "exceptions": [
+          "break-glass-account-untracked"
+        ]
+      }
+    ]
+  },
+  "organization_trail": {
+    "is_organization_trail": false,
+    "multi_region": true,
+    "management_events": "read_only",
+    "opt_in_regions_included": false,
+    "log_file_validation": false,
+    "kms_encrypted": false,
+    "covered_accounts": [
+      "444444444444"
+    ]
+  },
+  "config_aggregator": {
+    "all_accounts": false,
+    "all_regions": false,
+    "global_resources_recorded": false,
+    "stale_accounts": [
+      "555555555555"
+    ]
+  },
+  "delegated_admin_services": {
+    "security_hub": "audit_account_only",
+    "guardduty": "not_provided",
+    "access_analyzer": "home_region_only",
+    "macie": "not_enabled",
+    "inspector": "not_provided"
+  },
+  "exception_register": [
+    {
+      "account_id": "999999999999",
+      "reason": "break-glass",
+      "owner": null,
+      "expiry": null,
+      "monitoring": null
+    }
+  ]
+}


### PR DESCRIPTION
/claim #1358

## What changed

Adds fixture-backed AWS Organizations coverage evidence gates to `aws-review`.

- Adds `AWS-ORG-COV-01` through `AWS-ORG-COV-08` for account inventory, OU/SCP attachments, organization CloudTrail, Config aggregator, delegated security services, Control Tower / landing-zone drift, exception / break-glass accounts, and explicit organization-scope decisions.
- Adds organization coverage severity guidance and an Organization Coverage Evidence output table.
- Adds common pitfalls for treating one account as the organization and assuming delegated admin means full coverage.
- Adds benign/vulnerable JSON fixtures for fresh organization-wide evidence versus a single account export incorrectly claimed as organization coverage.

## Why this PR

Existing PR #1360 is a useful Markdown edge-case implementation. This PR is intentionally structured-evidence-fixture-backed so future checks can distinguish organization-wide evidence from single-account or partial delegated-admin exports.

## Validation

- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`
- JSON parse check for both added fixtures
- Markdown fence balance for `aws-review/SKILL.md`
- Marker checks for `version: "1.0.1"`, `AWS Organizations Coverage Evidence`, `AWS-ORG-COV-01` through `AWS-ORG-COV-08`, `Organization Coverage Evidence`, `Scope decision`, `Treating one account as the organization`, and `Assuming delegated admin means full coverage`
- Fixture marker checks for `expected_skill_decision`, `organization_evidence`, `account_inventory`, `scp_attachment_map`, `organization_trail`, `config_aggregator`, `delegated_admin_services`, and `exception_register`
- Added-line ASCII scan
- Added-line sensitive/public-contact pattern scan
- Remote compare verification before PR creation

## Bounty tier

Requesting Improver Moderate ($100) if accepted. This adds structured local fixtures in addition to the organization-wide guardrail evidence guidance requested by the issue.