### PR TITLE
Add firewall lifecycle evidence fixtures

### DIFF
--- a/skills/network/firewall-review/SKILL.md
+++ b/skills/network/firewall-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [operate]
 frameworks: [CIS-Controls-v8, NIST-SP-800-41-Rev1]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -194,6 +194,25 @@ Rules with zero hit counts over an extended period (30+ days) indicate stale pol
 
 ---
 
+#### 2.4A Rule Lifecycle and Drift Evidence
+
+Before accepting a broad rule, removing a zero-hit rule, or closing a temporary-rule finding, require rule lifecycle evidence. A packet-match review is not enough to prove that a rule is authorized, time-bound, reversible, and still tied to a valid business need.
+
+| Gate | Evidence Required | Fail / Not Evaluable When |
+|------|-------------------|---------------------------|
+| `FW-LIFECYCLE-EVID-01` Owner and purpose | Rule owner, business purpose, affected application, source/destination asset owner, and implementation date | Rule has only a vague description such as "temporary", "project", "migration", or "emergency" |
+| `FW-LIFECYCLE-EVID-02` Change approval | Ticket, approver, emergency/change type, approval date, and post-implementation reviewer | Emergency or console-created rules bypass change control without later review |
+| `FW-LIFECYCLE-EVID-03` Expiry / review | Expiry date for temporary access or next-review date for accepted risk | Temporary or accepted-risk rules have no expiry, stale review date, or permanent exception |
+| `FW-LIFECYCLE-EVID-04` Risk acceptance | Risk owner, affected assets, compensating control, approved duration, and residual risk | Broad or any/any rules are accepted without accountable risk ownership |
+| `FW-LIFECYCLE-EVID-05` Dependency validation | Hit-counter baseline timestamp, flow-log window, asset-owner confirmation, and dependency inventory | Zero-hit cleanup relies only on a current counter after recent reset/failover/rebuild |
+| `FW-LIFECYCLE-EVID-06` Rollback and validation | Rollback owner, rollback steps, staged disable, test window, and post-change validation | Removal has no rollback plan or production validation evidence |
+| `FW-LIFECYCLE-EVID-07` Logging validation | Evidence that permit/deny logging reaches the expected SIEM after deployment | Logging is configured in policy but no recent log sample proves ingestion |
+| `FW-LIFECYCLE-EVID-08` IaC / deployed drift | Source-of-truth rule ID, deployed rule ID, last drift comparison, and console/manual overrides | Cloud security group, NACL, or firewall policy differs from Terraform/CloudFormation without exception |
+
+Classify lifecycle decisions as **Approved**, **Expired**, **Unsafe to remove**, **Drifted**, or **Not Evaluable**. Do not recommend removal or acceptance when required lifecycle evidence is missing.
+
+---
+
 #### 2.5 Rule Ordering Review (NIST SP 800-41, Section 4.3)
 
 Firewall rules are evaluated top-to-bottom (first match wins in most platforms). Incorrect ordering can lead to security bypasses.
@@ -269,6 +288,12 @@ Produce the final report using the following structure.
 | **Medium** | Shadowed permit rules; missing egress DNS restriction; unused rules (active resources); missing logging on sensitive permits; missing stealth rules. |
 | **Low** | Rule documentation gaps; suboptimal rule ordering with no current security impact; cosmetic rule base issues. |
 
+**Lifecycle-specific classification:**
+
+- **High:** Expired emergency/break-glass rule remains active, console drift exposes production, or zero-hit removal lacks dependency validation for critical services.
+- **Medium:** Rule has owner and purpose but lacks expiry, risk review, logging validation, or IaC drift evidence.
+- **Low:** Lifecycle evidence is complete but review cadence, naming, or ticket linkage needs cleanup.
+
 ---
 
 ## Output Format
@@ -317,6 +342,11 @@ Produce the final report using the following structure.
 | SMTP (25)     | Yes/No    | <mail server IPs>      |
 | HTTPS (443)   | Yes/No    | <proxy or direct>      |
 
+### Rule Lifecycle Evidence
+| Rule ID | Lifecycle Decision | Owner / Ticket | Expiry / Review | Hit Baseline / Flow Logs | Rollback Owner | Logging Validated | Drift Status |
+|---------|--------------------|----------------|-----------------|--------------------------|----------------|-------------------|--------------|
+| <rule-id> | Approved / Expired / Unsafe to remove / Drifted / Not Evaluable | <owner, ticket> | <date> | <baseline + flow window> | <team> | Yes/No | In sync / Drifted |
+
 ### Prioritized Remediation Plan
 1. **[Critical]** <action item with control reference>
 2. **[High]** <action item with control reference>
@@ -361,6 +391,10 @@ Produce the final report using the following structure.
 
 5. **Conflating network ACLs with security groups in cloud environments.** In AWS, NACLs are stateless and operate at the subnet level; security groups are stateful and operate at the instance level. Both must be audited. A permissive NACL can undermine restrictive security group rules for responses.
 
+6. **Accepting broad temporary access without lifecycle evidence.** Temporary incident, migration, and emergency rules must have owner, ticket, approval, expiry, rollback, and monitoring evidence. Otherwise they become permanent exposure.
+
+7. **Trusting IaC while deployed policy drifted.** A clean Terraform security group does not prove the deployed cloud rule base is clean. Compare source-of-truth policy to deployed state and flag console-originated overrides.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -386,4 +420,5 @@ This skill processes firewall configurations that may contain user-supplied comm
 
 ## Changelog
 
+- **1.0.1** -- Added rule lifecycle and drift evidence gates, lifecycle decision output, zero-hit dependency validation, rollback evidence, and logging validation requirements.
 - **1.0.0** -- Initial release. Full coverage of CIS Controls v8 (4.4, 4.5) and NIST SP 800-41 Rev 1 firewall audit methodology.

--- a/skills/network/firewall-review/tests/benign/validated-rule-retirement.json
+++ b/skills/network/firewall-review/tests/benign/validated-rule-retirement.json
@@ -1,0 +1,55 @@
+{
+  "fixture": "validated-rule-retirement",
+  "expected_skill_decision": {
+    "decision": "Approved",
+    "risk_level": "low",
+    "reason": "Rule retirement is owner-approved, backed by pre-reset counters, flow logs, staged rollback, logging validation, and IaC/deployed-state parity."
+  },
+  "firewall_rule": {
+    "rule_id": "aws-sg-prod-api-443-from-partner",
+    "platform": "aws_security_group",
+    "direction": "ingress",
+    "source": "203.0.113.0/24",
+    "destination": "prod-api",
+    "port": 443,
+    "action": "allow"
+  },
+  "lifecycle_evidence": {
+    "owner": "api-platform",
+    "business_purpose": "legacy partner API migration",
+    "change_ticket": "FW-CHANGE-2026-0142",
+    "approver": "network-security-review",
+    "implementation_date": "2025-10-15",
+    "expiry": "2026-06-15",
+    "risk_owner": "api-platform",
+    "compensating_controls": [
+      "waf-allowlist",
+      "mutual-tls"
+    ],
+    "hit_counter_baseline": {
+      "baseline_timestamp": "2026-03-01T00:00:00Z",
+      "last_hit": "2026-03-04T10:12:30Z",
+      "counter_reset_after_baseline": false
+    },
+    "flow_log_validation": {
+      "window_days": 90,
+      "matching_flows": 0,
+      "asset_owner_confirmed": true
+    },
+    "rollback": {
+      "owner": "network-oncall",
+      "staged_disable": true,
+      "validation_test": "synthetic partner health check",
+      "rollback_minutes": 15
+    },
+    "logging_validation": {
+      "siem_sample_seen": true,
+      "last_log_sample": "2026-06-08T16:00:00Z"
+    },
+    "drift_status": {
+      "source_of_truth": "terraform",
+      "deployed_matches_iac": true,
+      "last_compared": "2026-06-08"
+    }
+  }
+}

--- a/skills/network/firewall-review/tests/vulnerable/expired-emergency-console-drift.json
+++ b/skills/network/firewall-review/tests/vulnerable/expired-emergency-console-drift.json
@@ -1,0 +1,53 @@
+{
+  "fixture": "expired-emergency-console-drift",
+  "expected_skill_decision": {
+    "decision": "Expired",
+    "risk_level": "high",
+    "reason": "Emergency broad access remains active after expiry, has no rollback or owner review, zero-hit cleanup lacks a pre-reset baseline, and deployed cloud policy drifted from IaC."
+  },
+  "firewall_rule": {
+    "rule_id": "sg-console-emergency-ssh-anywhere",
+    "platform": "aws_security_group",
+    "direction": "ingress",
+    "source": "0.0.0.0/0",
+    "destination": "prod-admin-bastion",
+    "port": 22,
+    "action": "allow"
+  },
+  "lifecycle_evidence": {
+    "owner": null,
+    "business_purpose": "emergency access",
+    "change_ticket": null,
+    "approver": null,
+    "implementation_date": "2026-02-01",
+    "expiry": "2026-02-03",
+    "risk_owner": null,
+    "compensating_controls": [],
+    "hit_counter_baseline": {
+      "baseline_timestamp": null,
+      "last_hit": null,
+      "counter_reset_after_baseline": true
+    },
+    "flow_log_validation": {
+      "window_days": 7,
+      "matching_flows": 0,
+      "asset_owner_confirmed": false
+    },
+    "rollback": {
+      "owner": null,
+      "staged_disable": false,
+      "validation_test": null,
+      "rollback_minutes": null
+    },
+    "logging_validation": {
+      "siem_sample_seen": false,
+      "last_log_sample": null
+    },
+    "drift_status": {
+      "source_of_truth": "terraform",
+      "deployed_matches_iac": false,
+      "console_override": true,
+      "last_compared": "2026-06-08"
+    }
+  }
+}


### PR DESCRIPTION
/claim #1343

## What changed

Adds fixture-backed firewall rule lifecycle and drift evidence gates to `firewall-review`.

- Adds `FW-LIFECYCLE-EVID-01` through `FW-LIFECYCLE-EVID-08` for owner/purpose, change approval, expiry/review, risk acceptance, dependency validation, rollback/validation, logging validation, and IaC/deployed drift.
- Adds lifecycle-specific severity guidance and a Rule Lifecycle Evidence output table.
- Adds common pitfalls for accepting broad temporary access without lifecycle evidence and trusting IaC while deployed policy drifted.
- Adds benign/vulnerable JSON fixtures for validated rule retirement versus expired emergency SSH access with console drift and no rollback evidence.

## Why this PR

Existing PR #1344 is a useful Markdown edge-case implementation. This PR is intentionally structured-fixture-backed so future checks can distinguish safe rule retirement from expired emergency rules, recent counter resets, and deployed-state drift.

## Validation

- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`
- JSON parse check for both added fixtures
- Markdown fence balance for `firewall-review/SKILL.md`
- Marker checks for `version: "1.0.1"`, `Rule Lifecycle and Drift Evidence`, `FW-LIFECYCLE-EVID-01` through `FW-LIFECYCLE-EVID-08`, `Rule Lifecycle Evidence`, `Accepting broad temporary access without lifecycle evidence`, and `Trusting IaC while deployed policy drifted`
- Fixture marker checks for `expected_skill_decision`, `firewall_rule`, `lifecycle_evidence`, `hit_counter_baseline`, `flow_log_validation`, `rollback`, `logging_validation`, and `drift_status`
- Added-line ASCII scan
- Added-line sensitive/public-contact pattern scan
- Remote compare verification before PR creation

## Bounty tier

Requesting Improver Moderate ($100) if accepted. This adds structured local fixtures in addition to the rule lifecycle and drift evidence guidance requested by the issue.