### PR TITLE
Add forensics encryption feasibility fixtures

### DIFF
--- a/skills/incident-response/forensics-checklist/SKILL.md
+++ b/skills/incident-response/forensics-checklist/SKILL.md
@@ -13,7 +13,7 @@ phase: [respond]
 frameworks: [NIST-SP-800-86, RFC-3227]
 difficulty: advanced
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -62,6 +62,9 @@ Before beginning evidence collection, gather or confirm:
 - [ ] **Cloud provider access** -- IAM permissions for snapshot creation, log export, and API access (if cloud environment).
 - [ ] **Time synchronization** -- NTP configuration of affected systems; UTC timestamps preferred.
 - [ ] **Encryption status** -- BitLocker, LUKS, FileVault, or cloud-managed encryption on affected volumes.
+- [ ] **Recovery-key escrow evidence** -- Key ID, escrow location, accessor role, and custody path for BitLocker, FileVault, LUKS, or equivalent full-volume encryption.
+- [ ] **Cloud decrypt authority** -- KMS key ID/version, grant or key-policy evidence, and forensic account permission to decrypt, copy, or export encrypted snapshots.
+- [ ] **Live-session fallback** -- Whether the system is still powered on and whether volatile capture or live logical collection is required before shutdown because offline unlock is not proven.
 
 ---
 
@@ -221,6 +224,33 @@ ls -latr /tmp /var/tmp /dev/shm
 
 Create a forensically sound disk image -- a bit-for-bit copy that preserves all data including deleted files, slack space, and unallocated areas.
 
+#### 4a: Encryption Feasibility Gate
+
+Before scheduling powered-off disk imaging or accepting a cloud snapshot as disk evidence, prove that encrypted media can actually be unlocked, decrypted, copied, or examined. Treat encryption as a go/no-go acquisition constraint, not as passive metadata.
+
+If unlock/decrypt evidence is missing, do not shut down or detach a powered-on system merely to follow the disk-imaging step. Preserve volatile data first, document the blocker, and switch to a live logical acquisition or provider-approved export path when that is the only feasible collection route.
+
+**FVE escrow and decrypt evidence requirements:**
+
+| Gate | Evidence Required | Decision Rule |
+|---|---|---|
+| `FVE-ESCROW-01` | Protector inventory for each target volume or snapshot: BitLocker, FileVault, LUKS, TPM-only, PIN, recovery password, network unlock, or cloud-managed key. | If protector type is unknown, mark disk acquisition **Not Evaluable**. |
+| `FVE-ESCROW-02` | Recovery key escrow location and accessor role independent of the compromised user session. | User-only notes, personal cloud backups, or disabled user accounts do not satisfy escrow. |
+| `FVE-ESCROW-03` | Key ID, version, or recovery-password identifier bound to the evidence source, device ID, volume ID, snapshot ID, or KMS key. | A generic "key available" statement is not enough. |
+| `FVE-ESCROW-04` | Test unlock/decrypt evidence, provider dry-run, or successful read-only mount under forensic custody. | Without test proof, powered-off full-disk imaging remains blocked. |
+| `FVE-ESCROW-05` | Powered-on fallback plan when offline unlock is not proven: memory capture, volatile state, hibernation/pagefile handling, and live logical collection scope. | Do not power off until the fallback evidence is preserved or explicitly waived by legal/IR leadership. |
+| `FVE-ESCROW-06` | Cloud snapshot decrypt/copy authority: KMS key policy, grant, service account role, encryption context, and copied-snapshot or export proof. | Snapshot creation alone is not disk acquisition if the forensic role cannot decrypt or copy it. |
+| `FVE-ESCROW-07` | Partial-encryption map identifying readable, encrypted, recovery, data, and attached volumes. | Do not claim full acquisition when only unencrypted partitions are readable. |
+| `FVE-ESCROW-08` | Legal-hold binding for escrow records: timestamp, custodian, key version, rotation status, and chain-of-custody reference. | If keys rotate or custody cannot be tied to collection time, record an evidence gap. |
+
+**Platform-specific branches:**
+
+- **BitLocker TPM-only or TPM+PIN:** If no recovery password is escrowed, keep the system powered on when authorized, capture memory and volatile state, then perform live logical collection or memory-assisted triage before shutdown.
+- **FileVault:** Require institutional escrow or documented SecureToken/recovery-key access. If only a user's iCloud recovery path exists and the account is disabled or unavailable, mark powered-off imaging blocked.
+- **LUKS / clevis / Tang:** Verify key slots, escrowed passphrase or keyfile, and network-unlock reachability. Containment that blocks Tang can make powered-off imaging infeasible.
+- **Cloud-managed encryption:** Require decrypt/copy/export evidence for AWS KMS, Azure Disk Encryption / Key Vault, or GCP CMEK before marking snapshots complete.
+- **Partial volume encryption:** Map every partition and attached disk. Preserve readable segments, but report encrypted segments separately with unlock status.
+
 **Forensic imaging principles:**
 - Always write to a SEPARATE destination drive -- never write to the evidence drive
 - Use write blockers (hardware or software) when connecting evidence drives
@@ -338,6 +368,7 @@ gcloud logging read 'timestamp>="YYYY-MM-DDT00:00:00Z" AND timestamp<="YYYY-MM-D
 - Cloud provider logs are the primary evidence source; without pre-enabled logging, critical evidence may not exist
 - Multi-region deployments require evidence collection across all regions
 - Serverless environments (Lambda, Cloud Functions) produce only invocation logs -- there is no disk to image
+- Encrypted snapshots require decrypt, copy, or export authority in the forensic account. Record the KMS key, grant/key-policy proof, and copied-snapshot or export hash before marking disk evidence complete.
 
 ---
 
@@ -351,6 +382,15 @@ gcloud logging read 'timestamp>="YYYY-MM-DDT00:00:00Z" AND timestamp<="YYYY-MM-D
 | P3 | Low | Supplementary evidence that may support investigation but is not primary. | Log preservation. Disk imaging if convenient. |
 | P4 | Informational | Contextual information (network topology, configuration baselines) supporting analysis. | Document and preserve digitally. |
 
+**Encryption feasibility severity calibration:**
+
+| Condition | Minimum Severity | Required Response |
+|---|---|---|
+| Powered-on encrypted endpoint has no proven offline recovery key and disk evidence is required. | P1 High | Preserve memory and live-session evidence before any shutdown, and document full-disk imaging as blocked until escrow is proven. |
+| Cloud snapshot exists but forensic account cannot decrypt, copy, or export it. | P1 High | Escalate KMS/grant access or collect alternate logs/config evidence; do not mark snapshot evidence complete. |
+| Recovery key source is controlled only by a compromised or disabled user account. | P2 Medium | Record custody gap and require independent escrow, legal process, or live logical collection. |
+| Partial encryption map shows uncollected encrypted data partitions. | P2 Medium | Separate readable evidence from blocked encrypted segments and document the acquisition limitation. |
+
 ---
 
 ## 5. Output Format
@@ -360,7 +400,7 @@ Produce the evidence collection report with these exact sections:
 ```markdown
 ## Forensic Evidence Collection Report: [Incident ID]
 **Date:** [YYYY-MM-DD]
-**Skill:** forensics-checklist v1.0.0
+**Skill:** forensics-checklist v1.0.1
 **Frameworks:** NIST SP 800-86, RFC 3227
 **Examiner:** [Name or "AI-assisted -- human examiner required for court-admissible evidence"]
 
@@ -396,6 +436,11 @@ the order of collection, and any evidence that could not be obtained.]
 
 ### Evidence Gaps
 [List any evidence that could not be collected and the reason]
+
+### Encryption Feasibility Gate
+| Evidence Source | Encryption / Protector | Escrow Source | Test Unlock / Decrypt | Acquisition Decision | Notes |
+|---|---|---|---|---|---|
+| [Host / volume / snapshot] | [BitLocker/FileVault/LUKS/KMS] | [Escrow system / role] | [Pass/Fail/Not tested] | [Proceed / Live fallback / Not Evaluable] | [Key ID, KMS grant, custody note] |
 
 ### Cloud Evidence (if applicable)
 | Cloud Provider | Resource | Evidence Type | Collected | Notes |
@@ -461,6 +506,10 @@ Applying traditional forensic methods to cloud environments without adaptation l
 
 Every action on a live system modifies it -- writing memory dump files to the evidence drive changes timestamps and consumes disk space, running commands updates shell history and modifies access times. Minimize evidence contamination by writing collection output to external media (USB, network share, S3 bucket), documenting every command executed on the system, and noting the expected impact of each collection action on the evidence state.
 
+### Pitfall 6: Treating Encryption Status as Imaging Feasibility
+
+Documenting "BitLocker enabled" or "snapshot encrypted" does not prove the evidence can be acquired. If recovery keys are missing, escrow depends on the compromised user, cloud KMS grants exclude the forensic role, or network unlock is broken by containment, the planned disk image may be impossible after shutdown. Prove escrow and decrypt authority before changing power state, detaching disks, or reporting disk evidence as complete.
+
 ---
 
 ## 8. Prompt Injection Safety Notice
@@ -487,3 +536,8 @@ This skill processes forensic artifacts, log files, memory dumps, and system con
 8. **ACSC Digital Forensics Guide** -- https://www.cyber.gov.au/resources-business-and-government/essential-cyber-security/publications/digital-forensics
 9. **SWGDE Best Practices for Computer Forensics** -- https://www.swgde.org/documents
 10. **AWS Security Incident Response Guide** -- https://docs.aws.amazon.com/whitepapers/latest/aws-security-incident-response-guide/
+11. **Microsoft BitLocker recovery guide** -- https://learn.microsoft.com/windows/security/operating-system-security/data-protection/bitlocker/recovery-overview
+12. **Apple FileVault deployment reference** -- https://support.apple.com/guide/deployment/use-filevault-to-encrypt-mac-computers-dep82064ec40/web
+13. **cryptsetup FAQ** -- https://gitlab.com/cryptsetup/cryptsetup/-/wikis/FrequentlyAskedQuestions
+14. **AWS KMS grants** -- https://docs.aws.amazon.com/kms/latest/developerguide/grants.html
+15. **Google Cloud CMEK guide** -- https://cloud.google.com/kms/docs/cmek

--- a/skills/incident-response/forensics-checklist/tests/benign/fve-escrow-cloud-decrypt-ready.json
+++ b/skills/incident-response/forensics-checklist/tests/benign/fve-escrow-cloud-decrypt-ready.json
@@ -1,0 +1,93 @@
+{
+  "case_id": "IR-2026-0610",
+  "expected_skill_decision": "disk_acquisition_feasible",
+  "incident_context": {
+    "severity": "P1",
+    "legal_hold": "issued",
+    "examiner": "forensics-team",
+    "collection_window_utc": "2026-06-10T03:00:00Z/2026-06-10T07:00:00Z"
+  },
+  "targets": [
+    {
+      "source_id": "LAPTOP-HR-119",
+      "platform": "Windows 11",
+      "state": "powered_on",
+      "volume_id": "bitlocker-volume-c",
+      "protector_inventory": {
+        "encryption": "BitLocker",
+        "protectors": [
+          {
+            "type": "TPM",
+            "protector_id": "TPM-22"
+          },
+          {
+            "type": "RecoveryPassword",
+            "protector_id": "RP-8842"
+          }
+        ],
+        "partial_encryption_map": "C: encrypted, recovery partition readable, external USB evidence drive not encrypted"
+      },
+      "fve_escrow_evidence": {
+        "gate_ids": [
+          "FVE-ESCROW-01",
+          "FVE-ESCROW-02",
+          "FVE-ESCROW-03",
+          "FVE-ESCROW-04",
+          "FVE-ESCROW-05",
+          "FVE-ESCROW-07",
+          "FVE-ESCROW-08"
+        ],
+        "escrow_location": "Intune device recovery-key record",
+        "accessor_role": "forensic-key-custodian",
+        "custody_reference": "COC-2026-0610-004",
+        "key_version": "RP-8842",
+        "test_unlock": {
+          "method": "read-only mount validation on isolated forensic workstation",
+          "result": "pass",
+          "timestamp_utc": "2026-06-10T03:42:00Z"
+        },
+        "live_session_fallback": {
+          "required": false,
+          "reason": "offline recovery key is independently escrowed and test unlock passed"
+        }
+      },
+      "acquisition_decision": {
+        "decision": "proceed_with_powered_off_full_disk_image",
+        "notes": "Capture memory first because system is powered on, then shut down under custody and image the full disk with verified recovery-password unlock."
+      }
+    },
+    {
+      "source_id": "aws-ebs-vol-0abc",
+      "platform": "AWS EC2",
+      "state": "cloud_volume",
+      "snapshot_id": "snap-0def",
+      "fve_escrow_evidence": {
+        "gate_ids": [
+          "FVE-ESCROW-01",
+          "FVE-ESCROW-03",
+          "FVE-ESCROW-04",
+          "FVE-ESCROW-06",
+          "FVE-ESCROW-08"
+        ],
+        "kms_key_id": "arn:aws:kms:us-east-1:111122223333:key/forensic-case-key",
+        "kms_grant_id": "grant-ir-2026-0610",
+        "forensic_role": "arn:aws:iam::111122223333:role/ForensicSnapshotReader",
+        "decrypt_copy_proof": {
+          "copy_snapshot_id": "snap-copy-0fed",
+          "dry_run": "DecodeAuthorizationMessage allowed CreateGrant, Decrypt, ReEncryptFrom",
+          "export_hash_sha256": "b8d4f0d34c91772df0ef51ebc4dd559ff77fe9a12aa1293de75b3b6b54207e35"
+        }
+      },
+      "acquisition_decision": {
+        "decision": "snapshot_evidence_complete",
+        "notes": "Encrypted snapshot was copied under forensic role and hash recorded before analysis."
+      }
+    }
+  ],
+  "output_expectations": {
+    "include_encryption_feasibility_gate": true,
+    "disk_evidence_status": "complete_after_memory_capture",
+    "cloud_evidence_status": "complete_with_decrypt_copy_proof",
+    "not_evaluable": false
+  }
+}

--- a/skills/incident-response/forensics-checklist/tests/vulnerable/tpm-only-cloud-kms-blocked.json
+++ b/skills/incident-response/forensics-checklist/tests/vulnerable/tpm-only-cloud-kms-blocked.json
@@ -1,0 +1,93 @@
+{
+  "case_id": "IR-2026-0611",
+  "expected_skill_decision": "not_evaluable_until_escrow_or_live_fallback",
+  "incident_context": {
+    "severity": "P1",
+    "legal_hold": "issued",
+    "examiner": "forensics-team",
+    "collection_window_utc": "2026-06-11T02:00:00Z/2026-06-11T06:00:00Z"
+  },
+  "targets": [
+    {
+      "source_id": "LAPTOP-FIN-077",
+      "platform": "Windows 11",
+      "state": "powered_on",
+      "volume_id": "bitlocker-volume-c",
+      "protector_inventory": {
+        "encryption": "BitLocker",
+        "protectors": [
+          {
+            "type": "TPM",
+            "protector_id": "TPM-ONLY"
+          }
+        ],
+        "partial_encryption_map": "unknown"
+      },
+      "claimed_collection_plan": {
+        "step": "shut down laptop and image internal SSD tonight",
+        "encryption_note": "BitLocker enabled; recovery key available in IT portal"
+      },
+      "fve_escrow_evidence": {
+        "gate_ids_present": [
+          "FVE-ESCROW-01"
+        ],
+        "gate_ids_missing": [
+          "FVE-ESCROW-02",
+          "FVE-ESCROW-03",
+          "FVE-ESCROW-04",
+          "FVE-ESCROW-05",
+          "FVE-ESCROW-07",
+          "FVE-ESCROW-08"
+        ],
+        "escrow_location": "not found in Intune or Entra device record",
+        "user_only_source": "user personal cloud note inaccessible after containment",
+        "test_unlock": {
+          "result": "not_tested",
+          "reason": "no recovery password or key ID available"
+        },
+        "live_session_fallback": {
+          "required": true,
+          "missing_from_plan": true
+        }
+      },
+      "acquisition_decision": {
+        "decision": "do_not_power_off",
+        "severity": "P1",
+        "notes": "Capture memory, volatile state, pagefile or hibernation artifacts, and authorized live logical evidence before shutdown. Powered-off full-disk imaging is blocked until independent escrow is proven."
+      }
+    },
+    {
+      "source_id": "aws-ebs-vol-0bad",
+      "platform": "AWS EC2",
+      "state": "cloud_volume",
+      "snapshot_id": "snap-0bad",
+      "claimed_collection_plan": {
+        "step": "snapshot created and marked as disk evidence complete",
+        "encryption_note": "AWS managed encryption"
+      },
+      "fve_escrow_evidence": {
+        "gate_ids_missing": [
+          "FVE-ESCROW-03",
+          "FVE-ESCROW-04",
+          "FVE-ESCROW-06",
+          "FVE-ESCROW-08"
+        ],
+        "kms_key_id": "arn:aws:kms:us-east-1:111122223333:key/app-prod-key",
+        "forensic_role": "arn:aws:iam::111122223333:role/ForensicSnapshotReader",
+        "kms_grant_or_policy": "forensic role denied kms:Decrypt and ec2:CopySnapshot",
+        "decrypt_copy_proof": null
+      },
+      "acquisition_decision": {
+        "decision": "snapshot_not_complete",
+        "severity": "P1",
+        "notes": "Snapshot creation without decrypt or copy authority is not sufficient cloud disk evidence."
+      }
+    }
+  ],
+  "output_expectations": {
+    "include_encryption_feasibility_gate": true,
+    "disk_evidence_status": "blocked_live_fallback_required",
+    "cloud_evidence_status": "blocked_kms_decrypt_missing",
+    "not_evaluable": true
+  }
+}


### PR DESCRIPTION
/claim #1526

## Bounty type
Skill Improvement bounty

## Modified skill
`skills/incident-response/forensics-checklist/`

## What was missing
The checklist collected encryption status as context, but it could still treat an encrypted endpoint or encrypted cloud snapshot as acquirable without proof that recovery keys, KMS grants, or a live-session fallback made acquisition feasible. That creates a false-positive "disk evidence complete" outcome for TPM-only BitLocker devices, user-only FileVault keys, blocked LUKS network unlock, partial encryption, or cloud snapshots the forensic role cannot decrypt/copy.

## What changed
- Bumped `forensics-checklist` to `v1.0.1`.
- Added recovery-key escrow, cloud decrypt authority, and live-session fallback context requirements.
- Added an `Encryption Feasibility Gate` before disk imaging with `FVE-ESCROW-01` through `FVE-ESCROW-08`.
- Added platform branches for BitLocker TPM-only/TPM+PIN, FileVault, LUKS/clevis/Tang, cloud-managed encryption, and partial volume encryption.
- Added cloud snapshot KMS decrypt/copy/export guidance and severity calibration.
- Added `Encryption Feasibility Gate` output fields.
- Added benign fixture `fve-escrow-cloud-decrypt-ready.json`.
- Added vulnerable fixture `tpm-only-cloud-kms-blocked.json`.

## Validation
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`
- JSON parse check for both fixtures
- Markdown fence-balance check for `SKILL.md`
- Marker checks for `version: "1.0.1"`, `Encryption Feasibility Gate`, `FVE-ESCROW-01` through `FVE-ESCROW-08`, `Cloud snapshot decrypt/copy authority`, and `Treating Encryption Status as Imaging Feasibility`
- Fixture marker checks for `expected_skill_decision`, `FVE-ESCROW-01`, `FVE-ESCROW-06`, `acquisition_decision`, and `output_expectations`
- Added-line ASCII scan
- Added-line sensitive/public-contact pattern scan

## Bounty request
Requesting Improver Moderate consideration if accepted/merged. Payment method can be provided privately after acceptance.
