### PR TITLE
Add agentic side-effect idempotency fixtures

### DIFF
--- a/skills/ai-security/agentic-top-10/SKILL.md
+++ b/skills/ai-security/agentic-top-10/SKILL.md
@@ -13,7 +13,7 @@ phase: [design, build, review]
 frameworks: [OWASP-Agentic-AI, MITRE-ATLAS, NIST-AI-RMF]
 difficulty: advanced
 time_estimate: "45-90min"
-version: "1.0.1"
+version: "1.0.2"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -67,6 +67,7 @@ Before beginning the assessment, gather the following. If any item is unavailabl
 | Human approval gates | Workflow configs, UI code, approval logic | Determines if HITL can be bypassed |
 | Multi-agent communication | Message bus configs, inter-agent protocols, shared state | Identifies trust boundary violations |
 | Error handling and retry logic | Exception handlers, circuit breaker configs | Reveals cascading failure potential |
+| Side-effecting tool semantics | Tool specs, outbox tables, idempotency middleware, workflow engine config | Determines whether retries can duplicate refunds, emails, IAM grants, deployments, or webhooks |
 | Authentication and identity | Auth middleware, token management, agent identity configs | Exposes identity gaps |
 | Rate limiting and quotas | API gateway configs, token budgets, cost controls | Determines resource exhaustion risk |
 | Data flow diagrams | Architecture docs, network diagrams | Shows exfiltration paths |
@@ -278,6 +279,8 @@ In 2023, security researcher Johann Rehberger demonstrated that Bing Chat (now C
 - Absence of circuit breakers or timeout mechanisms in agent orchestration logic.
 - Error handling that catches exceptions but not semantic errors (the agent returned a confidently wrong answer — no exception is thrown).
 - Retry logic without jitter or backoff that can amplify failures under load.
+- Side-effecting tools that retry after timeout without an idempotency key, operation ledger, or outbox record.
+- Human-approved actions whose approval hash is not bound to the exact canonical tool payload that is retried.
 - Multi-agent systems without a health-check or consensus mechanism for critical decisions.
 
 **Real-World Failure Mode:**
@@ -292,6 +295,27 @@ In 2024, a financial services firm reported an incident (disclosed at a CISO rou
 4. Implement idempotent operations and rollback mechanisms for agents that take real-world actions (send emails, update databases, trigger payments).
 5. Set hard limits on chain depth. Define maximum pipeline length and require human review for chains exceeding the limit.
 6. Implement structured error propagation — agents must explicitly signal uncertainty rather than passing through low-confidence outputs as if they were facts.
+
+**Side-Effect Idempotency Evidence Gate:**
+
+For every tool that creates external side effects, record an `AI-IDEM-*` evidence row before marking AG07 or AG09 as controlled. Treat missing evidence as **NOT EVALUABLE** for low-impact actions and **HIGH** for payments, access grants, deployments, customer communication, destructive changes, or irreversible external calls.
+
+| Gate | Evidence Required | Unsafe Pattern |
+|---|---|---|
+| AI-IDEM-01 | Tool inventory classifies read-only, reversible, compensating, and irreversible side effects | High-impact tools are reviewed only as generic API calls |
+| AI-IDEM-02 | Idempotency key or operation ID is derived from actor, target, action type, and canonical payload hash | Retry creates a new downstream operation ID |
+| AI-IDEM-03 | Durable outbox, operation ledger, or workflow history records pending, submitted, succeeded, failed, and replayed states | Agent memory or chat transcript is the only record of attempted action |
+| AI-IDEM-04 | Timeout-after-success behavior is tested and proves the second attempt becomes an idempotent replay | Client timeout triggers the same refund, email, deployment, or grant again |
+| AI-IDEM-05 | Human approval, risk score, and approval TTL bind to the exact canonical payload hash and actor identity | Retry payload can change after approval |
+| AI-IDEM-06 | Compensation feasibility is documented per tool, including irreversible effects that cannot be undone | Rollback plan assumes emails, webhooks, transfers, or external notifications can be deleted |
+| AI-IDEM-07 | Multi-agent deduplication uses a shared ledger across orchestrators, workers, and fallback agents | Two agents can submit the same side effect with different local state |
+| AI-IDEM-08 | Retry budget, backoff, circuit breaker, and alerting distinguish safe idempotent replay from retry storms | Rate limits exist but duplicate side effects are still possible inside the limit |
+
+**False Positive Calibration:**
+
+- Longer retry windows are acceptable when the operation ledger proves exactly-once or safe at-least-once semantics for the side effect.
+- A compensation tool is not equivalent to idempotency when the external effect is irreversible or may already have reached a third party.
+- Approval evidence is only reusable when the retried payload, actor, target, risk score, and approval TTL still match the approved canonical payload hash.
 
 **Framework Mapping:**
 
@@ -343,6 +367,8 @@ In 2024, a red team exercise at a technology company (published in their securit
 - Absence of token budgets or API call limits per agent session.
 - Recursive agent patterns (agent spawns sub-agents that spawn sub-agents) without depth limits.
 - Retry logic without exponential backoff or maximum retry counts.
+- Retry loops that repeatedly invoke non-idempotent side-effecting tools after partial failure or ambiguous downstream status.
+- No distinction between API rate limiting and duplicate side-effect prevention.
 - Agents that process user-supplied data where the data volume is unbounded (e.g., "summarize this 10GB file").
 - No cost monitoring or alerting on LLM API spend.
 - Agents with access to auto-scaling infrastructure where runaway calls can trigger unbounded scale-up.
@@ -360,6 +386,7 @@ In multiple documented incidents throughout 2023-2024, developers using autonomo
 5. Monitor and alert on token consumption rate, API call frequency, and cost accumulation in real time.
 6. Use pre-provisioned, non-auto-scaling infrastructure for agent workloads where possible, or set hard caps on auto-scaling limits.
 7. Implement dead-letter queues for agent tasks that exceed resource limits, enabling post-mortem analysis without continued resource consumption.
+8. Route retries for side-effecting tools through the shared operation ledger used by AI-IDEM-03, and alert when duplicate attempts, replay spikes, or approval-expired retries exceed policy.
 
 **Framework Mapping:**
 
@@ -428,6 +455,10 @@ Grep: "send_message|delegate|dispatch|publish|subscribe|queue" in **/*.{py,ts,js
 
 # Human approval gates
 Grep: "approve|confirm|human_in_the_loop|hitl|review|authorize" in **/*.{py,ts,js,yaml,yml}
+
+# Side-effecting retries and operation ledgers
+Grep: "idempotency|operation_id|outbox|ledger|retry|backoff|timeout|compensat" in **/*.{py,ts,js,yaml,yml,json}
+Grep: "refund|email|deploy|grant|webhook|delete|transfer|payment|ticket" in **/*.{py,ts,js,yaml,yml,json}
 ```
 
 ### Hands-On Assessment Tooling
@@ -494,6 +525,8 @@ Structure the final report as follows:
 - Memory stores: [types]
 - Human approval gates: [present/absent, description]
 - Multi-agent communication: [method]
+- Side-effecting tools: [count and highest-impact action types]
+- Operation ledger / outbox: [present/absent, scope, durability]
 
 ## Findings by Threat Category
 
@@ -513,6 +546,11 @@ Structure the final report as follows:
 |---|---|---|---|
 | AG01 | [rating] | [one-line summary] | [priority] |
 | ... | ... | ... | ... |
+
+## Side-Effect Idempotency Evidence
+| Tool / Action | Side Effect | Idempotency Key / Operation ID | Ledger Scope | Approval Binding | Retry Policy | Compensation Feasibility | Decision |
+|---|---|---|---|---|---|---|---|
+| [tool] | [refund/email/grant/deploy/etc.] | [source and payload hash binding] | [per-agent/shared/external] | [hash, actor, TTL] | [max attempts/backoff/circuit breaker] | [reversible/partial/irreversible] | [safe to retry / unsafe / not evaluable] |
 
 ## Recommendations
 1. [Highest priority recommendation]
@@ -585,6 +623,10 @@ Persistent agent memory is a high-value target because it persists across sessio
 ### 5. Assuming Tool Calls Are Safe Because the Tool Is Legitimate
 
 A tool functioning correctly is not the same as a tool being used correctly. The agent controls what parameters it passes, what sequence it calls tools in, and how it interprets results. A legitimate database query tool becomes an exfiltration vector when the agent is manipulated into querying sensitive tables and sending the results to an external webhook. Secure the tool invocation, not just the tool implementation.
+
+### 6. Confusing Retry Limits With Idempotency
+
+A maximum retry count or API rate limit reduces volume, but it does not prove duplicate side effects are safe. A single retry after a lost response can still duplicate a refund, email, IAM grant, deployment, or customer notification. High-impact tools need a durable operation ledger, payload-bound idempotency key, approval binding, and tested timeout-after-success behavior.
 
 ---
 

--- a/skills/ai-security/agentic-top-10/tests/benign/idempotent-retry-operation-ledger.json
+++ b/skills/ai-security/agentic-top-10/tests/benign/idempotent-retry-operation-ledger.json
@@ -1,0 +1,95 @@
+{
+  "case_id": "agentic-idempotent-retry-operation-ledger",
+  "skill": "agentic-top-10",
+  "expected_skill_decision": "safe_to_retry_with_evidence",
+  "scenario": "A customer support refund agent retries after a client timeout, but the refund tool is bound to a shared operation ledger and payload-hash idempotency key.",
+  "agent_workflow": {
+    "agent": "support-refund-agent",
+    "tool": "billing.issue_refund",
+    "side_effect": "payment_refund",
+    "impact": "financial",
+    "approval_required": true
+  },
+  "approved_action": {
+    "actor_id": "agent:support-refund-agent",
+    "human_approver": "finance-approver-17",
+    "target": "customer:C-1042",
+    "amount": "42.00",
+    "currency": "USD",
+    "canonical_payload_hash": "sha256:refund-c1042-42-approved-v3",
+    "approval_hash": "sha256:refund-c1042-42-approved-v3",
+    "approval_ttl_minutes": 30,
+    "approved_at": "2026-06-08T20:12:00Z"
+  },
+  "idempotency_evidence": {
+    "AI-IDEM-01": {
+      "status": "pass",
+      "evidence": "Tool inventory classifies billing.issue_refund as irreversible financial side effect."
+    },
+    "AI-IDEM-02": {
+      "status": "pass",
+      "operation_id": "refund:C-1042:sha256:refund-c1042-42-approved-v3",
+      "idempotency_key": "refund:C-1042:sha256:refund-c1042-42-approved-v3"
+    },
+    "AI-IDEM-03": {
+      "status": "pass",
+      "ledger": "durable_outbox.refund_operations",
+      "ledger_scope": "shared_across_orchestrator_and_workers",
+      "states": ["pending", "submitted", "succeeded", "idempotent_replay"]
+    },
+    "AI-IDEM-04": {
+      "status": "pass",
+      "test": "timeout_after_success_replay_test",
+      "first_attempt": "downstream_succeeded_agent_timeout",
+      "second_attempt": "idempotent_replay_no_second_refund"
+    },
+    "AI-IDEM-05": {
+      "status": "pass",
+      "approval_binding": "actor_target_amount_currency_and_payload_hash_match"
+    },
+    "AI-IDEM-06": {
+      "status": "pass",
+      "compensation_feasibility": "partial_manual_reversal_only",
+      "primary_control": "idempotency_required_before_tool_call"
+    },
+    "AI-IDEM-07": {
+      "status": "pass",
+      "dedupe": "same_operation_id_checked_by_all_support_agents_before_execution"
+    },
+    "AI-IDEM-08": {
+      "status": "pass",
+      "retry_policy": {
+        "max_attempts": 2,
+        "backoff": "exponential_with_jitter",
+        "circuit_breaker": "opens_after_3_replay_spikes_per_10m",
+        "alert": "duplicate_attempt_rate"
+      }
+    }
+  },
+  "observed_attempts": [
+    {
+      "attempt": 1,
+      "agent_observed_result": "timeout",
+      "downstream_result": "refund_created",
+      "ledger_state": "succeeded"
+    },
+    {
+      "attempt": 2,
+      "agent_observed_result": "replayed_success",
+      "downstream_result": "no_new_refund",
+      "ledger_state": "idempotent_replay"
+    }
+  ],
+  "output_expectations": {
+    "AG07_rating": "PASS",
+    "AG09_rating": "LOW",
+    "side_effect_idempotency_decision": "safe_to_retry",
+    "report_fields": [
+      "operation_id",
+      "approval_hash",
+      "ledger_scope",
+      "timeout_after_success_test",
+      "compensation_feasibility"
+    ]
+  }
+}

--- a/skills/ai-security/agentic-top-10/tests/vulnerable/retry-storm-stale-approval-duplicate-side-effect.json
+++ b/skills/ai-security/agentic-top-10/tests/vulnerable/retry-storm-stale-approval-duplicate-side-effect.json
@@ -1,0 +1,110 @@
+{
+  "case_id": "agentic-retry-storm-stale-approval-duplicate-side-effect",
+  "skill": "agentic-top-10",
+  "expected_skill_decision": "high_risk_duplicate_side_effect",
+  "scenario": "Two agents retry a customer notification and IAM grant workflow after timeouts. The retry payload changes after approval, no shared ledger exists, and rate limits do not prevent duplicate external effects.",
+  "agent_workflow": {
+    "agents": ["support-agent-a", "fallback-agent-b"],
+    "tools": ["mail.send_customer_notice", "iam.grant_temporary_access"],
+    "side_effects": ["external_email", "privilege_grant"],
+    "impact": "customer_communication_and_access_control",
+    "approval_required": true
+  },
+  "approved_action": {
+    "actor_id": "agent:support-agent-a",
+    "target": "customer:C-8110",
+    "canonical_payload_hash": "sha256:old-approved-email-and-access",
+    "approval_hash": "sha256:old-approved-email-and-access",
+    "approval_ttl_minutes": 15,
+    "approved_at": "2026-06-08T21:00:00Z"
+  },
+  "retry_payload": {
+    "actor_id": "agent:fallback-agent-b",
+    "target": "customer:C-8110",
+    "recipient": "changed-recipient-alias",
+    "canonical_payload_hash": "sha256:new-unapproved-email-and-access",
+    "approval_hash_used": "sha256:old-approved-email-and-access",
+    "approval_age_minutes": 44,
+    "granted_role": "support-admin",
+    "duration_hours": 24
+  },
+  "idempotency_evidence": {
+    "AI-IDEM-01": {
+      "status": "fail",
+      "evidence": "Tools are reviewed as generic API calls; external email and privilege grant side effects are not classified."
+    },
+    "AI-IDEM-02": {
+      "status": "fail",
+      "operation_id": null,
+      "idempotency_key": null,
+      "unsafe_pattern": "Each retry creates a new mail message and access grant."
+    },
+    "AI-IDEM-03": {
+      "status": "fail",
+      "ledger": "agent_local_memory_only",
+      "ledger_scope": "per_agent",
+      "durability": "lost_on_restart"
+    },
+    "AI-IDEM-04": {
+      "status": "fail",
+      "test": "not_performed",
+      "observed_timeout_after_success": "retried_without_downstream_status_check"
+    },
+    "AI-IDEM-05": {
+      "status": "fail",
+      "approval_binding": "payload_hash_mismatch_and_ttl_expired"
+    },
+    "AI-IDEM-06": {
+      "status": "fail",
+      "compensation_feasibility": "email_cannot_be_unsent_and_privilege_grant_was_used_before_revoke"
+    },
+    "AI-IDEM-07": {
+      "status": "fail",
+      "dedupe": "fallback_agent_cannot_see_support_agent_local_retry_state"
+    },
+    "AI-IDEM-08": {
+      "status": "fail",
+      "retry_policy": {
+        "max_attempts": 5,
+        "backoff": "fixed_100ms",
+        "rate_limit": "10_calls_per_minute",
+        "gap": "All duplicate side effects occur inside the rate limit."
+      }
+    }
+  },
+  "observed_attempts": [
+    {
+      "attempt": 1,
+      "agent": "support-agent-a",
+      "tool": "mail.send_customer_notice",
+      "agent_observed_result": "timeout",
+      "downstream_result": "email_sent"
+    },
+    {
+      "attempt": 2,
+      "agent": "support-agent-a",
+      "tool": "mail.send_customer_notice",
+      "agent_observed_result": "timeout",
+      "downstream_result": "second_email_sent"
+    },
+    {
+      "attempt": 3,
+      "agent": "fallback-agent-b",
+      "tool": "iam.grant_temporary_access",
+      "agent_observed_result": "success",
+      "downstream_result": "unapproved_privilege_grant"
+    }
+  ],
+  "output_expectations": {
+    "AG07_rating": "HIGH",
+    "AG09_rating": "HIGH",
+    "side_effect_idempotency_decision": "unsafe_to_retry",
+    "required_findings": [
+      "missing_shared_operation_ledger",
+      "missing_idempotency_key",
+      "stale_approval_payload_mismatch",
+      "timeout_after_success_not_tested",
+      "rate_limit_confused_with_idempotency"
+    ]
+  }
+}


### PR DESCRIPTION
/claim #2044

## Summary
- Adds side-effect idempotency evidence gates to `agentic-top-10` for timeout-after-success retries, stale approval reuse, cross-agent duplicate execution, and retry storms that still fit inside API rate limits.
- Adds `AI-IDEM-01` through `AI-IDEM-08` covering side-effect classification, payload-bound operation IDs, durable operation ledgers, timeout replay tests, approval binding, compensation feasibility, shared multi-agent dedupe, and retry-budget alerting.
- Extends the inventory and output template with side-effecting tool semantics and a Side-Effect Idempotency Evidence table.
- Adds skill-local benign and vulnerable JSON fixtures for safe idempotent replay versus duplicate side effects with stale approval and no shared ledger.

## Validation
- `git diff --check origin/main...HEAD`
- JSON parse check for both added fixtures
- Markdown fence balance check
- Marker checks for `version: "1.0.2"`, `Side-Effect Idempotency Evidence Gate`, `AI-IDEM-01` through `AI-IDEM-08`, and `Confusing Retry Limits With Idempotency`
- Fixture marker checks for `expected_skill_decision`, `AI-IDEM-01`, `AI-IDEM-08`, and `output_expectations`
- Added-line ASCII and sensitive/public-contact pattern scans
- `git merge-tree --write-tree origin/main HEAD`

## Bounty request
Requesting Improver Moderate consideration if accepted/merged. Payment method can be provided privately after acceptance.
