### PR TITLE
Add IAM downstream revocation fixtures

### DIFF
--- a/skills/identity/iam-review/SKILL.md
+++ b/skills/identity/iam-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [design, operate]
 frameworks: [NIST-SP-800-63B, NIST-SP-800-207, CIS-Controls-v8]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -256,6 +256,10 @@ IAM-STALE-05: Deprovisioning SLA not met (industry standard: same-day for termin
 IAM-STALE-06: No automated lifecycle management (SCIM provisioning/deprovisioning)
 IAM-STALE-07: Accounts disabled but not deleted after retention period
 IAM-STALE-08: Access reviews not conducted on required cadence (quarterly for privileged, semi-annual for standard)
+IAM-STALE-09: IdP-disabled user still has relying-party sessions, refresh tokens, API tokens, or mobile tokens
+IAM-STALE-10: Group or role removal does not propagate to app-local RBAC, cached claims, or entitlement tables
+IAM-STALE-11: Human owner lifecycle changes do not trigger machine identity, deploy key, OAuth app, OIDC trust, or CI/CD secret review
+IAM-STALE-12: Non-SCIM application lacks compensating disablement, token revocation, reconciliation, and residual-access evidence
 ```
 
 **Platform-specific checks:**
@@ -273,8 +277,32 @@ IAM-STALE-08: Access reviews not conducted on required cadence (quarterly for pr
 |---|---|---|
 | Former employee with active admin access | **Critical** | Immediate unauthorized access risk |
 | Orphaned service account with production access | **High** | No owner to monitor or respond to abuse |
+| IdP disabled but relying-party sessions or refresh tokens remain valid | **High** | Source-of-truth disablement did not revoke effective access |
+| Departed owner still controls service accounts, OAuth apps, deploy keys, or OIDC trusts | **High** | Machine identities can outlive human lifecycle controls |
 | Inactive human account > 90 days | **Medium** | Credential stuffing / takeover target |
 | Disabled but not deleted account > 180 days | **Low** | Hygiene improvement |
+
+#### Downstream Deprovisioning Evidence Gate
+
+Before marking deprovisioning complete, prove that the source lifecycle event propagated to every relying party and credential form that can continue access after the IdP object is disabled. Treat unknown downstream state as **NOT EVALUABLE**; treat confirmed residual access for privileged, regulated, production, or externally exposed systems as **HIGH** or **CRITICAL** depending on scope.
+
+| Field | Evidence Required | Unsafe Shortcut |
+|---|---|---|
+| Source lifecycle event | HRIS ticket, IdP event ID, SCIM PATCH/DELETE, group removal, owner transfer, termination timestamp | Deprovisioning is inferred from a disabled directory object only |
+| Relying-party account state | App-local user status, local role/group table, warehouse grants, SaaS admin console, last sync result | SSO login blocked but app-local account remains active |
+| Session and token revocation | Browser/mobile sessions, OAuth refresh tokens, personal API tokens, CLI tokens, device tokens, recovery tokens | Logout or IdP disable is assumed to revoke all tokens |
+| Group/role propagation | Group delta, cached claim TTL, entitlement table result, app-local RBAC removal, data-plane authorization test | IdP group removal is not checked in the application |
+| Machine identity impact | Owned service accounts, deploy keys, OAuth apps, certificates, OIDC trusts, CI/CD secrets, cloud role bindings | Departed owner leaves non-human credentials unreviewed |
+| Exception and compensating control | Non-SCIM owner, manual disable SLA, reconciliation cadence, monitoring, expiry/review date | Non-SCIM app is either auto-failed or auto-passed without evidence |
+| Verification result | Complete, partial, failed, not evaluable, residual access remaining, retest date | Ticket closure is used as proof of effective revocation |
+
+**False Positive Calibration:**
+
+- Do not flag a SaaS app solely because it lacks SCIM when documented manual disablement, token revocation, reconciliation, and residual-access tests are current.
+- Do not close a stale-account finding solely because SCIM succeeded; SCIM can disable a user while sessions, refresh tokens, app-local roles, or personal tokens remain valid.
+- Workload identity federation reduces static key risk, but OIDC trust policies, deploy keys, OAuth applications, and service account ownership still need review when owners leave or teams change.
+
+**Additional references:** RFC 7009 (OAuth 2.0 Token Revocation), RFC 7644 (SCIM Protocol), and NIST SP 800-207 zero-trust per-session access decisions.
 
 ---
 
@@ -408,11 +436,17 @@ For each finding, produce a row with:
 - Least Privilege (Step 3): [count]
 - Service Accounts (Step 4): [count]
 - Stale Accounts (Step 5): [count]
+- Downstream Deprovisioning (Step 5): [complete / partial / failed / not evaluable]
 - JIT Access (Step 6): [count]
 - Zero Trust (Step 7): [count]
 
 ### Detailed Findings
 [Findings table — see above]
+
+### Downstream Deprovisioning Evidence
+| Lifecycle Event | IdP / SCIM Evidence | Relying Party | App Account State | Token / Session Revocation | Group / Role Propagation | Machine Identity Impact | Verification Result |
+|---|---|---|---|---|---|---|---|
+| [termination/group removal/owner change] | [event ID and timestamp] | [app/cloud/SaaS] | [disabled/active/unknown] | [revoked/active/unknown] | [complete/partial/failed] | [none/reassigned/revoked/unknown] | [complete/partial/failed/not evaluable] |
 
 ### Remediation Roadmap
 [Prioritized actions: immediate (0-7 days), short-term (30 days), medium-term (90 days)]

--- a/skills/identity/iam-review/tests/benign/downstream-deprovisioning-token-revocation-complete.json
+++ b/skills/identity/iam-review/tests/benign/downstream-deprovisioning-token-revocation-complete.json
@@ -1,0 +1,75 @@
+{
+  "case_id": "iam-downstream-deprovisioning-token-revocation-complete",
+  "skill": "iam-review",
+  "expected_skill_decision": "deprovisioning_complete_with_evidence",
+  "scenario": "A terminated employee is disabled in the IdP and every relying party proves app-local disablement, token revocation, group removal, and machine identity reassignment.",
+  "source_lifecycle_event": {
+    "event_type": "termination",
+    "source_of_truth": "hris",
+    "idp": "okta",
+    "idp_event_id": "evt-term-1042",
+    "scim_patch_result": "success",
+    "terminated_user": "user-1042",
+    "terminated_at": "2026-06-06T09:00:00Z"
+  },
+  "downstream_evidence": [
+    {
+      "relying_party": "payroll-saas",
+      "app_account_state": "disabled",
+      "app_audit_event_id": "audit-payroll-disable-778",
+      "browser_sessions": "revoked",
+      "oauth_refresh_tokens": "revoked",
+      "personal_api_tokens": "revoked",
+      "mobile_device_tokens": "revoked",
+      "group_role_propagation": "complete",
+      "last_sync_at": "2026-06-06T09:04:00Z",
+      "verification_result": "complete"
+    },
+    {
+      "relying_party": "data-warehouse",
+      "app_account_state": "disabled",
+      "warehouse_grants": "removed",
+      "cached_claim_ttl_minutes": 15,
+      "data_plane_authorization_test": "denied_after_revocation",
+      "verification_result": "complete"
+    }
+  ],
+  "machine_identity_review": {
+    "owned_service_accounts": [
+      {
+        "service_account": "svc-billing-export",
+        "owner_reassigned_to": "team-billing-platform",
+        "static_keys": "none",
+        "oidc_trust_policy_reviewed": true,
+        "ci_secrets_reassigned": true,
+        "verification_result": "complete"
+      }
+    ],
+    "oauth_apps": [
+      {
+        "app_id": "oauth-export-tool",
+        "owner_reassigned": true,
+        "refresh_tokens_revoked": true,
+        "verification_result": "complete"
+      }
+    ]
+  },
+  "evidence_gate_results": {
+    "IAM-STALE-09": "pass",
+    "IAM-STALE-10": "pass",
+    "IAM-STALE-11": "pass",
+    "IAM-STALE-12": "not_applicable"
+  },
+  "output_expectations": {
+    "downstream_deprovisioning_status": "complete",
+    "finding_severity": "PASS",
+    "required_report_fields": [
+      "source_lifecycle_event",
+      "relying_party_account_state",
+      "token_session_revocation",
+      "group_role_propagation",
+      "machine_identity_impact",
+      "verification_result"
+    ]
+  }
+}

--- a/skills/identity/iam-review/tests/vulnerable/idp-disabled-residual-sessions-machine-identities.json
+++ b/skills/identity/iam-review/tests/vulnerable/idp-disabled-residual-sessions-machine-identities.json
@@ -1,0 +1,76 @@
+{
+  "case_id": "iam-idp-disabled-residual-sessions-machine-identities",
+  "skill": "iam-review",
+  "expected_skill_decision": "high_risk_residual_access",
+  "scenario": "The IdP user is disabled and the SCIM ticket is closed, but SaaS sessions, OAuth refresh tokens, app-local RBAC, and owner-linked machine identities remain active.",
+  "source_lifecycle_event": {
+    "event_type": "termination",
+    "source_of_truth": "idp_only",
+    "idp": "entra-id",
+    "idp_event_id": "evt-disable-7781",
+    "scim_patch_result": "success",
+    "terminated_user": "user-7781",
+    "terminated_at": "2026-06-06T10:00:00Z",
+    "ticket_state": "closed"
+  },
+  "downstream_evidence": [
+    {
+      "relying_party": "support-saas",
+      "app_account_state": "disabled",
+      "browser_sessions": "active",
+      "oauth_refresh_tokens": "active",
+      "personal_api_tokens": "active",
+      "mobile_device_tokens": "unknown",
+      "last_successful_api_call_after_disable": "2026-06-06T10:27:00Z",
+      "verification_result": "failed"
+    },
+    {
+      "relying_party": "data-warehouse",
+      "idp_group_removed": "engineering-prod-admin",
+      "app_local_role": "prod_admin",
+      "cached_claim_ttl_hours": 24,
+      "last_full_sync": "2026-06-01T00:00:00Z",
+      "data_plane_authorization_test": "allowed_after_idp_group_removal",
+      "verification_result": "failed"
+    }
+  ],
+  "machine_identity_review": {
+    "owned_service_accounts": [
+      {
+        "service_account": "svc-prod-deploy",
+        "former_owner": "user-7781",
+        "cloud_role": "prod-deploy-admin",
+        "static_key_count": 2,
+        "last_key_use_after_termination": "2026-06-06T10:31:00Z",
+        "oidc_trust_policy": "still_allows_legacy_repo_branch",
+        "breakglass_exception": "missing",
+        "verification_result": "failed"
+      }
+    ],
+    "deploy_keys": [
+      {
+        "repository": "prod-infra",
+        "former_owner": "user-7781",
+        "key_state": "active",
+        "last_use_after_termination": true
+      }
+    ]
+  },
+  "evidence_gate_results": {
+    "IAM-STALE-09": "fail",
+    "IAM-STALE-10": "fail",
+    "IAM-STALE-11": "fail",
+    "IAM-STALE-12": "not_evaluable"
+  },
+  "output_expectations": {
+    "downstream_deprovisioning_status": "failed",
+    "finding_severity": "HIGH",
+    "required_findings": [
+      "residual_sessions_after_idp_disable",
+      "active_refresh_and_personal_tokens",
+      "app_local_role_cache_not_revoked",
+      "machine_identity_owner_lifecycle_gap",
+      "ticket_closure_used_as_revocation_proof"
+    ]
+  }
+}


### PR DESCRIPTION
/claim #1441

## Summary
- Adds downstream deprovisioning and token/session revocation evidence gates to `iam-review`.
- Adds `IAM-STALE-09` through `IAM-STALE-12` for residual relying-party sessions/tokens, app-local RBAC propagation gaps, machine identity owner lifecycle gaps, and non-SCIM compensating-control evidence.
- Adds a Downstream Deprovisioning Evidence table to the output template with IdP/SCIM evidence, relying-party state, token/session revocation, group/role propagation, machine identity impact, and verification result.
- Adds skill-local benign and vulnerable JSON fixtures for complete downstream revocation versus IdP-disabled residual access with active sessions, tokens, app-local role cache, and owner-linked machine identities.

## Validation
- `git diff --check origin/main...HEAD`
- JSON parse check for both added fixtures
- Markdown fence balance check
- Marker checks for `version: "1.0.1"`, `IAM-STALE-09` through `IAM-STALE-12`, `Downstream Deprovisioning Evidence Gate`, `Session and token revocation`, `Machine identity impact`, `RFC 7009`, and `RFC 7644`
- Fixture marker checks for `expected_skill_decision`, downstream evidence, machine identity review, and output expectations
- Added-line ASCII and sensitive/public-contact pattern scans
- `git merge-tree --write-tree origin/main HEAD`

## Bounty request
Requesting Improver Moderate consideration if accepted/merged. Payment method can be provided privately after acceptance.
