### PR TITLE
Improve dependency lifecycle script gates

### DIFF
--- a/skills/appsec/dependency-scanning/SKILL.md
+++ b/skills/appsec/dependency-scanning/SKILL.md
@@ -12,7 +12,7 @@ phase: [build, deploy]
 frameworks: [SLSA-v1.0, CycloneDX, SPDX, CISA-KEV]
 difficulty: intermediate
 time_estimate: "15-30min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -181,6 +181,34 @@ Typosquatting (also called dependency confusion or combosquatting) is a supply c
 - Implement dependency confusion protections: claim your internal package names on public registries, or use registry proxy tools like Artifactory or Nexus with routing rules.
 - Run `socket.dev`, `npm audit signatures`, or `sigstore` verification to validate package provenance.
 
+## Install-Time Lifecycle Script Evidence Gate
+
+Known-vulnerability scanners can report a clean dependency tree while package installation still executes code through lifecycle hooks. For Node.js projects, review `preinstall`, `install`, `postinstall`, `prepare`, `prepack`, `postpack`, and workspace/root scripts before trusting the dependency posture.
+
+Do not fail a dependency only because a lifecycle hook exists. Native modules and optional platform packages often use install hooks for expected build or binary selection. The review must separate expected build behavior from risky install-time execution by recording source type, direct/transitive ownership, script behavior, and script-disabled validation evidence.
+
+### Required Evidence
+
+| Gate | Evidence Required | Finding Trigger |
+|---|---|---|
+| DEP-LIFE-01 | Enumerate lifecycle hooks from direct and transitive packages, including workspace packages and root scripts. | The review only checks direct `package.json` scripts or relies on CVE output without dependency-tree hook enumeration. |
+| DEP-LIFE-02 | Classify package source as registry, Git, tarball, file, workspace, or private registry, and record lockfile integrity or immutable pin evidence. | Mutable Git branch dependencies, tarballs, or file/workspace links run install hooks without immutable revision or integrity evidence. |
+| DEP-LIFE-03 | Classify hook behavior without executing untrusted code: network access, process spawning, shell use, binary download, environment reads, filesystem writes, or code generation. | Script behavior is unknown, broad shell commands are present, or network/environment behavior is not reviewed. |
+| DEP-LIFE-04 | Record package owner, direct/transitive path, hook name, command summary, package manager, and install context. | A finding only says "packages have install scripts" without ownership or reachability context. |
+| DEP-LIFE-05 | Test or reason about script suppression with `npm ci --ignore-scripts`, `pnpm install --ignore-scripts`, `yarn install --mode=skip-builds`, or an equivalent package-manager control. | The review cannot show whether build/test still works when lifecycle scripts are disabled or isolated. |
+| DEP-LIFE-06 | Distinguish benign native or optional-platform scripts from suspicious behavior using documented build purpose and limited filesystem/network scope. | Expected native build hooks are auto-failed, or suspicious hooks are accepted because "postinstall is common." |
+| DEP-LIFE-07 | Treat Git dependencies with `prepare` hooks, branch pins, or missing lockfile integrity as high risk until reviewed and pinned to immutable revisions. | A Git dependency runs `prepare` from a branch or moving tag without review, pinning, or replacement plan. |
+| DEP-LIFE-08 | Include lifecycle risk decisions in the final report with evidence, residual risk, and remediation owner. | Lifecycle-script review happens informally and is not visible in the output. |
+
+### Review Guidance
+
+- Prefer metadata and lockfile inspection over script execution. Read package manifests and lockfiles; do not run lifecycle commands from untrusted packages.
+- For direct dependencies, require a package owner or application owner to explain why the hook is needed.
+- For transitive dependencies, record the dependency path and determine whether an override, resolution, version pin, or replacement is available.
+- For Git dependencies, prefer commit SHA pins over branch names and verify whether `prepare` runs during installation.
+- Treat `curl`, `wget`, `bash`, `sh`, `powershell`, outbound telemetry during install, environment scraping, and opaque binary downloads as manual-review triggers.
+- When scripts cannot be disabled because a native module must build, document the expected failure mode and any safer rebuild path.
+
 ## Assessment Output Template
 
 When performing a dependency scan, produce findings in the following structure:
@@ -210,8 +238,15 @@ When performing a dependency scan, produce findings in the following structure:
 - [ ] Typosquatting risk detected
 - [ ] Packages with no license
 - [ ] Packages with install scripts
+- [ ] Lifecycle scripts without direct/transitive evidence or script-disabled validation
 - [ ] Unmaintained packages (no release in 2+ years)
 - [ ] Dependency confusion risk (internal name collisions)
+
+### Lifecycle Script Evidence
+
+| Package | Path | Source | Hook | Behavior | Script-Disabled Test | Decision |
+|---|---|---|---|---|---|---|
+| ... | direct/transitive path | registry/Git/workspace | postinstall | native build / network / shell / other | passed/failed/not feasible | accept/finding/follow-up |
 
 ### Recommendations
 
@@ -226,8 +261,9 @@ When performing a dependency scan, produce findings in the following structure:
 4. **Vulnerability scan**: Cross-reference packages and versions against known CVE databases. Apply the EPSS+CVSS+KEV triage model.
 5. **License audit**: Extract license declarations from lockfiles or registry metadata. Flag copyleft and unlicensed packages.
 6. **Typosquatting check**: Review dependency names for patterns described in the detection section.
-7. **Supply chain assessment**: Evaluate SLSA posture -- lockfile presence, pinned versions, provenance availability.
-8. **Report**: Produce the assessment using the output template above, with prioritized remediation recommendations.
+7. **Lifecycle script gate**: Enumerate direct and transitive install-time hooks, classify source and behavior, and record script-disabled validation evidence.
+8. **Supply chain assessment**: Evaluate SLSA posture -- lockfile presence, pinned versions, provenance availability.
+9. **Report**: Produce the assessment using the output template above, with prioritized remediation recommendations.
 
 ## Prompt Injection Safety Notice
 

--- a/skills/appsec/dependency-scanning/tests/benign/npm-native-lifecycle-script-isolated.json
+++ b/skills/appsec/dependency-scanning/tests/benign/npm-native-lifecycle-script-isolated.json
@@ -1,0 +1,61 @@
+{
+  "id": "dependency-scanning-lifecycle-benign-native-001",
+  "skill": "dependency-scanning",
+  "skill_version": "1.0.1",
+  "scenario": "Benign native dependency lifecycle script with isolation evidence",
+  "expected_result": "Document the lifecycle hook as accepted native-build behavior instead of flagging the package solely because postinstall exists.",
+  "manifest": {
+    "package_manager": "npm",
+    "dependencies": {
+      "better-sqlite3": "11.3.0",
+      "sharp": "0.33.5"
+    },
+    "scripts": {
+      "test": "node ./tests/smoke-native-modules.js"
+    }
+  },
+  "lockfile_evidence": {
+    "lockfile": "package-lock.json",
+    "package": "better-sqlite3",
+    "source_type": "registry",
+    "integrity_present": true,
+    "resolved_url": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.3.0.tgz"
+  },
+  "lifecycle_scripts": [
+    {
+      "gate_ids": [
+        "DEP-LIFE-01",
+        "DEP-LIFE-02",
+        "DEP-LIFE-03",
+        "DEP-LIFE-04",
+        "DEP-LIFE-05",
+        "DEP-LIFE-06",
+        "DEP-LIFE-08"
+      ],
+      "package": "better-sqlite3",
+      "dependency_path": "app > better-sqlite3",
+      "direct_dependency": true,
+      "source_type": "registry",
+      "hook": "install",
+      "command_summary": "prebuild-install fallback to node-gyp rebuild",
+      "behavior_classification": [
+        "native-binary-resolution",
+        "local-build"
+      ],
+      "network_scope": "documented registry or prebuild host only",
+      "environment_read_scope": "node and platform metadata",
+      "filesystem_scope": "package directory and node-gyp cache",
+      "script_disabled_test": {
+        "command": "npm ci --ignore-scripts",
+        "result": "install completed, but native import smoke test failed until rebuild",
+        "expected_failure": true
+      },
+      "risk_decision": "accept with monitoring because source integrity, direct ownership, documented native build purpose, and script-disabled behavior are recorded"
+    }
+  ],
+  "output_expectations": [
+    "Lifecycle Script Evidence includes package owner, direct path, registry source, install hook, and native-build behavior.",
+    "The report does not mark a finding only because postinstall exists.",
+    "The report records script-disabled validation and the expected native-module failure mode."
+  ]
+}

--- a/skills/appsec/dependency-scanning/tests/vulnerable/transitive-git-prepare-exfil.json
+++ b/skills/appsec/dependency-scanning/tests/vulnerable/transitive-git-prepare-exfil.json
@@ -1,0 +1,81 @@
+{
+  "id": "dependency-scanning-lifecycle-vulnerable-transitive-git-001",
+  "skill": "dependency-scanning",
+  "skill_version": "1.0.1",
+  "scenario": "Transitive lifecycle script and mutable Git prepare hook bypass CVE-only dependency scanning",
+  "expected_result": "Flag install-time execution risk even when no known CVE is present.",
+  "manifest": {
+    "package_manager": "npm",
+    "dependencies": {
+      "build-toolkit": "^2.4.0",
+      "theme-tools": "github:example/theme-tools#main"
+    }
+  },
+  "dependency_tree": [
+    {
+      "package": "build-toolkit",
+      "dependency_path": "app > build-toolkit",
+      "source_type": "registry",
+      "lifecycle_scripts": []
+    },
+    {
+      "package": "leftpad-helper",
+      "dependency_path": "app > build-toolkit > leftpad-helper",
+      "source_type": "registry",
+      "lifecycle_scripts": [
+        {
+          "hook": "postinstall",
+          "command_summary": "node collect-env.js",
+          "behavior_classification": [
+            "environment-read",
+            "outbound-network",
+            "process-spawn"
+          ],
+          "network_destination": "https://telemetry.example.invalid/install"
+        }
+      ]
+    },
+    {
+      "package": "theme-tools",
+      "dependency_path": "app > theme-tools",
+      "source_type": "git",
+      "git_ref": "main",
+      "immutable_revision_pinned": false,
+      "lifecycle_scripts": [
+        {
+          "hook": "prepare",
+          "command_summary": "node scripts/bootstrap.js && npm run build",
+          "behavior_classification": [
+            "mutable-source-build",
+            "shell-command",
+            "network-access-unknown"
+          ]
+        }
+      ]
+    }
+  ],
+  "missing_evidence": [
+    "DEP-LIFE-01 direct and transitive lifecycle hook inventory",
+    "DEP-LIFE-02 immutable source classification for Git dependency",
+    "DEP-LIFE-03 behavior classification for install-time scripts",
+    "DEP-LIFE-04 dependency path and owner for transitive hook",
+    "DEP-LIFE-05 script-disabled install or isolation result",
+    "DEP-LIFE-07 Git prepare hook pinned to immutable revision",
+    "DEP-LIFE-08 lifecycle risk decision in final report"
+  ],
+  "should_flag": [
+    {
+      "gate_id": "DEP-LIFE-03",
+      "finding": "Transitive postinstall script reads environment data and performs outbound network activity during package installation."
+    },
+    {
+      "gate_id": "DEP-LIFE-07",
+      "finding": "Git dependency uses a moving branch and prepare hook without immutable revision or lockfile integrity evidence."
+    },
+    {
+      "gate_id": "DEP-LIFE-05",
+      "finding": "No npm ci --ignore-scripts or equivalent isolation result proves whether install/test can run without lifecycle execution."
+    }
+  ],
+  "false_negative_to_prevent": "A CVE-only dependency scan reports no vulnerable packages and misses install-time execution risk."
+}


### PR DESCRIPTION
/claim #2160

## Summary
- Bump `dependency-scanning` to `1.0.1`.
- Add an Install-Time Lifecycle Script Evidence Gate for npm/package-manager lifecycle hooks.
- Require direct/transitive hook enumeration, package source classification, behavior classification, script-disabled validation, benign native-module handling, and Git `prepare` immutability evidence.
- Extend the output template with a Lifecycle Script Evidence table.
- Add skill-local benign and vulnerable JSON fixtures.

## Validation
- `git diff --cached --check`
- `git diff --check origin/main...HEAD`
- JSON parse check for both lifecycle fixtures
- Markdown code-fence balance check
- Marker check for `DEP-LIFE-01` through `DEP-LIFE-08`
- Added-line sensitive-pattern scan
- `git merge-tree --write-tree origin/main HEAD` with merge tree matching `HEAD^{tree}`
- Remote Git Data API tree verification matched local `HEAD^{tree}` after HTTPS push timed out

## Bounty
Requested tier: Improver - Moderate ($100)

Preferred payment method: GitHub Sponsors if accepted, otherwise private payment details can be provided after acceptance.
