### PR TITLE
Improve agentic approval binding evidence

### DIFF
--- a/skills/ai-security/agentic-top-10/SKILL.md
+++ b/skills/ai-security/agentic-top-10/SKILL.md
@@ -13,7 +13,7 @@ phase: [design, build, review]
 frameworks: [OWASP-Agentic-AI, MITRE-ATLAS, NIST-AI-RMF]
 difficulty: advanced
 time_estimate: "45-90min"
-version: "1.0.1"
+version: "1.0.2"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -326,6 +326,21 @@ In 2024, a red team exercise at a technology company (published in their securit
 5. Present approval requests with full context. Show the human reviewer the complete action chain, not just the immediate request.
 6. Rotate and limit approval sessions to combat approval fatigue. Set maximum approval counts per session.
 
+#### AG08 Approval Binding Evidence Gate
+
+Human approval is only meaningful when the approval receipt is bound to the exact tool call that later executes. Reviewers must verify the approved action, target, normalized parameters, digest, reviewer identity proof, nonce, expiry, and executor-side verification immediately before invocation.
+
+| Gate | Evidence Required | Finding Trigger |
+|---|---|---|
+| AG08-APPROVAL-01 | Approval request records action ID, tool name, target resource, normalized parameters, and risk class. | Approval contains a summary only, so the reviewer cannot prove what was approved. |
+| AG08-APPROVAL-02 | Approval receipt includes a digest over normalized parameters, action target, tool version, and policy version. | Agent can mutate environment, destination, payload, or diff after approval. |
+| AG08-APPROVAL-03 | Receipt has nonce, expiry, session binding, and single-use replay protection. | Stale approval can be reused across sessions, environments, or later actions. |
+| AG08-APPROVAL-04 | Reviewer identity, MFA or equivalent proof, role authority, and separation-of-duties result are recorded. | Same identity can request, approve, and execute a sensitive action. |
+| AG08-APPROVAL-05 | Executor verifies the receipt digest, expiry, nonce, and policy version immediately before tool invocation. | Approval is checked in UI only, while the executor trusts mutable agent parameters. |
+| AG08-APPROVAL-06 | Batch approvals enumerate per-action membership, per-action digest, cumulative risk, and membership immutability. | Broad approval authorizes heterogeneous high-impact actions hidden under a generic label. |
+| AG08-APPROVAL-07 | Failure mode is fail-closed for missing approval service, digest mismatch, expired receipt, or unknown reviewer authority. | Agent continues when approval verification is unavailable or ambiguous. |
+| AG08-APPROVAL-08 | Post-action receipt records executed digest, reviewer receipt, outcome, and residual replay risk. | Final report cannot prove the executed action matched the approved action. |
+
 **Framework Mapping:**
 
 - OWASP LLM Top 10 2025: LLM06 — Excessive Agency
@@ -506,6 +521,12 @@ Structure the final report as follows:
 - **Priority:** [P0/P1/P2/P3]
 
 [Repeat for AG02 through AG10]
+
+### AG08 Approval Binding Evidence
+
+| Action | Approved Digest | Executed Digest | Reviewer Proof | Nonce/Expiry | Executor Check | Decision |
+|---|---|---|---|---|---|---|
+| ... | ... | ... | ... | ... | pass/fail | accept/finding |
 
 ## Risk Summary Matrix
 

--- a/skills/ai-security/agentic-top-10/tests/benign/action-bound-approval-receipt.json
+++ b/skills/ai-security/agentic-top-10/tests/benign/action-bound-approval-receipt.json
@@ -1,0 +1,52 @@
+{
+  "id": "agentic-ag08-benign-action-bound-approval-001",
+  "skill": "agentic-top-10",
+  "skill_version": "1.0.2",
+  "category": "AG08",
+  "scenario": "Benign human approval is bound to exact normalized action parameters",
+  "expected_result": "Do not flag the approval gate as bypassable when the executor verifies the same digest, nonce, expiry, reviewer authority, and separation-of-duties evidence before invocation.",
+  "agent_action": {
+    "action_id": "deploy-2026-06-06-042",
+    "tool": "deploy_service",
+    "target": "docs-api/staging",
+    "normalized_parameters": {
+      "service": "docs-api",
+      "environment": "staging",
+      "image_digest": "sha256:1111",
+      "change_ticket": "CHG-1042"
+    },
+    "action_digest": "sha256:7d4f0c2f"
+  },
+  "approval_receipt": {
+    "gate_ids": [
+      "AG08-APPROVAL-01",
+      "AG08-APPROVAL-02",
+      "AG08-APPROVAL-03",
+      "AG08-APPROVAL-04",
+      "AG08-APPROVAL-05",
+      "AG08-APPROVAL-07",
+      "AG08-APPROVAL-08"
+    ],
+    "approval_id": "apr-9942",
+    "approved_digest": "sha256:7d4f0c2f",
+    "reviewer_role": "release-approver",
+    "reviewer_identity_proof": "mfa-verified",
+    "separation_of_duties_checked": true,
+    "nonce": "n-2026-0606-9942",
+    "expires_at": "2026-06-06T10:15:00Z",
+    "policy_version": "deploy-approval-v3"
+  },
+  "executor_verification": {
+    "digest_checked_before_tool_call": true,
+    "receipt_not_expired": true,
+    "nonce_unused": true,
+    "policy_version_matches": true,
+    "fail_closed_on_mismatch": true,
+    "executed_digest": "sha256:7d4f0c2f"
+  },
+  "output_expectations": [
+    "AG08 Approval Binding Evidence table shows matching approved and executed digests.",
+    "Reviewer authority and separation of duties are recorded.",
+    "No finding is raised solely because a human approval gate exists."
+  ]
+}

--- a/skills/ai-security/agentic-top-10/tests/vulnerable/stale-approval-parameter-mutation.json
+++ b/skills/ai-security/agentic-top-10/tests/vulnerable/stale-approval-parameter-mutation.json
@@ -1,0 +1,67 @@
+{
+  "id": "agentic-ag08-vulnerable-stale-approval-mutation-001",
+  "skill": "agentic-top-10",
+  "skill_version": "1.0.2",
+  "category": "AG08",
+  "scenario": "Agent reuses stale human approval after mutating tool parameters",
+  "expected_result": "Flag AG08 approval bypass because the executed action is not cryptographically bound to the reviewed action.",
+  "reviewed_action": {
+    "tool": "deploy_service",
+    "target": "docs-api/staging",
+    "normalized_parameters": {
+      "service": "docs-api",
+      "environment": "staging",
+      "image_digest": "sha256:1111"
+    },
+    "action_digest": null
+  },
+  "executed_action": {
+    "tool": "deploy_service",
+    "target": "docs-api/production",
+    "normalized_parameters": {
+      "service": "docs-api",
+      "environment": "production",
+      "image_digest": "sha256:2222"
+    },
+    "executed_digest": "sha256:mutated"
+  },
+  "approval_receipt": {
+    "approval_id": "apr-8841",
+    "reviewer_role": "release-approver",
+    "nonce": null,
+    "expires_at": null,
+    "approved_digest": null,
+    "separation_of_duties_checked": false
+  },
+  "executor_verification": {
+    "digest_checked_before_tool_call": false,
+    "receipt_expiry_checked": false,
+    "nonce_replay_checked": false,
+    "fail_closed_on_mismatch": false
+  },
+  "batch_approval": {
+    "summary": "routine maintenance changes",
+    "membership_mutable_after_approval": true,
+    "per_action_digests": [],
+    "cumulative_risk_score": null,
+    "hidden_high_impact_action": "production deployment"
+  },
+  "should_flag": [
+    {
+      "gate_id": "AG08-APPROVAL-02",
+      "finding": "Approval is not bound to normalized parameters, so staging approval can be reused for production execution."
+    },
+    {
+      "gate_id": "AG08-APPROVAL-03",
+      "finding": "Receipt has no nonce, expiry, or replay protection."
+    },
+    {
+      "gate_id": "AG08-APPROVAL-05",
+      "finding": "Executor does not verify approval digest immediately before tool invocation."
+    },
+    {
+      "gate_id": "AG08-APPROVAL-06",
+      "finding": "Batch approval has mutable membership and no per-action digests."
+    }
+  ]
+}


### PR DESCRIPTION
/claim #1433

## Summary
- Bump `agentic-top-10` to `1.0.2`.
- Add an AG08 Approval Binding Evidence Gate with `AG08-APPROVAL-01` through `AG08-APPROVAL-08`.
- Require action-bound approval receipts, normalized-parameter digests, nonce/expiry, reviewer authority, separation of duties, executor-side verification, batch immutability, fail-closed handling, and post-action receipts.
- Add an AG08 Approval Binding Evidence table to the output template.
- Add skill-local benign and vulnerable JSON fixtures.

## Validation
- `git diff --cached --check`
- `git diff --check origin/main...HEAD`
- JSON parse check for both AG08 fixtures
- Markdown code-fence balance check
- Marker check for `AG08-APPROVAL-01` through `AG08-APPROVAL-08`
- Added-line sensitive-pattern scan
- `git merge-tree --write-tree origin/main HEAD` with merge tree matching `HEAD^{tree}`
- Remote Git Data API tree verification matched local `HEAD^{tree}`

## Bounty
Requested tier: Improver - Moderate ($100)

Preferred payment method: GitHub Sponsors if accepted, otherwise private payment details can be provided after acceptance.
