### PR TITLE
Improve alert dedup suppression evidence

### DIFF
--- a/skills/secops/alert-triage/SKILL.md
+++ b/skills/secops/alert-triage/SKILL.md
@@ -13,7 +13,7 @@ phase: [operate, respond]
 frameworks: [MITRE-ATT&CK-v16, NIST-SP-800-61-Rev2]
 difficulty: beginner
 time_estimate: "10-20min per alert"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -107,6 +107,22 @@ Connect the alert data with surrounding context to build a picture of what happe
 ### Phase 3: Classify
 
 Assign a disposition and priority based on collected and correlated data.
+
+#### De-duplication and Suppression Safety Gate
+
+Before closing a group of alerts as duplicate, BTP, or FP, prove that grouping and suppression will not hide distributed attack spread or later-stage activity. De-duplication reduces analyst noise; suppression changes detection coverage and therefore needs owner, scope, expiry, rollback, and follow-up evidence.
+
+| Gate | Evidence Required | Finding Trigger |
+|---|---|---|
+| TRIAGE-DEDUP-01 | Duplicate grouping key includes rule ID, raw event ID or source event hash, user, host, process, source/destination, tenant or cloud account, and time bucket. | Alerts are collapsed only by rule name or alert title. |
+| TRIAGE-DEDUP-02 | Cardinality is checked across users, hosts, source IPs, destinations, tenants, geographies, and time buckets before labeling an alert storm as noise. | Many affected entities are grouped as duplicate notifications without spread analysis. |
+| TRIAGE-DEDUP-03 | Prior disposition reuse records prior close date, analyst, rule version, asset criticality, threat intel context, and current raw event match. | Stale FP/BTP decisions are reused after rule, asset, or threat context changed. |
+| TRIAGE-DEDUP-04 | Case count, unique entity count, grouping reason, and excluded outliers are retained in the triage record. | The final report cannot reconstruct which alerts were grouped or why outliers were excluded. |
+| TRIAGE-SUP-01 | Suppression request records owner, ticket, exact field scope, expiry, rollback path, and change window. | Broad or permanent suppression is proposed from a single alert closure. |
+| TRIAGE-SUP-02 | Suppression is blocked or escalated for privileged users, critical assets, high-risk tenants, or late-stage ATT&CK tactics unless specifically risk-accepted. | High-value activity is hidden under a generic benign filter. |
+| TRIAGE-SUP-03 | BTP/FP rationale includes raw evidence, expected activity proof, rule-logic mismatch, or data-quality cause. | Alert fatigue or volume is used as the reason to close the alert. |
+| TRIAGE-SUP-04 | Detection-engineering follow-up includes compensating detection, monitoring query, test plan, and rollback validation. | Tuning removes coverage without replacement detection or retest evidence. |
+| TRIAGE-SUP-05 | Kill-chain coverage is checked before suppression to confirm related initial access, execution, lateral movement, collection, or impact signals are not present. | Recurring activity is suppressed before surrounding tactics are reviewed. |
 
 #### Disposition Categories
 
@@ -234,6 +250,16 @@ Produce the triage decision as a structured report:
 - **Threat Intel:** [IOC match results]
 - **Kill Chain Position:** [Where this falls in the attack lifecycle]
 
+### De-duplication and Suppression Safety
+| Field | Value |
+|-------|-------|
+| Duplicate Grouping Key | [rule/raw event/user/host/process/source/destination/tenant/time bucket] |
+| Unique Entity Counts | [users, hosts, IPs, tenants, geographies] |
+| Prior Disposition Freshness | [date, analyst, rule version, asset context] |
+| Suppression Scope | [exact field filters, owner, expiry, rollback, ticket] |
+| Kill-Chain Coverage Check | [related tactics reviewed before close/tuning] |
+| Decision | [group/close/escalate/tuning request] |
+
 ### Recommended Actions
 - [ ] [Action 1 -- e.g., isolate host, disable account, block IP]
 - [ ] [Action 2 -- e.g., collect forensic artifacts, memory dump]
@@ -318,6 +344,10 @@ Investigating an alert in isolation without checking for activity before and aft
 ### Pitfall 5: Delaying Escalation While Seeking Perfect Information
 
 Waiting for complete certainty before escalating a high-priority alert costs response time. NIST SP 800-61 recommends erring on the side of over-notification. If 20 minutes of investigation has not resolved the disposition and the alert involves a critical asset or privileged account, escalate to Tier 2 or the IR team with your current findings and continue investigation in parallel.
+
+### Pitfall 6: Treating Alert Volume as Proof of Benign Noise
+
+High alert volume can mean duplicate tool notifications, but it can also mean distributed credential attack activity, malware propagation, or recurring command execution across many assets. Do not collapse or suppress a storm until grouping keys, unique entity counts, prior disposition freshness, and kill-chain coverage have been reviewed.
 
 ---
 

--- a/skills/secops/alert-triage/tests/benign/duplicate-tool-notifications-scoped-suppression.json
+++ b/skills/secops/alert-triage/tests/benign/duplicate-tool-notifications-scoped-suppression.json
@@ -1,0 +1,46 @@
+{
+  "id": "alert-triage-benign-dedup-scoped-suppression-001",
+  "skill": "alert-triage",
+  "skill_version": "1.0.1",
+  "scenario": "Duplicate notifications from multiple tools map to one raw event and a narrowly scoped BTP tuning request",
+  "expected_result": "Group duplicate notifications, close as BTP with evidence, and request narrowly scoped time-bound tuning.",
+  "alerts": [
+    {
+      "alert_id": "siem-501",
+      "source_system": "SIEM",
+      "rule_id": "SUSPICIOUS_ADMIN_TOOL",
+      "raw_event_id": "evt-9a1",
+      "user": "svc-deploy",
+      "host": "build-runner-07",
+      "process": "approved-admin-tool.exe",
+      "tenant": "prod",
+      "timestamp_bucket": "2026-06-06T09:00Z"
+    },
+    {
+      "alert_id": "edr-774",
+      "source_system": "EDR",
+      "rule_id": "SUSPICIOUS_ADMIN_TOOL",
+      "raw_event_id": "evt-9a1",
+      "user": "svc-deploy",
+      "host": "build-runner-07",
+      "process": "approved-admin-tool.exe",
+      "tenant": "prod",
+      "timestamp_bucket": "2026-06-06T09:00Z"
+    }
+  ],
+  "evidence": {
+    "TRIAGE-DEDUP-01": "grouping key includes rule, raw event, user, host, process, tenant, and time bucket",
+    "TRIAGE-DEDUP-02": "unique entity count is one user, one host, one raw event, one tenant",
+    "TRIAGE-DEDUP-03": "prior BTP disposition is current for the same rule version and same build-runner asset context",
+    "TRIAGE-DEDUP-04": "triage record preserves source alert IDs and duplicate grouping reason",
+    "TRIAGE-SUP-01": "suppression request is limited to svc-deploy on build-runner hosts for approved-admin-tool.exe, expires in 30 days, and has rollback owner",
+    "TRIAGE-SUP-03": "BTP rationale links change ticket and expected deployment window",
+    "TRIAGE-SUP-04": "detection-engineering ticket includes retest query and rollback validation",
+    "TRIAGE-SUP-05": "no related execution, lateral movement, collection, or impact alerts in the review window"
+  },
+  "output_expectations": [
+    "De-duplication table records the grouping key and unique entity counts.",
+    "Tuning recommendation has exact scope, owner, expiry, rollback path, and ticket.",
+    "The alert group is not counted as multiple independent incidents."
+  ]
+}

--- a/skills/secops/alert-triage/tests/vulnerable/alert-storm-broad-suppression-hides-spread.json
+++ b/skills/secops/alert-triage/tests/vulnerable/alert-storm-broad-suppression-hides-spread.json
@@ -1,0 +1,56 @@
+{
+  "id": "alert-triage-vulnerable-alert-storm-suppression-001",
+  "skill": "alert-triage",
+  "skill_version": "1.0.1",
+  "scenario": "Distributed failed-auth storm is collapsed as noise and converted into a broad permanent suppression",
+  "expected_result": "Flag unsafe de-duplication and suppression because spread and kill-chain context were not reviewed.",
+  "alert_storm": {
+    "rule_id": "FAILED_AUTH_ANOMALY",
+    "alert_count": 340,
+    "unique_users": 96,
+    "unique_hosts": 41,
+    "source_ip_count": 18,
+    "tenants": [
+      "prod",
+      "corp"
+    ],
+    "time_buckets": [
+      "2026-06-06T08:00Z",
+      "2026-06-06T09:00Z",
+      "2026-06-06T10:00Z"
+    ],
+    "proposed_disposition": "duplicate noise"
+  },
+  "unsafe_tuning_request": {
+    "filter": "suppress FAILED_AUTH_ANOMALY for all admin users",
+    "owner": null,
+    "expiry": null,
+    "rollback_path": null,
+    "ticket_id": null,
+    "compensating_detection": null
+  },
+  "missing_evidence": [
+    "TRIAGE-DEDUP-01 full grouping key for each raw event",
+    "TRIAGE-DEDUP-02 cardinality analysis across users, hosts, source IPs, tenants, and time buckets",
+    "TRIAGE-DEDUP-03 fresh prior disposition tied to current rule and asset context",
+    "TRIAGE-DEDUP-04 retained outlier list and grouping rationale",
+    "TRIAGE-SUP-01 scoped owner, expiry, rollback, and ticket",
+    "TRIAGE-SUP-02 high-value user and tenant risk acceptance",
+    "TRIAGE-SUP-04 compensating detection and retest plan",
+    "TRIAGE-SUP-05 kill-chain coverage before suppression"
+  ],
+  "should_flag": [
+    {
+      "gate_id": "TRIAGE-DEDUP-02",
+      "finding": "Alert storm spans many users, hosts, source IPs, and tenants, so it cannot be collapsed as duplicate notifications without spread analysis."
+    },
+    {
+      "gate_id": "TRIAGE-SUP-01",
+      "finding": "Suppression is broad and permanent with no owner, expiry, ticket, or rollback path."
+    },
+    {
+      "gate_id": "TRIAGE-SUP-05",
+      "finding": "Kill-chain coverage was not checked before hiding recurring authentication anomaly activity."
+    }
+  ]
+}


### PR DESCRIPTION
/claim #1341

## Summary
- Bump `alert-triage` to `1.0.1`.
- Add a De-duplication and Suppression Safety Gate with `TRIAGE-DEDUP-01` through `TRIAGE-DEDUP-04` and `TRIAGE-SUP-01` through `TRIAGE-SUP-05`.
- Require grouping keys, cardinality checks, prior-disposition freshness, suppression owner/expiry/scope/rollback, compensating detection, and kill-chain coverage before closing or tuning.
- Add a de-duplication and suppression safety table to the triage output.
- Add skill-local benign and vulnerable JSON fixtures.

## Validation
- `git diff --cached --check`
- `git diff --check origin/main...HEAD`
- JSON parse check for both alert-triage fixtures
- Markdown code-fence balance check
- Marker check for `TRIAGE-DEDUP-*` and `TRIAGE-SUP-*`
- Added-line sensitive-pattern scan
- `git merge-tree --write-tree origin/main HEAD` with merge tree matching `HEAD^{tree}`
- Remote Git Data API tree verification matched local `HEAD^{tree}`

## Bounty
Requested tier: Improver - Moderate ($100)

Preferred payment method: GitHub Sponsors if accepted, otherwise private payment details can be provided after acceptance.
