### PR TITLE
Improve DAST authorization replay gates

### DIFF
--- a/skills/devsecops/dast-config/SKILL.md
+++ b/skills/devsecops/dast-config/SKILL.md
@@ -12,7 +12,7 @@ phase: [build, deploy]
 frameworks: [OWASP-Top-10-2021, OWASP-Testing-Guide-v4.2]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -331,6 +331,48 @@ env:
 
 ---
 
+#### 4.2 Multi-User Authorization Replay Evidence
+
+Authenticated scanning improves reachability, but it does not prove authorization coverage by itself. For broken access control, require replay evidence across distinct users, roles, object owners, and tenants where applicable. A single authenticated crawl can still miss horizontal access control, vertical privilege escalation, object ownership, and tenant isolation.
+
+**What to verify:**
+
+- The DAST plan defines a role/user matrix that includes unauthenticated, ordinary user, peer user, privileged user, and cross-tenant identities when those boundaries exist.
+- Browser contexts, cookie jars, bearer tokens, CSRF/state values, local storage, and session caches are isolated per identity.
+- Peer-object replay tests use object IDs owned by a different user in the same role.
+- Role replay tests send lower-privilege sessions to privileged routes and actions.
+- Cross-tenant replay tests use object IDs from another tenant or organization when the application is multi-tenant.
+- Expected-deny responses are documented per route and identity (`401`, `403`, `404`, redirect to login, or explicit error), not inferred from a generic scan pass.
+- Destructive routes excluded from DAST have manual authorization-test follow-up or documented residual risk.
+
+**Detection methods using allowed tools:**
+
+```
+# Find multi-user, role, and replay configuration
+Grep: "user|role|tenant|authorization|authz|replay|matrix|expected" in **/*zap* **/*dast* **/*.{yaml,yml,json,md}
+Grep: "cookie|csrf|state|session|browserContext|storageState|token" in **/*zap* **/*dast* **/*.{yaml,yml,json,js,ts,py}
+
+# Find object-owner and tenant test data
+Grep: "tenant-a|tenant_b|owner|peer|other_user|admin|standard-user" in **/*.{yaml,yml,json,md,js,ts,py}
+```
+
+**Authorization replay gates:**
+
+| Gate | Evidence Required | Finding Trigger |
+|---|---|---|
+| DAST-AUTHZ-01 | Role/user matrix includes relevant unauthenticated, low-privilege, peer, privileged, and tenant identities. | Report claims broken-access-control coverage from one authenticated identity. |
+| DAST-AUTHZ-02 | Session state is isolated per identity: cookies, bearer tokens, CSRF/state values, browser context, and local storage. | Replay uses shared cookie jars, copied CSRF values, or mixed browser storage. |
+| DAST-AUTHZ-03 | Horizontal replay covers peer-owned object IDs for read and write routes. | Private routes are crawled, but peer-object access is never replayed. |
+| DAST-AUTHZ-04 | Vertical replay covers privileged routes/actions with lower-privilege identities. | Admin paths are reached only with admin credentials. |
+| DAST-AUTHZ-05 | Cross-tenant replay covers tenant-scoped object IDs and route prefixes where multi-tenancy exists. | Same-tenant role checks are treated as tenant-isolation proof. |
+| DAST-AUTHZ-06 | Expected-deny status and response pattern are recorded per route, method, and identity. | Any non-200 or generic scanner pass is treated as authorization evidence. |
+| DAST-AUTHZ-07 | API/OpenAPI/GraphQL route coverage maps object classes to replayed identities and expected-deny assertions. | API scan imports a spec but lacks object-owner or tenant replay evidence. |
+| DAST-AUTHZ-08 | Excluded destructive or state-changing routes list residual authorization risk and manual follow-up. | Destructive routes are excluded with no compensating authorization test. |
+
+**Finding classification:** Single-user authenticated scans claiming authorization coverage are **High**. Shared-session replay that invalidates expected-deny evidence is **High**. Missing cross-tenant replay for tenant-owned APIs is **High**. Missing expected-deny documentation is **Medium**.
+
+---
+
 ### Step 5: CI/CD DAST Integration
 
 #### 5.1 Pipeline Integration Patterns
@@ -519,6 +561,14 @@ DAST tools report findings per-URL, producing hundreds of duplicate alerts for t
 | Active scanning (staging) | Yes/No | <workflow file> |
 | API scanning | Yes/No | <OpenAPI/GraphQL import> |
 | Results deduplication | Yes/No | <dedup method> |
+
+### Authorization Replay Evidence
+
+| Boundary | Identities Tested | Session Isolation | Replay Objects / Routes | Expected Denies | Residual Risk |
+|----------|-------------------|-------------------|--------------------------|-----------------|---------------|
+| Horizontal object ownership | <user A, user B> | <cookie/token/browser isolation> | <route + object IDs> | <status/pattern> | <none/manual follow-up> |
+| Vertical role access | <standard, admin> | <isolation evidence> | <admin routes/actions> | <status/pattern> | <none/manual follow-up> |
+| Tenant isolation | <tenant A, tenant B> | <isolation evidence> | <tenant object IDs/routes> | <status/pattern> | <none/manual follow-up> |
 
 ### Findings
 

--- a/skills/devsecops/dast-config/tests/benign/multi-user-authorization-replay-complete.json
+++ b/skills/devsecops/dast-config/tests/benign/multi-user-authorization-replay-complete.json
@@ -1,0 +1,53 @@
+{
+  "case": "multi_user_authorization_replay_complete",
+  "skill": "dast-config",
+  "expected_result": "pass",
+  "tool": "OWASP ZAP Automation Framework",
+  "identities": [
+    "unauthenticated",
+    "tenant-a-user",
+    "tenant-a-admin",
+    "tenant-a-peer-user",
+    "tenant-b-user"
+  ],
+  "session_isolation": {
+    "cookie_jars": "per_identity",
+    "browser_contexts": "per_identity",
+    "csrf_tokens": "refreshed_per_identity",
+    "local_storage": "per_identity",
+    "shared_state_detected": false
+  },
+  "authorization_replay": {
+    "horizontal": {
+      "routes": ["GET /api/projects/{projectId}", "PATCH /api/projects/{projectId}"],
+      "peer_object_ids": ["proj-a-owned-by-peer"],
+      "expected_denies_recorded": true
+    },
+    "vertical": {
+      "routes": ["GET /admin/users", "POST /admin/users/{id}/disable"],
+      "lower_privilege_identity": "tenant-a-user",
+      "expected_denies_recorded": true
+    },
+    "tenant": {
+      "routes": ["GET /api/invoices/{invoiceId}"],
+      "cross_tenant_object_ids": ["tenant-b-invoice-771"],
+      "expected_denies_recorded": true
+    }
+  },
+  "coverage": {
+    "openapi_snapshot": "openapi-2026-06-06.json",
+    "object_classes_mapped": ["project", "invoice", "user"],
+    "destructive_routes_excluded": ["DELETE /api/projects/{projectId}"],
+    "manual_follow_up": ["DELETE /api/projects/{projectId} authorization test in seeded disposable tenant"]
+  },
+  "covered_gates": [
+    "DAST-AUTHZ-01",
+    "DAST-AUTHZ-02",
+    "DAST-AUTHZ-03",
+    "DAST-AUTHZ-04",
+    "DAST-AUTHZ-05",
+    "DAST-AUTHZ-06",
+    "DAST-AUTHZ-07",
+    "DAST-AUTHZ-08"
+  ]
+}

--- a/skills/devsecops/dast-config/tests/vulnerable/single-user-shared-session-authz-overclaim.json
+++ b/skills/devsecops/dast-config/tests/vulnerable/single-user-shared-session-authz-overclaim.json
@@ -1,0 +1,63 @@
+{
+  "case": "single_user_shared_session_authz_overclaim",
+  "skill": "dast-config",
+  "expected_result": "finding",
+  "tool": "OWASP ZAP Automation Framework",
+  "identities": [
+    "standard-user"
+  ],
+  "report_claims": {
+    "authenticated_scanning": true,
+    "broken_access_control_coverage": "complete"
+  },
+  "session_isolation": {
+    "cookie_jars": "shared",
+    "browser_contexts": "shared",
+    "csrf_tokens": "copied_from_admin_seed",
+    "local_storage": "shared",
+    "shared_state_detected": true
+  },
+  "authorization_replay": {
+    "horizontal": null,
+    "vertical": {
+      "route": "GET /admin/users",
+      "source_identity": "admin-seed",
+      "replay_identity": "standard-user",
+      "response_status": 200,
+      "expected_deny_documented": false
+    },
+    "tenant": null
+  },
+  "coverage": {
+    "openapi_snapshot": "openapi-current.json",
+    "object_classes_mapped": [],
+    "destructive_routes_excluded": ["DELETE /api/users/{id}"],
+    "manual_follow_up": []
+  },
+  "expected_findings": [
+    {
+      "gate": "DAST-AUTHZ-01",
+      "reason": "Only one authenticated identity is configured while the report claims complete broken-access-control coverage."
+    },
+    {
+      "gate": "DAST-AUTHZ-02",
+      "reason": "Shared cookies, browser context, CSRF values, and local storage contaminate replay results."
+    },
+    {
+      "gate": "DAST-AUTHZ-03",
+      "reason": "No peer-owned object replay evidence exists."
+    },
+    {
+      "gate": "DAST-AUTHZ-05",
+      "reason": "Multi-tenant object replay is absent despite tenant-scoped APIs."
+    },
+    {
+      "gate": "DAST-AUTHZ-06",
+      "reason": "Expected-deny status and response pattern are not recorded."
+    },
+    {
+      "gate": "DAST-AUTHZ-08",
+      "reason": "Destructive routes are excluded with no compensating manual authorization test."
+    }
+  ]
+}


### PR DESCRIPTION
/claim #1488

## Summary
- Adds multi-user authorization replay evidence gates to `dast-config`.
- Separates authenticated reachability from broken-access-control coverage by requiring role/user matrices, isolated sessions, peer-object replay, vertical replay, cross-tenant replay, expected-deny evidence, and residual-risk tracking.
- Adds benign and vulnerable JSON fixtures for complete authorization replay versus single-user/shared-session overclaiming.

## Validation
- `git diff --check origin/main...HEAD`
- JSON parse check for both fixtures
- Markdown fence-balance and required-marker checks
- Added-line sensitive-pattern scan
- `git merge-tree --write-tree origin/main HEAD` matched `HEAD^{tree}`
