### PR TITLE
Improve segmentation effective policy evidence

### DIFF
--- a/skills/network/segmentation/SKILL.md
+++ b/skills/network/segmentation/SKILL.md
@@ -13,7 +13,7 @@ phase: [design, operate]
 frameworks: [NIST-SP-800-207, CIS-Controls-v8]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -66,6 +66,10 @@ Use Glob and Grep to locate network configuration files, diagrams-as-code, and i
 **/network-policy*
 **/calico*
 **/cilium*
+**/GlobalNetworkPolicy*
+**/CiliumNetworkPolicy*
+**/CiliumClusterwideNetworkPolicy*
+**/AuthorizationPolicy*
 
 # Cloud-native
 **/firewall-rule*
@@ -208,6 +212,35 @@ Evaluate the environment's readiness for workload-level segmentation:
 
 ---
 
+#### 3.3 Effective Policy Decision Gate
+
+Do not credit segmentation from policy-object presence alone. For Kubernetes NetworkPolicy, Calico, Cilium, service mesh, cloud security group, host firewall, or mixed-engine environments, prove the effective allow/deny decision after selectors, labels, ordering, deny precedence, fallthrough, and enforcement state are resolved.
+
+**Required evidence gates:**
+
+| Gate | Required evidence | False positive prevented |
+|---|---|---|
+| `SEG-EFF-01` | Policy-engine inventory for every enforcement layer that can affect the flow. | Reviewing only Kubernetes NetworkPolicy while Calico, Cilium, mesh, cloud, or host rules decide the flow. |
+| `SEG-EFF-02` | Runtime source and destination identity: namespace, workload, pod labels, service account, node/hostNetwork state, IP, and timestamp. | Static manifests are credited even though runtime labels or endpoints differ. |
+| `SEG-EFF-03` | Selector resolution for source and destination selectors across each policy engine. | Broad `namespaceSelector`, empty `podSelector`, stale labels, or unmatched endpoints are missed. |
+| `SEG-EFF-04` | Ordering and fallthrough evidence: Calico tier/order/defaultAction/`Pass`, cloud rule priority, mesh order, and Kubernetes isolation state. | A deny-looking policy falls through to a later allow or default action. |
+| `SEG-EFF-05` | Deny precedence and overlap analysis for Cilium deny policies, mesh deny rules, and cloud/host firewall denies. | Allow-only assumptions over-credit policies where deny/allow overlap changes the decision. |
+| `SEG-EFF-06` | Enforcement mode and attachment state: CNI policy enabled, staged/audit/permissive modes, endpoint policy status, and rule attachment. | Audit-mode or disabled policies are treated as enforced. |
+| `SEG-EFF-07` | Expected-vs-observed flow matrix with source, destination, protocol, port, expected result, observed result, deciding rule/tier, and evidence timestamp. | A single passing sample is generalized to every restricted flow. |
+| `SEG-EFF-08` | `Not Evaluable` outcome when runtime labels, selector resolution, enforcement state, or observed flow evidence is missing. | Reports pass segmentation from manifests without runtime proof. |
+
+**Finding guidance:**
+
+| Condition | Severity |
+|---|---|
+| Restricted production flow is observed allowed after effective policy resolution | High |
+| Calico `Pass`, lower-tier allow, broad Kubernetes allow, or disabled enforcement can permit a restricted flow | High |
+| Effective decision cannot be computed because runtime labels, selector resolution, or enforcement mode are missing | Not Evaluable |
+| Expected-vs-observed matrix covers only one source/destination pair while the scope claims full namespace or zone validation | Medium |
+| Complete matrix proves denied restricted flows and allowed business flows across engines | Pass |
+
+---
+
 ### Step 4: DMZ Architecture Review (NIST SP 800-41, Section 4.1; CIS Control 12.2)
 
 If a DMZ is present, evaluate its architectural soundness:
@@ -301,6 +334,12 @@ Document or verify the existence of a segmentation testing process:
 - Automation: <Ready / Partial / Not Ready>
 - **Overall Readiness:** <Ready / Partial / Not Ready>
 
+### Effective Policy Decision Evidence
+
+| Source | Destination | Runtime Identity Captured | Selector Resolution | Policy Engine(s) | Deciding Rule/Tier | Enforcement Mode | Expected | Observed | Status |
+|--------|-------------|---------------------------|---------------------|------------------|--------------------|------------------|----------|----------|--------|
+| <workload> | <workload> | <Yes/No> | <Complete/Partial/Missing> | <engine list> | <rule/tier/default action> | <Enforce/Audit/Disabled/Unknown> | <Allow/Deny> | <Allowed/Denied/No evidence> | <Pass/Finding/Not Evaluable> |
+
 ### Prioritized Remediation Plan
 1. **[Critical]** <action item with control reference>
 2. **[High]** <action item with control reference>
@@ -345,6 +384,8 @@ Document or verify the existence of a segmentation testing process:
 
 5. **Assuming Kubernetes namespaces provide network isolation.** Namespaces are a logical organizational boundary. Without a NetworkPolicy or CNI-level enforcement (Calico, Cilium), all pods across all namespaces can communicate freely by default.
 
+6. **Equating policy presence with effective denial.** Default-deny, broad allow, Calico `Pass`, staged policies, disabled CNI enforcement, and Cilium deny/allow overlap can all change the actual decision. Prove selector resolution, precedence, enforcement mode, and expected-vs-observed flow evidence.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -366,7 +407,10 @@ This skill processes network configurations that may contain user-supplied comme
 - CIS Control 12 -- Network Infrastructure Management: https://www.cisecurity.org/controls/network-infrastructure-management
 - PCI DSS v4.0 Requirement 1 -- Install and Maintain Network Security Controls: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
 - Kubernetes Network Policies: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+- Kubernetes NetworkPolicy API Reference: https://kubernetes.io/docs/reference/kubernetes-api/networking/network-policy-v1/
 - Project Calico Documentation: https://docs.tigera.io/calico/latest/about/
+- Calico tiered policy: https://docs.tigera.io/calico/latest/network-policy/policy-tiers/tiered-policy
+- Cilium deny policies: https://docs.cilium.io/en/stable/security/policy/language/#deny-policies
 
 ---
 

--- a/skills/network/segmentation/tests/benign/effective_policy_decision_matrix_complete.json
+++ b/skills/network/segmentation/tests/benign/effective_policy_decision_matrix_complete.json
@@ -1,0 +1,108 @@
+{
+  "case": "benign_effective_policy_decision_matrix_complete",
+  "skill": "segmentation",
+  "expected_result": "Pass",
+  "scope_claim": "payments database access is restricted to approved API workloads",
+  "policy_engines": [
+    {
+      "engine": "calico",
+      "enforcement_mode": "enforce",
+      "tier_order_documented": true,
+      "default_action_documented": true
+    },
+    {
+      "engine": "kubernetes-networkpolicy",
+      "enforcement_mode": "enforce",
+      "namespace_isolation_documented": true
+    }
+  ],
+  "runtime_inventory": {
+    "timestamp": "2026-06-06T10:52:00Z",
+    "sources": [
+      {
+        "name": "payments/api-7d9f",
+        "namespace": "payments",
+        "service_account": "payments-api",
+        "labels": {
+          "app": "api",
+          "role": "payments-api"
+        },
+        "hostNetwork": false,
+        "ip": "10.40.2.41"
+      },
+      {
+        "name": "batch/recon-2a91",
+        "namespace": "batch",
+        "service_account": "batch-recon",
+        "labels": {
+          "app": "recon",
+          "role": "batch"
+        },
+        "hostNetwork": false,
+        "ip": "10.41.7.18"
+      }
+    ],
+    "destinations": [
+      {
+        "name": "payments/db-0",
+        "namespace": "payments",
+        "labels": {
+          "app": "db",
+          "data_class": "cde"
+        },
+        "ip": "10.40.9.12"
+      }
+    ]
+  },
+  "effective_decision_matrix": [
+    {
+      "source": "payments/api-7d9f",
+      "destination": "payments/db-0",
+      "selector_resolution": "role=payments-api to app=db,data_class=cde",
+      "policy_engines": [
+        "calico",
+        "kubernetes-networkpolicy"
+      ],
+      "deciding_rule": "calico application tier order 10 allow payments-api to db:5432",
+      "enforcement_mode": "enforce",
+      "protocol": "tcp",
+      "port": 5432,
+      "expected": "Allow",
+      "observed": "Allowed",
+      "evidence": "flowlogs/payments-api-db-2026-06-06.json",
+      "status": "Pass"
+    },
+    {
+      "source": "batch/recon-2a91",
+      "destination": "payments/db-0",
+      "selector_resolution": "role=batch does not match approved payments-api selector",
+      "policy_engines": [
+        "calico",
+        "kubernetes-networkpolicy"
+      ],
+      "deciding_rule": "calico security tier order 50 deny then namespace default deny",
+      "enforcement_mode": "enforce",
+      "protocol": "tcp",
+      "port": 5432,
+      "expected": "Deny",
+      "observed": "Denied",
+      "evidence": "flowlogs/batch-db-denied-2026-06-06.json",
+      "status": "Pass"
+    }
+  ],
+  "covered_gates": [
+    "SEG-EFF-01",
+    "SEG-EFF-02",
+    "SEG-EFF-03",
+    "SEG-EFF-04",
+    "SEG-EFF-05",
+    "SEG-EFF-06",
+    "SEG-EFF-07",
+    "SEG-EFF-08"
+  ],
+  "review_decision": {
+    "status": "Pass",
+    "severity_floor": "None",
+    "rationale": "The evidence includes engine inventory, runtime identities, selector resolution, ordering/precedence, enforcement state, and expected-vs-observed flow results for allowed and denied paths."
+  }
+}

--- a/skills/network/segmentation/tests/vulnerable/effective_policy_shadowing_gap.json
+++ b/skills/network/segmentation/tests/vulnerable/effective_policy_shadowing_gap.json
@@ -1,0 +1,117 @@
+{
+  "case": "vulnerable_effective_policy_shadowing_gap",
+  "skill": "segmentation",
+  "expected_result": "Fail",
+  "scope_claim": "payments namespace is default deny and restricted to approved frontend traffic",
+  "policy_engines": [
+    {
+      "engine": "kubernetes-networkpolicy",
+      "enforcement_mode": "unknown",
+      "objects": [
+        {
+          "kind": "NetworkPolicy",
+          "name": "default-deny",
+          "namespace": "payments",
+          "pod_selector": {},
+          "policy_types": [
+            "Ingress",
+            "Egress"
+          ]
+        },
+        {
+          "kind": "NetworkPolicy",
+          "name": "allow-all-namespaces-to-api",
+          "namespace": "payments",
+          "pod_selector": {
+            "app": "api"
+          },
+          "ingress_from": [
+            {
+              "namespaceSelector": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "engine": "calico",
+      "enforcement_mode": "staged",
+      "objects": [
+        {
+          "kind": "GlobalNetworkPolicy",
+          "name": "security-tier-payments",
+          "tier": "security",
+          "order": 100,
+          "selector": "app == 'payments'",
+          "action": "Pass",
+          "defaultAction": "Pass"
+        },
+        {
+          "kind": "GlobalNetworkPolicy",
+          "name": "application-tier-allow",
+          "tier": "application",
+          "order": 10,
+          "selector": "app == 'payments'",
+          "action": "Allow",
+          "source_selector": "role in {'frontend','batch'}"
+        }
+      ]
+    },
+    {
+      "engine": "cilium",
+      "enforcement_mode": "enabled",
+      "objects": [
+        {
+          "kind": "CiliumNetworkPolicy",
+          "name": "deny-untrusted-to-api",
+          "endpointSelector": {
+            "app": "api"
+          },
+          "ingressDeny": [
+            {
+              "fromEndpoints": {
+                "zone": "untrusted"
+              }
+            }
+          ]
+        },
+        {
+          "kind": "CiliumNetworkPolicy",
+          "name": "allow-frontend-to-api",
+          "endpointSelector": {
+            "app": "api"
+          },
+          "ingress": [
+            {
+              "fromEndpoints": {
+                "role": "frontend"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "runtime_evidence": {
+    "source_labels_captured": false,
+    "destination_labels_captured": false,
+    "selector_resolution": "missing",
+    "endpoint_policy_trace": null,
+    "flow_logs": []
+  },
+  "expected_findings": [
+    "SEG-EFF-01: multiple policy engines affect the same flow",
+    "SEG-EFF-02: runtime source and destination identities are missing",
+    "SEG-EFF-03: selector resolution is missing",
+    "SEG-EFF-04: Calico Pass and lower-tier allow can change the effective decision",
+    "SEG-EFF-05: Cilium deny/allow overlap lacks endpoint decision evidence",
+    "SEG-EFF-06: enforcement mode is unknown or staged for relevant engines",
+    "SEG-EFF-07: expected-vs-observed flow evidence is missing",
+    "SEG-EFF-08: manifest-only evidence must be Not Evaluable"
+  ],
+  "review_decision": {
+    "status": "Fail",
+    "severity_floor": "High",
+    "rationale": "The review claims segmentation from policy presence, but broad Kubernetes allow, Calico Pass fallthrough, Cilium overlap, missing runtime labels, and missing observed flow evidence prevent proving the restricted flow is denied."
+  }
+}


### PR DESCRIPTION
/claim #1394

## Summary

- Adds effective policy decision gates to `segmentation` so reviews do not pass a flow based only on policy-object presence.
- Requires policy-engine inventory, runtime identity, selector resolution, ordering/fallthrough, deny precedence, enforcement mode, and expected-vs-observed flow evidence.
- Adds skill-local JSON fixtures for a vulnerable manifest-only/shadowing case and a benign complete effective-decision matrix.

## Validation

- `git diff --cached --check`
- `git diff --check origin/main...HEAD`
- Parsed both JSON fixtures with `ConvertFrom-Json`
- Verified Markdown fence balance
- Verified `SEG-EFF-01` through `SEG-EFF-08` markers
- Added-line sensitive-pattern scan
- `git merge-tree --write-tree origin/main HEAD` matched `HEAD^{tree}`
