### PR TITLE
Improve Azure Functions evidence gates

### DIFF
--- a/skills/cloud/azure-review/SKILL.md
+++ b/skills/cloud/azure-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-Azure-v2.1.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -88,6 +88,58 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, Bic
 
 ---
 
+### Supplemental Gate: Azure Functions HTTP Trigger, Key, and Admin Endpoint Evidence
+
+Azure Functions share App Service infrastructure, but HTTP triggers, function/host keys, runtime admin endpoints, SCM/Kudu exposure, and downstream identity patterns create serverless-specific review paths. Apply this supplemental gate when IaC or exports include `azurerm_linux_function_app`, `azurerm_windows_function_app`, `Microsoft.Web/sites` with `kind=functionapp`, `function.json`, host.json, deployment packages, or Azure Functions runtime settings.
+
+This gate is supplemental evidence and does not claim a CIS Azure recommendation ID. Keep its findings separate from Section 9 App Service scoring while still including them in the prioritized remediation plan.
+
+```
+AZFUNC-EVID-01: HTTP trigger `authLevel` is `anonymous` in production without enforced upstream identity-aware control
+AZFUNC-EVID-02: HTTP trigger uses `function` or `admin` key level as the only client authentication for sensitive routes
+AZFUNC-EVID-03: Function, host, or master/admin key inventory lacks owner, storage location, read/list permission, or rotation evidence
+AZFUNC-EVID-04: `/admin`, runtime admin APIs, SCM/Kudu, or deployment endpoints are reachable from public networks without strong identity and network controls
+AZFUNC-EVID-05: `functionsRuntimeAdminIsolationEnabled` support is ignored or not evidenced for eligible function apps
+AZFUNC-EVID-06: Downstream access relies on static connection material where managed identity or identity-based connections are available
+AZFUNC-EVID-07: Public network access, CORS, private endpoint, APIM/App Gateway, or access restriction evidence is missing or not tied to the function app
+AZFUNC-EVID-08: Invocation, failed authorization, key-use, and admin-operation telemetry is missing or cannot be tied to the reviewed function app
+```
+
+**Evidence to collect:**
+
+| Evidence Area | Required Evidence | Decision Rule |
+|---|---|---|
+| HTTP trigger authorization | `function.json`, code annotation, or deployment export for each route and `authLevel` | Public production anonymous routes need upstream identity-aware enforcement or a documented public-use rationale |
+| Function and host keys | Inventory of function, host, and master/admin keys; owner; read/list permissions; rotation evidence | Keys are shared access material, not per-user authorization |
+| Admin endpoint isolation | `/admin`, runtime admin API, SCM/Kudu, deployment endpoint, private endpoint, access restriction, and `functionsRuntimeAdminIsolationEnabled` evidence | Public admin or SCM exposure without strong identity and network controls is High severity |
+| Downstream identity | System/user-assigned managed identity and identity-based connections for Storage, Key Vault, Service Bus, Event Hubs, SQL, or other dependencies | Prefer managed identity; justify remaining static connection material |
+| Public ingress controls | `publicNetworkAccess`, access restrictions, private endpoints, APIM/App Gateway, App Service Authentication, and CORS | Function keys alone do not satisfy authentication for sensitive APIs |
+| Diagnostics | App Insights, diagnostic settings, invocation logs, failed authorization, key-use, admin API calls, and anomalous invocation volume | Missing telemetry makes the function-specific control `Not Evaluable` |
+
+```
+Azure Functions Evidence:
+- Function App:                 [name/resource ID]
+- Environment / Sensitivity:    [prod/non-prod, public/internal, data sensitivity]
+- Trigger Route:                [method/path]
+- Auth Level:                   [anonymous | function | admin]
+- Upstream Auth Control:        [App Service Auth | APIM JWT | App Gateway/WAF | None | Not Evaluable]
+- Public Network Access:        [Enabled/Disabled]
+- Private Endpoint:             [Yes/No]
+- Key Inventory / Rotation:     [owner/date/source/read-list permissions]
+- Admin Endpoint Isolation:     [functionsRuntimeAdminIsolationEnabled/network restrictions/SCM state]
+- Downstream Identity:          [managed identity | identity-based connection | static connection material]
+- Diagnostic Evidence:          [App Insights/diagnostic setting/log query]
+- Decision:                     [Pass | Fail | Not Evaluable]
+```
+
+**False-positive guardrails:**
+
+- Do not fail intentionally public anonymous functions such as health checks or public webhooks when route scope, upstream validation, rate limiting, and monitoring are evidenced.
+- Do not treat the presence of a function key as per-user authorization; require identity-aware control for sensitive operations.
+- Do not mark diagnostics as Pass from IaC alone when no invocation/admin telemetry export is available; use `Not Evaluable`.
+
+---
+
 
 ---
 
@@ -141,6 +193,13 @@ Produce the final report using the structure defined in the Output Format sectio
 | 7 | Virtual Machines | X | Y | Z | nn% |
 | 8 | Key Vault | X | Y | Z | nn% |
 | 9 | App Service | X | Y | Z | nn% |
+| Supplemental | Azure Functions | X | Y | Z | nn% |
+
+### Azure Functions Supplemental Evidence
+
+| Function App | Environment | Trigger | Auth Level | Upstream Auth | Key Governance | Admin / SCM Isolation | Downstream Identity | Diagnostics | Status |
+|---|---|---|---|---|---|---|---|---|---|
+| [function app] | [prod/non-prod] | [method/path] | [anonymous/function/admin] | [control] | [owner/rotation/read-list evidence] | [isolation evidence] | [managed identity/static material] | [evidence] | [Pass/Fail/Not Evaluable] |
 
 ### Detailed Findings
 
@@ -184,6 +243,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | 7 | Virtual Machines | Azure Bastion, managed disks, disk encryption with CMK, approved extensions, endpoint protection |
 | 8 | Key Vault | Key/secret expiration, soft delete, purge protection, RBAC authorization, private endpoints |
 | 9 | App Service | Authentication, HTTPS redirect, TLS version, client certificates, Entra ID registration, HTTP/2, FTP disabled |
+| Supplemental | Azure Functions | HTTP trigger auth levels, function/host keys, admin endpoint isolation, managed identity, public ingress, diagnostics |
 
 ### CIS Profile Levels
 
@@ -200,6 +260,8 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **NSG rules using service tags.** A rule with `source_address_prefix = "Internet"` is equivalent to `0.0.0.0/0`. Both must be flagged for CIS 6.1 and 6.2.
 5. **Key Vault purge protection is irreversible.** CIS 8.5 requires `purge_protection_enabled = true`. Note this cannot be disabled once enabled -- flag this for awareness during remediation.
 6. **App Service TLS version on both Linux and Windows.** Check `azurerm_linux_web_app` and `azurerm_windows_web_app` resources separately.
+7. **Treating Azure Functions as generic Web Apps.** Function apps need route-level `authLevel`, key governance, admin endpoint isolation, downstream identity, ingress, and diagnostics evidence beyond the generic App Service checks.
+8. **Treating function keys as user authentication.** Function and host keys are shared access material. Sensitive routes need identity-aware upstream enforcement and auditable key governance.
 
 ---
 
@@ -225,10 +287,14 @@ Produce the final report using the structure defined in the Output Format sectio
 - Azure Storage Security: https://learn.microsoft.com/en-us/azure/storage/common/storage-security-guide
 - Azure Key Vault Best Practices: https://learn.microsoft.com/en-us/azure/key-vault/general/best-practices
 - Azure App Service Security: https://learn.microsoft.com/en-us/azure/app-service/overview-security
+- Azure Functions Security Concepts: https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts
+- Azure Functions HTTP Trigger: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger
+- Azure Functions Identity-Based Connections: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
 - Terraform AzureRM Provider Documentation: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
 
 ---
 
 ## Changelog
 
+- **1.0.1** -- Add Azure Functions HTTP trigger, key governance, admin endpoint, managed identity, and diagnostics evidence gates.
 - **1.0.0** -- Initial release. Full coverage of CIS Microsoft Azure Foundations Benchmark v2.1.0 sections 1 through 9.

--- a/skills/cloud/azure-review/benchmark-checklist.md
+++ b/skills/cloud/azure-review/benchmark-checklist.md
@@ -704,3 +704,114 @@ resource "azurerm_linux_web_app" {
   }
 }
 ```
+---
+
+## Supplemental -- Azure Functions HTTP Trigger, Key, and Admin Endpoint Evidence
+
+These checks are not CIS Azure v2.1.0 recommendation IDs. Use them as supplemental evidence when the repository contains Azure Functions resources, `function.json`, host.json, ARM/Bicep/Terraform function app resources, deployment packages, or runtime configuration exports.
+
+### AZURE-FUNCTIONS-HTTP-AUTH -- Verify HTTP trigger auth levels and upstream identity controls
+
+Review every HTTP trigger route and its `authLevel`:
+
+```json
+{
+  "bindings": [
+    {
+      "type": "httpTrigger",
+      "authLevel": "anonymous",
+      "methods": ["get", "post"],
+      "route": "orders/{id}"
+    }
+  ]
+}
+```
+
+Flag production `anonymous` triggers unless evidence shows enforced upstream identity-aware control such as App Service Authentication, API Management JWT validation, App Gateway/WAF authentication, or an equivalent control. For intentionally public routes, record route purpose, allowed methods, rate limits, validation, and monitoring evidence.
+
+### AZURE-FUNCTIONS-KEYS -- Verify function, host, and master/admin key governance
+
+Function and host keys are shared access material, not user identity. Require evidence for:
+
+- Function-specific keys
+- Host keys
+- Master/admin key handling
+- Who can read, list, regenerate, or deploy keys
+- Storage location and rotation evidence
+- Separation between production and non-production keys
+
+### AZURE-FUNCTIONS-ADMIN -- Verify admin endpoint and SCM/Kudu isolation
+
+Check runtime admin, `/admin`, SCM/Kudu, and deployment endpoints:
+
+```hcl
+resource "azurerm_linux_function_app" "example" {
+  public_network_access_enabled = false
+
+  site_config {
+    scm_minimum_tls_version = "1.2"
+
+    ip_restriction {
+      action     = "Deny"
+      ip_address = "0.0.0.0/0"
+    }
+  }
+
+  app_settings = {
+    "functionsRuntimeAdminIsolationEnabled" = "1"
+  }
+}
+```
+
+Flag public admin or SCM exposure when it lacks strong identity controls, private access, or access restrictions. If `functionsRuntimeAdminIsolationEnabled` is supported but not evidenced, mark the admin isolation dimension `Not Evaluable`.
+
+### AZURE-FUNCTIONS-MANAGED-IDENTITY -- Prefer managed identity for downstream resources
+
+Check for system-assigned or user-assigned managed identity and identity-based connections:
+
+```hcl
+resource "azurerm_linux_function_app" "example" {
+  identity {
+    type = "SystemAssigned"
+  }
+
+  app_settings = {
+    "AzureWebJobsStorage__accountName" = azurerm_storage_account.example.name
+  }
+}
+```
+
+Flag static connection material for Storage, Service Bus, Event Hubs, SQL, or Key Vault access when managed identity or identity-based connections are available and no compensating rationale is provided.
+
+### AZURE-FUNCTIONS-INGRESS -- Verify public network, private endpoint, APIM/App Gateway, and CORS scope
+
+Review:
+
+- `publicNetworkAccess`
+- Private endpoint configuration
+- Access restrictions and deny-by-default rules
+- API Management or App Gateway fronting
+- App Service Authentication settings
+- CORS allowed origins and credentials behavior
+- Route-level exposure and environment sensitivity
+
+### AZURE-FUNCTIONS-DIAGNOSTICS -- Verify invocation, authorization, key-use, and admin-operation telemetry
+
+Require Application Insights or diagnostic settings for invocation telemetry, failed authorization, key-use events, admin API calls, and anomalous invocation volume:
+
+```hcl
+resource "azurerm_monitor_diagnostic_setting" "function_app" {
+  target_resource_id = azurerm_linux_function_app.example.id
+
+  enabled_log {
+    category = "FunctionAppLogs"
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
+}
+```
+
+If only IaC is available and no log export is provided, mark diagnostics `Not Evaluable` instead of Pass.

--- a/skills/cloud/azure-review/tests/benign/function_public_webhook_with_upstream_controls.json
+++ b/skills/cloud/azure-review/tests/benign/function_public_webhook_with_upstream_controls.json
@@ -1,0 +1,56 @@
+{
+  "scenario": "function-public-webhook-with-upstream-controls",
+  "skill": "azure-review",
+  "expected_skill_version": "1.0.1",
+  "function_app": {
+    "name": "prod-webhook-func",
+    "environment": "production",
+    "kind": "functionapp,linux",
+    "public_network_access_enabled": true,
+    "private_endpoint": false
+  },
+  "http_triggers": [
+    {
+      "route": "webhooks/vendor",
+      "methods": [
+        "post"
+      ],
+      "authLevel": "anonymous",
+      "upstream_auth_control": {
+        "control": "api-management-jwt-validation",
+        "required_claims": [
+          "aud",
+          "iss"
+        ],
+        "rate_limit_policy": "per-vendor"
+      },
+      "sensitivity": "public-webhook-receiver"
+    }
+  ],
+  "key_governance": {
+    "function_keys_inventoried": true,
+    "host_keys_inventoried": true,
+    "read_list_permissions_reviewed": true,
+    "rotation_evidence": "CHG-2026-0609"
+  },
+  "admin_endpoint": {
+    "scm_public": false,
+    "admin_api_public": false,
+    "functionsRuntimeAdminIsolationEnabled": "1",
+    "access_restrictions": [
+      "deny-internet",
+      "allow-build-agent-subnet"
+    ]
+  },
+  "downstream_access": {
+    "uses_managed_identity": true,
+    "identity_based_connection_evidence": "AzureWebJobsStorage__accountName"
+  },
+  "diagnostics": {
+    "app_insights_enabled": true,
+    "admin_operation_logs_available": true,
+    "failed_authorization_logs_available": true
+  },
+  "expected_status": "pass",
+  "false_positive_guardrail": "anonymous public webhook route is acceptable when upstream identity validation, key governance, admin isolation, managed identity, and telemetry are evidenced"
+}

--- a/skills/cloud/azure-review/tests/vulnerable/function_public_admin_and_static_connection_gap.json
+++ b/skills/cloud/azure-review/tests/vulnerable/function_public_admin_and_static_connection_gap.json
@@ -1,0 +1,73 @@
+{
+  "scenario": "function-public-admin-and-static-connection-gap",
+  "skill": "azure-review",
+  "expected_skill_version": "1.0.1",
+  "function_app": {
+    "name": "prod-orders-func",
+    "environment": "production",
+    "kind": "functionapp,linux",
+    "public_network_access_enabled": true,
+    "private_endpoint": false
+  },
+  "http_triggers": [
+    {
+      "route": "orders/{id}",
+      "methods": [
+        "get",
+        "post"
+      ],
+      "authLevel": "anonymous",
+      "upstream_auth_control": null,
+      "sensitivity": "customer-order-data"
+    }
+  ],
+  "key_governance": {
+    "function_keys_inventoried": false,
+    "host_keys_inventoried": false,
+    "read_list_permissions_reviewed": false,
+    "rotation_evidence": null
+  },
+  "admin_endpoint": {
+    "scm_public": true,
+    "admin_api_public": true,
+    "functionsRuntimeAdminIsolationEnabled": null,
+    "access_restrictions": []
+  },
+  "downstream_access": {
+    "uses_managed_identity": false,
+    "uses_static_connection_material": true,
+    "identity_based_connection_evidence": null
+  },
+  "diagnostics": {
+    "app_insights_enabled": false,
+    "admin_operation_logs_available": false,
+    "failed_authorization_logs_available": false
+  },
+  "expected_findings": [
+    {
+      "id": "AZFUNC-EVID-01",
+      "severity": "high",
+      "reason": "production anonymous HTTP trigger lacks enforced upstream identity-aware control"
+    },
+    {
+      "id": "AZFUNC-EVID-03",
+      "severity": "medium",
+      "reason": "function and host key governance evidence is missing"
+    },
+    {
+      "id": "AZFUNC-EVID-04",
+      "severity": "high",
+      "reason": "admin and SCM endpoints are publicly reachable without network restrictions"
+    },
+    {
+      "id": "AZFUNC-EVID-06",
+      "severity": "medium",
+      "reason": "downstream access uses static connection material where managed identity evidence is missing"
+    },
+    {
+      "id": "AZFUNC-EVID-08",
+      "severity": "medium",
+      "reason": "invocation, authorization, and admin-operation telemetry is unavailable"
+    }
+  ]
+}


### PR DESCRIPTION
/claim #1758

## Summary
- Add Azure Functions HTTP trigger, key governance, admin endpoint, managed identity, ingress, and diagnostics evidence gates
- Add supplemental checklist sections without claiming CIS recommendation IDs
- Add JSON fixtures for public/admin/static-connection gaps and a benign public webhook with upstream controls

## Validation
- `git diff --cached --check`
- `git diff --check origin/main...HEAD`
- JSON fixture parse check with `ConvertFrom-Json`
- Markdown fence balance check for `SKILL.md` and `benchmark-checklist.md`
- Marker check for `AZFUNC-EVID-01` through `AZFUNC-EVID-08`
- Checklist marker check for Azure Functions sections and `functionsRuntimeAdminIsolationEnabled`
- Added-line sensitive-pattern scan
- `git merge-tree --write-tree origin/main HEAD` matched `HEAD^{tree}`
