### PR TITLE
Improve CVE alias lifecycle gates

### DIFF
--- a/skills/vuln-management/cve-triage/SKILL.md
+++ b/skills/vuln-management/cve-triage/SKILL.md
@@ -12,7 +12,7 @@ phase: [operate, respond]
 frameworks: [CVSS-4.0, SSVC-2.1, CISA-KEV, EPSS]
 difficulty: intermediate
 time_estimate: "10-20min per CVE"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob, WebFetch
@@ -52,6 +52,8 @@ Before starting, collect or confirm:
 - [ ] **Business criticality:** What business function does the affected system support? (Revenue-generating, customer-facing, internal tooling, development)
 - [ ] **Compensating controls:** Are there existing mitigations in place? (WAF, network segmentation, EDR, disabled feature)
 - [ ] **Compliance requirements:** Any regulatory mandates affecting patch timelines? (CISA BOD 22-01 for federal, PCI DSS, HIPAA)
+- [ ] **Canonical vulnerability identity:** CVE, GHSA, OSV, vendor advisory, distro advisory, scanner plugin IDs, and duplicate/superseded relationships for the same underlying vulnerability.
+- [ ] **Source lifecycle status:** Published, Reserved, Rejected, Disputed, Withdrawn, Duplicate, Not Affected, or Fixed status from CNA/CVE List, NVD, GHSA, OSV, vendor, distro, and VEX sources before SLA assignment.
 
 If the CVE ID is provided but other context is missing, proceed with conservative assumptions (internet-facing, business-critical) and flag the assumptions in the output.
 
@@ -82,7 +84,33 @@ CVE Context Summary:
 - Known Aliases:       [Common names, e.g., "Log4Shell", "Heartbleed"]
 ```
 
-### Step 2: CVSS 4.0 Assessment
+### Step 2: Normalize Vulnerability Identity and Lifecycle Status
+
+Before CVSS, EPSS, KEV, SSVC, or SLA assignment, consolidate all aliases for the same underlying vulnerability and verify whether each source still treats it as active.
+
+**Identity and status evidence gates:**
+
+| Gate | Evidence Required | Blocks If Missing |
+|---|---|---|
+| `CVE-IDENT-01` | Canonical ID chosen from CVE List/CNA/NVD/GHSA/OSV/vendor/distro records, with source URL and retrieval date. | Starting duplicate SLA clocks from scanner-only IDs |
+| `CVE-IDENT-02` | Alias map for CVE, GHSA, OSV, vendor advisory, distro advisory, package advisory, scanner plugin, and common-name IDs. | Creating multiple tickets for one vulnerability |
+| `CVE-IDENT-03` | Source lifecycle status for each identity: Published, Reserved, Rejected, Disputed, Withdrawn, Duplicate, Not Affected, or Fixed. | Scoring inactive or withdrawn records as live vulnerabilities |
+| `CVE-IDENT-04` | Rejection, duplicate-of, superseded-by, or disputed rationale copied as a short paraphrase with source reference. | Treating REJECTED/Duplicate records as Immediate or Out-of-Cycle |
+| `CVE-IDENT-05` | Identity confidence (`high`, `medium`, `low`) based on overlapping affected product, version range, package URL, CPE/PURL, fix version, references, and CNA/vendor text. | Merging unrelated vulnerabilities only because titles or scanners look similar |
+| `CVE-IDENT-06` | One consolidated ticket or recommendation per canonical vulnerability, listing all aliases and per-source evidence. | Backlog inflation from duplicate CVE/GHSA/OSV/vendor records |
+| `CVE-IDENT-07` | Human-review disposition for Disputed, low-confidence alias, source-conflict, or scanner-only findings. | Fully automated SLA assignment when identity or lifecycle status is uncertain |
+| `CVE-IDENT-08` | SLA eligibility decision made after status normalization: inactive records receive no active vulnerability SLA unless compensating vendor guidance says action remains required. | SLA escalation before lifecycle status is checked |
+
+**Status handling rules:**
+
+- **Published/Active:** Continue to CVSS, KEV, EPSS, SSVC, and SLA after alias consolidation.
+- **Rejected/Withdrawn/Duplicate:** Do not assign an active vulnerability SLA. Record the reason, source, and duplicate/superseding ID if present.
+- **Reserved:** Do not score from scanner severity alone. Mark as `Not Evaluable` until public details or vendor guidance exist.
+- **Disputed:** Require human review. Continue only with an explicit confidence statement and source comparison.
+- **Not Affected/Fixed VEX:** De-escalate only when the VEX or vendor statement matches the deployed product, version, component, and configuration.
+- **Conflicting sources:** Prefer CNA/vendor status for lifecycle, but show the disagreement and require human review before SLA.
+
+### Step 3: CVSS 4.0 Assessment
 
 Walk through the CVSS 4.0 metric groups to compute or validate the Base score. CVSS 4.0 replaces the CVSS 3.1 "Temporal" group with "Threat" metrics and adds a Supplemental metric group.
 
@@ -143,7 +171,7 @@ CVSS 4.0 Assessment:
 - Vector String:       CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N/E:A
 ```
 
-### Step 3: CISA KEV Cross-Check
+### Step 4: CISA KEV Cross-Check
 
 Determine whether this CVE appears on the CISA Known Exploited Vulnerabilities catalog.
 
@@ -170,7 +198,7 @@ CISA KEV Status:
 - Ransomware Use:      [Known | Unknown | N/A]
 ```
 
-### Step 4: EPSS Score Check
+### Step 5: EPSS Score Check
 
 Retrieve the Exploit Prediction Scoring System probability for this CVE.
 
@@ -200,7 +228,7 @@ EPSS Assessment:
 - Data Date:           [YYYY-MM-DD]
 ```
 
-### Step 5: SSVC 2.1 Decision Tree
+### Step 6: SSVC 2.1 Decision Tree
 
 Walk through the CERT/CC Stakeholder-Specific Vulnerability Categorization (SSVC) version 2.1 decision tree. SSVC produces an action-oriented decision, not a numeric score.
 
@@ -269,9 +297,9 @@ SSVC 2.1 Decision:
 - Rationale:           [1-2 sentences explaining the decision path]
 ```
 
-### Step 6: SLA Assignment and Remediation Recommendation
+### Step 7: SLA Assignment and Remediation Recommendation
 
-Combine all assessment data to assign a remediation SLA and produce a final recommendation.
+Combine all assessment data to assign a remediation SLA and produce a final recommendation. Do not start the SLA clock until `CVE-IDENT-01` through `CVE-IDENT-08` have been evaluated for the canonical vulnerability.
 
 **Framework mapping:** Enterprise Vulnerability Management SLA Matrix
 
@@ -312,7 +340,7 @@ Produce a structured report with these exact sections:
 ```markdown
 ## CVE Triage Report: [CVE-YYYY-NNNNN]
 **Date:** [YYYY-MM-DD]
-**Skill:** cve-triage v1.0.0
+**Skill:** cve-triage v1.0.1
 **Frameworks:** CVSS 4.0, SSVC 2.1, EPSS, CISA KEV
 **Reviewer:** AI-assisted (human review required for Immediate/Out-of-Cycle findings)
 
@@ -328,6 +356,28 @@ recommended SLA tier. Lead with the most critical fact.]
 | Affected Software | [Product vX.Y.Z] |
 | Affected Component | [Component] |
 | Patch Available | [Yes/No/Workaround] |
+
+### Identity and Lifecycle Normalization
+| Field | Value |
+|---|---|
+| Canonical ID | [CVE/GHSA/OSV/vendor ID used for the consolidated recommendation] |
+| Source Status | [Published / Reserved / Rejected / Disputed / Withdrawn / Duplicate / Not Affected / Fixed] |
+| Alias Set | [CVE, GHSA, OSV, vendor, distro, scanner plugin IDs] |
+| Identity Confidence | [High / Medium / Low] |
+| Duplicate/Superseded By | [ID or N/A] |
+| Human Review Required | [Yes / No, with reason] |
+| SLA Eligibility | [Eligible / Not eligible / Human review required] |
+
+| Gate | Evidence | Result |
+|---|---|---|
+| CVE-IDENT-01 | [Canonical source and retrieval date] | [Pass / Fail / Not Evaluable] |
+| CVE-IDENT-02 | [Alias map] | [Pass / Fail / Not Evaluable] |
+| CVE-IDENT-03 | [Lifecycle status per source] | [Pass / Fail / Not Evaluable] |
+| CVE-IDENT-04 | [Rejected/duplicate/disputed rationale] | [Pass / Fail / Not Evaluable] |
+| CVE-IDENT-05 | [Identity confidence evidence] | [Pass / Fail / Not Evaluable] |
+| CVE-IDENT-06 | [Consolidated ticket/recommendation] | [Pass / Fail / Not Evaluable] |
+| CVE-IDENT-07 | [Human-review disposition] | [Pass / Fail / Not Evaluable] |
+| CVE-IDENT-08 | [Post-normalization SLA eligibility] | [Pass / Fail / Not Evaluable] |
 
 ### CVSS 4.0 Assessment
 | Metric Group | Score | Severity |
@@ -395,12 +445,12 @@ When triaging multiple CVEs (e.g., from a scan report), produce a summary table 
 **Date:** [YYYY-MM-DD]
 **Total CVEs:** [N]
 
-| CVE ID | CVSS 4.0 | EPSS | KEV | SSVC Decision | SLA | Affected System |
-|---|---|---|---|---|---|---|
-| CVE-YYYY-NNNNN | 9.8 Critical | 0.95 | Yes | Immediate | 24h | [System] |
-| CVE-YYYY-NNNNN | 7.5 High | 0.15 | No | Out-of-Cycle | 72h | [System] |
-| CVE-YYYY-NNNNN | 5.3 Medium | 0.02 | No | Scheduled | 30d | [System] |
-| CVE-YYYY-NNNNN | 3.1 Low | 0.001 | No | Defer | 90d | [System] |
+| Canonical ID | Aliases | Source Status | Identity Confidence | CVSS 4.0 | EPSS | KEV | SSVC Decision | SLA | Affected System |
+|---|---|---|---|---|---|---|---|---|---|
+| CVE-YYYY-NNNNN | GHSA/OSV/vendor IDs | Published | High | 9.8 Critical | 0.95 | Yes | Immediate | 24h | [System] |
+| CVE-YYYY-NNNNN | GHSA/OSV/vendor IDs | Disputed | Medium | 7.5 High | 0.15 | No | Human Review | Hold | [System] |
+| CVE-YYYY-NNNNN | Duplicate of CVE-YYYY-NNNNN | Duplicate | High | N/A | N/A | N/A | Consolidated | No separate SLA | [System] |
+| CVE-YYYY-NNNNN | Scanner plugin IDs | Reserved | Low | N/A | N/A | N/A | Not Evaluable | Hold | [System] |
 
 ### Priority Order
 1. [CVE with Immediate SLA -- full assessment below]

--- a/skills/vuln-management/cve-triage/tests/benign/canonical_alias_status_reviewed_before_sla.json
+++ b/skills/vuln-management/cve-triage/tests/benign/canonical_alias_status_reviewed_before_sla.json
@@ -1,0 +1,70 @@
+{
+  "scenario": "canonical-alias-status-reviewed-before-sla",
+  "skill": "cve-triage",
+  "expected_skill_version": "1.0.1",
+  "canonical_identity": {
+    "canonical_id": "CVE-2026-27777",
+    "source": "CVE List",
+    "source_status": "Published",
+    "retrieved_at": "2026-06-09T11:15:00Z",
+    "identity_confidence": "high",
+    "confidence_evidence": [
+      "same affected package purl pkg:pypi/example-lib",
+      "same vulnerable range <2.5.0",
+      "same fixed version 2.5.1",
+      "vendor advisory references the CVE and GHSA"
+    ]
+  },
+  "alias_map": [
+    {
+      "id": "CVE-2026-27777",
+      "source": "CVE List",
+      "status": "Published"
+    },
+    {
+      "id": "GHSA-qwer-5678-asdf",
+      "source": "GitHub Advisory Database",
+      "status": "Published"
+    },
+    {
+      "id": "OSV-2026-27777",
+      "source": "OSV",
+      "status": "Published"
+    },
+    {
+      "id": "VENDOR-ADV-2026-17",
+      "source": "Vendor",
+      "status": "Superseded",
+      "superseded_by": "CVE-2026-27777"
+    }
+  ],
+  "triage_inputs": {
+    "cvss_4_base": 8.7,
+    "epss_score": 0.21,
+    "kev_listed": false,
+    "ssvc_exploitation": "Proof of Concept",
+    "automatable": true,
+    "technical_impact": "Partial",
+    "mission_prevalence": "Support"
+  },
+  "triage_output": {
+    "consolidated_ticket": "CVE-2026-27777",
+    "duplicate_tickets_created": false,
+    "sla": "Out-of-Cycle",
+    "ssvc_decision": "Out-of-Cycle",
+    "aliases_visible_in_batch_table": true,
+    "human_review_required": false
+  },
+  "expected_gate_results": {
+    "CVE-IDENT-01": "pass",
+    "CVE-IDENT-02": "pass",
+    "CVE-IDENT-03": "pass",
+    "CVE-IDENT-04": "pass",
+    "CVE-IDENT-05": "pass",
+    "CVE-IDENT-06": "pass",
+    "CVE-IDENT-07": "pass",
+    "CVE-IDENT-08": "pass"
+  },
+  "expected_status": "pass",
+  "false_positive_guardrail": "do not flag duplicate backlog risk when aliases are consolidated, lifecycle status is Published, identity confidence is high, and exactly one SLA-bound ticket is produced"
+}

--- a/skills/vuln-management/cve-triage/tests/vulnerable/rejected_alias_duplicate_sla_overclaim.json
+++ b/skills/vuln-management/cve-triage/tests/vulnerable/rejected_alias_duplicate_sla_overclaim.json
@@ -1,0 +1,104 @@
+{
+  "scenario": "rejected-alias-duplicate-sla-overclaim",
+  "skill": "cve-triage",
+  "expected_skill_version": "1.0.1",
+  "scanner_findings": [
+    {
+      "id": "CVE-2026-40404",
+      "scanner_severity": "critical",
+      "affected_package": "example-lib",
+      "affected_version": "2.4.1",
+      "source_status": "REJECTED",
+      "aliases": [
+        "GHSA-abcd-1234-wxyz",
+        "OSV-2026-40404"
+      ]
+    },
+    {
+      "id": "GHSA-abcd-1234-wxyz",
+      "scanner_severity": "high",
+      "affected_package": "example-lib",
+      "affected_version": "2.4.1",
+      "aliases": [
+        "CVE-2026-40404",
+        "OSV-2026-40404"
+      ]
+    },
+    {
+      "id": "VENDOR-ADV-2026-17",
+      "scanner_severity": "critical",
+      "affected_package": "example-lib",
+      "affected_version": "2.4.1",
+      "superseded_by": "CVE-2026-27777"
+    }
+  ],
+  "source_evidence": {
+    "cve_list": {
+      "CVE-2026-40404": {
+        "status": "REJECTED",
+        "reason": "duplicate assignment",
+        "duplicate_of": "CVE-2026-27777",
+        "retrieved_at": "2026-06-09T11:00:00Z"
+      }
+    },
+    "ghsa": {
+      "GHSA-abcd-1234-wxyz": {
+        "status": "withdrawn",
+        "mapped_cve": "CVE-2026-40404"
+      }
+    },
+    "osv": {
+      "OSV-2026-40404": {
+        "withdrawn": true,
+        "aliases": [
+          "CVE-2026-40404",
+          "GHSA-abcd-1234-wxyz"
+        ]
+      }
+    }
+  },
+  "triage_output": {
+    "tickets_created": [
+      "CVE-2026-40404-critical",
+      "GHSA-abcd-1234-wxyz-high",
+      "VENDOR-ADV-2026-17-critical"
+    ],
+    "sla": "Immediate",
+    "ssvc_decision": "Immediate",
+    "identity_confidence": null,
+    "canonical_id": null
+  },
+  "expected_findings": [
+    {
+      "id": "CVE-IDENT-01",
+      "severity": "high",
+      "reason": "triage started from scanner IDs without selecting a canonical active vulnerability"
+    },
+    {
+      "id": "CVE-IDENT-02",
+      "severity": "medium",
+      "reason": "CVE, GHSA, OSV, and vendor aliases were not consolidated before ticket creation"
+    },
+    {
+      "id": "CVE-IDENT-03",
+      "severity": "high",
+      "reason": "REJECTED and withdrawn source statuses were ignored before scoring"
+    },
+    {
+      "id": "CVE-IDENT-04",
+      "severity": "medium",
+      "reason": "duplicate-of and superseded-by rationale was not retained"
+    },
+    {
+      "id": "CVE-IDENT-06",
+      "severity": "medium",
+      "reason": "multiple tickets were created for the same underlying vulnerability"
+    },
+    {
+      "id": "CVE-IDENT-08",
+      "severity": "high",
+      "reason": "Immediate SLA was assigned before lifecycle status made the record ineligible"
+    }
+  ],
+  "expected_disposition": "no_active_sla_for_rejected_duplicate_record"
+}


### PR DESCRIPTION
/claim #2057

## Skill Improvement ($50-150 Bounty)

Related review issue: #2057

## Summary

This improves `cve-triage` by adding CVE alias and lifecycle-status evidence gates so rejected, duplicate, disputed, or alias-only records are normalized before SLA and priority decisions are credited.

## Changes

- Add `CVE-IDENT-01` through `CVE-IDENT-08` evidence gates.
- Require canonical ID selection, alias maps, lifecycle status, rejected/duplicate/disputed rationale, identity confidence, consolidated recommendations, human-review disposition, and post-normalization SLA eligibility.
- Add skill-local benign and vulnerable JSON fixtures.

## Bounty Tier

- [ ] Minor ($50) - Doc update, small logic tweak, typo fix
- [x] Moderate ($100) - New edge case coverage, FP reduction with evidence
- [ ] Substantial ($150) - Rewritten detection logic, major coverage expansion

## Validation

- `git diff --cached --check`
- `git diff --check origin/main...HEAD`
- JSON parse check for both fixtures
- Markdown fence balance check
- marker checks for `CVE-IDENT-01` through `CVE-IDENT-08`
- added-line sensitive-pattern scan
- `git merge-tree --write-tree origin/main HEAD` matches `HEAD^{tree}`
- fork branch created through GitHub Git Data API; remote tree verified against local `HEAD^{tree}`

## Payment preference

GitHub Sponsors, if accepted.