### PR TITLE
Improve HIPAA transmission security gates

### DIFF
--- a/skills/compliance/hipaa-review/SKILL.md
+++ b/skills/compliance/hipaa-review/SKILL.md
@@ -334,6 +334,19 @@ Hybrid Entity: [Yes/No] — If yes, document healthcare component designation
 - Implement a mechanism to encrypt ePHI whenever deemed appropriate
 - Note: Encryption of ePHI in transit is strongly recommended by OCR. Unencrypted transmission of ePHI over the internet is a frequent enforcement target.
 
+##### Transmission Path Evidence Gate
+
+Do not mark 164.312(e) as Compliant or Addressable - Alternative Implemented from a generic "TLS enabled" statement. Require path-level evidence for every electronic ePHI transmission route, including exception and manual routes.
+
+- `HIPAA-TRANS-01` - Maintain a transmission path register covering primary APIs, EDI/AS2, SFTP jobs, email, webhook callbacks, vendor portal exports, support attachments, clearinghouse routes, emergency/manual transfers, and decommissioned-but-still-enabled routes.
+- `HIPAA-TRANS-02` - For each path, document source system, destination, ePHI elements, data owner, operational owner, external recipient, Business Associate status, and whether the recipient or subcontractor is covered by a current BAA or equivalent arrangement.
+- `HIPAA-TRANS-03` - Record encryption evidence per path: protocol, minimum version, cipher or algorithm policy, certificate validation, mutual authentication where used, key ownership, downgrade/STARTTLS stripping controls, and sampled runtime proof such as headers, logs, or configuration exports.
+- `HIPAA-TRANS-04` - Record integrity controls per path, such as digital signatures, signed payload digests, EDI control totals, AS2 MICs, SFTP file hashes, tamper-evident queues, immutable audit logs, message acknowledgements, or reconciliation jobs.
+- `HIPAA-TRANS-05` - Treat non-TLS, opportunistic TLS, manual email, portable-media handoff, vendor portal download, and emergency transfer paths as Not Evaluable or Non-Compliance unless documented with an addressable rationale, equivalent controls, owner approval, and risk-analysis linkage.
+- `HIPAA-TRANS-06` - Confirm external and Business Associate recipient handling, including BAA service scope, subcontractor flow-down, portal storage/archive behavior, mailbox retention, downstream export handling, and termination/offboarding controls.
+- `HIPAA-TRANS-07` - Verify operational evidence is current and sampled from production-equivalent paths: transfer logs, failed-authentication or failed-integrity logs, certificate expiry monitoring, key/cert rotation records, exception approvals, and retest cadence.
+- `HIPAA-TRANS-08` - Cap status at Partial Compliance when any known ePHI route is inventoried but lacks encryption proof, integrity proof, recipient/BAA proof, or addressable rationale; cap status at Not Evaluable when the path inventory itself is incomplete.
+
 ---
 
 ### Step 5: Organizational Requirements (45 CFR 164.314)
@@ -445,6 +458,23 @@ Assess:
 
 ### Technical Safeguards (164.312)
 [same table format]
+
+#### Transmission Security Evidence (164.312(e))
+
+| Path ID | Source | Destination / Recipient | ePHI Elements | External / BA Status | Encryption Evidence | Integrity Evidence | Addressable Rationale / Equivalent Control | Status |
+|---------|--------|-------------------------|---------------|----------------------|---------------------|-------------------|--------------------------------------------|--------|
+| [path] | [system] | [recipient] | [data] | [CE/BA/vendor/internal] | [protocol/cert/downgrade proof] | [signature/hash/MIC/reconciliation proof] | [if applicable] | [Compliant / Partial / Non-Compliance / Not Evaluable] |
+
+| Gate | Evidence Required | Result | Finding |
+|------|-------------------|--------|---------|
+| HIPAA-TRANS-01 | Complete primary and exception ePHI transmission path register | [Pass/Fail/NE] | [notes] |
+| HIPAA-TRANS-02 | Per-path source, destination, ePHI elements, owner, recipient, and BAA status | [Pass/Fail/NE] | [notes] |
+| HIPAA-TRANS-03 | Encryption, certificate validation, and downgrade-control evidence | [Pass/Fail/NE] | [notes] |
+| HIPAA-TRANS-04 | Integrity-control evidence | [Pass/Fail/NE] | [notes] |
+| HIPAA-TRANS-05 | Addressable rationale or equivalent controls for nonstandard/exception paths | [Pass/Fail/NE] | [notes] |
+| HIPAA-TRANS-06 | External recipient, BA, subcontractor, archive, and export handling | [Pass/Fail/NE] | [notes] |
+| HIPAA-TRANS-07 | Current operational logs, monitoring, approvals, and retest cadence | [Pass/Fail/NE] | [notes] |
+| HIPAA-TRANS-08 | Status cap applied when path inventory or evidence is incomplete | [Pass/Fail/NE] | [notes] |
 
 ### Organizational Requirements (164.314)
 [same table format]
@@ -570,6 +600,8 @@ Policies, Procedures, and Documentation — 164.316
 4. **Confusing HIPAA Security Rule with HIPAA Privacy Rule.** The Security Rule (Subpart C) applies only to ePHI and focuses on technical, physical, and administrative safeguards. The Privacy Rule (Subpart E) covers all PHI including paper records and addresses permitted uses and disclosures. A Security Rule review does not satisfy Privacy Rule obligations and vice versa.
 
 5. **Failing to document the "why" behind security decisions.** The Security Rule is designed to be flexible and scalable. But that flexibility requires documentation. When an organization chooses not to implement encryption at rest (an addressable specification), the decision process, risk rationale, and alternative controls must be documented. OCR auditors expect written justification, not verbal explanations.
+
+6. **Treating "TLS enabled" as complete transmission security.** Transmission Security requires path-by-path review. A compliant primary API does not prove claims resubmission email, SFTP exports, vendor portal downloads, support attachments, webhook callbacks, or emergency/manual transfers have encryption, integrity controls, recipient/BAA coverage, and addressable rationale.
 
 ---
 

--- a/skills/compliance/hipaa-review/tests/benign/transmission_register_encryption_integrity_documented.json
+++ b/skills/compliance/hipaa-review/tests/benign/transmission_register_encryption_integrity_documented.json
@@ -1,0 +1,247 @@
+{
+  "case_id": "hipaa_transmission_security_documented_register",
+  "description": "A covered entity documents all production and exception ePHI transmission paths with encryption, integrity, recipient, and addressable-rationale evidence before crediting 45 CFR 164.312(e).",
+  "entity_type": "covered_entity",
+  "assessment_date": "2026-06-09",
+  "transmission_register": [
+    {
+      "path_id": "api-claims-primary",
+      "route_type": "primary_api",
+      "source": "ehr-core",
+      "destination": "claims-clearinghouse-api",
+      "ephi_elements": [
+        "patient_id",
+        "encounter_id",
+        "diagnosis_code",
+        "procedure_code"
+      ],
+      "data_owner": "Revenue Cycle",
+      "operational_owner": "Integration Services",
+      "external_recipient": true,
+      "business_associate": {
+        "name": "North Clearinghouse",
+        "baa_id": "BAA-NCH-2026-01",
+        "service_scope": "claims submission and acknowledgement",
+        "subcontractor_flow_down_reviewed": true
+      },
+      "encryption_evidence": {
+        "protocol": "TLS",
+        "minimum_version": "1.3",
+        "certificate_validation": "enforced with hostname validation and private CA pin set",
+        "downgrade_controls": "TLS 1.0/1.1 disabled; HSTS enforced where browser-mediated",
+        "runtime_evidence": [
+          "load-balancer-export-2026-06-07",
+          "mtls-handshake-sample-2026-06-08"
+        ]
+      },
+      "integrity_evidence": {
+        "control": "signed payload digest",
+        "algorithm": "HMAC-SHA256 over canonical claim envelope",
+        "reconciliation": "daily claim acknowledgement reconciliation job RC-EDI-ACK"
+      },
+      "operational_evidence": {
+        "transfer_logs": "splunk-query-api-claims-2026-06-08",
+        "failed_integrity_alert": "SIEM-HIPAA-TRANS-FAIL-02",
+        "certificate_monitoring": "cert-expiry-monitor-api-claims",
+        "retest_cadence": "quarterly"
+      },
+      "status": "Compliant"
+    },
+    {
+      "path_id": "edi-837-as2",
+      "route_type": "edi_as2",
+      "source": "billing-edi-gateway",
+      "destination": "payer-as2-endpoint",
+      "ephi_elements": [
+        "patient_name",
+        "member_id",
+        "diagnosis_code",
+        "claim_amount"
+      ],
+      "data_owner": "Revenue Cycle",
+      "operational_owner": "EDI Operations",
+      "external_recipient": true,
+      "business_associate": {
+        "name": "Payer Network Services",
+        "baa_id": "BAA-PNS-2025-11",
+        "service_scope": "EDI claims transport",
+        "subcontractor_flow_down_reviewed": true
+      },
+      "encryption_evidence": {
+        "protocol": "AS2 over TLS",
+        "minimum_version": "1.2",
+        "certificate_validation": "partner certificate thumbprints verified during rotation",
+        "downgrade_controls": "plain HTTP listener disabled",
+        "runtime_evidence": [
+          "as2-mdn-sample-2026-06-08",
+          "partner-cert-rotation-ticket-CHG-8421"
+        ]
+      },
+      "integrity_evidence": {
+        "control": "AS2 signed MDN MIC plus EDI control totals",
+        "algorithm": "SHA-256 MIC",
+        "reconciliation": "999/277CA acknowledgement reconciliation"
+      },
+      "operational_evidence": {
+        "transfer_logs": "edi-gateway-transfer-log-2026-06-08",
+        "failed_integrity_alert": "AS2-MIC-MISMATCH",
+        "certificate_monitoring": "partner-cert-expiry-dashboard",
+        "retest_cadence": "after each payer endpoint change"
+      },
+      "status": "Compliant"
+    },
+    {
+      "path_id": "sftp-lab-results",
+      "route_type": "sftp_batch",
+      "source": "lab-interface-engine",
+      "destination": "contract-lab-sftp",
+      "ephi_elements": [
+        "patient_name",
+        "date_of_birth",
+        "lab_order_id",
+        "lab_result"
+      ],
+      "data_owner": "Clinical Operations",
+      "operational_owner": "Interface Team",
+      "external_recipient": true,
+      "business_associate": {
+        "name": "Contract Lab LLC",
+        "baa_id": "BAA-CLAB-2026-02",
+        "service_scope": "lab testing and result exchange",
+        "subcontractor_flow_down_reviewed": true
+      },
+      "encryption_evidence": {
+        "protocol": "SFTP",
+        "minimum_version": "SSH-2 with approved ciphers only",
+        "certificate_validation": "host key pinned in managed known_hosts",
+        "downgrade_controls": "FTP and FTPS disabled on gateway",
+        "runtime_evidence": [
+          "sftp-session-log-2026-06-07",
+          "known-hosts-change-ticket-CHG-8388"
+        ]
+      },
+      "integrity_evidence": {
+        "control": "SHA-256 manifest signed by sender",
+        "algorithm": "SHA-256 plus detached signature",
+        "reconciliation": "manifest count compared to received result acknowledgements"
+      },
+      "operational_evidence": {
+        "transfer_logs": "mft-job-history-2026-06-08",
+        "failed_integrity_alert": "MFT-HASH-MISMATCH",
+        "certificate_monitoring": "ssh-host-key-review-calendar",
+        "retest_cadence": "semiannual and after host-key rotation"
+      },
+      "status": "Compliant"
+    },
+    {
+      "path_id": "support-portal-attachment",
+      "route_type": "vendor_portal",
+      "source": "clinical-support-queue",
+      "destination": "ehr-vendor-support-portal",
+      "ephi_elements": [
+        "patient_id",
+        "encounter_note_excerpt"
+      ],
+      "data_owner": "Clinical Applications",
+      "operational_owner": "Application Support",
+      "external_recipient": true,
+      "business_associate": {
+        "name": "EHR Vendor Inc.",
+        "baa_id": "BAA-EHR-2025-06",
+        "service_scope": "application support with minimum necessary ePHI attachments",
+        "subcontractor_flow_down_reviewed": true
+      },
+      "encryption_evidence": {
+        "protocol": "TLS",
+        "minimum_version": "1.3",
+        "certificate_validation": "browser and API client validation enforced",
+        "downgrade_controls": "portal denies HTTP and obsolete TLS",
+        "runtime_evidence": [
+          "portal-security-header-capture-2026-06-08",
+          "vendor-soc2-tls-control-map"
+        ]
+      },
+      "integrity_evidence": {
+        "control": "portal attachment digest and immutable ticket audit log",
+        "algorithm": "SHA-256 attachment hash",
+        "reconciliation": "ticket export hash compared before closure"
+      },
+      "operational_evidence": {
+        "transfer_logs": "support-ticket-attachments-sample-2026-06",
+        "failed_integrity_alert": "portal-audit-tamper-alert",
+        "certificate_monitoring": "vendor-certificate-expiry-attestation",
+        "retest_cadence": "annual vendor review and after portal change"
+      },
+      "status": "Compliant"
+    },
+    {
+      "path_id": "emergency-manual-transfer",
+      "route_type": "manual_exception",
+      "source": "hospital-incident-command",
+      "destination": "receiving-facility-secure-mailbox",
+      "ephi_elements": [
+        "patient_name",
+        "transfer_summary",
+        "active_medication_list"
+      ],
+      "data_owner": "Emergency Preparedness",
+      "operational_owner": "Incident Command",
+      "external_recipient": true,
+      "business_associate": {
+        "name": "Receiving Facility",
+        "baa_id": "treatment-disclosure-documented-no-baa-required",
+        "service_scope": "patient transfer for treatment",
+        "subcontractor_flow_down_reviewed": "not_applicable"
+      },
+      "encryption_evidence": {
+        "protocol": "secure message portal",
+        "minimum_version": "TLS 1.2",
+        "certificate_validation": "managed portal endpoint only",
+        "downgrade_controls": "ordinary email prohibited by playbook",
+        "runtime_evidence": [
+          "emergency-transfer-drill-2026-05-14"
+        ]
+      },
+      "integrity_evidence": {
+        "control": "portal audit receipt and receiving clinician confirmation",
+        "algorithm": "platform message integrity log",
+        "reconciliation": "transfer checklist confirmation"
+      },
+      "addressable_rationale": {
+        "implemented_as_written": false,
+        "equivalent_controls": [
+          "secure portal only",
+          "minimum necessary template",
+          "incident commander approval",
+          "post-event privacy review"
+        ],
+        "risk_analysis_link": "RA-EP-2026-04",
+        "approval_ticket": "GRC-EXC-441"
+      },
+      "operational_evidence": {
+        "transfer_logs": "drill-artifacts-2026-05-14",
+        "failed_integrity_alert": "not_applicable_manual_exception",
+        "certificate_monitoring": "portal-vendor-review",
+        "retest_cadence": "annual emergency-preparedness exercise"
+      },
+      "status": "Addressable - Alternative Implemented"
+    }
+  ],
+  "expected_gate_results": {
+    "HIPAA-TRANS-01": "Pass",
+    "HIPAA-TRANS-02": "Pass",
+    "HIPAA-TRANS-03": "Pass",
+    "HIPAA-TRANS-04": "Pass",
+    "HIPAA-TRANS-05": "Pass",
+    "HIPAA-TRANS-06": "Pass",
+    "HIPAA-TRANS-07": "Pass",
+    "HIPAA-TRANS-08": "Pass"
+  },
+  "expected_assessment": {
+    "164.312(e)(1)": "Compliant",
+    "164.312(e)(2)(i)": "Compliant",
+    "164.312(e)(2)(ii)": "Compliant",
+    "status_cap": "None",
+    "finding": "All known ePHI transmission routes, including emergency/manual exception handling, have current encryption, integrity, recipient, BAA, and operational evidence."
+  }
+}

--- a/skills/compliance/hipaa-review/tests/vulnerable/transmission_tls_only_exception_paths_missing.json
+++ b/skills/compliance/hipaa-review/tests/vulnerable/transmission_tls_only_exception_paths_missing.json
@@ -1,0 +1,174 @@
+{
+  "case_id": "hipaa_transmission_security_tls_only_overclaim",
+  "description": "A review credits 45 CFR 164.312(e) from a primary API TLS checkbox while exception ePHI routes lack encryption, integrity, recipient, and addressable-rationale evidence.",
+  "entity_type": "business_associate",
+  "assessment_date": "2026-06-09",
+  "claimed_status": {
+    "164.312(e)(1)": "Compliant",
+    "basis": "All production systems use TLS enabled connections."
+  },
+  "transmission_register": [
+    {
+      "path_id": "primary-api",
+      "route_type": "primary_api",
+      "source": "care-management-platform",
+      "destination": "payer-api",
+      "ephi_elements": [
+        "patient_id",
+        "care_plan_id",
+        "diagnosis_code"
+      ],
+      "data_owner": "Care Management",
+      "operational_owner": "Platform Engineering",
+      "external_recipient": true,
+      "business_associate": {
+        "name": "Payer API",
+        "baa_id": "not_provided",
+        "service_scope": "not_documented",
+        "subcontractor_flow_down_reviewed": false
+      },
+      "encryption_evidence": {
+        "protocol": "TLS enabled",
+        "minimum_version": "not_documented",
+        "certificate_validation": "not_documented",
+        "downgrade_controls": "not_documented",
+        "runtime_evidence": []
+      },
+      "integrity_evidence": {
+        "control": "not_documented",
+        "reconciliation": "not_documented"
+      },
+      "operational_evidence": {
+        "transfer_logs": "monthly volume screenshot only",
+        "failed_integrity_alert": "not_documented",
+        "certificate_monitoring": "not_documented",
+        "retest_cadence": "not_documented"
+      }
+    },
+    {
+      "path_id": "claims-resubmission-email",
+      "route_type": "manual_email_exception",
+      "source": "billing-operations-mailbox",
+      "destination": "payer-appeals-mailbox",
+      "ephi_elements": [
+        "patient_name",
+        "member_id",
+        "diagnosis_code",
+        "appeal_note"
+      ],
+      "data_owner": "Revenue Cycle",
+      "operational_owner": "Billing Operations",
+      "external_recipient": true,
+      "business_associate": {
+        "name": "Payer Appeals",
+        "baa_id": "not_provided",
+        "service_scope": "not_documented",
+        "subcontractor_flow_down_reviewed": false
+      },
+      "encryption_evidence": {
+        "protocol": "ordinary email",
+        "minimum_version": "opportunistic_tls_unknown",
+        "certificate_validation": "not_documented",
+        "downgrade_controls": "none",
+        "runtime_evidence": []
+      },
+      "integrity_evidence": {
+        "control": "none",
+        "reconciliation": "manual spreadsheet without message digest"
+      },
+      "addressable_rationale": null,
+      "operational_evidence": {
+        "transfer_logs": "mailbox search not exported",
+        "failed_integrity_alert": "none",
+        "certificate_monitoring": "none",
+        "retest_cadence": "none"
+      }
+    },
+    {
+      "path_id": "vendor-portal-export",
+      "route_type": "vendor_portal_download",
+      "source": "population-health-export",
+      "destination": "analytics-vendor-portal",
+      "ephi_elements": [
+        "patient_name",
+        "date_of_birth",
+        "encounter_notes"
+      ],
+      "data_owner": "Population Health",
+      "operational_owner": "Analytics Team",
+      "external_recipient": true,
+      "business_associate": {
+        "name": "Analytics Vendor",
+        "baa_id": "expired",
+        "service_scope": "portal export not covered",
+        "subcontractor_flow_down_reviewed": false
+      },
+      "encryption_evidence": {
+        "protocol": "browser portal",
+        "minimum_version": "not_documented",
+        "certificate_validation": "not_documented",
+        "downgrade_controls": "not_documented",
+        "runtime_evidence": []
+      },
+      "integrity_evidence": {
+        "control": "none",
+        "reconciliation": "not_documented"
+      },
+      "addressable_rationale": null,
+      "operational_evidence": {
+        "transfer_logs": "not_collected",
+        "failed_integrity_alert": "none",
+        "certificate_monitoring": "not_documented",
+        "retest_cadence": "none"
+      },
+      "archive_behavior": {
+        "portal_storage_retention": "unknown",
+        "downstream_export_controls": "unknown"
+      }
+    }
+  ],
+  "known_missing_paths": [
+    "support attachments sent to vendor case notes",
+    "webhook callback for appointment reminders",
+    "emergency manual transfer procedure"
+  ],
+  "expected_gate_results": {
+    "HIPAA-TRANS-01": "Fail",
+    "HIPAA-TRANS-02": "Fail",
+    "HIPAA-TRANS-03": "Fail",
+    "HIPAA-TRANS-04": "Fail",
+    "HIPAA-TRANS-05": "Fail",
+    "HIPAA-TRANS-06": "Fail",
+    "HIPAA-TRANS-07": "Fail",
+    "HIPAA-TRANS-08": "Fail"
+  },
+  "expected_findings": [
+    {
+      "gate": "HIPAA-TRANS-01",
+      "finding": "The register omits known support attachment, webhook callback, and emergency/manual transfer routes, so 164.312(e) is Not Evaluable until path coverage is complete."
+    },
+    {
+      "gate": "HIPAA-TRANS-03",
+      "finding": "The primary API only states TLS enabled and lacks minimum version, certificate validation, downgrade controls, and runtime proof."
+    },
+    {
+      "gate": "HIPAA-TRANS-04",
+      "finding": "Email and portal export paths lack signatures, hashes, MICs, control totals, tamper-evident logs, or reconciliation evidence."
+    },
+    {
+      "gate": "HIPAA-TRANS-05",
+      "finding": "Manual email sends diagnosis codes without documented encryption, equivalent controls, owner approval, or risk-analysis rationale."
+    },
+    {
+      "gate": "HIPAA-TRANS-06",
+      "finding": "External recipient and BA handling is incomplete because BAA scope is missing or expired and portal archive/export behavior is unknown."
+    }
+  ],
+  "expected_assessment": {
+    "164.312(e)(1)": "Not Evaluable",
+    "164.312(e)(2)(i)": "Non-Compliance",
+    "164.312(e)(2)(ii)": "Non-Compliance",
+    "status_cap": "Not Evaluable",
+    "reason": "The path inventory is incomplete and known ePHI routes lack encryption, integrity, recipient, BAA, and addressable-rationale evidence."
+  }
+}


### PR DESCRIPTION
/claim #2054

## Skill Improvement ($50-150 Bounty)

Related review issue: #2054

## Summary

This improves `hipaa-review` by adding 45 CFR 164.312(e) transmission security evidence gates that require path-by-path ePHI transmission inventory, encryption, integrity, exception-route, recipient/BAA, and addressable-specification evidence before compliance is credited.

## Changes

- Add `HIPAA-TRANS-01` through `HIPAA-TRANS-08` evidence gates.
- Require primary and exception ePHI transmission paths, including email, SFTP, EDI/AS2, vendor portal exports, webhook callbacks, support attachments, and emergency/manual transfers.
- Require per-path source, destination, ePHI elements, owner, external/BA recipient, encryption evidence, certificate/downgrade controls, integrity controls, and addressable rationale/equivalent controls.
- Extend output with path-level transmission evidence and gate results.
- Add skill-local benign and vulnerable JSON fixtures.

## Bounty Tier

- [ ] Minor ($50) - Doc update, small logic tweak, typo fix
- [x] Moderate ($100) - New edge case coverage, FP reduction with evidence
- [ ] Substantial ($150) - Rewritten detection logic, major coverage expansion

## Validation

- `git diff --cached --check`
- `git diff --check origin/main...HEAD`
- JSON parse check for both fixtures
- Markdown fence balance check
- marker checks for `HIPAA-TRANS-01` through `HIPAA-TRANS-08`
- added-line sensitive-pattern scan
- `git merge-tree --write-tree origin/main HEAD` matches `HEAD^{tree}`
- fork branch created through GitHub Git Data API; remote tree verified against local `HEAD^{tree}`

## Payment preference

GitHub Sponsors, if accepted.