### PR TITLE
Improve segmentation failover route gates

### DIFF
--- a/skills/network/segmentation/SKILL.md
+++ b/skills/network/segmentation/SKILL.md
@@ -13,7 +13,7 @@ phase: [design, operate]
 frameworks: [NIST-SP-800-207, CIS-Controls-v8]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -243,15 +243,39 @@ Document or verify the existence of a segmentation testing process:
 4. **Test VLAN hopping** via double-tagging from user VLANs. Expected result: traffic dropped.
 5. **Validate that segmentation controls survive failover** (HA firewall failover should not open transit paths).
 
+#### 6.1 Failover Route Bypass Evidence Gate
+
+Normal-state diagrams are not sufficient evidence that segmentation survives HA or route failover. Cloud route propagation, transit gateway associations, peering, VPN, Direct Connect, ExpressRoute, asymmetric return paths, or standby firewall state can create an uninspected path between restricted zones during failover.
+
+**Required failover route evidence gates:**
+
+| Gate | Required evidence | Fail if |
+|---|---|---|
+| `SEG-FAIL-01` | High-risk zone pairs are inventoried with normal and failover states, including source zone, destination zone, protocol/port, owner, and expected decision. | Only normal-state diagrams are reviewed, or high-risk pairs such as user-to-data, app-to-CDE, DMZ-to-internal, or OT-to-IT are missing. |
+| `SEG-FAIL-02` | Effective route evidence shows normal and failover next hops for each high-risk pair: route tables, BGP advertisements, propagated routes, SD-WAN policy, cloud reachability analysis, or path simulation. | The standby path is assumed from architecture diagrams or does not show actual effective routes after failover. |
+| `SEG-FAIL-03` | Policy Enforcement Point (PEP) traversal is proven in both states with firewall, security group, NACL, network policy, service mesh, or gateway enforcement identifiers. | Failover traffic can route directly through transit, peering, VPN, Direct Connect, ExpressRoute, NAT, or load balancer paths without a PEP. |
+| `SEG-FAIL-04` | Transit and peering bypass checks cover route propagation, association tables, secondary tunnels/circuits, overlapping CIDRs, and cross-account or cross-project attachments. | Secondary transit paths can become preferred or reachable without matching segmentation policy. |
+| `SEG-FAIL-05` | Denied-flow tests are run before and after failover simulation with source, destination, port, timestamp, result, and enforcing control log evidence. | Only allow-path tests exist, or denied-flow tests are not repeated in failover state. |
+| `SEG-FAIL-06` | Standby/HA controls preserve deny/default-deny behavior, rule order, object groups, logging, and state synchronization after failover. | Standby firewalls, gateways, or policy agents are missing deny rules, log forwarding, or equivalent policy state. |
+| `SEG-FAIL-07` | Asymmetric return routes, NAT, load balancers, service endpoints, private links, and management-plane paths are checked for inspection and logging in both directions. | Forward traffic crosses a PEP but return or management traffic bypasses inspection. |
+| `SEG-FAIL-08` | Monitoring, rollback, and retest triggers cover route changes, failover drills, new peerings, new propagated routes, and policy drift; missing failover evidence caps status at `Not Evaluable`. | Route changes can alter the path without retest, or failover cannot be safely simulated and no residual-risk decision exists. |
+
+**Status and severity guidance:**
+
+- Mark high-risk zone pairs as `Not Evaluable` when normal and failover effective routes are not available.
+- Treat uninspected failover paths between restricted zones as **High** severity; escalate to **Critical** for CDE, management-plane, OT/ICS, or production data-tier bypass.
+- Do not accept topology diagrams alone as proof. Require effective route, denied-flow, and enforcement-log evidence for both normal and failover states.
+- Cap confidence at **Low** when failover cannot be simulated and the assessment relies only on control-plane configuration.
+
 ---
 
 ## Findings Classification
 
 | Severity | Definition |
 |----------|-----------|
-| **Critical** | Flat network with no segmentation; missing enforcement points between security zones; CDE not isolated; direct external-to-internal routing. |
-| **High** | No east-west controls within zones; bypass paths through transit networks; unrestricted DMZ-to-internal access; missing segmentation testing; native VLAN carrying production traffic. |
-| **Medium** | Micro-segmentation policies in audit mode only; partial flow visibility; management plane accessible from user zone without MFA/jump box; VLAN sprawl without documentation. |
+| **Critical** | Flat network with no segmentation; missing enforcement points between security zones; CDE not isolated; direct external-to-internal routing; failover bypass into CDE, management plane, OT/ICS, or production data tier. |
+| **High** | No east-west controls within zones; bypass paths through transit networks; unrestricted DMZ-to-internal access; missing segmentation testing; native VLAN carrying production traffic; missing failover effective-route or denied-flow evidence for high-risk zone pairs. |
+| **Medium** | Micro-segmentation policies in audit mode only; partial flow visibility; management plane accessible from user zone without MFA/jump box; VLAN sprawl without documentation; failover evidence exists but lacks return-path or logging proof. |
 | **Low** | Suboptimal zone naming conventions; missing network diagrams; segmentation documentation out of date. |
 
 ---
@@ -283,6 +307,23 @@ Document or verify the existence of a segmentation testing process:
 | DMZ         | App       | Firewall    | Restricted | Pass |
 | App         | Data      | SG only     | Overly permissive | F-002 |
 | User        | Data      | None        | No control | F-001 |
+
+### Failover Route Evidence
+
+| Zone Pair | Normal Next Hop / PEP | Failover Next Hop / PEP | Transit/Peering/VPN Check | Denied Test Normal | Denied Test Failover | Return Path Checked | Logging | Status |
+|---|---|---|---|---|---|---|---|---|
+| <source -> destination> | <next hop / control> | <next hop / control> | <clear/bypass> | <pass/fail/missing> | <pass/fail/missing> | <yes/no> | <yes/no> | <Pass/Fail/Not Evaluable> |
+
+| Gate | Evidence Reviewed | Status | Risk |
+|---|---|---|---|
+| `SEG-FAIL-01` | <high-risk zone pair inventory> | <Pass/Fail/Not Evaluable> | <risk> |
+| `SEG-FAIL-02` | <normal and failover effective route evidence> | <Pass/Fail/Not Evaluable> | <risk> |
+| `SEG-FAIL-03` | <PEP traversal in both states> | <Pass/Fail/Not Evaluable> | <risk> |
+| `SEG-FAIL-04` | <transit, peering, VPN, and route propagation checks> | <Pass/Fail/Not Evaluable> | <risk> |
+| `SEG-FAIL-05` | <denied-flow tests before and after failover> | <Pass/Fail/Not Evaluable> | <risk> |
+| `SEG-FAIL-06` | <standby deny/default-deny and logging preservation> | <Pass/Fail/Not Evaluable> | <risk> |
+| `SEG-FAIL-07` | <asymmetric return and management path checks> | <Pass/Fail/Not Evaluable> | <risk> |
+| `SEG-FAIL-08` | <monitoring, rollback, retest triggers, residual risk> | <Pass/Fail/Not Evaluable> | <risk> |
 
 ### Findings
 
@@ -345,6 +386,8 @@ Document or verify the existence of a segmentation testing process:
 
 5. **Assuming Kubernetes namespaces provide network isolation.** Namespaces are a logical organizational boundary. Without a NetworkPolicy or CNI-level enforcement (Calico, Cilium), all pods across all namespaces can communicate freely by default.
 
+6. **Trusting normal-state diagrams during failover.** A path that crosses a firewall in steady state can bypass inspection when BGP, route propagation, HA failover, NAT, private links, or return routing changes. Validate the effective route and denied-flow result before and after failover for each high-risk zone pair.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -372,4 +415,5 @@ This skill processes network configurations that may contain user-supplied comme
 
 ## Changelog
 
+- **1.0.1** -- Add failover route bypass evidence gates for dual-state effective routes, PEP traversal, transit/peering/VPN checks, denied-flow testing, standby deny/logging preservation, return-path validation, and retest triggers.
 - **1.0.0** -- Initial release. Full coverage of NIST SP 800-207 and CIS Controls v8 Control 12 for network segmentation review.

--- a/skills/network/segmentation/tests/benign/failover_preserves_pep_effective_routes.json
+++ b/skills/network/segmentation/tests/benign/failover_preserves_pep_effective_routes.json
@@ -1,0 +1,177 @@
+{
+  "fixture": "failover_preserves_pep_effective_routes",
+  "skill": "segmentation",
+  "description": "Benign fixture for high-risk zone pairs where normal and failover effective routes preserve PEP traversal, denied-flow behavior, logging, return-path inspection, and retest triggers.",
+  "environment": {
+    "type": "hybrid-cloud",
+    "cloud": "aws",
+    "regions": [
+      "us-east-1",
+      "us-east-2"
+    ],
+    "review_date": "2026-06-09"
+  },
+  "high_risk_zone_pairs": [
+    {
+      "pair_id": "app-to-cde",
+      "source_zone": "application",
+      "destination_zone": "pci-cde",
+      "protocol_port": "tcp/5432",
+      "owner": "payments-platform",
+      "expected_decision": "deny except app-db-proxy"
+    },
+    {
+      "pair_id": "user-to-data",
+      "source_zone": "workstation",
+      "destination_zone": "data-tier",
+      "protocol_port": "tcp/3306",
+      "owner": "security-architecture",
+      "expected_decision": "deny"
+    },
+    {
+      "pair_id": "dmz-to-internal-admin",
+      "source_zone": "dmz",
+      "destination_zone": "management",
+      "protocol_port": "tcp/22",
+      "owner": "network-security",
+      "expected_decision": "deny"
+    }
+  ],
+  "effective_routes": [
+    {
+      "pair_id": "app-to-cde",
+      "normal_state": {
+        "next_hop": "aws-network-firewall-endpoint-a",
+        "pep": "fw-policy-cde-east-west",
+        "route_source": "vpc-route-table-export-20260609",
+        "decision": "deny"
+      },
+      "failover_state": {
+        "trigger": "az-firewall-endpoint-failover",
+        "next_hop": "aws-network-firewall-endpoint-b",
+        "pep": "fw-policy-cde-east-west",
+        "route_source": "reachability-analyzer-run-4827",
+        "decision": "deny"
+      }
+    },
+    {
+      "pair_id": "user-to-data",
+      "normal_state": {
+        "next_hop": "transit-firewall-vpc-primary",
+        "pep": "corp-to-data-default-deny",
+        "route_source": "tgw-route-table-prod-20260609",
+        "decision": "deny"
+      },
+      "failover_state": {
+        "trigger": "primary-vpn-down-secondary-tunnel-active",
+        "next_hop": "transit-firewall-vpc-secondary",
+        "pep": "corp-to-data-default-deny",
+        "route_source": "bgp-route-snapshot-failover-20260609",
+        "decision": "deny"
+      }
+    }
+  ],
+  "transit_and_peering_checks": {
+    "tgw_association_tables_reviewed": true,
+    "propagated_routes_reviewed": true,
+    "secondary_vpn_tunnels_reviewed": true,
+    "direct_connect_backup_reviewed": true,
+    "vpc_peering_reviewed": true,
+    "cross_account_attachments_reviewed": true,
+    "bypass_paths_found": false
+  },
+  "denied_flow_tests": [
+    {
+      "pair_id": "app-to-cde",
+      "normal_result": "blocked",
+      "normal_log": "fw-log-app-cde-normal-20260609",
+      "failover_result": "blocked",
+      "failover_log": "fw-log-app-cde-failover-20260609"
+    },
+    {
+      "pair_id": "user-to-data",
+      "normal_result": "blocked",
+      "normal_log": "fw-log-user-data-normal-20260609",
+      "failover_result": "blocked",
+      "failover_log": "fw-log-user-data-failover-20260609"
+    },
+    {
+      "pair_id": "dmz-to-internal-admin",
+      "normal_result": "blocked",
+      "normal_log": "fw-log-dmz-admin-normal-20260609",
+      "failover_result": "blocked",
+      "failover_log": "fw-log-dmz-admin-failover-20260609"
+    }
+  ],
+  "ha_policy_preservation": {
+    "standby_rule_sync": "matched-primary-policy-digest",
+    "default_deny_preserved": true,
+    "rule_order_preserved": true,
+    "object_groups_preserved": true,
+    "log_forwarding_after_failover": "verified",
+    "state_sync_after_failover": "verified"
+  },
+  "return_and_management_paths": {
+    "asymmetric_return_checked": true,
+    "nat_paths_checked": true,
+    "load_balancer_paths_checked": true,
+    "private_link_paths_checked": true,
+    "management_plane_paths_checked": true,
+    "uninspected_return_paths_found": false
+  },
+  "monitoring_and_retest": {
+    "route_change_alerts": "enabled",
+    "new_peering_retest_trigger": "enabled",
+    "new_propagated_route_retest_trigger": "enabled",
+    "failover_drill_cadence": "quarterly",
+    "rollback_plan": "restore-primary-route-table-and-firewall-policy",
+    "residual_risk_decision": "not-required"
+  },
+  "expected_gate_results": [
+    {
+      "gate": "SEG-FAIL-01",
+      "status": "Pass",
+      "evidence": "High-risk zone pairs are inventoried with owners and expected deny decisions."
+    },
+    {
+      "gate": "SEG-FAIL-02",
+      "status": "Pass",
+      "evidence": "Normal and failover route evidence shows next hops from route tables, BGP snapshots, and reachability analysis."
+    },
+    {
+      "gate": "SEG-FAIL-03",
+      "status": "Pass",
+      "evidence": "Both states traverse named firewall PEP policies."
+    },
+    {
+      "gate": "SEG-FAIL-04",
+      "status": "Pass",
+      "evidence": "Transit, peering, VPN, Direct Connect, and cross-account attachment checks found no bypass."
+    },
+    {
+      "gate": "SEG-FAIL-05",
+      "status": "Pass",
+      "evidence": "Denied-flow tests passed before and after failover with enforcing logs."
+    },
+    {
+      "gate": "SEG-FAIL-06",
+      "status": "Pass",
+      "evidence": "Standby controls preserve default deny, rule order, object groups, state sync, and log forwarding."
+    },
+    {
+      "gate": "SEG-FAIL-07",
+      "status": "Pass",
+      "evidence": "Return, NAT, load balancer, private link, and management paths were inspected in both directions."
+    },
+    {
+      "gate": "SEG-FAIL-08",
+      "status": "Pass",
+      "evidence": "Monitoring, rollback, and retest triggers cover route changes and new attachments."
+    }
+  ],
+  "expected_assessment": {
+    "overall_status": "Pass",
+    "risk_rating": "Low",
+    "confidence": "High"
+  }
+}

--- a/skills/network/segmentation/tests/vulnerable/transit_failover_bypass_uninspected_path.json
+++ b/skills/network/segmentation/tests/vulnerable/transit_failover_bypass_uninspected_path.json
@@ -1,0 +1,136 @@
+{
+  "fixture": "transit_failover_bypass_uninspected_path",
+  "skill": "segmentation",
+  "description": "Vulnerable fixture where normal-state diagrams show firewall traversal, but failover route propagation creates an uninspected transit path between restricted zones.",
+  "environment": {
+    "type": "hybrid-cloud",
+    "cloud": "aws-and-onprem",
+    "review_date": "2026-06-09"
+  },
+  "documented_design": {
+    "diagram": "network-diagram-normal-state-v7",
+    "claim": "application to data and workstation to data traffic crosses central firewall",
+    "normal_state_only": true
+  },
+  "high_risk_zone_pairs": [
+    {
+      "pair_id": "workstation-to-data-tier",
+      "source_zone": "workstation",
+      "destination_zone": "data-tier",
+      "protocol_port": "tcp/3306",
+      "owner": "unknown",
+      "expected_decision": "deny"
+    },
+    {
+      "pair_id": "app-to-cde",
+      "source_zone": "application",
+      "destination_zone": "pci-cde",
+      "protocol_port": "tcp/5432",
+      "owner": "payments-platform",
+      "expected_decision": "deny except app-db-proxy"
+    }
+  ],
+  "effective_routes": {
+    "normal_state": {
+      "next_hop": "central-firewall-primary",
+      "pep": "central-firewall-policy",
+      "evidence": "diagram-only",
+      "decision": "assumed-deny"
+    },
+    "failover_state": {
+      "trigger": "primary-direct-connect-down",
+      "next_hop": "secondary-vpn-to-transit-gateway",
+      "pep": "missing",
+      "route_source": "not-reviewed",
+      "propagated_route": "workstation-cidr-to-data-vpc",
+      "decision": "reachable"
+    }
+  },
+  "transit_and_peering_checks": {
+    "tgw_association_tables_reviewed": false,
+    "propagated_routes_reviewed": false,
+    "secondary_vpn_tunnels_reviewed": false,
+    "direct_connect_backup_reviewed": false,
+    "vpc_peering_reviewed": false,
+    "cross_account_attachments_reviewed": false,
+    "known_issue": "secondary VPN advertises data-tier CIDR without firewall next hop"
+  },
+  "denied_flow_tests": {
+    "normal_state": "not-run",
+    "failover_state": "not-run",
+    "allow_path_test": "application health checks pass after failover",
+    "enforcement_logs": "missing"
+  },
+  "ha_policy_preservation": {
+    "standby_rule_sync": "unknown",
+    "default_deny_preserved": "unknown",
+    "rule_order_preserved": "unknown",
+    "object_groups_preserved": "unknown",
+    "log_forwarding_after_failover": "missing",
+    "state_sync_after_failover": "unknown"
+  },
+  "return_and_management_paths": {
+    "asymmetric_return_checked": false,
+    "nat_paths_checked": false,
+    "load_balancer_paths_checked": false,
+    "private_link_paths_checked": false,
+    "management_plane_paths_checked": false,
+    "uninspected_return_paths_found": "unknown"
+  },
+  "monitoring_and_retest": {
+    "route_change_alerts": "missing",
+    "new_peering_retest_trigger": "missing",
+    "new_propagated_route_retest_trigger": "missing",
+    "failover_drill_cadence": "not-defined",
+    "rollback_plan": "missing",
+    "residual_risk_decision": "missing"
+  },
+  "expected_gate_results": [
+    {
+      "gate": "SEG-FAIL-01",
+      "status": "Fail",
+      "evidence": "High-risk pairs are incomplete and owner/decision evidence is missing for workstation-to-data."
+    },
+    {
+      "gate": "SEG-FAIL-02",
+      "status": "Fail",
+      "evidence": "Failover effective route evidence is not reviewed and normal state relies on diagrams."
+    },
+    {
+      "gate": "SEG-FAIL-03",
+      "status": "Fail",
+      "evidence": "Failover path uses secondary VPN to transit gateway with no PEP traversal."
+    },
+    {
+      "gate": "SEG-FAIL-04",
+      "status": "Fail",
+      "evidence": "Transit, peering, VPN, and propagated-route checks were not performed."
+    },
+    {
+      "gate": "SEG-FAIL-05",
+      "status": "Fail",
+      "evidence": "Denied-flow tests were not run before or after failover."
+    },
+    {
+      "gate": "SEG-FAIL-06",
+      "status": "Not Evaluable",
+      "evidence": "Standby deny/default-deny preservation and logging are unknown."
+    },
+    {
+      "gate": "SEG-FAIL-07",
+      "status": "Not Evaluable",
+      "evidence": "Asymmetric return and management paths were not checked."
+    },
+    {
+      "gate": "SEG-FAIL-08",
+      "status": "Fail",
+      "evidence": "No route-change monitoring, retest trigger, rollback plan, or residual-risk decision exists."
+    }
+  ],
+  "expected_assessment": {
+    "overall_status": "Fail",
+    "risk_rating": "Critical",
+    "confidence": "Low",
+    "finding": "Failover can create an uninspected transit route between restricted zones."
+  }
+}


### PR DESCRIPTION
/claim #2074

## Skill Improvement ($50-150 Bounty)

Related review issue: #2074

## Summary

This improves `segmentation` by adding failover route bypass evidence gates so normal-state diagrams are not treated as proof that segmentation survives HA, cloud route propagation, transit, peering, VPN, Direct Connect, ExpressRoute, NAT, or asymmetric return-path changes.

## Changes
- Add `SEG-FAIL-01` through `SEG-FAIL-08` evidence gates.
- Require high-risk zone-pair inventory, normal and failover effective routes, PEP traversal in both states, transit/peering/VPN bypass checks, denied-flow tests before and after failover, standby deny/default-deny and logging preservation, return-path checks, and monitoring/retest triggers.
- Extend the output format with Failover Route Evidence inventory and gate results.
- Add skill-local benign and vulnerable JSON fixtures.

## Bounty Tier
- [ ] Minor ($50) - Small improvements, typo fixes, minor clarifications
- [x] Moderate ($100) - Adds meaningful coverage, new validation gates, or useful fixtures
- [ ] Substantial ($150) - Major restructuring, broad new coverage, or comprehensive test suite additions

## Validation
- `git diff --cached --check`
- `git diff --check origin/main...HEAD`
- JSON parse check for both fixtures
- Markdown fence balance check
- marker checks for `SEG-FAIL-01` through `SEG-FAIL-08`
- added-line realistic-secret-pattern scan
- `git merge-tree --write-tree origin/main HEAD` matches `HEAD^{tree}`
- fork branch pushed; remote branch commit verified against local `HEAD`

## Payment preference
GitHub Sponsors, if accepted.