### PR TITLE
Improve AWS GuardDuty coverage gates

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-AWS-v3.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -97,6 +97,28 @@ Evaluate all AWS configurations against CIS AWS v3.0.0 Sections 1 through 5, cov
 
 For detailed CIS benchmark checklist items with specific Terraform patterns, grep patterns, and configuration examples for all five sections, see [benchmark-checklist.md](benchmark-checklist.md) in this skill directory.
 
+#### Supplemental GuardDuty Coverage Evidence Gate
+
+Security Hub, CloudTrail, and CloudWatch alarms are not proof that GuardDuty detectors, protection plans, finding delivery, Runtime Monitoring agents, or suppression-filter governance are working. For production, regulated, or security-monitored AWS environments, record GuardDuty coverage separately from CIS Section 4 monitoring checks.
+
+| Gate | Required evidence | Fail if |
+|---|---|---|
+| `AWS-GD-01` | Account and Region denominator for in-scope accounts, including excluded sandbox/lab accounts with owner, reason, expiry, and review date. | Coverage is claimed from a single detector or Security Hub account without account/Region denominator evidence. |
+| `AWS-GD-02` | Detector enablement in every in-scope account/Region, plus delegated administrator and organization membership evidence where AWS Organizations is used. | Security Hub is enabled but no GuardDuty detector exists, or member accounts/Regions are missing. |
+| `AWS-GD-03` | Organization auto-enable setting for existing and new accounts, including evidence that `ALL` or equivalent backfill covers existing accounts. | Auto-enable covers only `NEW` accounts and no separate existing-account enablement evidence exists. |
+| `AWS-GD-04` | Workload-relevant protection plans are enabled or explicitly excepted: S3 protection, Malware Protection for S3, EKS/ECS/EC2 Runtime Monitoring, Lambda network logs, EBS malware scanning, or equivalent controls. | Sensitive workloads exist but related GuardDuty protection plans are missing or assumed. |
+| `AWS-GD-05` | Runtime Monitoring agent/workload coverage evidence for EKS, ECS/Fargate, and EC2, including deployment mode, coverage percentage, unsupported workload exceptions, and agent health. | Runtime Monitoring is enabled in configuration but agent/workload coverage is unknown. |
+| `AWS-GD-06` | Finding delivery path from GuardDuty to SOC/ticketing/EventBridge/Security Hub and durable encrypted export with required retention. | Findings can be generated but are not routed, retained, or operationally triaged. |
+| `AWS-GD-07` | Suppression filters and archive rules include owner, reason, severity/type scope, expiry/review date, compensating detection, and last review evidence. | High-severity or high-impact finding types are archived without governance. |
+| `AWS-GD-08` | Sample finding or test event is observed at the operational destination, and missing detector/protection-plan/agent/export evidence is marked `Not Evaluable` rather than Pass. | Export is assumed from Terraform only, or missing evidence is counted as passing coverage. |
+
+**Severity guidance:**
+
+- Mark as **High** when in-scope production or regulated accounts lack GuardDuty detector coverage, finding delivery, or governed suppression-filter review.
+- Mark as **High** when sensitive S3, EKS, ECS, EC2, Lambda, or EBS workflows lack relevant protection-plan coverage and no documented equivalent exists.
+- Mark as **Medium** when coverage exists but Runtime Monitoring agent health, durable retention, CMEK, or sample-destination evidence is incomplete.
+- Mark as `Not Evaluable` when the account/Region denominator, delegated administrator, finding route, or sample destination evidence is missing.
+
 ---
 
 ### Step 7: Compile Assessment Report
@@ -110,8 +132,8 @@ Produce the final report using the structure defined in the Output Format sectio
 | Severity | Definition | Examples |
 |----------|-----------|----------|
 | **Critical** | Immediate risk of data breach or account compromise | Public S3 buckets with sensitive data, `*:*` admin policies on users, security groups open to 0.0.0.0/0 on admin ports |
-| **High** | Significant security gap that materially weakens posture | Missing CloudTrail, no MFA enforcement, unencrypted RDS, IMDSv1 enabled |
-| **Medium** | Control gap that should be addressed in normal cycle | Missing log metric filters, password policy below requirements, no VPC flow logs |
+| **High** | Significant security gap that materially weakens posture | Missing CloudTrail, no MFA enforcement, unencrypted RDS, IMDSv1 enabled, in-scope accounts without GuardDuty detectors or finding delivery |
+| **Medium** | Control gap that should be addressed in normal cycle | Missing log metric filters, password policy below requirements, no VPC flow logs, GuardDuty coverage evidence missing sample destination or Runtime Monitoring agent health |
 | **Low** | Hardening recommendation or defense-in-depth measure | Missing Macie classification, no hardware MFA on root (when virtual MFA exists), missing access analyzer in non-primary regions |
 | **Informational** | Best practice observation, no direct security impact | Naming conventions, tag hygiene, documentation gaps |
 
@@ -145,6 +167,23 @@ Produce the final report using the structure defined in the Output Format sectio
 | 3 | Logging | X/11 | Y | Z | nn% |
 | 4 | Monitoring | X/16 | Y | Z | nn% |
 | 5 | Networking | X/6 | Y | Z | nn% |
+
+### GuardDuty Coverage Evidence
+
+| Scope | Detector Coverage | Org Auto-Enable | Protection Plans | Runtime Agent Coverage | Finding Route / Retention | Suppression Review | Sample at Destination | Status |
+|---|---|---|---|---|---|---|---|---|
+| <accounts/regions> | <complete/partial/missing> | <ALL/NEW/none/N/A> | <complete/partial/excepted> | <complete/partial/N/A/missing> | <verified/missing> | <current/stale/missing> | <observed/missing> | <Pass/Fail/Not Evaluable> |
+
+| Gate | Evidence Reviewed | Status | Risk |
+|---|---|---|---|
+| `AWS-GD-01` | <account/Region denominator and exceptions> | <Pass/Fail/Not Evaluable> | <risk> |
+| `AWS-GD-02` | <detectors, delegated admin, organization members> | <Pass/Fail/Not Evaluable> | <risk> |
+| `AWS-GD-03` | <organization auto-enable and existing-account backfill> | <Pass/Fail/Not Evaluable> | <risk> |
+| `AWS-GD-04` | <workload-relevant protection plans> | <Pass/Fail/Not Evaluable> | <risk> |
+| `AWS-GD-05` | <Runtime Monitoring agent/workload coverage> | <Pass/Fail/Not Evaluable> | <risk> |
+| `AWS-GD-06` | <finding delivery route and retention> | <Pass/Fail/Not Evaluable> | <risk> |
+| `AWS-GD-07` | <suppression filter governance> | <Pass/Fail/Not Evaluable> | <risk> |
+| `AWS-GD-08` | <sample finding observed at destination> | <Pass/Fail/Not Evaluable> | <risk> |
 
 ### Detailed Findings
 
@@ -200,6 +239,7 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
 5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
 6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
+7. **Treating Security Hub as GuardDuty proof.** Security Hub can aggregate findings, but it does not prove that GuardDuty detectors, organization auto-enable, protection plans, Runtime Monitoring agents, finding export, or suppression filters are configured correctly.
 
 ---
 
@@ -224,6 +264,10 @@ Produce the final report using the structure defined in the Output Format sectio
 - AWS IAM Best Practices: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 - AWS CloudTrail Documentation: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/
 - AWS Security Hub: https://docs.aws.amazon.com/securityhub/latest/userguide/
+- Amazon GuardDuty: https://docs.aws.amazon.com/guardduty/latest/ug/what-is-guardduty.html
+- Amazon GuardDuty protection plans: https://docs.aws.amazon.com/guardduty/latest/ug/protection-plans-overview.html
+- Amazon GuardDuty finding export: https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_exportfindings.html
+- Amazon GuardDuty Runtime Monitoring: https://docs.aws.amazon.com/guardduty/latest/ug/runtime-monitoring.html
 - AWS VPC Security: https://docs.aws.amazon.com/vpc/latest/userguide/security.html
 - Terraform AWS Provider Documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 
@@ -231,4 +275,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Add supplemental GuardDuty coverage evidence gates for detector denominator, delegated admin, organization auto-enable, workload protection plans, Runtime Monitoring agent coverage, finding delivery, suppression-filter governance, and sample-destination validation.
 - **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 (62 recommendations).

--- a/skills/cloud/aws-review/benchmark-checklist.md
+++ b/skills/cloud/aws-review/benchmark-checklist.md
@@ -405,6 +405,82 @@ aws_securityhub_account
 aws_securityhub_standards_subscription
 ```
 
+### Supplemental -- GuardDuty coverage and protection-plan evidence
+
+Security Hub enablement is not evidence that GuardDuty is deployed or operational. For accounts where GuardDuty is required, collect the following:
+
+**Detector and organization coverage patterns:**
+
+```hcl
+resource "aws_guardduty_detector" "this" {
+  enable = true
+}
+
+resource "aws_guardduty_organization_admin_account" "this" {
+  admin_account_id = var.security_account_id
+}
+
+resource "aws_guardduty_organization_configuration" "this" {
+  detector_id                      = aws_guardduty_detector.this.id
+  auto_enable_organization_members = "ALL"
+}
+```
+
+**Protection-plan patterns:**
+
+```hcl
+resource "aws_guardduty_organization_configuration_feature" "s3" {
+  detector_id = aws_guardduty_detector.this.id
+  name        = "S3_DATA_EVENTS"
+  auto_enable = "ALL"
+}
+
+resource "aws_guardduty_organization_configuration_feature" "runtime" {
+  detector_id = aws_guardduty_detector.this.id
+  name        = "RUNTIME_MONITORING"
+  auto_enable = "ALL"
+}
+
+resource "aws_guardduty_organization_configuration_feature" "lambda" {
+  detector_id = aws_guardduty_detector.this.id
+  name        = "LAMBDA_NETWORK_LOGS"
+  auto_enable = "ALL"
+}
+```
+
+**Finding delivery and suppression patterns:**
+
+```hcl
+resource "aws_cloudwatch_event_rule" "guardduty_findings" {
+  event_pattern = jsonencode({
+    source      = ["aws.guardduty"]
+    "detail-type" = ["GuardDuty Finding"]
+  })
+}
+
+resource "aws_guardduty_publishing_destination" "archive" {
+  detector_id     = aws_guardduty_detector.this.id
+  destination_arn = aws_s3_bucket.guardduty_findings.arn
+  kms_key_arn     = aws_kms_key.guardduty_findings.arn
+}
+
+resource "aws_guardduty_filter" "suppression" {
+  action = "ARCHIVE"
+}
+```
+
+**Review checklist:**
+
+- Account and Region denominator includes every production, regulated, and monitored account/Region.
+- GuardDuty detector evidence is separate from Security Hub evidence.
+- Delegated administrator and organization member coverage are recorded.
+- `auto_enable_organization_members = "ALL"` is present, or existing-account backfill evidence is attached when `NEW` is used.
+- S3, Malware Protection for S3, Runtime Monitoring, Lambda network logs, and EBS malware protection are enabled or explicitly excepted based on workload inventory.
+- Runtime Monitoring includes agent/workload coverage evidence for EKS, ECS/Fargate, and EC2 where applicable.
+- Findings route to SOC, ticketing, EventBridge, Security Hub, or another operational destination and are retained in encrypted durable storage when policy requires.
+- Suppression filters have owner, reason, severity/type scope, expiry/review date, and compensating detection.
+- A sample finding or test event is observed at the destination; otherwise mark the export path `Not Evaluable`.
+
 ---
 
 ## Section 5 -- Networking

--- a/skills/cloud/aws-review/tests/benign/guardduty_complete_org_coverage.json
+++ b/skills/cloud/aws-review/tests/benign/guardduty_complete_org_coverage.json
@@ -1,0 +1,130 @@
+{
+  "fixture": "guardduty_complete_org_coverage",
+  "skill": "aws-review",
+  "description": "Benign fixture for organization-wide GuardDuty coverage with documented sandbox exception, workload-relevant protection plans, Runtime Monitoring agent evidence, finding delivery, and suppression review.",
+  "scope": {
+    "organization_id": "o-example",
+    "delegated_admin_account": "security-audit",
+    "in_scope_accounts": [
+      "prod-app",
+      "prod-data",
+      "shared-services"
+    ],
+    "in_scope_regions": [
+      "us-east-1",
+      "us-west-2"
+    ],
+    "exceptions": [
+      {
+        "account": "sandbox-lab",
+        "regions": [
+          "us-east-1"
+        ],
+        "owner": "platform-security",
+        "reason": "isolated lab account with no production data and separate detective controls",
+        "expires": "2026-09-30",
+        "last_reviewed": "2026-06-01"
+      }
+    ]
+  },
+  "guardduty_configuration": {
+    "detectors_enabled": "all-in-scope-accounts-and-regions",
+    "delegated_admin_configured": true,
+    "organization_auto_enable": "ALL",
+    "existing_account_backfill": "completed",
+    "security_hub_enabled": true,
+    "security_hub_used_as_guardduty_proof": false
+  },
+  "protection_plans": {
+    "s3_data_events": "ALL",
+    "malware_protection_for_s3": "enabled-for-customer-upload-buckets",
+    "runtime_monitoring": "ALL",
+    "lambda_network_logs": "ALL",
+    "ebs_malware_protection": "enabled-for-prod-ec2",
+    "workload_inventory_matched": true
+  },
+  "runtime_monitoring_agent_coverage": {
+    "eks": {
+      "coverage_percent": 98,
+      "unsupported_workloads": "two daemonset-exempt nodes with approved exception",
+      "agent_health": "healthy"
+    },
+    "ecs_fargate": {
+      "coverage_percent": 100,
+      "agent_health": "managed"
+    },
+    "ec2": {
+      "coverage_percent": 96,
+      "agent_health": "healthy"
+    }
+  },
+  "finding_delivery": {
+    "eventbridge_rule": "guardduty-finding-to-soc",
+    "ticketing_target": "soc-triage-queue",
+    "security_hub_import": "enabled",
+    "s3_export": "encrypted-guardduty-findings-bucket",
+    "kms_key": "guardduty-findings-cmek",
+    "retention": "365-days-locked",
+    "sample_finding_observed": "guardduty-test-finding-20260609"
+  },
+  "suppression_filters": [
+    {
+      "name": "approved-red-team-dns-finding",
+      "action": "ARCHIVE",
+      "severity_scope": "low",
+      "type_scope": "Recon:EC2/PortProbeUnprotectedPort",
+      "owner": "detection-engineering",
+      "reason": "approved red-team exercise range",
+      "expires": "2026-07-15",
+      "last_reviewed": "2026-06-05",
+      "compensating_detection": "red-team-allowlist-ticket"
+    }
+  ],
+  "expected_gate_results": [
+    {
+      "gate": "AWS-GD-01",
+      "status": "Pass",
+      "evidence": "Account and Region denominator includes all production accounts plus documented sandbox exception."
+    },
+    {
+      "gate": "AWS-GD-02",
+      "status": "Pass",
+      "evidence": "Detectors are enabled in every in-scope account/Region with delegated administrator evidence."
+    },
+    {
+      "gate": "AWS-GD-03",
+      "status": "Pass",
+      "evidence": "Organization auto-enable is ALL and existing-account backfill is complete."
+    },
+    {
+      "gate": "AWS-GD-04",
+      "status": "Pass",
+      "evidence": "S3, malware, runtime, Lambda, and EBS protection plans match workload inventory."
+    },
+    {
+      "gate": "AWS-GD-05",
+      "status": "Pass",
+      "evidence": "Runtime Monitoring agent/workload coverage is recorded for EKS, ECS/Fargate, and EC2."
+    },
+    {
+      "gate": "AWS-GD-06",
+      "status": "Pass",
+      "evidence": "Findings route to SOC queue, Security Hub, EventBridge, and encrypted retained S3 export."
+    },
+    {
+      "gate": "AWS-GD-07",
+      "status": "Pass",
+      "evidence": "Suppression filter has owner, reason, expiry, scope, review date, and compensating detection."
+    },
+    {
+      "gate": "AWS-GD-08",
+      "status": "Pass",
+      "evidence": "Sample GuardDuty test finding was observed at the operational destination."
+    }
+  ],
+  "expected_assessment": {
+    "overall_status": "Pass",
+    "risk_rating": "Low",
+    "confidence": "High"
+  }
+}

--- a/skills/cloud/aws-review/tests/vulnerable/securityhub_without_guardduty_coverage.json
+++ b/skills/cloud/aws-review/tests/vulnerable/securityhub_without_guardduty_coverage.json
@@ -1,0 +1,133 @@
+{
+  "fixture": "securityhub_without_guardduty_coverage",
+  "skill": "aws-review",
+  "description": "Vulnerable fixture where Security Hub is enabled but GuardDuty detector coverage, protection plans, finding delivery, runtime agent evidence, and suppression governance are incomplete.",
+  "scope": {
+    "organization_id": "o-example",
+    "delegated_admin_account": "unknown",
+    "in_scope_accounts": [
+      "prod-app",
+      "prod-data",
+      "shared-services",
+      "analytics-prod"
+    ],
+    "in_scope_regions": [
+      "us-east-1",
+      "us-west-2",
+      "eu-west-1"
+    ],
+    "account_region_denominator": "not-reviewed",
+    "exceptions": []
+  },
+  "observed_configuration": {
+    "security_hub_enabled": true,
+    "security_hub_standards_subscription": "cis-aws-foundations",
+    "guardduty_detectors": [
+      {
+        "account": "prod-app",
+        "region": "us-east-1",
+        "enabled": true
+      }
+    ],
+    "organization_auto_enable": "NEW",
+    "existing_account_backfill": "missing",
+    "delegated_admin_configured": "unknown"
+  },
+  "protection_plans": {
+    "s3_data_events": "missing",
+    "malware_protection_for_s3": "missing",
+    "runtime_monitoring": "enabled-in-org-config",
+    "lambda_network_logs": "missing",
+    "ebs_malware_protection": "unknown",
+    "sensitive_workloads": [
+      "customer-upload-s3",
+      "prod-eks-payments",
+      "lambda-order-webhooks"
+    ],
+    "workload_inventory_matched": false
+  },
+  "runtime_monitoring_agent_coverage": {
+    "eks": {
+      "coverage_percent": "unknown",
+      "agent_health": "not-reviewed"
+    },
+    "ecs_fargate": {
+      "coverage_percent": "unknown",
+      "agent_health": "not-reviewed"
+    },
+    "ec2": {
+      "coverage_percent": "unknown",
+      "agent_health": "not-reviewed"
+    }
+  },
+  "finding_delivery": {
+    "eventbridge_rule": "missing",
+    "ticketing_target": "missing",
+    "security_hub_import": "assumed",
+    "s3_export": "missing",
+    "kms_key": "missing",
+    "retention": "unknown",
+    "sample_finding_observed": "missing"
+  },
+  "suppression_filters": [
+    {
+      "name": "archive-crypto-dns",
+      "action": "ARCHIVE",
+      "severity_scope": "unknown",
+      "type_scope": "CryptoCurrency:EC2/BitcoinTool.B!DNS",
+      "owner": "missing",
+      "reason": "noise",
+      "expires": "missing",
+      "last_reviewed": "missing",
+      "compensating_detection": "missing"
+    }
+  ],
+  "expected_gate_results": [
+    {
+      "gate": "AWS-GD-01",
+      "status": "Fail",
+      "evidence": "Account and Region denominator is not reviewed."
+    },
+    {
+      "gate": "AWS-GD-02",
+      "status": "Fail",
+      "evidence": "Only one detector is observed; Security Hub is incorrectly used as coverage proof."
+    },
+    {
+      "gate": "AWS-GD-03",
+      "status": "Fail",
+      "evidence": "Organization auto-enable covers NEW accounts only and existing backfill is missing."
+    },
+    {
+      "gate": "AWS-GD-04",
+      "status": "Fail",
+      "evidence": "Sensitive S3, EKS, and Lambda workloads lack matching protection-plan evidence."
+    },
+    {
+      "gate": "AWS-GD-05",
+      "status": "Not Evaluable",
+      "evidence": "Runtime Monitoring is configured but agent/workload coverage is unknown."
+    },
+    {
+      "gate": "AWS-GD-06",
+      "status": "Fail",
+      "evidence": "Findings do not have verified EventBridge, ticketing, encrypted export, or retention path."
+    },
+    {
+      "gate": "AWS-GD-07",
+      "status": "Fail",
+      "evidence": "Suppression filter archives a high-impact finding type without owner, expiry, review date, or compensating detection."
+    },
+    {
+      "gate": "AWS-GD-08",
+      "status": "Not Evaluable",
+      "evidence": "No sample GuardDuty finding was observed at the destination."
+    }
+  ],
+  "expected_assessment": {
+    "overall_status": "Fail",
+    "risk_rating": "High",
+    "confidence": "Low",
+    "finding": "Security Hub presence is over-credited while GuardDuty coverage and delivery evidence are incomplete."
+  }
+}


### PR DESCRIPTION
/claim #1337

## Skill Improvement ($50-150 Bounty)

Related review issue: #1337

## Summary

This improves `aws-review` by adding GuardDuty coverage evidence gates so Security Hub, CloudTrail, or CloudWatch evidence is not treated as proof of GuardDuty detector, protection-plan, Runtime Monitoring, finding-delivery, suppression-filter, or sample-destination coverage.

## Changes
- Add `AWS-GD-01` through `AWS-GD-08` evidence gates.
- Require account/Region denominator, detector and delegated-admin coverage, organization auto-enable/backfill, workload-relevant protection plans, Runtime Monitoring agent/workload evidence, finding delivery and retention, suppression-filter governance, and sample finding destination proof.
- Extend output with GuardDuty Coverage Evidence and gate results.
- Add benchmark-checklist GuardDuty review patterns.
- Add skill-local benign and vulnerable JSON fixtures.

## Bounty Tier
- [ ] Minor ($50) - Small improvements, typo fixes, minor clarifications
- [x] Moderate ($100) - Adds meaningful coverage, new validation gates, or useful fixtures
- [ ] Substantial ($150) - Major restructuring, broad new coverage, or comprehensive test suite additions

## Validation
- `git diff --cached --check`
- `git diff --check origin/main...HEAD`
- JSON parse check for both fixtures
- Markdown fence balance check
- marker checks for `AWS-GD-01` through `AWS-GD-08`
- added-line realistic-secret-pattern scan
- `git merge-tree --write-tree origin/main HEAD` matches `HEAD^{tree}`
- fork branch created through GitHub Git Data API after HTTPS push resets; remote tree verified to match local `HEAD^{tree}`

## Payment preference
GitHub Sponsors, if accepted.