### PR TITLE
Add SOC2 vendor concentration exit gates

### DIFF
--- a/skills/compliance/soc2-gap/SKILL.md
+++ b/skills/compliance/soc2-gap/SKILL.md
@@ -12,7 +12,7 @@ phase: [assess, operate]
 frameworks: [AICPA-TSC, NIST-CSF-2.0]
 difficulty: intermediate
 time_estimate: "60-120min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -99,10 +99,10 @@ Record the final scope determination:
 ```
 SOC 2 Scope:
 - Security (Common Criteria): IN SCOPE [mandatory]
-- Availability:               [IN SCOPE / OUT OF SCOPE] — Justification: ___
-- Confidentiality:             [IN SCOPE / OUT OF SCOPE] — Justification: ___
-- Processing Integrity:        [IN SCOPE / OUT OF SCOPE] — Justification: ___
-- Privacy:                     [IN SCOPE / OUT OF SCOPE] — Justification: ___
+- Availability:               [IN SCOPE / OUT OF SCOPE] â€” Justification: ___
+- Confidentiality:             [IN SCOPE / OUT OF SCOPE] â€” Justification: ___
+- Processing Integrity:        [IN SCOPE / OUT OF SCOPE] â€” Justification: ___
+- Privacy:                     [IN SCOPE / OUT OF SCOPE] â€” Justification: ___
 
 System Description Boundary:
 - Infrastructure: ___
@@ -122,7 +122,7 @@ Walk through each Common Criteria category. For every criterion, assess: (a) whe
 
 The control environment sets the tone for the organization's commitment to integrity, ethical values, and security.
 
-**CC1.1 — COSO Principle 1: The entity demonstrates a commitment to integrity and ethical values.**
+**CC1.1 â€” COSO Principle 1: The entity demonstrates a commitment to integrity and ethical values.**
 - Questions to ask:
   - Is there a Code of Conduct or Ethics policy?
   - Do employees acknowledge the Code of Conduct upon hire and annually?
@@ -136,7 +136,7 @@ The control environment sets the tone for the organization's commitment to integ
   - No anonymous reporting mechanism
   - Policy has not been updated in more than two years
 
-**CC1.2 — COSO Principle 2: The board of directors demonstrates independence from management and exercises oversight.**
+**CC1.2 â€” COSO Principle 2: The board of directors demonstrates independence from management and exercises oversight.**
 - Questions to ask:
   - Is there a board or governance body with oversight of security?
   - Does the board receive regular security briefings?
@@ -150,7 +150,7 @@ The control environment sets the tone for the organization's commitment to integ
   - Security reporting is ad-hoc rather than scheduled
   - No documented governance structure
 
-**CC1.3 — COSO Principle 3: Management establishes structures, reporting lines, and authorities.**
+**CC1.3 â€” COSO Principle 3: Management establishes structures, reporting lines, and authorities.**
 - Questions to ask:
   - Is there an organizational chart showing security responsibilities?
   - Is there a designated security leader (CISO, VP Security, or equivalent)?
@@ -163,7 +163,7 @@ The control environment sets the tone for the organization's commitment to integ
   - Security responsibilities are informal and undocumented
   - No dedicated security role (security is "everyone's job" with no owner)
 
-**CC1.4 — COSO Principle 4: The entity demonstrates a commitment to attract, develop, and retain competent individuals.**
+**CC1.4 â€” COSO Principle 4: The entity demonstrates a commitment to attract, develop, and retain competent individuals.**
 - Questions to ask:
   - Are background checks performed for employees with access to sensitive systems?
   - Is there a security awareness training program?
@@ -177,7 +177,7 @@ The control environment sets the tone for the organization's commitment to integ
   - Security training is one-time at onboarding with no annual refresh
   - No tracking of training completion rates
 
-**CC1.5 — COSO Principle 5: The entity holds individuals accountable for their internal control responsibilities.**
+**CC1.5 â€” COSO Principle 5: The entity holds individuals accountable for their internal control responsibilities.**
 - Questions to ask:
   - Are security responsibilities included in performance evaluations?
   - Is there a disciplinary process for security policy violations?
@@ -194,7 +194,7 @@ The control environment sets the tone for the organization's commitment to integ
 
 #### CC2: Communication and Information
 
-**CC2.1 — COSO Principle 13: The entity obtains or generates and uses relevant, quality information to support internal control.**
+**CC2.1 â€” COSO Principle 13: The entity obtains or generates and uses relevant, quality information to support internal control.**
 - Questions to ask:
   - Are information assets inventoried and classified?
   - Is there a data classification policy?
@@ -208,7 +208,7 @@ The control environment sets the tone for the organization's commitment to integ
   - Data classification policy exists but is not enforced technically
   - Architecture diagrams do not reflect current state
 
-**CC2.2 — COSO Principle 14: The entity internally communicates information necessary to support internal control.**
+**CC2.2 â€” COSO Principle 14: The entity internally communicates information necessary to support internal control.**
 - Questions to ask:
   - Are security policies accessible to all employees?
   - Is there a process for communicating policy changes?
@@ -221,7 +221,7 @@ The control environment sets the tone for the organization's commitment to integ
   - Policies exist but are buried in inaccessible locations
   - No formal change notification process for policy updates
 
-**CC2.3 — COSO Principle 15: The entity communicates with external parties regarding matters affecting internal control.**
+**CC2.3 â€” COSO Principle 15: The entity communicates with external parties regarding matters affecting internal control.**
 - Questions to ask:
   - Is there an external-facing security page or trust center?
   - Are customers notified of security incidents per contractual obligations?
@@ -239,7 +239,7 @@ The control environment sets the tone for the organization's commitment to integ
 
 #### CC3: Risk Assessment
 
-**CC3.1 — COSO Principle 6: The entity specifies objectives with sufficient clarity to enable identification of risks.**
+**CC3.1 â€” COSO Principle 6: The entity specifies objectives with sufficient clarity to enable identification of risks.**
 - Questions to ask:
   - Are security objectives documented and aligned with business objectives?
   - Are security objectives measurable?
@@ -250,7 +250,7 @@ The control environment sets the tone for the organization's commitment to integ
   - Security objectives are implicit rather than documented
   - No alignment between security and business objectives
 
-**CC3.2 — COSO Principle 7: The entity identifies risks to the achievement of its objectives and analyzes risks as a basis for determining how to manage them.**
+**CC3.2 â€” COSO Principle 7: The entity identifies risks to the achievement of its objectives and analyzes risks as a basis for determining how to manage them.**
 - Questions to ask:
   - Is there a formal risk assessment process?
   - How frequently are risk assessments performed?
@@ -264,7 +264,7 @@ The control environment sets the tone for the organization's commitment to integ
   - Risk register exists but is not reviewed or updated regularly
   - Risk assessments do not cover all in-scope systems
 
-**CC3.3 — COSO Principle 8: The entity considers the potential for fraud in assessing risks.**
+**CC3.3 â€” COSO Principle 8: The entity considers the potential for fraud in assessing risks.**
 - Questions to ask:
   - Does the risk assessment process include fraud risk factors?
   - Are insider threat scenarios considered?
@@ -278,7 +278,7 @@ The control environment sets the tone for the organization's commitment to integ
   - No insider threat program or assessment
   - Segregation of duties is not formally evaluated
 
-**CC3.4 — COSO Principle 9: The entity identifies and assesses changes that could significantly impact the system of internal controls.**
+**CC3.4 â€” COSO Principle 9: The entity identifies and assesses changes that could significantly impact the system of internal controls.**
 - Questions to ask:
   - Is there a process for assessing risks associated with significant changes?
   - Are new vendors, technologies, or business processes evaluated for risk before adoption?
@@ -301,15 +301,30 @@ For detailed Trust Services Criteria evaluation questions, evidence requirements
 
 Prioritize remediation by audit readiness impact. Items that would result in examination exceptions or qualifications take highest priority.
 
+#### CC9.2 Vendor Concentration and Exit Evidence
+
+For critical vendors and subservice organizations, verify that third-party risk management covers more than annual SOC report collection. Concentration and exit readiness should be reviewed when a vendor supports availability, confidentiality, privacy, processing integrity, or core security operations.
+
+**Evidence to collect:**
+
+- **Critical vendor tiering:** vendors ranked by business process, data sensitivity, system dependency, and customer commitment impact.
+- **Concentration analysis:** single points of failure, sole-source vendors, shared cloud regions, shared identity providers, and multiple critical services dependent on the same provider.
+- **Exit plan:** migration/termination procedure, data export format, deletion/return requirements, notice periods, contractual assistance, and fallback provider or manual workaround.
+- **Portability test:** evidence that backups, exports, escrow, API access, or configuration snapshots can actually be restored or imported elsewhere.
+- **Subservice dependency:** whether the vendor relies on subcontractors or subservice organizations that change the risk profile.
+- **Monitoring cadence:** owner, review frequency, trigger events, and risk acceptance for unresolved concentration risks.
+
+**Finding classification:** No exit plan for a critical vendor is **High** when the vendor supports in-scope services or customer commitments. Untested portability for customer data or operationally critical configuration is **Medium**. Unknown subservice dependencies are **Medium**. Single-provider concentration with no risk acceptance or fallback is **High**.
+
 #### 6.1 Priority Framework
 
 | Priority | Criteria | Timeline | Description |
 |----------|----------|----------|-------------|
-| **P0 — Critical** | Score 0-1 on CC6.x, CC7.x, CC8.1 | Days 1-30 | Access controls, monitoring, and change management are the most frequently tested areas. Gaps here almost certainly result in exceptions. |
-| **P1 — High** | Score 0-1 on CC3.x, CC5.x, CC9.2 | Days 1-30 | Risk assessment, control activities, and vendor management are foundational. Auditors expect these to be established. |
-| **P2 — Medium** | Score 0-2 on CC1.x, CC2.x, CC4.x | Days 31-60 | Control environment, communication, and monitoring support the overall program. Gaps here indicate program immaturity. |
-| **P3 — Standard** | Score 0-2 on CC9.1, additional criteria | Days 31-60 | Risk mitigation and optional category criteria. Important for completeness. |
-| **P4 — Enhancement** | Score 3 on any criteria (improving to 4) | Days 61-90 | Polishing controls that are defined but need evidence of sustained operating effectiveness. |
+| **P0 â€” Critical** | Score 0-1 on CC6.x, CC7.x, CC8.1 | Days 1-30 | Access controls, monitoring, and change management are the most frequently tested areas. Gaps here almost certainly result in exceptions. |
+| **P1 â€” High** | Score 0-1 on CC3.x, CC5.x, CC9.2 | Days 1-30 | Risk assessment, control activities, and vendor management are foundational. Auditors expect these to be established. |
+| **P2 â€” Medium** | Score 0-2 on CC1.x, CC2.x, CC4.x | Days 31-60 | Control environment, communication, and monitoring support the overall program. Gaps here indicate program immaturity. |
+| **P3 â€” Standard** | Score 0-2 on CC9.1, additional criteria | Days 31-60 | Risk mitigation and optional category criteria. Important for completeness. |
+| **P4 â€” Enhancement** | Score 3 on any criteria (improving to 4) | Days 61-90 | Polishing controls that are defined but need evidence of sustained operating effectiveness. |
 
 #### 6.2 90-Day Action Plan Template
 
@@ -368,6 +383,7 @@ When performing a SOC 2 gap analysis, produce the following deliverables:
 5. **Evidence Checklist**: Customized evidence requirements based on in-scope criteria, marking items as Exists / Partial / Missing.
 6. **90-Day Remediation Roadmap**: Prioritized action items with owners, deadlines, and dependencies.
 7. **Overall Readiness Assessment**: Go/no-go recommendation for engaging a SOC 2 auditor.
+8. **Critical Vendor Exit Matrix**: For each critical vendor, include concentration risk, exit owner, portability evidence, subservice dependency, and next review date.
 
 ## Prompt Injection Safety Notice
 
@@ -386,6 +402,10 @@ This skill processes user-supplied content including compliance documentation, p
 - **NIST CSF 2.0 Mapping**: CC1-CC2 maps to Govern (GV), CC3 to Identify (ID), CC5-CC6 to Protect (PR), CC7 to Detect (DE) and Respond (RS), CC7.5 to Recover (RC).
 - **ISO 27001:2022**: CC6 maps to Annex A.8 (Technology Controls), CC8 maps to Annex A.8.32 (Change Management), CC9.2 maps to Annex A.5.19-5.22 (Supplier Relationships).
 - **CIS Controls v8**: CC6.1 maps to CIS Control 6 (Access Control Management), CC6.8 maps to CIS Control 10 (Malware Defenses), CC7.1 maps to CIS Control 7 (Continuous Vulnerability Management).
+
+## Changelog
+
+- **1.0.1** -- Add CC9.2 vendor concentration and exit-readiness evidence for critical vendor tiering, portability tests, subservice dependencies, exit owners, and review cadence.
 
 ## Limitations
 


### PR DESCRIPTION
## Summary
- Adds CC9.2 vendor concentration and exit-readiness evidence to SOC 2 gap analysis.
- Covers critical vendor tiering, concentration analysis, exit plans, portability tests, subservice dependencies, owner/review cadence, and risk acceptance.
- Adds a Critical Vendor Exit Matrix deliverable.
- Links implementation to review issue #2239.

## Validation
- Confirmed markdown code fences are balanced.
- Checked the new version, vendor exit section, exit matrix deliverable, and changelog are present.

Bounty request: Improver Moderate ($100) if accepted. I can provide payment details if accepted.