### PR TITLE
Improve IaC state and supply chain guidance

### DIFF
--- a/skills/cloud/iac-security/SKILL.md
+++ b/skills/cloud/iac-security/SKILL.md
@@ -2,7 +2,7 @@
 name: iac-security
 description: >
   Performs a security review of Infrastructure as Code templates against the OWASP
-  IaC Security Cheat Sheet, SLSA v1.0, and CIS Benchmarks. Auto-invoked when
+  IaC Security Cheat Sheet, current SLSA guidance, and CIS Benchmarks. Auto-invoked when
   reviewing Terraform, CloudFormation, or Pulumi configurations. Detects hardcoded
   secrets, public exposure patterns, encryption gaps, overly permissive IAM, and
   misconfigurations equivalent to Checkov, tfsec, and KICS rules. Produces a
@@ -10,10 +10,10 @@ description: >
 tags: [cloud, iac, terraform, cloudformation]
 role: [cloud-security-engineer, security-engineer, devsecops]
 phase: [build, review]
-frameworks: [OWASP-IaC-Security, SLSA-v1.0, CIS-Benchmarks]
+frameworks: [OWASP-IaC-Security, SLSA, CIS-Benchmarks]
 difficulty: intermediate
 time_estimate: "45-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -25,7 +25,7 @@ argument-hint: "[target-file-or-directory]"
 
 ## Overview
 
-This skill performs a structured security review of Infrastructure as Code (IaC) templates covering Terraform, CloudFormation, Pulumi, and Bicep. It identifies security anti-patterns, misconfigurations, and policy violations by applying checks equivalent to those performed by static analysis tools (Checkov, tfsec, KICS, cfn-nag) while grounding findings in established frameworks: the OWASP Infrastructure as Code Security Cheat Sheet, SLSA v1.0 supply chain integrity requirements, and relevant CIS Benchmarks.
+This skill performs a structured security review of Infrastructure as Code (IaC) templates covering Terraform, OpenTofu, CloudFormation, Pulumi, and Bicep. It identifies security anti-patterns, misconfigurations, and policy violations by applying checks equivalent to those performed by static analysis tools (Checkov, tfsec, KICS, cfn-nag) while grounding findings in established frameworks: the OWASP Infrastructure as Code Security Cheat Sheet, current SLSA supply chain integrity guidance, and relevant CIS Benchmarks.
 
 The review covers eight security domains: secrets management, public exposure, encryption, IAM and access control, logging, network security, supply chain integrity, and resource hardening. Each finding is mapped to a specific policy rule equivalent from Checkov, tfsec, or KICS.
 
@@ -48,7 +48,7 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 
 Infrastructure as Code enables declarative, version-controlled management of cloud resources. This power also means that a single misconfiguration in a template can expose production systems, leak credentials, or create attack surfaces at scale. IaC security scanning is a critical gate in the deployment pipeline.
 
-The OWASP IaC Security Cheat Sheet categorizes common IaC vulnerabilities. SLSA v1.0 provides supply chain integrity requirements relevant to how IaC modules are sourced and deployed. CIS Benchmarks provide the specific configuration baselines against which resource configurations are evaluated.
+The OWASP IaC Security Cheat Sheet categorizes common IaC vulnerabilities. SLSA provides supply chain integrity requirements relevant to how IaC modules are sourced and deployed; use the current SLSA specification for provenance terminology while noting older SLSA v1.0 references when found in existing reports. CIS Benchmarks provide the specific configuration baselines against which resource configurations are evaluated.
 
 ### Prerequisites
 
@@ -71,6 +71,8 @@ Use Glob to locate all IaC configuration files.
 **/*.tf
 **/*.tfvars
 **/*.tf.json
+**/.terraform.lock.hcl
+**/.tofu.lock.hcl
 **/terraform.tfstate
 **/*.tfstate.backup
 **/cloudformation/**/*.yaml
@@ -86,13 +88,30 @@ Use Glob to locate all IaC configuration files.
 **/index.ts          # Pulumi TypeScript
 ```
 
-Classify the IaC stack(s) in use. Record the total file count and frameworks detected.
+Classify the IaC stack(s) in use. Record the total file count, frameworks detected, lock files present, and state file/backend evidence.
 
 ---
 
 ### Step 2 through Step 9: Security Domain Evaluation
 
 Evaluate all IaC configurations across eight security domains: Hardcoded Secrets Detection, Public Exposure Analysis, Encryption Gap Analysis, IAM and Access Control Review, Logging and Monitoring Gaps, Network Security Review, Supply Chain Integrity (SLSA Alignment), and Resource Hardening.
+
+For Terraform/OpenTofu supply chain posture, explicitly verify:
+
+- `.terraform.lock.hcl` or `.tofu.lock.hcl` is committed when providers are used.
+- Provider entries include checksums for the platforms that CI/deploy runners use.
+- Provider version constraints are paired with a lock file so allowed version ranges cannot drift silently.
+- Module sources are pinned appropriately: registry modules to explicit versions, git sources to immutable commit SHAs where possible, and tags only when release governance is documented.
+- Supply chain report language references current SLSA guidance rather than hardcoding stale SLSA v1.0-only terminology.
+
+For Terraform/OpenTofu state posture, explicitly classify:
+
+- Backend type: local, remote object storage, Terraform Cloud/Enterprise, or other managed backend.
+- Encryption: at rest and in transit, including whether customer-managed keys are required by the environment.
+- Access control: who can read/write state and whether access is separated from normal source-code access.
+- Locking and concurrency controls.
+- Whether `terraform.tfstate` or backup state files are committed to source control.
+- Whether sensitive values are present in state. A `sensitive = true` variable reference is not a hardcoded secret by itself, but sensitive values can still appear in state and must be handled there.
 
 For detailed tool-specific rule sets, detection patterns, vulnerable code examples, and remediation guidance for Checkov, tfsec, and KICS equivalents across all eight domains, see [tool-rules.md](tool-rules.md) in this skill directory.
 
@@ -111,9 +130,9 @@ Produce the final report using the structure defined in the Output Format sectio
 
 | Severity | Definition | Examples |
 |----------|-----------|----------|
-| **Critical** | Immediate exploitability, data exposure, or credential compromise | Hardcoded secrets, public S3 buckets with data, unrestricted ingress on all ports, `*:*` IAM policies, public database endpoints |
-| **High** | Significant misconfiguration that enables attack paths | Missing encryption at rest, security groups open on admin ports, unpinned module sources from public registries, local state files |
-| **Medium** | Control gap reducing defense-in-depth | Missing logging, no CMK encryption (provider-managed only), unpinned provider versions, missing backup retention |
+| **Critical** | Immediate exploitability, data exposure, or credential compromise | Literal hardcoded secrets, committed state files containing sensitive values, public S3 buckets with data, unrestricted ingress on all ports, `*:*` IAM policies, public database endpoints |
+| **High** | Significant misconfiguration that enables attack paths | Local or committed state files in secret-bearing stacks, missing encryption for sensitive regulated data, security groups open on admin ports, unpinned module sources from public registries |
+| **Medium** | Control gap reducing defense-in-depth | Missing lock file or incomplete provider checksums, detection of sensitive variable references without state exposure, provider-managed encryption where CMK is required by policy, unpinned provider versions, missing backup retention |
 | **Low** | Hardening opportunity or best-practice deviation | IMDSv1 not disabled, EBS not optimized, missing tags, no VPC for Lambda |
 | **Informational** | Observation with no direct security impact | Deprecated resource types, naming inconsistencies, module structure recommendations |
 
@@ -128,7 +147,8 @@ Produce the final report using the structure defined in the Output Format sectio
 - Repository: <identifier>
 - Date: <assessment date>
 - IaC Frameworks: <Terraform / CloudFormation / Pulumi / Bicep>
-- Frameworks Applied: OWASP IaC Security Cheat Sheet, SLSA v1.0, CIS Benchmarks
+- Frameworks Applied: OWASP IaC Security Cheat Sheet, current SLSA specification, CIS Benchmarks
+- SLSA Reference: <latest / v1.2 / v1.0 compatibility note>
 - Files reviewed: <N files>
 - Cloud providers: <AWS / Azure / GCP>
 
@@ -164,11 +184,25 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Remediation:** <fix with code example>
 
 ### Supply Chain Assessment (SLSA Alignment)
-- Module pinning: <pinned / partially pinned / unpinned>
-- Provider pinning: <pinned / unpinned>
-- State encryption: <encrypted / unencrypted>
-- State locking: <enabled / disabled>
-- Lock file committed: <yes / no>
+- Module pinning: <registry version / git SHA / git tag / branch / unpinned>
+- Provider pinning: <constraint only / exact version / lock-file enforced>
+- Provider lock file: <.terraform.lock.hcl / .tofu.lock.hcl / absent>
+- Provider checksums: <complete for deployment platforms / incomplete / absent>
+- SLSA terminology: <current / stale v1.0-only / not applicable>
+
+### State Posture
+- Backend type: <local / remote object storage / Terraform Cloud / managed backend / unknown>
+- State files committed: <yes / no / unknown>
+- State encryption: <encrypted / unencrypted / unknown>
+- State locking: <enabled / disabled / unknown>
+- State access controls: <separate least-privilege / same as source repo / public / unknown>
+- Sensitive values in state: <yes / no / unknown>
+
+### Severity Calibration Notes
+- Sensitive variable references: <not a hardcoded-secret finding unless literal values or exposed state are present>
+- Public exposure context: <internet-facing intended service vs admin port vs database/control plane>
+- Encryption context: <provider-managed default accepted / customer-managed key required by policy or data sensitivity>
+- Scanner suppressions: <documented risk acceptance / compensating control / unexplained suppression>
 
 ### Prioritized Remediation Plan
 
@@ -192,13 +226,13 @@ Produce the final report using the structure defined in the Output Format sectio
 | Logging | Missing audit trails, disabled monitoring, insufficient retention |
 | Resource Configuration | Missing hardening settings, insecure defaults, deprecated configurations |
 
-### SLSA v1.0 -- Relevant Requirements for IaC
+### SLSA -- Relevant Requirements for IaC
 
 | Requirement | IaC Application |
 |-------------|----------------|
 | Source integrity | Module sources pinned to immutable references (commit SHA, version tag) |
 | Build integrity | IaC plans generated in CI, not applied manually |
-| Provenance | State files track who applied what changes |
+| Provenance | Deployment workflow records who generated and applied plans, with traceability back to source revision |
 | Dependencies | Provider and module versions locked, lock file committed |
 
 ### Checkov / tfsec / KICS Rule Equivalents
@@ -223,13 +257,16 @@ This skill applies checks equivalent to the following high-impact rules:
 
 ## Common Pitfalls
 
-1. **False positives on variable references.** A `password = var.db_password` is not a hardcoded secret. Only flag literal string values, not variable references or data source lookups.
+1. **False positives on variable references.** A `password = var.db_password` is not a hardcoded secret. Only flag literal string values, not variable references or data source lookups. Move the review to state posture when sensitive variables may be materialized in Terraform/OpenTofu state.
 2. **Missing tfvars analysis.** Secrets may be hardcoded in `.tfvars` files rather than the main `.tf` files. Always scan both.
 3. **Module abstraction hiding misconfigurations.** A module call may look clean, but the module source may contain insecure defaults. When possible, trace into module source code.
 4. **CloudFormation parameters with NoEcho.** Parameters marked `NoEcho: true` are not necessarily secure -- the default value is still in plaintext in the template.
 5. **Confusing `aws_s3_bucket_acl` with `aws_s3_bucket_public_access_block`.** The public access block overrides ACLs. Check both, but the access block is the stronger control.
-6. **Terraform state file secrets.** Even when variables are marked `sensitive`, they may appear in plaintext in the state file. Verify state encryption and access controls.
-7. **Provider-specific encryption defaults.** Some providers encrypt by default (e.g., AWS S3 since January 2023). Know the defaults before flagging missing explicit encryption configuration.
+6. **Terraform/OpenTofu lock file drift.** A provider version constraint such as `~> 5.0` is not the same as a committed dependency lock file with checksums. Review `.terraform.lock.hcl` or `.tofu.lock.hcl` and confirm CI/deploy platform checksums are present.
+7. **Terraform state file secrets.** Even when variables are marked `sensitive`, they may appear in plaintext in the state file. Verify backend type, encryption, locking, access controls, and whether state files are committed.
+8. **Provider-specific encryption defaults.** Some providers encrypt by default (e.g., AWS S3 since January 2023). Know the defaults before flagging missing explicit encryption configuration. Escalate only when the data sensitivity, regulation, or organizational policy requires a customer-managed key.
+9. **Treating all public exposure the same.** `0.0.0.0/0:443` on an intended internet-facing load balancer is different from `0.0.0.0/0:22` on an instance or public access to a database/control plane. Severity must account for protocol, resource role, authentication, and compensating controls.
+10. **Scanner suppressions without context.** Suppression comments such as `checkov:skip` or `tfsec:ignore` should be reported, but severity depends on whether there is documented risk acceptance or an equivalent compensating control.
 
 ---
 
@@ -252,7 +289,11 @@ This skill applies checks equivalent to the following high-impact rules:
 ## References
 
 - OWASP Infrastructure as Code Security Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Infrastructure_as_Code_Security_Cheat_Sheet.html
-- SLSA v1.0 Specification: https://slsa.dev/spec/v1.0/
+- SLSA Latest Specification: https://slsa.dev/spec/latest/
+- SLSA v1.2 Specification: https://slsa.dev/spec/v1.2/
+- Terraform Dependency Lock File: https://developer.hashicorp.com/terraform/language/files/dependency-lock
+- Terraform Provider Requirements: https://developer.hashicorp.com/terraform/language/providers/requirements
+- Terraform Sensitive Variables and State: https://developer.hashicorp.com/terraform/tutorials/configuration-language/sensitive-variables
 - CIS Benchmarks: https://www.cisecurity.org/cis-benchmarks
 - Checkov Policy Index: https://www.checkov.io/5.Policy%20Index/
 - tfsec Documentation: https://aquasecurity.github.io/tfsec/
@@ -265,4 +306,5 @@ This skill applies checks equivalent to the following high-impact rules:
 
 ## Changelog
 
+- **1.0.1** -- Add Terraform/OpenTofu lock-file and provider checksum checks, SLSA current-version wording, state posture reporting, and severity calibration for variable references, encryption defaults, public exposure, and scanner suppressions.
 - **1.0.0** -- Initial release. Coverage of eight security domains across Terraform, CloudFormation, Pulumi, and Bicep with Checkov/tfsec/KICS rule equivalents.


### PR DESCRIPTION
## What This PR Does

Implements the `iac-security` review gaps documented in #25.

- Adds Terraform/OpenTofu lock-file discovery and provider checksum guidance.
- Adds state posture review requirements for backend type, encryption, locking, access controls, committed state files, and sensitive state values.
- Updates SLSA wording to use current guidance instead of v1.0-only terminology.
- Adds severity calibration for sensitive variable references, provider-managed encryption defaults, public exposure context, and scanner suppressions.
- Updates the assessment output template and bumps the skill version to 1.0.1.

## Testing

- Ran `git diff --check -- skills/cloud/iac-security/SKILL.md`.
- Checked the changed file for payment details, email addresses, and private credential shapes.
- Reviewed the diff against #25 coverage requirements.

Refs #25