### PR TITLE
Improve api-security cursor pagination gates

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -11,7 +11,7 @@ phase: [design, build, review]
 frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -36,8 +36,9 @@ Before analyzing any endpoint, establish a complete inventory of the API surface
 3. **Map authentication mechanisms** -- OAuth 2.0 flows, API keys, JWTs, session cookies, mTLS, or custom tokens. Note which endpoints require authentication and which are public.
 4. **Identify authorization models** -- RBAC, ABAC, ownership-based, or no authorization. Document how object-level and function-level access control decisions are made.
 5. **Catalog data objects** -- List the resources/entities exposed by the API and their sensitivity classification (PII, financial, internal, public).
-6. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, or cost-control mechanisms at the gateway or application layer.
-7. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
+6. **Catalog list and pagination semantics** -- For every list/search/export endpoint, record whether it uses offset, limit, cursor, Relay-style, or keyset pagination. Capture page-size policy, cursor format, tenant/principal binding, query-shape binding, sort tuple, expiry, replay behavior, and snapshot/high-watermark semantics.
+7. **Note rate limiting and quota configurations** -- Document any existing throttling, quota, or cost-control mechanisms at the gateway or application layer.
+8. **Identify downstream dependencies** -- Third-party APIs, internal microservices, or webhooks that the API consumes.
 
 > **Gate:** Do not proceed until the API style, authentication model, authorization model, and endpoint inventory are documented. Incomplete scope leads to missed findings.
 
@@ -92,7 +93,7 @@ The final review output must be structured as follows:
 **API Style:** [REST / GraphQL / gRPC / Hybrid]
 **Specification:** [OpenAPI spec path, if applicable]
 **Date:** [review date]
-**Reviewer:** AI Agent -- api-security skill v1.0.0
+**Reviewer:** AI Agent -- api-security skill v1.0.1
 
 ### Summary
 
@@ -111,6 +112,12 @@ The final review output must be structured as follows:
 
 **Total Findings:** [count]
 **Critical:** [count] | **High:** [count] | **Medium:** [count] | **Low:** [count] | **Info:** [count]
+
+### Cursor Pagination Assessment
+
+| Endpoint | Page Size Control | Cursor Integrity and Scope | Stable Ordering / Snapshot | Replay / Cost Control | Decision |
+|---|---|---|---|---|---|
+| [path/query] | [server-fixed/capped/client-controlled] | [tenant/principal/audience/query-shape/expiry evidence] | [unique sort tuple, snapshot, high-watermark, or eventual-consistency note] | [TTL, stale cursor handling, repeated scan monitoring] | [Pass/Partial/Fail/Not Evaluable] |
 
 ### Findings
 
@@ -213,7 +220,9 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 
 5. **Applying rate limiting only to authentication endpoints.** Every API endpoint requires rate limiting proportional to its cost and sensitivity. Data-heavy endpoints, search functions, and export operations are frequent targets for abuse even when properly authenticated.
 
-6. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
+6. **Treating cursor pagination as only a page-size problem.** A server-fixed page size is necessary, but cursor pagination can also carry authorization state, query filters, sort position, and cost-control state. Review signed/opaque cursors for tenant and principal binding, endpoint audience, query-shape binding, expiry, stable ordering, and replay behavior before closing API1 or API4 findings.
+
+7. **Ignoring upstream API trust.** Data received from third-party APIs and even internal microservices must be validated before use. A compromised upstream service can inject SQL, XSS, or SSRF payloads through otherwise trusted data channels.
 
 ---
 

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -17,6 +17,7 @@ BOLA occurs when an API endpoint accepts an object identifier from the client an
 - Authorization logic that checks only whether the user is authenticated, not whether they own or have access to the specific object.
 - Sequential or predictable resource identifiers (auto-increment integers) that enable enumeration.
 - Batch or list endpoints that return objects without filtering by the caller's permissions.
+- Cursor-based list endpoints where decoded cursor fields such as `tenant_id`, `user_id`, `after_id`, `filter`, `sort`, or `aud` are trusted as authorization or query state without being integrity-protected and revalidated against the authenticated principal.
 
 ### REST Vulnerable Patterns
 
@@ -99,6 +100,7 @@ Both can coexist in a single endpoint. An endpoint may lack both a role check (B
 - [ ] Every endpoint that accepts a resource identifier enforces ownership or relationship-based access control.
 - [ ] Authorization checks happen at the data access layer, not only at the controller/route layer.
 - [ ] Batch/list endpoints filter results by the caller's permissions.
+- [ ] Cursor-based list endpoints revalidate tenant, principal, delegated actor scope, and query shape against the current authorization context on every request.
 - [ ] Resource identifiers are UUIDs or non-sequential values to resist enumeration.
 - [ ] GraphQL resolvers enforce authorization on every field that returns sensitive data.
 
@@ -267,19 +269,85 @@ query {
 app.use(express.json()); // Default limit may be very large or unconfigured
 ```
 
+```python
+# VULNERABLE: Client-controlled cursor changes tenant scope and scan position
+@app.route('/api/v1/accounts')
+@require_auth
+def list_accounts():
+    cursor = json.loads(base64.urlsafe_b64decode(request.args['cursor']))
+    tenant_id = cursor.get('tenant_id', current_user.tenant_id)
+    after_id = cursor.get('after_id')
+
+    accounts = (
+        Account.query
+        .filter(Account.tenant_id == tenant_id)
+        .filter(Account.id > after_id)
+        .order_by(Account.id.asc())
+        .limit(100)
+        .all()
+    )
+    return jsonify([a.to_dict() for a in accounts])
+```
+
 ### Remediation Guidance
 
 - Implement rate limiting at the API gateway and/or application layer. Use sliding window or token bucket algorithms. Set per-endpoint limits based on expected legitimate usage.
 - Enforce maximum pagination size (e.g., `limit` capped at 100). Default to a reasonable page size (e.g., 20).
+- For cursor pagination, use server-issued opaque cursors that are integrity-protected and bound to the authenticated principal, tenant or relationship scope, endpoint audience, query shape, sort tuple, expiry, and page-size policy version. Revalidate these claims against current authorization before using them in a query.
 - Set maximum request body sizes (`express.json({ limit: '1mb' })`).
 - For GraphQL: enforce query depth limits (e.g., max depth 5), complexity analysis (weighted field costs), and batch query limits.
 - Set execution timeouts for database queries and downstream API calls.
 - Implement cost alerts and circuit breakers for operations that trigger billable third-party APIs.
 
+### Cursor Pagination Evidence Gate
+
+Cursor pagination must be reviewed as both API1:2023 and API4:2023 evidence when the cursor influences object scope, filters, sort position, or scan cost. Do not treat a capped `limit` as sufficient if the cursor is client-controlled or reusable across scopes.
+
+| Gate | Evidence Required | Fail / Downgrade Conditions |
+|---|---|---|
+| **API-CURSOR-01: Cursor integrity and scope gate** | Cursor is server-issued, opaque or signed/MACed, tenant-bound, principal- or delegated-actor-bound, endpoint-audience-bound, query-shape-bound, expiry-bound, and revalidated against current authorization before query construction. | Base64/JSON cursor is trusted directly; signed cursor omits tenant, user, audience, query shape, or expiry; cursor issued for one endpoint is accepted by another; delegated/admin scope is not represented. |
+| **API-CURSOR-02: Stable ordering and snapshot gate** | Pagination uses a deterministic unique sort tuple such as `(created_at, id)` or `(sequence, id)`, and documents snapshot, high-watermark, or explicit eventual-consistency behavior for concurrent inserts/deletes. | Cursor stores only a non-unique timestamp or offset; concurrent writes can duplicate or skip records; export/audit workflows assume completeness without snapshot or high-watermark evidence. |
+| **API-CURSOR-03: Replay and cost-control gate** | Page size is fixed or capped server-side, cursor TTL is bounded, stale/replayed cursors fail safely or are idempotent, and repeated cursor scans/query-shape abuse are rate-limited or monitored. | Replayed cursors trigger unbounded repeated scans; cursor lifetime is indefinite; client can change page size, sort, filters, or join scope through cursor fields. |
+
+#### Cursor Examples
+
+```python
+# SECURE: Signed cursor binds scope and stable sort tuple
+claims = verify_cursor(cursor, audience='transactions:list') if cursor else None
+if claims and claims['tenant_id'] != current_user.tenant_id:
+    abort(403)
+
+page_size = 50
+rows = (
+    Transaction.query
+    .filter(Transaction.tenant_id == current_user.tenant_id)
+    .filter(
+        tuple_(Transaction.created_at, Transaction.id)
+        < (claims['last_seen_at'], claims['last_id'])
+        if claims else True
+    )
+    .order_by(Transaction.created_at.desc(), Transaction.id.desc())
+    .limit(page_size + 1)
+    .all()
+)
+
+next_cursor = sign_cursor({
+    'tenant_id': current_user.tenant_id,
+    'aud': 'transactions:list',
+    'query_shape': 'tenant-transactions-v1',
+    'last_seen_at': rows[page_size - 1].created_at.isoformat(),
+    'last_id': rows[page_size - 1].id,
+    'page_size': page_size,
+    'exp': int(time.time()) + 900,
+}) if len(rows) > page_size else None
+```
+
 ### Review Checklist
 
 - [ ] Rate limiting is configured for all endpoints, with stricter limits on expensive operations.
 - [ ] Pagination has a maximum page size enforced server-side.
+- [ ] Cursor pagination satisfies `API-CURSOR-01` through `API-CURSOR-03` when cursor state affects authorization scope, query filters, sort position, or scan cost.
+- [ ] Cursor-based exports or audit feeds document whether results are snapshot-consistent, high-watermark based, or explicitly eventually consistent.
 - [ ] Request body size limits are configured.
 - [ ] GraphQL queries have depth limits, complexity limits, and batch restrictions.
 - [ ] Database queries and downstream calls have execution timeouts.

--- a/skills/appsec/api-security/tests/benign/signed-tenant-bound-cursor.yaml
+++ b/skills/appsec/api-security/tests/benign/signed-tenant-bound-cursor.yaml
@@ -1,0 +1,43 @@
+name: signed-tenant-bound-cursor
+owasp_api_risks:
+  - API1:2023
+  - API4:2023
+language: python
+expected_result: no_finding
+description: >
+  The endpoint uses a server-fixed page size, verifies a signed cursor audience,
+  revalidates tenant scope against the current principal, and carries a unique
+  stable sort tuple with an expiry.
+snippet: |
+  @app.route("/api/v1/transactions")
+  @require_auth
+  def list_transactions():
+      cursor = request.args.get("cursor")
+      claims = verify_cursor(cursor, audience="transactions:list") if cursor else None
+      page_size = 50
+
+      if claims and claims["tenant_id"] != current_user.tenant_id:
+          abort(403)
+
+      rows = (
+          Transaction.query
+          .filter(Transaction.tenant_id == current_user.tenant_id)
+          .filter(
+              tuple_(Transaction.created_at, Transaction.id)
+              < (claims["last_seen_at"], claims["last_id"])
+              if claims else True
+          )
+          .order_by(Transaction.created_at.desc(), Transaction.id.desc())
+          .limit(page_size + 1)
+          .all()
+      )
+
+      next_cursor = sign_cursor({
+          "tenant_id": current_user.tenant_id,
+          "aud": "transactions:list",
+          "query_shape": "tenant-transactions-v1",
+          "last_seen_at": rows[page_size - 1].created_at.isoformat(),
+          "last_id": rows[page_size - 1].id,
+          "page_size": page_size,
+          "exp": int(time.time()) + 900,
+      }) if len(rows) > page_size else None

--- a/skills/appsec/api-security/tests/vulnerable/client-controlled-cursor.yaml
+++ b/skills/appsec/api-security/tests/vulnerable/client-controlled-cursor.yaml
@@ -1,0 +1,29 @@
+name: client-controlled-cursor-tenant-bypass
+owasp_api_risks:
+  - API1:2023
+  - API4:2023
+language: python
+expected_findings:
+  - API-CURSOR-01
+  - API-CURSOR-03
+description: >
+  The cursor is decoded from client-controlled base64 JSON and trusted as query
+  authorization state. A caller can change tenant_id or after_id while retaining
+  a capped page size, so a max limit alone is not sufficient evidence.
+snippet: |
+  @app.route("/api/v1/accounts")
+  @require_auth
+  def list_accounts():
+      cursor = json.loads(base64.urlsafe_b64decode(request.args["cursor"]))
+      tenant_id = cursor.get("tenant_id", current_user.tenant_id)
+      after_id = cursor.get("after_id")
+
+      return jsonify([
+          a.to_dict()
+          for a in Account.query
+              .filter(Account.tenant_id == tenant_id)
+              .filter(Account.id > after_id)
+              .order_by(Account.id.asc())
+              .limit(100)
+              .all()
+      ])

--- a/skills/appsec/api-security/tests/vulnerable/cross-endpoint-reusable-cursor.yaml
+++ b/skills/appsec/api-security/tests/vulnerable/cross-endpoint-reusable-cursor.yaml
@@ -1,0 +1,34 @@
+name: cross-endpoint-reusable-cursor
+owasp_api_risks:
+  - API1:2023
+  - API4:2023
+language: python
+expected_findings:
+  - API-CURSOR-01
+  - API-CURSOR-03
+description: >
+  The cursor is signed, but it omits endpoint audience, query shape, and expiry.
+  A cursor minted for one list endpoint can be replayed against another endpoint
+  or reused indefinitely, so signature presence alone is not enough evidence.
+snippet: |
+  @app.route("/api/v1/orders")
+  @require_auth
+  def list_orders():
+      cursor = request.args.get("cursor")
+      claims = verify_signature(cursor) if cursor else {}
+
+      rows = (
+          Order.query
+          .filter(Order.tenant_id == current_user.tenant_id)
+          .filter(Order.id > claims.get("after_id", 0))
+          .order_by(Order.id.asc())
+          .limit(50)
+          .all()
+      )
+
+      next_cursor = sign_cursor({
+          "tenant_id": current_user.tenant_id,
+          "after_id": rows[-1].id,
+      }) if rows else None
+
+      return jsonify({"items": [row.to_dict() for row in rows], "cursor": next_cursor})

--- a/skills/appsec/api-security/tests/vulnerable/graphql-relay-cursor-scope-bypass.yaml
+++ b/skills/appsec/api-security/tests/vulnerable/graphql-relay-cursor-scope-bypass.yaml
@@ -1,0 +1,42 @@
+name: graphql-relay-cursor-scope-bypass
+owasp_api_risks:
+  - API1:2023
+  - API4:2023
+language: javascript
+expected_findings:
+  - API-CURSOR-01
+  - API-CURSOR-03
+description: >
+  The GraphQL Relay-style cursor is only base64 encoded and carries tenant and
+  object position state. A support actor can change the cursor tenant or replay
+  it across query scopes because delegated actor scope, audience, query shape,
+  and expiry are not integrity-protected or revalidated.
+snippet: |
+  const resolvers = {
+    Query: {
+      invoicesConnection: async (_, { after }, context) => {
+        const cursor = after
+          ? Buffer.from(after, "base64url").toString("utf8").split(":")
+          : ["Invoice", context.user.tenantId, "0"];
+
+        const [, tenantId, afterId] = cursor;
+
+        const rows = await db.invoice.findMany({
+          where: {
+            tenantId,
+            id: { gt: afterId },
+            supportVisible: true,
+          },
+          orderBy: { id: "asc" },
+          take: 100,
+        });
+
+        return {
+          edges: rows.map((row) => ({
+            node: row,
+            cursor: Buffer.from(`Invoice:${tenantId}:${row.id}`).toString("base64url"),
+          })),
+        };
+      },
+    },
+  };

--- a/skills/appsec/api-security/tests/vulnerable/unstable-cursor-ordering.yaml
+++ b/skills/appsec/api-security/tests/vulnerable/unstable-cursor-ordering.yaml
@@ -1,0 +1,30 @@
+name: unstable-cursor-ordering-scan-amplification
+owasp_api_risks:
+  - API4:2023
+language: javascript
+expected_findings:
+  - API-CURSOR-02
+  - API-CURSOR-03
+description: >
+  The cursor stores only createdAt, which is not a unique stable sort tuple.
+  Concurrent rows with the same timestamp can be skipped or repeated, and stale
+  cursor replay can force repeated scans.
+snippet: |
+  app.get("/api/v1/audit-events", requireAuth, async (req, res) => {
+    const cursor = JSON.parse(Buffer.from(req.query.cursor || "{}", "base64url"));
+    const rows = await db.auditEvents.findMany({
+      where: {
+        tenantId: req.user.tenantId,
+        createdAt: { lt: cursor.createdAt || new Date() }
+      },
+      orderBy: { createdAt: "desc" },
+      take: 100
+    });
+
+    res.json({
+      items: rows,
+      next_cursor: Buffer.from(JSON.stringify({
+        createdAt: rows.at(-1)?.createdAt
+      })).toString("base64url")
+    });
+  });


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `api-security`
**Skill path:** `skills/appsec/api-security/`

### What Was Wrong
Fixes #2254.

The API4 checklist enforced max pagination size, but cursor pagination also carries authorization and consistency state. A capped page size can still be unsafe when decoded cursor fields control tenant scope, delegated actor scope, query filters, sort position, or repeated scan cost. The skill also lacked a clear way to avoid false positives for safe server-fixed cursor pagination where the cursor is signed, scoped, and tied to stable ordering.

### What This PR Fixes
- Adds cursor pagination inventory fields to the main review workflow.
- Adds a `Cursor Pagination Assessment` output matrix.
- Adds cursor-specific API1/API4 guidance for tenant/principal binding, delegated actor scope, endpoint audience, query-shape binding, expiry, stable sort tuples, snapshot/high-watermark behavior, replay tolerance, and cost controls.
- Adds `API-CURSOR-01` through `API-CURSOR-03` evidence gates.
- Adds vulnerable and benign fixtures covering client-controlled tenant cursors, unstable timestamp-only cursors, signed cursor audience/replay gaps, GraphQL Relay-style delegated-scope bypass, and safe signed tenant-bound cursors.

### Evidence

**Before (skill misses this / false positive on this):**
```python
cursor = json.loads(base64.urlsafe_b64decode(request.args["cursor"]))
tenant_id = cursor.get("tenant_id", current_user.tenant_id)
Account.query.filter(Account.tenant_id == tenant_id).limit(100).all()
```

The old checklist could pass this because `limit(100)` is capped, even though the cursor changes authorization scope.

**After (now correctly handled):**
```text
API-CURSOR-01 requires server-issued cursor integrity, tenant/principal or delegated-actor binding, endpoint audience, query-shape binding, expiry, and authorization revalidation.
API-CURSOR-02 requires a deterministic unique sort tuple plus snapshot/high-watermark or explicit eventual-consistency evidence.
API-CURSOR-03 requires fixed/capped page size, bounded cursor lifetime, safe stale/replay behavior, and repeated-scan monitoring.
```

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Fixture/schema validations pass

Added fixtures:
- `skills/appsec/api-security/tests/vulnerable/client-controlled-cursor.yaml`
- `skills/appsec/api-security/tests/vulnerable/unstable-cursor-ordering.yaml`
- `skills/appsec/api-security/tests/vulnerable/cross-endpoint-reusable-cursor.yaml`
- `skills/appsec/api-security/tests/vulnerable/graphql-relay-cursor-scope-bypass.yaml`
- `skills/appsec/api-security/tests/benign/signed-tenant-bound-cursor.yaml`

### Bounty Tier
- [ ] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Can provide privately after maintainer acceptance

## Validation

- `rg` marker check for `Cursor Pagination Evidence Gate`, `API-CURSOR-01`, `API-CURSOR-02`, `API-CURSOR-03`, `Cursor Pagination Assessment`, and `api-security skill v1.0.1`
- Ruby YAML parse / fixture schema check for all `api-security` benign and vulnerable fixtures
- Semantic check for the GraphQL Relay-style delegated-scope bypass fixture
- Frontmatter required-field check across `skills/` and `roles/`
- Prompt injection scan equivalent to `.github/workflows/injection-scan.yml`
- Indexed file path existence check from `index.yaml`
- ASCII scan for `skills/appsec/api-security`
- Added-line sensitive-pattern scan
- `git diff --check`
- Post-push head check: local HEAD, fork branch, and GitHub PR head all match `4aa1f9359dc6fdaa3b54a6115f79e164da5351f8`

/claim #2254
