### PR TITLE
Add CVE precondition evidence gates

### DIFF
--- a/skills/vuln-management/cve-triage/SKILL.md
+++ b/skills/vuln-management/cve-triage/SKILL.md
@@ -82,6 +82,38 @@ CVE Context Summary:
 - Known Aliases:       [Common names, e.g., "Log4Shell", "Heartbleed"]
 ```
 
+### Step 1A: Exploit Preconditions and Asset Applicability
+
+Before applying CVSS Environmental metrics, SSVC automatable/impact decisions, or SLA de-escalation, bind the vulnerability's exploit preconditions to the actual affected asset.
+
+**Framework mapping:** CVSS 4.0 Attack Requirements / Privileges Required / User Interaction, SSVC exploitation and automatable decision points
+
+**Evidence to collect:**
+
+- **Version evidence:** scanner plugin output, package manager inventory, SBOM, container image digest, runtime banner, or vendor product inventory proving the vulnerable version is present.
+- **Feature/configuration evidence:** whether the vulnerable module, protocol, endpoint, parser, plugin, route, or optional feature is enabled.
+- **Reachability evidence:** network path, exposed port, route, ingress, firewall/security group, service mesh policy, API gateway route, or local-access requirement.
+- **Authentication and privilege evidence:** required role, token scope, local account, tenant relationship, user interaction, or chained vulnerability needed before exploitation.
+- **Data/control-plane impact path:** whether successful exploitation reaches production data, privileged identity, admin APIs, CI/CD, cloud control plane, or only an isolated component.
+- **Compensating control verification:** WAF/IPS rule, feature disablement, segmentation, EDR block, or configuration hardening tested against the specific exploit preconditions.
+
+**What to look for:**
+
+```
+CVE-PRECOND-01: Vulnerable version is assumed from scanner title without package/runtime/SBOM evidence
+CVE-PRECOND-02: Optional vulnerable feature, parser, endpoint, or plugin is not proven enabled on the affected asset
+CVE-PRECOND-03: Network or local reachability is assumed without ingress, firewall, route, or host-access evidence
+CVE-PRECOND-04: Exploit requires authentication, role, tenant relationship, or user interaction that is not reflected in SSVC/CVSS environmental scoring
+CVE-PRECOND-05: De-escalation cites segmentation, WAF/IPS, disabled feature, or VEX status without specific verification against exploit preconditions
+CVE-PRECOND-06: Impact is scored as total control of an essential system without proving the exploit path reaches that asset, privilege boundary, or data/control plane
+```
+
+**False-positive guardrails:**
+
+- Do not mark a CVE as not applicable solely because a scanner finding is missing from one source; reconcile scanner, SBOM, runtime, and package inventory evidence.
+- Do not downgrade a CISA KEV finding solely because exploit preconditions are unclear; keep urgency high and mark applicability evidence gaps.
+- Do not treat a disabled feature or compensating control as effective unless it is verified on the affected asset and tied to the specific exploit path.
+
 ### Step 2: CVSS 4.0 Assessment
 
 Walk through the CVSS 4.0 metric groups to compute or validate the Base score. CVSS 4.0 replaces the CVSS 3.1 "Temporal" group with "Threat" metrics and adds a Supplemental metric group.
@@ -303,6 +335,8 @@ The following conditions may justify a longer SLA (document the justification):
 - Network segmentation prevents attacker access to the vulnerable system
 - VEX (Vulnerability Exploitability eXchange) status is "not_affected" or "fixed"
 
+**Common pitfall:** Do not skip precondition validation when de-escalating. A generic statement that a service is segmented, a WAF exists, or a feature is "usually disabled" is not enough unless the evidence shows the control applies to this asset and this exploit path.
+
 ---
 
 ## Output Format
@@ -328,6 +362,16 @@ recommended SLA tier. Lead with the most critical fact.]
 | Affected Software | [Product vX.Y.Z] |
 | Affected Component | [Component] |
 | Patch Available | [Yes/No/Workaround] |
+
+### Exploit Preconditions and Asset Applicability
+| Evidence Area | Status | Evidence | Impact on Triage |
+|---|---|---|---|
+| Vulnerable version present | [Pass/Fail/Not Evaluable] | [scanner/SBOM/package/runtime evidence] | [confirms scope / requires reconciliation] |
+| Vulnerable feature enabled | [Pass/Fail/Not Evaluable] | [config/route/module/plugin evidence] | [affects applicability] |
+| Reachability | [Pass/Fail/Not Evaluable] | [network/local/API path evidence] | [affects AV/SSVC automatable] |
+| Auth / user interaction preconditions | [Pass/Fail/Not Evaluable] | [role/token/UI/chained exploit evidence] | [affects PR/UI/SSVC] |
+| Impact path | [Pass/Fail/Not Evaluable] | [data/control-plane evidence] | [affects technical impact and mission prevalence] |
+| Compensating controls | [Pass/Fail/Not Evaluable] | [tested control evidence] | [supports or rejects de-escalation] |
 
 ### CVSS 4.0 Assessment
 | Metric Group | Score | Severity |

--- a/skills/vuln-management/cve-triage/tests/benign/kev-with-unclear-preconditions-keeps-urgency.yaml
+++ b/skills/vuln-management/cve-triage/tests/benign/kev-with-unclear-preconditions-keeps-urgency.yaml
@@ -1,0 +1,20 @@
+id: cve-triage-kev-with-unclear-preconditions-keeps-urgency
+category: benign
+description: A KEV-listed CVE has incomplete local precondition evidence, so urgency remains high while applicability is investigated.
+input:
+  cve: CVE-2026-10003
+  asset: edge-vpn-prod
+  threat_context:
+    cisa_kev: true
+    exploitation: active
+  evidence:
+    vulnerable_version_present: not_evaluable
+    vulnerable_feature_enabled: not_evaluable
+    reachability: pass
+  proposed_decision:
+    ssvc_exploitation: active
+    sla: out_of_cycle
+expected:
+  status: pass
+  reason_codes: []
+  triage_action: Preserve KEV urgency and record precondition evidence gaps instead of downgrading due to uncertainty.

--- a/skills/vuln-management/cve-triage/tests/benign/verified-disabled-feature-not-applicable.yaml
+++ b/skills/vuln-management/cve-triage/tests/benign/verified-disabled-feature-not-applicable.yaml
@@ -1,0 +1,22 @@
+id: cve-triage-verified-disabled-feature-not-applicable
+category: benign
+description: Runtime and configuration evidence prove the vulnerable optional feature is disabled on the affected asset.
+input:
+  cve: CVE-2026-10004
+  asset: analytics-worker-prod
+  vulnerable_component:
+    product: ExampleXML
+    version: 2.7.0
+    affected_feature: external entity parser
+  evidence:
+    package_inventory: "ExampleXML 2.7.0 installed"
+    runtime_config: "external_entities=false"
+    integration_test: "xxe-payload-2026-06-10 blocked before parser invocation"
+    route_inventory: "No XML upload route enabled for this worker"
+  proposed_decision:
+    applicability: not_affected
+    deescalation_basis: verified disabled feature and absent route
+expected:
+  status: pass
+  reason_codes: []
+  triage_action: Allow not-applicable or de-escalated treatment because feature and reachability preconditions are verified.

--- a/skills/vuln-management/cve-triage/tests/vulnerable/scanner-title-without-version-evidence.yaml
+++ b/skills/vuln-management/cve-triage/tests/vulnerable/scanner-title-without-version-evidence.yaml
@@ -1,0 +1,19 @@
+id: cve-triage-scanner-title-without-version-evidence
+category: vulnerable
+description: Scanner title names a CVE, but no package, runtime, or SBOM evidence proves the vulnerable version is present.
+input:
+  cve: CVE-2026-10001
+  asset: payments-api-prod-03
+  scanner_finding:
+    title: "Critical OpenSSL CVE-2026-10001 detected"
+    plugin_output: "Service banner unavailable; inferred from port 443 fingerprint."
+  evidence:
+    package_inventory: null
+    sbom_component: null
+    runtime_banner: null
+    container_digest: sha256:8d9f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f
+expected:
+  status: fail
+  reason_codes:
+    - CVE-PRECOND-01
+  triage_action: Reconcile scanner output with package, SBOM, image, or runtime evidence before confirming scope.

--- a/skills/vuln-management/cve-triage/tests/vulnerable/unverified-waf-deescalation.yaml
+++ b/skills/vuln-management/cve-triage/tests/vulnerable/unverified-waf-deescalation.yaml
@@ -1,0 +1,25 @@
+id: cve-triage-unverified-waf-deescalation
+category: vulnerable
+description: A WAF is cited for SLA de-escalation, but there is no test or rule evidence tied to the exploit path.
+input:
+  cve: CVE-2026-10002
+  asset: customer-portal-prod
+  vulnerable_component:
+    product: AcmeCMS
+    version: 4.2.1
+    affected_range: "< 4.2.8"
+  exploit_preconditions:
+    attack_vector: network
+    required_feature: file-upload endpoint
+    authentication: none
+  proposed_deescalation:
+    claim: Internet traffic is behind the standard WAF profile.
+    provided_evidence:
+      waf_profile_name: default-web
+      exploit_test_result: null
+      rule_id: null
+expected:
+  status: fail
+  reason_codes:
+    - CVE-PRECOND-05
+  triage_action: Reject de-escalation until the WAF or compensating control is verified against the upload exploit path.


### PR DESCRIPTION
## Summary
- add a dedicated CVE exploit precondition and asset applicability step before CVSS Environmental, SSVC, or SLA de-escalation decisions
- add reason codes for scanner-title-only findings, optional feature uncertainty, reachability gaps, auth/user-interaction preconditions, unverified compensating controls, and unsupported total-impact scoring
- add an output table so reviewers record applicability evidence and triage impact explicitly
- add four YAML fixtures covering vulnerable and benign precondition/applicability cases

Closes #2259

## Validation
- `git diff --check`
- `git diff --cached --check`
- Parsed 4 YAML fixtures under `skills/vuln-management/cve-triage/tests`

## Bounty Info
Requested bounty: $100