### PR TITLE
Add admin impersonation review skill

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -6,7 +6,7 @@
 meta:
   version: "1.0.0"
   last_updated: "2026-03-05"
-  skill_count: 45
+  skill_count: 46
   role_count: 5
 
 tag_vocabulary:
@@ -136,6 +136,18 @@ skills:
     difficulty: intermediate
     time_estimate: "45-90min"
     file: skills/identity/privileged-access/SKILL.md
+    compatible_tools: [claude-code, gemini-cli, cursor, codex-cli, openclaw, kiro]
+
+  - id: admin-impersonation-feature-review
+    name: "Admin Impersonation Feature Review"
+    tags: [identity, impersonation, admin, audit, authorization]
+    role: [security-engineer, appsec-engineer, vciso]
+    phase: [design, build, operate, review]
+    activity: [review, audit, assess, test]
+    frameworks: [OWASP-ASVS, NIST-SP-800-53-AC, NIST-SP-800-53-AU, CWE]
+    difficulty: intermediate
+    time_estimate: "30-60min"
+    file: skills/identity/admin-impersonation-feature-review/SKILL.md
     compatible_tools: [claude-code, gemini-cli, cursor, codex-cli, openclaw, kiro]
 
   # -- Cloud ----------------------------------------------------------------

--- a/skills/identity/admin-impersonation-feature-review/README.md
+++ b/skills/identity/admin-impersonation-feature-review/README.md
@@ -1,0 +1,48 @@
+# Admin Impersonation Feature Review
+
+This skill reviews SaaS admin impersonation and support "login as user" features
+for approval, scope, tenant boundaries, action restrictions, session visibility,
+auditability, revocation, and timeout behavior.
+
+It is intended for defensive review of authorized systems. It does not require
+or encourage live access to customer accounts.
+
+## Included Fixtures
+
+Vulnerable examples:
+
+- `fixtures/vulnerable/typescript_unscoped_impersonation.js`
+- `fixtures/vulnerable/python_actor_lost_audit.py`
+- `fixtures/vulnerable/typescript_cross_tenant_target.js`
+
+Benign examples:
+
+- `fixtures/benign/python_approved_readonly_session.py`
+- `fixtures/benign/typescript_action_gate.js`
+- `fixtures/benign/python_revocation_timeout_audit.py`
+
+## Review Targets
+
+- admin/support impersonation route handlers;
+- session and token claim builders;
+- tenant and staff assignment checks;
+- approval, ticket, and reason capture;
+- action authorization during impersonation;
+- audit event emitters;
+- timeout and revocation workflows.
+
+## Validation
+
+Run syntax checks for the included fixtures:
+
+```bash
+python -m py_compile fixtures/vulnerable/python_actor_lost_audit.py \
+  fixtures/benign/python_approved_readonly_session.py \
+  fixtures/benign/python_revocation_timeout_audit.py
+
+node --check fixtures/vulnerable/typescript_unscoped_impersonation.js
+node --check fixtures/vulnerable/typescript_cross_tenant_target.js
+node --check fixtures/benign/typescript_action_gate.js
+```
+
+Use `SKILL.md` for the review checklist and reporting template.

--- a/skills/identity/admin-impersonation-feature-review/SKILL.md
+++ b/skills/identity/admin-impersonation-feature-review/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: admin-impersonation-feature-review
+description: >
+  Reviews SaaS admin impersonation and support "login as user" features for
+  approval, reason capture, session marking, action restrictions, actor/target
+  audit trails, tenant boundaries, revocation, and timeout controls. Use when a
+  product lets staff, support, success, or administrators act through a customer
+  user's account or view their experience.
+tags: [identity, impersonation, admin, audit, authorization]
+role: [security-engineer, appsec-engineer, vciso]
+phase: [design, build, operate, review]
+frameworks: [OWASP-ASVS, NIST-SP-800-53-AC, NIST-SP-800-53-AU, CWE-285]
+difficulty: intermediate
+time_estimate: "30-60min"
+version: "1.0.0"
+author: unitoneai
+license: MIT
+allowed-tools: Read, Grep, Glob
+injection-hardened: true
+argument-hint: "[admin-or-support-impersonation-code]"
+---
+
+# Admin Impersonation Feature Review
+
+If a target is provided via arguments, focus the review on: $ARGUMENTS
+
+> **This skill is strictly for defensive review.** It helps teams assess
+> impersonation features they own or are authorized to test. Do not use this
+> guidance to access accounts, change customer data, bypass consent, or perform
+> live impersonation. Review code, configuration, logs, and documented behavior.
+
+## Security Outcome
+
+Ensure staff impersonation is explicit, approved, scoped, visible, auditable,
+revocable, and unable to cross tenants or perform high-risk customer actions
+without independent authorization.
+
+## When to Use
+
+Use this skill when reviewing:
+
+- "login as user", "view as customer", support sessions, customer success
+  sessions, or admin impersonation flows;
+- staff dashboards that mint user sessions or switch actor context;
+- debugging tools that proxy customer API calls;
+- production support tooling that can see, edit, export, or approve customer
+  data;
+- audit trails for staff activity inside customer accounts.
+
+Do not substitute this for a full PAM review. Pair it with `privileged-access`
+when standing admin privilege, break-glass access, or credential vaulting is also
+in scope.
+
+## Review Workflow
+
+### 1. Map Actor, Target, and Scope
+
+For every impersonation entry point, record:
+
+| Field | Evidence to collect |
+|---|---|
+| Actor | staff user, role, group, MFA state, support assignment |
+| Target | customer user, tenant, environment, account status |
+| Reason | ticket, incident, customer approval, business justification |
+| Approval | approver, policy rule, expiration, dual-control requirement |
+| Session scope | read-only, writable, billing, security, admin, export |
+| Session identity | token claims, session marker, UI banner, API header |
+| Exit path | manual stop, timeout, revocation, target password reset |
+
+If actor and target cannot be reconstructed for a session, treat that as a high
+confidence auditability gap.
+
+### 2. Check Entry-Point Authorization
+
+Confirm the system verifies all of the following before creating an
+impersonation session:
+
+- actor is authenticated with a staff account and recent MFA;
+- actor has a role allowed to impersonate the target's tenant;
+- actor is assigned to a valid case, ticket, incident, or approval;
+- reason is captured and cannot be empty or generic;
+- target account is eligible for impersonation;
+- session scope is the narrowest needed for the support task;
+- tenant and environment boundaries are enforced server-side.
+
+High-risk targets, such as tenant owners, billing admins, security admins, and
+regulated accounts, should require stronger approval or be excluded.
+
+### 3. Verify Session Marking and User Visibility
+
+Impersonation sessions must not look like normal customer sessions.
+
+Review for:
+
+- token/session claims that preserve both `actor_id` and `target_user_id`;
+- visible staff banner or watermark in UI;
+- API request context that carries impersonation state;
+- inability to hide or downgrade the impersonation marker client-side;
+- notifications or audit visibility when policy requires customer awareness;
+- logs that never collapse actor and target into the same principal.
+
+### 4. Restrict High-Risk Actions
+
+During impersonation, the safest default is read-only unless the task requires a
+specific write capability.
+
+Block or require separate step-up approval for:
+
+- password, MFA, SSO, recovery email, or passkey changes;
+- payment method, payout, billing owner, invoice, or refund changes;
+- security policy, role, SCIM, SAML, OAuth app, or API token changes;
+- data export, bulk download, deletion, legal hold, or retention changes;
+- actions that approve, sign, purchase, transfer funds, or accept contracts;
+- actions that erase evidence of the impersonation session.
+
+### 5. Confirm Audit Trail Integrity
+
+Each event produced during impersonation should include:
+
+- event ID and timestamp;
+- actor staff ID and target user ID;
+- tenant, workspace, and environment;
+- reason/ticket/approval reference;
+- session ID and impersonation scope;
+- action name, resource, outcome, and request ID;
+- source IP or device context when available.
+
+Audit records must be immutable to support staff and inaccessible to the target
+user for alteration. Logs must not be written only under the target user's ID.
+
+### 6. Review Revocation, Timeout, and Lifecycle
+
+Check whether sessions terminate predictably:
+
+- short default timeout and absolute maximum lifetime;
+- one-click staff exit;
+- automatic end when ticket, approval, assignment, or employment state changes;
+- revocation if target account is disabled or tenant status changes;
+- re-authentication for new target users or elevated scopes;
+- no reuse of normal customer refresh tokens.
+
+## High-Signal Findings
+
+Report a finding when:
+
+- a staff user can create an impersonation session with only a target user ID;
+- the target tenant is not checked against staff assignment or approval;
+- reason or ticket capture is optional;
+- token claims overwrite the principal with the target user and lose the actor;
+- high-risk writes are allowed with normal customer permissions;
+- audit events show only the target user or are editable by staff;
+- sessions have no short timeout or survive approval revocation;
+- customer-visible UI and API responses cannot tell the session is staff-driven.
+
+## Remediation Guidance
+
+- Require explicit reason, ticket, and approval before impersonation starts.
+- Preserve both actor and target identity in server-side session claims.
+- Scope impersonation sessions to read-only by default.
+- Add deterministic deny rules for billing, security, export, destructive, and
+  consent-like actions.
+- Enforce tenant boundaries from server-side actor assignment and target tenant.
+- Make impersonation visible in staff UI and logs.
+- Emit immutable audit events for session start, every action, scope change, and
+  session end.
+- Expire sessions quickly and revoke them when approval, assignment, or target
+  eligibility changes.
+
+## Verification Checklist
+
+- [ ] all entry points require staff authentication and recent MFA;
+- [ ] target tenant and staff assignment are checked server-side;
+- [ ] reason and approval references are required;
+- [ ] session claims preserve actor, target, tenant, scope, and expiry;
+- [ ] UI/API context marks impersonation visibly;
+- [ ] high-risk actions are denied or require separate approval;
+- [ ] audit events include actor and target for every impersonated action;
+- [ ] sessions expire and revoke on approval, assignment, or target changes;
+- [ ] tests cover cross-tenant target selection and write-action denial.
+
+## Evidence to Request
+
+- admin/support route handlers and controllers;
+- session minting and token claim builders;
+- middleware that resolves current user and tenant;
+- policy engine or authorization rules;
+- audit event emitters and log schema;
+- UI banner or staff console components;
+- approval/ticket integration code;
+- tests for tenant boundaries, action gates, timeouts, and revocation.
+
+## Reporting Template
+
+```markdown
+### Finding: unsafe admin impersonation in <flow>
+
+Severity: High
+Affected flow: <entry point -> session -> action>
+Evidence:
+- <file/function showing session creation>
+- <file/function showing missing audit/action/tenant control>
+Impact: <what staff or compromised staff account can do>
+Required fix:
+- <approval/session/audit/action-gate control>
+Verification:
+- <test that proves blocked cross-tenant or high-risk action>
+```
+
+## Common False Positives
+
+- A read-only preview mode that never mints a target user session and cannot
+  trigger customer actions.
+- A support screen that displays customer data through staff-only APIs while
+  preserving staff identity and full audit context.
+- Local development impersonation disabled in production and covered by
+  environment guard tests.
+- Break-glass access handled by a separate PAM workflow with stronger controls.
+
+## References
+
+- OWASP ASVS: authentication, session management, access control, and logging
+  verification requirements
+- NIST SP 800-53 AC-6 Least Privilege
+- NIST SP 800-53 AU-2, AU-3, AU-12 audit event generation and content
+- CWE-285 Improper Authorization
+- CWE-863 Incorrect Authorization

--- a/skills/identity/admin-impersonation-feature-review/fixtures/benign/python_approved_readonly_session.py
+++ b/skills/identity/admin-impersonation-feature-review/fixtures/benign/python_approved_readonly_session.py
@@ -1,0 +1,51 @@
+"""Benign impersonation start: approval, reason, tenant, scope, and audit."""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+
+@dataclass
+class StaffUser:
+    id: str
+    assigned_tenant: str
+    mfa_recent: bool
+
+
+@dataclass
+class TargetUser:
+    id: str
+    tenant: str
+    role: str
+
+
+def start_impersonation(staff, target, approval):
+    if not staff.mfa_recent:
+        raise PermissionError("recent staff MFA required")
+    if staff.assigned_tenant != target.tenant:
+        raise PermissionError("staff is not assigned to target tenant")
+    if approval["tenant"] != target.tenant or approval["target_user_id"] != target.id:
+        raise PermissionError("approval does not match target")
+    if not approval.get("reason") or not approval.get("ticket_id"):
+        raise ValueError("reason and ticket are required")
+    if target.role in {"tenant_owner", "billing_admin", "security_admin"}:
+        raise PermissionError("high-risk target requires a separate workflow")
+
+    return {
+        "actor_id": staff.id,
+        "target_user_id": target.id,
+        "tenant_id": target.tenant,
+        "scope": "read_only_support",
+        "reason": approval["reason"],
+        "ticket_id": approval["ticket_id"],
+        "expires_at": datetime.now(timezone.utc) + timedelta(minutes=30),
+        "is_impersonating": True,
+    }
+
+
+if __name__ == "__main__":
+    session = start_impersonation(
+        StaffUser("staff-1", "tenant-a", True),
+        TargetUser("user-a", "tenant-a", "member"),
+        {"tenant": "tenant-a", "target_user_id": "user-a", "reason": "support case", "ticket_id": "SUP-123"},
+    )
+    print(session)

--- a/skills/identity/admin-impersonation-feature-review/fixtures/benign/python_revocation_timeout_audit.py
+++ b/skills/identity/admin-impersonation-feature-review/fixtures/benign/python_revocation_timeout_audit.py
@@ -1,0 +1,49 @@
+"""Benign session lifecycle: timeout, revocation, and dual-identity audit."""
+
+from datetime import datetime, timedelta, timezone
+
+
+AUDIT_LOG = []
+
+
+def emit_audit(session, action, resource, outcome):
+    AUDIT_LOG.append(
+        {
+            "actor_id": session["actor_id"],
+            "target_user_id": session["target_user_id"],
+            "tenant_id": session["tenant_id"],
+            "session_id": session["session_id"],
+            "ticket_id": session["ticket_id"],
+            "action": action,
+            "resource": resource,
+            "outcome": outcome,
+        }
+    )
+
+
+def ensure_active(session, revoked_approvals):
+    now = datetime.now(timezone.utc)
+    if now >= session["expires_at"]:
+        raise PermissionError("session expired")
+    if session["approval_id"] in revoked_approvals:
+        raise PermissionError("approval revoked")
+
+
+def handle_request(session, action, resource, revoked_approvals):
+    ensure_active(session, revoked_approvals)
+    emit_audit(session, action, resource, "allowed")
+    return {"ok": True}
+
+
+if __name__ == "__main__":
+    support_session = {
+        "actor_id": "staff-1",
+        "target_user_id": "user-a",
+        "tenant_id": "tenant-a",
+        "session_id": "imp-123",
+        "ticket_id": "SUP-123",
+        "approval_id": "approval-1",
+        "expires_at": datetime.now(timezone.utc) + timedelta(minutes=15),
+    }
+    handle_request(support_session, "view_invoice", "invoice-1", set())
+    print(AUDIT_LOG)

--- a/skills/identity/admin-impersonation-feature-review/fixtures/benign/typescript_action_gate.js
+++ b/skills/identity/admin-impersonation-feature-review/fixtures/benign/typescript_action_gate.js
@@ -1,0 +1,32 @@
+"use strict";
+
+const HIGH_RISK_ACTIONS = new Set([
+  "change_password",
+  "disable_mfa",
+  "add_payment_method",
+  "create_api_token",
+  "export_workspace",
+  "delete_project",
+]);
+
+function authorizeAction(session, action) {
+  if (!session.isImpersonating) {
+    return true;
+  }
+
+  if (Date.now() >= session.expiresAt) {
+    throw new Error("impersonation session expired");
+  }
+
+  if (HIGH_RISK_ACTIONS.has(action)) {
+    throw new Error("action blocked during impersonation");
+  }
+
+  if (session.scope !== "read_only_support" && action.startsWith("write_")) {
+    throw new Error("write scope not approved");
+  }
+
+  return true;
+}
+
+module.exports = { authorizeAction };

--- a/skills/identity/admin-impersonation-feature-review/fixtures/vulnerable/python_actor_lost_audit.py
+++ b/skills/identity/admin-impersonation-feature-review/fixtures/vulnerable/python_actor_lost_audit.py
@@ -1,0 +1,25 @@
+"""Vulnerable audit trail: impersonated actions are logged as the target user."""
+
+
+AUDIT_LOG = []
+
+
+def emit_audit(actor, action, resource):
+    AUDIT_LOG.append({"actor": actor, "action": action, "resource": resource})
+
+
+def handle_impersonated_request(session, action, resource):
+    # Vulnerable: the staff actor is overwritten by the customer identity. A
+    # destructive write now appears to have been performed by the customer.
+    current_user_id = session["target_user_id"]
+    emit_audit(current_user_id, action, resource)
+    return {"ok": True}
+
+
+if __name__ == "__main__":
+    handle_impersonated_request(
+        {"staff_user_id": "staff-7", "target_user_id": "customer-42"},
+        "delete_api_token",
+        "token-1",
+    )
+    print(AUDIT_LOG)

--- a/skills/identity/admin-impersonation-feature-review/fixtures/vulnerable/typescript_cross_tenant_target.js
+++ b/skills/identity/admin-impersonation-feature-review/fixtures/vulnerable/typescript_cross_tenant_target.js
@@ -1,0 +1,27 @@
+"use strict";
+
+const users = new Map([
+  ["user-a", { id: "user-a", tenantId: "tenant-a" }],
+  ["user-b", { id: "user-b", tenantId: "tenant-b" }],
+]);
+
+function findUserById(id) {
+  return users.get(id);
+}
+
+function startSupportSession(staffUser, targetUserId) {
+  const target = findUserById(targetUserId);
+  if (!target) {
+    throw new Error("missing target");
+  }
+
+  // Vulnerable: the staff assignment is not compared with the target tenant.
+  return {
+    actorId: staffUser.id,
+    targetUserId: target.id,
+    tenantId: target.tenantId,
+    scope: "full",
+  };
+}
+
+console.log(startSupportSession({ id: "staff-1", assignedTenantId: "tenant-a" }, "user-b"));

--- a/skills/identity/admin-impersonation-feature-review/fixtures/vulnerable/typescript_unscoped_impersonation.js
+++ b/skills/identity/admin-impersonation-feature-review/fixtures/vulnerable/typescript_unscoped_impersonation.js
@@ -1,0 +1,23 @@
+"use strict";
+
+function createSession(userId) {
+  return {
+    userId,
+    roles: ["customer"],
+    expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+  };
+}
+
+function postImpersonate(req, res) {
+  // Vulnerable: any support admin can mint a normal customer session with only
+  // the target ID. Reason, approval, actor identity, scope, and audit context are
+  // all missing.
+  if (!req.user.roles.includes("support_admin")) {
+    throw new Error("forbidden");
+  }
+
+  const session = createSession(req.body.targetUserId);
+  res.json({ session });
+}
+
+module.exports = { postImpersonate };

--- a/skills/identity/admin-impersonation-feature-review/references/patterns.md
+++ b/skills/identity/admin-impersonation-feature-review/references/patterns.md
@@ -1,0 +1,43 @@
+# Admin Impersonation Review Patterns
+
+## Vulnerable Patterns
+
+| Pattern | Why it matters | Review signal |
+|---|---|---|
+| Target-only session minting | Staff identity is lost | `session.userId = targetUserId` with no actor claim |
+| No reason or ticket requirement | Abuse cannot be justified or investigated | empty `reason`, optional `ticketId` |
+| Tenantless target lookup | Staff can cross customer boundaries | `findUser(targetUserId)` without tenant condition |
+| Full customer permissions during impersonation | Staff can perform sensitive actions as the customer | no deny list or scope check for writes |
+| Normal refresh token reuse | Impersonation persists like a customer login | refresh token minted for target user |
+| Target-only audit events | Staff activity looks like customer activity | `actor=userId` where userId is the target |
+| No UI or API marker | Users and reviewers cannot detect impersonation | missing `isImpersonating` session flag |
+| Timeout not enforced | Temporary access becomes standing access | no expiry or revocation listener |
+
+## Safe Patterns
+
+| Control | Expected evidence |
+|---|---|
+| Server-side approval gate | ticket, reason, approver, scope, expiry before session creation |
+| Dual identity claims | `actor_id`, `target_user_id`, `tenant_id`, `scope`, `expires_at` |
+| Read-only default scope | high-risk writes denied unless explicitly approved |
+| Tenant assignment check | actor support assignment matches target tenant |
+| Immutable audit trail | session start, action, scope change, and end events include actor and target |
+| Visible session marker | UI banner and API context expose impersonation state |
+| Short lifetime | absolute timeout and revocation on approval or assignment change |
+
+## Suggested Search Terms
+
+- `impersonate`, `loginAs`, `actAs`, `viewAs`, `supportSession`
+- `targetUserId`, `actorId`, `adminId`, `staffId`, `reason`, `ticket`
+- `isImpersonating`, `impersonationSession`, `originalUser`
+- `audit`, `session.start`, `session.end`, `readOnly`
+- `tenantId`, `workspaceId`, `assignment`, `approval`
+
+## Review Questions
+
+1. Can staff create a session with only a target user ID?
+2. Does every impersonated request carry both actor and target identity?
+3. Are billing, security, export, destructive, and consent-like actions blocked?
+4. Is cross-tenant target selection impossible server-side?
+5. Are session start, every action, and session end audited immutably?
+6. Can approval or assignment revocation terminate the active session?


### PR DESCRIPTION
/claim #298

## Summary
- Add a new `admin-impersonation-feature-review` identity/auth skill for SaaS support and admin login-as-user flows.
- Cover approval, reason capture, visible session marking, action restrictions, actor/target audit trails, tenant boundaries, revocation, and timeout behavior.
- Include README, pattern references, three vulnerable fixtures, three benign fixtures, and index registration.

## Validation
- `git diff --check`
- `git diff --cached --check`
- required frontmatter check across `skills/` and `roles/`
- `index.yaml` listed-file existence check
- `skill_count` consistency check
- prompt-injection pattern scan equivalent to the repository workflow
- `python -m py_compile` for the new Python fixtures, with generated cache files removed before commit
- `node --check` for the new JavaScript fixtures

## Safety
- Defensive review guidance only.
- Synthetic fixtures only.
- No credentials, private keys, tokens, cookies, real customer data, payment credentials, or external API calls.

Closes #298
