### PR TITLE
Improve container metadata egress coverage

### DIFF
--- a/skills/cloud/container-security/SKILL.md
+++ b/skills/cloud/container-security/SKILL.md
@@ -5,15 +5,16 @@ description: >
   Benchmark v1.6.0, CIS Kubernetes Benchmark v1.9.0, and NIST SP 800-190.
   Auto-invoked when reviewing Dockerfiles, Kubernetes manifests, Helm charts,
   or container orchestration configurations. Evaluates image security, runtime
-  hardening, RBAC, Pod Security Standards, network policies, and secrets
-  management. Produces a prioritized findings report with remediation guidance.
+  hardening, RBAC, Pod Security Standards, network policies, cloud metadata
+  exposure, and secrets management. Produces a prioritized findings report
+  with remediation guidance.
 tags: [cloud, containers, kubernetes, docker]
 role: [cloud-security-engineer, security-engineer]
 phase: [build, deploy, operate]
 frameworks: [CIS-Docker-v1.6.0, CIS-Kubernetes-v1.9.0, NIST-SP-800-190]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -59,7 +60,8 @@ NIST SP 800-190 identifies five risk categories: image risks, registry risks, or
 - Access to Dockerfiles and container build configurations
 - Kubernetes manifests (YAML), Helm charts, or Kustomize overlays
 - RBAC configuration files (Roles, ClusterRoles, RoleBindings)
-- NetworkPolicy definitions
+- NetworkPolicy definitions, especially default-deny egress policies and
+  workload-specific egress allowlists
 - Pod Security Standard configurations or OPA/Gatekeeper policies
 - Container registry configurations (if available)
 
@@ -109,7 +111,7 @@ Classify findings by type: Dockerfiles, Kubernetes manifests, Helm charts, Kusto
 
 ### Step 2 through Step 6: CIS Benchmark and NIST SP 800-190 Evaluation
 
-Evaluate all container and Kubernetes configurations against CIS Docker Benchmark v1.6.0, CIS Kubernetes Benchmark v1.9.0, and NIST SP 800-190 countermeasures. This covers Dockerfile security, Pod Security Standards, RBAC, Network Policies, Secrets Management, Control Plane configuration, and Container Runtime Hardening.
+Evaluate all container and Kubernetes configurations against CIS Docker Benchmark v1.6.0, CIS Kubernetes Benchmark v1.9.0, and NIST SP 800-190 countermeasures. This covers Dockerfile security, Pod Security Standards, RBAC, Network Policies, cloud metadata/workload identity exposure, Secrets Management, Control Plane configuration, and Container Runtime Hardening.
 
 For detailed CIS benchmark checklist items, NIST SP 800-190 countermeasure tables, and comprehensive security context evaluation criteria, see [cis-benchmarks.md](cis-benchmarks.md) in this skill directory.
 
@@ -126,8 +128,8 @@ Produce the final report using the structure defined in the Output Format sectio
 
 | Severity | Definition | Examples |
 |----------|-----------|----------|
-| **Critical** | Container escape, cluster compromise, or credential exposure | Privileged containers, Docker socket mounts, cluster-admin bound to application SA, secrets in plaintext manifests, `hostPID`/`hostNetwork` on app pods |
-| **High** | Significant security gap enabling lateral movement or privilege escalation | Running as root, missing network policies, wildcard RBAC, `allowPrivilegeEscalation: true`, host path mounts to sensitive directories |
+| **Critical** | Container escape, cluster compromise, or credential exposure | Privileged containers, Docker socket mounts, cluster-admin bound to application SA, secrets in plaintext manifests, cloud metadata credentials reachable from untrusted workloads, `hostPID`/`hostNetwork` on app pods |
+| **High** | Significant security gap enabling lateral movement or privilege escalation | Running as root, missing network policies, wildcard RBAC, unrestricted egress from cloud-identity workloads to metadata endpoints, `allowPrivilegeEscalation: true`, host path mounts to sensitive directories |
 | **Medium** | Missing hardening that weakens defense-in-depth | No resource limits, mutable image tags, missing seccomp profile, read-write root filesystem, secrets as env vars |
 | **Low** | Best-practice deviation with limited immediate risk | No HEALTHCHECK in Dockerfile, ADD instead of COPY, missing liveness/readiness probes, using default namespace |
 | **Informational** | Observation with no direct security impact | Image size optimization, multi-stage build suggestions, label recommendations |
@@ -159,7 +161,7 @@ Produce the final report using the structure defined in the Output Format sectio
 | Dockerfile Security | CIS Docker 4.x | X | X | X | X | X |
 | Pod Security | CIS K8s 5.2.x | X | X | X | X | X |
 | RBAC | CIS K8s 5.1.x | X | X | X | X | X |
-| Network Policies | CIS K8s 5.3.x | X | X | X | X | X |
+| Network Policies & Metadata Egress | CIS K8s 5.3.x / NIST 800-190 | X | X | X | X | X |
 | Secrets Management | CIS K8s 5.4.x | X | X | X | X | X |
 | Runtime Hardening | NIST 800-190 | X | X | X | X | X |
 | Control Plane | CIS K8s 1.x-4.x | X | X | X | X | X |
@@ -228,7 +230,7 @@ Produce the final report using the structure defined in the Output Format sectio
 |--------------|-----------|---------------------|
 | Image Risks | Vulnerabilities, malware, embedded secrets, unpatched software | Minimal base images, scanning, signing, immutable references |
 | Registry Risks | Unauthorized access, stale images, insufficient authentication | Registry authentication, image lifecycle policies |
-| Orchestrator Risks | Unrestricted access, mixed sensitivity workloads, insufficient logging | RBAC, namespaces, network policies, audit logging |
+| Orchestrator Risks | Unrestricted access, mixed sensitivity workloads, cloud metadata credential exposure, insufficient logging | RBAC, namespaces, network policies, metadata egress controls, audit logging |
 | Container Risks | Runtime privilege escalation, unbounded resources, writable filesystems | Non-root, capabilities, resource limits, read-only FS |
 | Host OS Risks | Shared kernel, large attack surface, unpatched hosts | Minimal host OS, regular patching, immutable infrastructure |
 
@@ -257,6 +259,7 @@ Produce the final report using the structure defined in the Output Format sectio
 5. **`readOnlyRootFilesystem` breaks many applications.** When recommending this control, also recommend adding writable `emptyDir` volume mounts for directories the application needs to write to (e.g., `/tmp`, `/var/cache`).
 6. **Network policies are additive, not subtractive.** A default-deny policy must be explicitly created. Without it, all pod-to-pod traffic is allowed regardless of other NetworkPolicy resources.
 7. **Distroless images have no shell.** While this is excellent for security, note that debugging requires ephemeral containers (`kubectl debug`). Flag this as a consideration, not a problem.
+8. **Cloud metadata exposure is separate from Kubernetes API token exposure.** Setting `automountServiceAccountToken: false` prevents the pod from receiving a Kubernetes API token, but it does not by itself stop the workload from reaching cloud metadata or workload identity endpoints. Check egress controls for `169.254.169.254`, provider-specific metadata hosts, and workload identity annotations.
 
 ---
 
@@ -285,6 +288,7 @@ Produce the final report using the structure defined in the Output Format sectio
 - Kubernetes Pod Security Admission: https://kubernetes.io/docs/concepts/security/pod-security-admission/
 - Kubernetes Network Policies: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 - Kubernetes RBAC: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Kubernetes Service Accounts: https://kubernetes.io/docs/concepts/security/service-accounts/
 - Docker Security Best Practices: https://docs.docker.com/develop/security-best-practices/
 - Dockerfile Best Practices: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
 - NSA/CISA Kubernetes Hardening Guide: https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF

--- a/skills/cloud/container-security/cis-benchmarks.md
+++ b/skills/cloud/container-security/cis-benchmarks.md
@@ -431,6 +431,124 @@ spec:
 
 **Critical check:** A default-deny NetworkPolicy should exist in every namespace.
 
+### NIST SP 800-190 -- Cloud Metadata and Workload Identity Egress
+
+Cloud provider metadata services and workload identity endpoints can expose
+short-lived credentials to a compromised pod even when Kubernetes API tokens are
+disabled. Review pod egress and cloud identity bindings together instead of
+treating `automountServiceAccountToken: false` as complete credential isolation.
+
+**High-risk indicators:**
+
+- Workloads using cloud identity bindings without a namespace default-deny egress policy.
+- Service accounts annotated for cloud roles while pods can reach link-local metadata endpoints.
+- Pods with broad outbound egress and no workload-specific allowlist.
+- Host-networked pods or privileged workloads with cloud identity annotations.
+
+**Provider-specific evidence to search for:**
+
+```yaml
+# AWS IRSA / EKS Pod Identity
+metadata:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/app-role
+
+# GKE Workload Identity
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: app@project.iam.gserviceaccount.com
+
+# Azure Workload Identity
+metadata:
+  labels:
+    azure.workload.identity/use: "true"
+```
+
+**Grep patterns:**
+
+```
+169.254.169.254
+169.254.170.2
+metadata.google.internal
+metadata.azure.com
+eks.amazonaws.com/role-arn
+iam.gke.io/gcp-service-account
+azure.workload.identity/use
+AWS_WEB_IDENTITY_TOKEN_FILE
+AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
+```
+
+**Vulnerable pattern: cloud role with unrestricted egress**
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: report-worker
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/report-worker
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: report-worker
+spec:
+  template:
+    spec:
+      serviceAccountName: report-worker
+      containers:
+        - name: worker
+          image: example/report-worker:1.2.3
+  # No default-deny egress NetworkPolicy exists for this namespace.
+  # A compromised container can attempt metadata/workload identity credential access.
+```
+
+**Safer pattern: default-deny egress with explicit application destinations**
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-egress
+  namespace: production
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: report-worker-egress
+  namespace: production
+spec:
+  podSelector:
+    matchLabels:
+      app: report-worker
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 10.20.0.0/16
+      ports:
+        - protocol: TCP
+          port: 443
+```
+
+**Finding format:** Report whether each cloud-identity workload has namespace
+default-deny egress, workload-specific allowlists, and no unnecessary metadata
+endpoint reachability. Classify unrestricted metadata egress from workloads with
+cloud-role bindings as High, or Critical if the role grants sensitive data,
+deployment, or administrative access.
+
 ### CIS 5.4 -- Secrets Management
 
 #### CIS 5.4.1 -- Prefer using Secrets as files over Secrets as environment variables

--- a/skills/cloud/container-security/tests/benign/cloud-metadata-egress-restricted.yaml
+++ b/skills/cloud/container-security/tests/benign/cloud-metadata-egress-restricted.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: reporting
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: report-worker
+  namespace: reporting
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/report-worker-prod
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-egress
+  namespace: reporting
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: report-worker-egress
+  namespace: reporting
+spec:
+  podSelector:
+    matchLabels:
+      app: report-worker
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 10.20.0.0/16
+      ports:
+        - protocol: TCP
+          port: 443
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: report-worker
+  namespace: reporting
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: report-worker
+  template:
+    metadata:
+      labels:
+        app: report-worker
+    spec:
+      serviceAccountName: report-worker
+      containers:
+        - name: worker
+          image: registry.example.com/report-worker@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+      # Expected result: no metadata-egress finding because the namespace has
+      # default-deny egress and the workload policy only allows DNS plus the
+      # private application API CIDR, not link-local metadata endpoints. Service
+      # account token handling is evaluated separately according to the workload
+      # identity mechanism in use.

--- a/skills/cloud/container-security/tests/vulnerable/cloud-metadata-egress-unrestricted.yaml
+++ b/skills/cloud/container-security/tests/vulnerable/cloud-metadata-egress-unrestricted.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: reporting
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: report-worker
+  namespace: reporting
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/report-worker-prod
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: report-worker
+  namespace: reporting
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: report-worker
+  template:
+    metadata:
+      labels:
+        app: report-worker
+    spec:
+      serviceAccountName: report-worker
+      containers:
+        - name: worker
+          image: registry.example.com/report-worker:1.4.2
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+      # No default-deny egress NetworkPolicy or workload allowlist exists.
+      # Expected finding: the cloud role binding plus unrestricted egress can
+      # expose provider credentials through metadata/workload identity endpoints
+      # if the pod is compromised.


### PR DESCRIPTION
## Summary

Adds explicit cloud metadata/workload identity egress coverage to the `container-security` skill so Kubernetes reviews do not treat a hardened pod spec as sufficient when a cloud-identity workload can still reach provider metadata endpoints.

## Bounty tier

Moderate improvement ($100): new edge-case coverage and false-negative reduction for container/Kubernetes reviews.

## What changed

- Adds cloud metadata/workload identity exposure to the main `container-security` scope and severity guidance.
- Extends `cis-benchmarks.md` with NIST SP 800-190-aligned checks for metadata endpoint reachability, provider identity annotations, default-deny egress, and workload-specific allowlists.
- Adds paired fixtures:
  - vulnerable: cloud role binding with unrestricted egress
  - benign: cloud role binding with namespace default-deny egress and a workload allowlist that excludes link-local metadata endpoints

## Validation

- `git diff --cached --check`
- frontmatter required-field check across `skills/**/SKILL.md` and `roles/**/SKILL.md`
- prompt-injection pattern scan matching `.github/workflows/injection-scan.yml`
- index path existence check for all `index.yaml` skill paths
- ASCII-only check for the added fixtures

## Bounty checklist

- [x] I have read and agree to the `CONTRIBUTING.md` bounty terms
- Preferred payment method: PayPal