### PR TITLE
Add IaC sensitive default evidence gates

### DIFF
--- a/skills/cloud/iac-security/SKILL.md
+++ b/skills/cloud/iac-security/SKILL.md
@@ -13,7 +13,7 @@ phase: [build, review]
 frameworks: [OWASP-IaC-Security, SLSA-v1.0, CIS-Benchmarks]
 difficulty: intermediate
 time_estimate: "45-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -227,9 +227,11 @@ This skill applies checks equivalent to the following high-impact rules:
 2. **Missing tfvars analysis.** Secrets may be hardcoded in `.tfvars` files rather than the main `.tf` files. Always scan both.
 3. **Module abstraction hiding misconfigurations.** A module call may look clean, but the module source may contain insecure defaults. When possible, trace into module source code.
 4. **CloudFormation parameters with NoEcho.** Parameters marked `NoEcho: true` are not necessarily secure -- the default value is still in plaintext in the template.
-5. **Confusing `aws_s3_bucket_acl` with `aws_s3_bucket_public_access_block`.** The public access block overrides ACLs. Check both, but the access block is the stronger control.
-6. **Terraform state file secrets.** Even when variables are marked `sensitive`, they may appear in plaintext in the state file. Verify state encryption and access controls.
-7. **Provider-specific encryption defaults.** Some providers encrypt by default (e.g., AWS S3 since January 2023). Know the defaults before flagging missing explicit encryption configuration.
+5. **Terraform sensitive variables with literal defaults.** A variable marked `sensitive = true` is safe only when the secret value is supplied at runtime or from a secret store. A credential-looking `default` still commits the value to source.
+6. **Placeholder and empty defaults.** Do not flag empty strings, obvious placeholders, examples, or references as confirmed secrets without stronger evidence. Report them as hygiene findings only when they can be confused with deployable defaults.
+7. **Confusing `aws_s3_bucket_acl` with `aws_s3_bucket_public_access_block`.** The public access block overrides ACLs. Check both, but the access block is the stronger control.
+8. **Terraform state file secrets.** Even when variables are marked `sensitive`, they may appear in plaintext in the state file. Verify state encryption and access controls.
+9. **Provider-specific encryption defaults.** Some providers encrypt by default (e.g., AWS S3 since January 2023). Know the defaults before flagging missing explicit encryption configuration.
 
 ---
 
@@ -259,10 +261,13 @@ This skill applies checks equivalent to the following high-impact rules:
 - KICS (Keeping Infrastructure as Code Secure): https://docs.kics.io/
 - cfn-nag Rules: https://github.com/stelligent/cfn_nag
 - Terraform Security Best Practices: https://developer.hashicorp.com/terraform/cloud-docs/recommended-practices
+- Terraform Input Variables: https://developer.hashicorp.com/terraform/language/values/variables
+- AWS CloudFormation Parameters: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html
 - AWS Security Best Practices in IAM: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 
 ---
 
 ## Changelog
 
+- **1.0.1** -- Add evidence gates for Terraform sensitive variables with literal defaults and CloudFormation `NoEcho` parameters with plaintext defaults.
 - **1.0.0** -- Initial release. Coverage of eight security domains across Terraform, CloudFormation, Pulumi, and Bicep with Checkov/tfsec/KICS rule equivalents.

--- a/skills/cloud/iac-security/tests/secret-default-evidence-fixtures.md
+++ b/skills/cloud/iac-security/tests/secret-default-evidence-fixtures.md
@@ -1,0 +1,60 @@
+# IaC Secret Default Evidence Fixtures
+
+Use these fixtures to calibrate hardcoded-secret review of Terraform `sensitive`
+variables and CloudFormation `NoEcho` parameters.
+
+## Vulnerable: Terraform Sensitive Variable With Plaintext Default
+
+```hcl
+variable "db_password" {
+  type      = string
+  sensitive = true
+  default   = "SuperSecret123!"
+}
+```
+
+Expected result: fail. `sensitive = true` suppresses display in some Terraform
+surfaces, but the default still commits a plaintext credential-like value.
+
+## Benign: Terraform Sensitive Variable Without Default
+
+```hcl
+variable "db_password" {
+  type      = string
+  sensitive = true
+}
+```
+
+Expected result: pass. The value is not stored in source and can be supplied at
+runtime, by CI, or through a secret-management workflow.
+
+## Vulnerable: CloudFormation NoEcho Parameter With Plaintext Default
+
+```yaml
+Parameters:
+  DBPassword:
+    Type: String
+    NoEcho: true
+    Default: SuperSecret123!
+```
+
+Expected result: fail. `NoEcho` masks some display paths but does not protect a
+source-controlled default value in the template.
+
+## Benign: CloudFormation NoEcho Parameter Without Default
+
+```yaml
+Parameters:
+  DBPassword:
+    Type: String
+    NoEcho: true
+```
+
+Expected result: pass. The template declares a sensitive parameter without
+embedding the value.
+
+## Review Boundary
+
+Do not treat empty strings, `example`, `changeme`, `REPLACE_ME`, or other obvious
+placeholders as confirmed credentials unless adjacent deployment context proves
+that the placeholder is actually used as a live secret.

--- a/skills/cloud/iac-security/tool-rules.md
+++ b/skills/cloud/iac-security/tool-rules.md
@@ -59,6 +59,65 @@ redis://:[^@]+@
 
 **Severity:** Critical for any confirmed hardcoded secret.
 
+### IaC Secret Wrapper Evidence Gates
+
+Secret wrappers reduce display or output exposure, but they do not make a plaintext
+value safe to commit. Treat the wrapper as a control only when the value is supplied
+at runtime, pulled from a secret store, or left unset in source.
+
+**Terraform sensitive variables:**
+
+```hcl
+# FAIL: Sensitive flag does not protect a committed default
+variable "db_password" {
+  type      = string
+  sensitive = true
+  default   = "SuperSecret123!"
+}
+
+# PASS: Sensitive variable with no source-controlled value
+variable "db_password" {
+  type      = string
+  sensitive = true
+}
+```
+
+Flag Terraform variables when all of the following are true:
+
+- The variable has `sensitive = true`.
+- The same variable block includes a literal `default`.
+- The default is a credential-looking string, token, key, connection string, or other non-placeholder secret value.
+
+Do not report an empty default, obvious placeholder (`"changeme"`, `"example"`,
+`"REPLACE_ME"`), expression reference, data source, or CI/environment input as a
+confirmed hardcoded secret without additional evidence.
+
+**CloudFormation NoEcho parameters:**
+
+```yaml
+# FAIL: NoEcho masks output display, not a committed template default
+Parameters:
+  DBPassword:
+    Type: String
+    NoEcho: true
+    Default: SuperSecret123!
+
+# PASS: Runtime-supplied secret parameter with no plaintext default
+Parameters:
+  DBPassword:
+    Type: String
+    NoEcho: true
+```
+
+Flag CloudFormation parameters when all of the following are true:
+
+- `NoEcho` is set to `true`.
+- The parameter also has a plaintext `Default`.
+- The default is a credential-looking value rather than an empty or placeholder value.
+
+Recommend removing plaintext defaults and sourcing values from AWS Secrets Manager,
+SSM Parameter Store dynamic references, CI secret stores, or runtime variable input.
+
 **Remediation pattern:**
 
 ```hcl
@@ -76,6 +135,7 @@ resource "aws_db_instance" "example" {
 variable "db_password" {
   type      = string
   sensitive = true
+  # No default: value is provided by CI, the operator, or a secret store.
 }
 ```
 


### PR DESCRIPTION
## Summary
- Adds explicit IaC secret-wrapper evidence gates for Terraform `sensitive = true` variables with literal defaults.
- Adds CloudFormation `NoEcho` parameter default guidance, distinguishing masking from source-code secrecy.
- Adds calibration fixtures for vulnerable and benign Terraform/CloudFormation cases.

Closes #2302.

## Validation
- `git diff --check`
- `git diff --cached --check`
- Frontmatter version check for `iac-security` v1.0.1
- Markdown fence balance and ASCII checks across changed files
