### PR TITLE
Add AWS effective organization evidence gates

### DIFF
--- a/skills/cloud/aws-review/SKILL.md
+++ b/skills/cloud/aws-review/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [CIS-AWS-v3.0.0]
 difficulty: intermediate
 time_estimate: "60-90min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -55,6 +55,9 @@ The CIS Amazon Web Services Foundations Benchmark v3.0.0 is a consensus-driven s
 - S3 bucket policies and ACL configurations
 - VPC, security group, and NACL definitions
 - CloudTrail and CloudWatch configuration files
+- AWS Organizations exports, including account OU path, attached SCPs, delegated administrator registrations, trusted service access, and permission boundaries where available
+- IAM service-linked role inventory and service-managed role documentation
+- CloudTrail event selectors or event data store selectors showing management, data, network activity, and Insights event coverage where applicable
 
 ---
 
@@ -99,7 +102,72 @@ For detailed CIS benchmark checklist items with specific Terraform patterns, gre
 
 ---
 
-### Step 7: Compile Assessment Report
+### Step 7: Effective Organization, Service-Managed Role, and Event Coverage Evidence
+
+Before finalizing pass/fail status, reconcile account-local evidence with organization-wide controls and service-managed behavior. Do not mark a control as pass or fail from a single account-local artifact when effective permissions or logging coverage depend on AWS Organizations, delegated administrators, resource policies, service-linked roles, or CloudTrail selector scope.
+
+#### 7.1 Effective Permission Boundary Gate
+
+For IAM and access findings, record the effective permission picture:
+
+| Evidence | Required Fields |
+|----------|-----------------|
+| AWS Organizations scope | Organization ID if available, account ID, OU path, attached SCP names/IDs, and retrieval timestamp |
+| SCP decision impact | Explicit denies, allow-list posture if used, inherited SCPs, and whether the tested action is blocked by SCP |
+| Permission boundary | Boundary policy ARN/hash, allowed/denied action classes, and whether it applies to the principal under review |
+| Resource policy impact | S3/KMS/SNS/SQS/Lambda/API Gateway/resource policy grants that can reintroduce access despite identity restrictions |
+| Effective result | Direct IAM allow/deny, inherited deny, boundary restriction, resource-policy grant, or Not Evaluable |
+
+Rules:
+- Treat SCPs and permission boundaries as risk-reducing only when the attached policy, OU/account attachment, and retrieval timestamp are documented.
+- Do not treat a local IAM allow as exploitable if an explicit inherited SCP deny blocks the action, unless a service-linked role or resource-policy path bypasses that assumption.
+- Do not treat a local IAM deny as sufficient if a resource policy, cross-account trust, or delegated administrator path grants the same effective action.
+- Mark as Not Evaluable when only role names or screenshots are available without policy JSON, OU path, or effective-policy evidence.
+
+#### 7.2 Delegated Administrator and Service-Linked Role Gate
+
+Review delegated administration and AWS service-managed identities as first-class privilege paths:
+
+| Area | Evidence to Capture |
+|------|---------------------|
+| Delegated administrators | Service, delegated account, registration source, allowed admin operations, owner, and review date |
+| Trusted service access | Enabled services, management account approval evidence, and whether service access is still required |
+| Service-linked roles | Role name, linked service, managed policy/permissions summary, related resources, and deletion constraints |
+| Cross-account service behavior | Source account, target resource/account, service principal, resource policy, and operational justification |
+| Exception handling | Migration or break-glass justification, owner, expiry/review date, and compensating controls |
+
+Finding triggers:
+- Service-linked or service-managed role has broad access and no owner, related-resource inventory, or review cadence.
+- Delegated administrator account can create, update, delete, or query organization-level security resources without approval or logging evidence.
+- Cross-account service integrations can access target groups, buckets, keys, trails, logs, or event data stores without resource-policy and ownership evidence.
+- A temporary migration exception for a service-linked role, delegated admin, or service-managed role has no expiry or post-change review.
+
+False-positive guardrails:
+- Do not report a service-linked role solely because it exists; many AWS services require them. Report only missing ownership, excessive related-resource exposure, stale exception, or unreviewed delegated capability.
+- Do not report read-only delegated visibility as administrative control unless the role can change organization resources, logging, security configuration, identity, or data access.
+
+#### 7.3 CloudTrail Data-Event and Region Coverage Gate
+
+Separate "CloudTrail exists" from "the required event classes are captured for the target services and regions":
+
+| Coverage Item | Required Evidence |
+|---------------|-------------------|
+| Trail/event data store scope | Organization trail vs account trail, multi-region setting, home region, member-account application |
+| Management events | Read/write setting, exclusions, and global service event handling |
+| Data events | Resource types selected, S3/Lambda/DynamoDB or advanced event selectors, read/write selection, and all-current/future coverage |
+| Network activity and Insights events | Whether required by scope, enabled state, and rationale when not applicable |
+| Sensitive services | S3 object-level access, Lambda invoke, DynamoDB item access, KMS usage, or other scoped data-plane events relevant to the environment |
+| Blind spots | Exclusions, single-region trails, missing member accounts, bucket/function/table selectors, and retention/query access |
+
+Finding triggers:
+- A report passes CIS logging controls because an organization trail exists, but required S3 object-level, Lambda invoke, DynamoDB item-level, or other in-scope data events are not configured.
+- Data events are enabled only for one bucket/function/table while the assessment claims coverage for all sensitive resources.
+- Organization trail is present but not applied to all accounts/regions in scope, or member account evidence cannot prove ingestion.
+- CloudTrail Lake/event data store exists but selectors exclude security-relevant data-plane events or retention/query access is not documented.
+
+---
+
+### Step 8: Compile Assessment Report
 
 Produce the final report using the structure defined in the Output Format section.
 
@@ -127,6 +195,8 @@ Produce the final report using the structure defined in the Output Format sectio
 - Date: <assessment date>
 - Framework: CIS Amazon Web Services Foundations Benchmark v3.0.0
 - Files reviewed: <list of IaC files>
+- AWS Organizations scope: <org/account/OU path or Not Evaluable>
+- Effective-policy evidence cutoff: <timestamp/source>
 
 ### Executive Summary
 - Total CIS recommendations evaluated: <N>/62
@@ -156,7 +226,27 @@ Produce the final report using the structure defined in the Output Format sectio
 - **Line(s):** <line numbers if applicable>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration or code snippet>
+- **Effective Permission Context:** <SCP / permission boundary / resource policy / delegated admin / service-linked role impact>
+- **CloudTrail Event Coverage:** <management events / data events / region/member-account coverage when relevant>
 - **Remediation:** <specific fix with code example>
+
+### Effective Permission and Organization Controls
+
+| Account/OU | Principal/Role | Local IAM Result | SCP/Boundary Result | Resource Policy Impact | Service-Linked/Delegated Path | Final Effective Result | Evidence Timestamp |
+|------------|----------------|------------------|---------------------|------------------------|-------------------------------|------------------------|--------------------|
+| <account> | <principal> | <allow/deny> | <allow/deny/not evaluated> | <grant/deny/none> | <none/path> | <pass/fail/not evaluable> | <timestamp> |
+
+### Delegated Administrator and Service-Linked Role Review
+
+| Service | Role/Admin Account | Capability | Related Resources | Owner | Expiry/Review Date | Finding |
+|---------|--------------------|------------|-------------------|-------|--------------------|---------|
+| <service> | <role/account> | <operations> | <resources> | <owner> | <date> | <pass/fail/not evaluable> |
+
+### CloudTrail Event Coverage
+
+| Trail/Event Data Store | Scope | Management Events | Data Events | Selectors/Resources | Regions/Accounts | Exclusions | Status |
+|------------------------|-------|-------------------|-------------|---------------------|------------------|------------|--------|
+| <name> | <org/account> | <read/write> | <types> | <selectors> | <coverage> | <excluded events> | <pass/fail/not evaluable> |
 
 ### Prioritized Remediation Plan
 
@@ -200,6 +290,9 @@ Produce the final report using the structure defined in the Output Format sectio
 4. **Assuming default security groups are empty.** AWS default security groups allow all inbound traffic from the same security group and all outbound traffic. CIS 5.4 requires explicitly managing them to have zero rules.
 5. **Overlooking IMDSv2 in launch templates.** CIS 5.6 applies to both `aws_instance` and `aws_launch_template` resources. Checking only direct instance definitions misses auto-scaled instances.
 6. **Counting not-evaluable controls as passing.** If a control cannot be verified from the available IaC (e.g., contact details in CIS 1.1), mark it "Not Evaluable" rather than "Pass."
+7. **Treating account-local IAM as the full effective permission model.** SCPs, permission boundaries, resource policies, delegated administrators, and service-linked roles can materially change what a principal or service can do. Record the effective path before assigning severity.
+8. **Assuming service-linked roles are governed like ordinary IAM roles.** Many service-linked roles are required by AWS services and have service-managed permissions. Review ownership, related resources, and exceptions instead of flagging existence alone.
+9. **Equating CloudTrail presence with data-plane visibility.** By default, trails and event data stores log management events but not data events. S3 object-level, Lambda invoke, DynamoDB item-level, and other data-plane activity require explicit selector evidence.
 
 ---
 
@@ -222,7 +315,11 @@ Produce the final report using the structure defined in the Output Format sectio
 - CIS Amazon Web Services Foundations Benchmark v3.0.0: https://www.cisecurity.org/benchmark/amazon_web_services
 - AWS Security Best Practices: https://docs.aws.amazon.com/security/
 - AWS IAM Best Practices: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
+- AWS Organizations service control policies: https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html
+- AWS Organizations and service-linked roles: https://docs.aws.amazon.com/organizations/latest/userguide/orgs_integrate_services.html
+- AWS CloudTrail delegated administrator: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-delegated-administrator.html
 - AWS CloudTrail Documentation: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/
+- AWS CloudTrail data events: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-data-events-with-cloudtrail.html
 - AWS Security Hub: https://docs.aws.amazon.com/securityhub/latest/userguide/
 - AWS VPC Security: https://docs.aws.amazon.com/vpc/latest/userguide/security.html
 - Terraform AWS Provider Documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
@@ -231,4 +328,5 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Changelog
 
+- **1.0.1** -- Adds effective permission, AWS Organizations/SCP, delegated administrator, service-linked role, and CloudTrail data-event coverage evidence gates.
 - **1.0.0** -- Initial release. Full coverage of CIS Amazon Web Services Foundations Benchmark v3.0.0 sections 1 through 5 (62 recommendations).


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `aws-review`
**Skill path:** `skills/cloud/aws-review/`

### What Was Wrong

Issue #108 notes that an AWS account-local review can overstate or understate risk when it does not preserve evidence for AWS Organizations SCPs, permission boundaries, resource policies, delegated administrators, service-linked roles, and CloudTrail event-class coverage.

That creates false positives and false negatives:

- a local IAM allow can look exploitable even when an inherited SCP blocks the action;
- a local IAM deny can look safe while a resource policy or delegated admin path still grants effective access;
- service-linked roles can be flagged only for existing, even though many AWS services require them;
- CloudTrail can be treated as complete because a trail exists, while relevant data events are not selected.

### What This PR Fixes

- Bumps `aws-review` to `1.0.1`.
- Adds prerequisites for AWS Organizations exports, service-linked role inventory, and CloudTrail event selectors/event data store selectors.
- Adds an `Effective Organization, Service-Managed Role, and Event Coverage Evidence` step.
- Adds an effective permission boundary gate covering SCPs, permission boundaries, resource policies, and final effective result.
- Adds delegated administrator and service-linked role evidence requirements, finding triggers, and false-positive guardrails.
- Adds CloudTrail data-event and region coverage gates that separate trail existence from management/data/network/Insights event coverage.
- Extends output with AWS Organizations scope, effective-policy evidence cutoff, effective permission context, CloudTrail event coverage, organization controls, delegated admin/service-linked role review, and CloudTrail event coverage tables.
- Adds common pitfalls and official AWS references for SCPs, service-linked roles, CloudTrail delegated administrator, and CloudTrail data events.

### Evidence

**Before:** A report could score account-local IAM or CloudTrail presence without proving organization-level guardrails, service-managed privilege paths, or data-plane event selector coverage.

**After:** Reviewers must record the effective permission path and event coverage evidence before assigning pass/fail status or severity.

### Test Cases Added/Updated
- [ ] Added vulnerable test cases (`tests/vulnerable/`)
- [ ] Added benign test cases (`tests/benign/`)
- [x] Existing checks still pass

This existing skill stores examples in Markdown guidance files; the change keeps scope to `SKILL.md`.

### Validation

- `git diff --check`
- `git diff --cached --check`
- Frontmatter required-field check matching `.github/workflows/lint-skills.yml`
- `index.yaml` file-existence check matching `.github/workflows/validate-index.yml`
- Markdown code fence balance check for changed file
- Workflow-equivalent prompt-injection scan over `skills/` and `roles/`
- Targeted marker check for `version: "1.0.1"`, effective organization evidence, effective permission boundary gate, AWS Organizations scope, SCP decision impact, permission boundary, resource policy impact, delegated administrator/service-linked role gate, CloudTrail data-event gate, CloudTrail event coverage, AWS SCP docs, and AWS CloudTrail data-event docs

### References

- AWS Organizations SCPs: https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html
- AWS Organizations and service-linked roles: https://docs.aws.amazon.com/organizations/latest/userguide/orgs_integrate_services.html
- AWS CloudTrail delegated administrator: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-delegated-administrator.html
- AWS CloudTrail data events: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-data-events-with-cloudtrail.html

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Payment details can be provided privately after maintainer acceptance

Fixes #108