### PR TITLE
Add SBOM purl and VEX evidence gates

### DIFF
--- a/skills/vuln-management/sbom-analysis/SKILL.md
+++ b/skills/vuln-management/sbom-analysis/SKILL.md
@@ -13,7 +13,7 @@ phase: [build, operate]
 frameworks: [CycloneDX-1.5, SPDX-2.3, VEX-CSAF, NTIA-SBOM-Minimum-Elements]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -48,10 +48,12 @@ Before starting, collect or confirm:
 - [ ] **SBOM format and version:** CycloneDX 1.5, SPDX 2.3, or other (identify version explicitly)
 - [ ] **VEX document(s):** Associated VEX statements, if available (CSAF 2.0 format, CycloneDX VEX, or OpenVEX)
 - [ ] **Software identity:** Name, version, and vendor of the software the SBOM describes
+- [ ] **Artifact identity:** Release artifact digest, container image digest, package URL, installer hash, or deployed artifact identifier that the SBOM claims to describe
 - [ ] **Intended use context:** Is this SBOM for procurement evaluation, compliance audit, incident response, or continuous monitoring?
 - [ ] **Compliance requirements:** Applicable mandates (EO 14028 for US federal suppliers, EU Cyber Resilience Act, FDA premarket guidance for medical devices)
 - [ ] **License policy:** Organization's approved/prohibited license list, if applicable
 - [ ] **Known vulnerability data:** CVE data sources to cross-reference (NVD, OSV, GitHub Advisory Database)
+- [ ] **Shipped artifact evidence:** Source tree, build output, container layers, package contents, generated clients, vendored directories, or archive inventory used to verify SBOM coverage
 
 If the SBOM format is ambiguous, inspect the file structure to determine the format before proceeding.
 
@@ -170,7 +172,111 @@ VEX Assessment:
 - Under Investigation: [N] (monitor for updates)
 ```
 
-### Step 4: Transitive Dependency Analysis
+### Step 4: Component Identity and purl Normalization
+
+Before vulnerability, VEX, or license conclusions are accepted, normalize the component identity used by the SBOM and the advisory source. A public package name match is not enough when the component resolves to a private fork, curated mirror, renamed package, generated component, or generic purl.
+
+#### Identity Evidence Matrix
+
+| Evidence | Required Fields |
+|---|---|
+| SBOM identity | Component name, version, supplier, `bom-ref`/SPDXID, package type, and purl/CPE/SWID if present |
+| Normalized purl | Ecosystem/type, namespace, name, version, qualifiers, subpath, decoded scoped names, and canonical registry |
+| Source/provenance | Source repository, commit/tag, distribution URL, registry, private mirror/fork evidence, signature or digest |
+| Advisory identity | Advisory ecosystem, affected package coordinates, affected ranges, aliases, fixed versions, and matching rule |
+| Decision | Applies, does not apply, private fork needs proof, ambiguous identity, or Not Evaluable |
+
+Rules:
+- Decode and normalize purl values before matching. For example, `pkg:npm/%40scope/lib@1.2.3` must be treated as `@scope/lib`, not as a different package name.
+- Preserve namespace/group/scope. Do not flatten scoped npm packages, Maven group IDs, Go module paths, container registry paths, or generic purls into bare names.
+- Treat package aliases, mirrors, private forks, relocated Maven artifacts, Go `replace`, Cargo `[patch]`, direct URLs, and generic `pkg:generic` components as identity changes that require provenance evidence.
+- Do not apply a public advisory solely from upstream name/version when the SBOM points to a private fork or curated mirror. Require evidence that the fork still contains the vulnerable code, or mark advisory applicability as Not Evaluable.
+- Do not clear a finding solely because the component is private. Require fork lineage, patch commit, VEX, source diff, or maintainer evidence that proves the vulnerable code is absent or unreachable.
+
+Finding triggers:
+- SBOM lacks purl/CPE/SWID and advisory matching is performed only by display name.
+- purl is malformed, percent-encoding is not normalized, namespace is dropped, or qualifiers/subpath change component identity.
+- A private fork or mirror is treated as public upstream without proof of equivalence.
+- A generic purl, archive, binary package, or container component is mapped to a CVE without source or package-coordinate evidence.
+
+### Step 5: Shipped Artifact, Vendored, and Generated Component Coverage
+
+SBOM completeness must be checked against what actually ships, not only against the declared component list. Inspect artifact contents or build output evidence for components that may bypass SBOM generation.
+
+#### Paths and artifacts to check
+
+```
+vendor/**
+third_party/**
+external/**
+deps/**
+generated/**
+codegen/**
+openapi-client/**
+proto-gen/**
+node_modules bundled into images
+container layers
+*.jar
+*.war
+*.ear
+*.tgz
+*.tar.gz
+*.whl
+*.gem
+*.crate
+git submodules
+```
+
+#### Coverage evidence
+
+| Evidence | Required Fields |
+|---|---|
+| Shipped artifact | Artifact digest, image digest, package hash, file inventory source, and retrieval timestamp |
+| Component origin | Source repository, archive URL, generator/tool version, commit/tag, supplier, license source |
+| SBOM representation | Component entry, purl or external reference, dependency relationship, file relationship, and scope |
+| Scan coverage | Tool, inclusion/exclusion rule, timestamp, vulnerable/license database source, and known limitations |
+| Decision | Covered, missing from SBOM, generated-only, vendored-only, test-only, not shipped, or Not Evaluable |
+
+Finding triggers:
+- Generated client, SDK, protobuf/OpenAPI output, or copied source ships in the artifact but is missing from SBOM components and dependency relationships.
+- Vendored code is excluded as `vendor` or `generated` without a separate SBOM, purl, license, origin, or vulnerability coverage.
+- A compiled artifact contains dependencies that are absent from the SBOM or only represented as one opaque root package.
+- Archive or binary dependencies lack source, digest, supplier, license, or update path evidence.
+
+False-positive guardrails:
+- Do not flag a vendored/generated directory if artifact evidence proves it is test-only, not shipped, or represented in a separate referenced SBOM.
+- Do not require every generated file to have a separate component when the generator, template, source spec, generated dependency set, and shipped artifact are represented with relationships and provenance.
+
+### Step 6: VEX Reachability and Justification Evidence Gate
+
+VEX status can reduce remediation work only when the status is tied to the exact product, component identity, artifact, and reachability evidence.
+
+For each `not_affected` or equivalent VEX assertion, require:
+
+| Evidence | Required Fields |
+|---|---|
+| VEX statement | VEX format, document ID, author, timestamp, product ID, vulnerability ID, status, and justification |
+| Product binding | Product/version, artifact digest, SBOM identifier, component `bom-ref`/SPDXID, and purl/CPE mapping |
+| Reachability evidence | Dependency path, call graph, import path, feature flag, runtime config, exposed interface, or test result |
+| Justification proof | Evidence matching the specific justification category, owner, method, and review timestamp |
+| Decision | Accepted, rejected, weak evidence, stale, product mismatch, component mismatch, or Not Evaluable |
+
+Rules:
+- `component_not_present` must be verified against the SBOM and shipped artifact, not only the VEX text.
+- `vulnerable_code_not_present` requires source, binary, package diff, or vendor attestation specific to the artifact.
+- `vulnerable_code_not_in_execute_path` requires call graph, import graph, runtime configuration, feature flag, or test evidence.
+- `vulnerable_code_cannot_be_controlled_by_adversary` requires threat-model or data-flow evidence showing the vulnerable path is not reachable by attacker-controlled input.
+- `inline_mitigations_already_exist` requires mitigation configuration and proof that the mitigation is enabled in the reviewed deployment.
+- Mark as Not Evaluable when the VEX document is stale, unsigned/untrusted, missing product binding, refers to a different artifact, or lacks evidence for the stated justification.
+
+Finding triggers:
+- A generic `not_affected` VEX status is accepted without component identity, artifact digest, or reachability evidence.
+- VEX product ID, SBOM component ID, and shipped artifact cannot be linked.
+- VEX status is older than the SBOM/release or predates a dependency update.
+- VEX says `fixed` but the fixed version or patched artifact is not deployed.
+- VEX says `component_not_present` while the component appears in shipped artifact evidence.
+
+### Step 7: Transitive Dependency Analysis
 
 Analyze the dependency tree to identify risk concentration in transitive (indirect) dependencies.
 
@@ -203,7 +309,7 @@ Transitive Dependency Analysis:
 - Stale Dependencies:       [N] components with no update in >= 18 months
 ```
 
-### Step 5: License Conflict Detection
+### Step 8: License Conflict Detection
 
 Analyze component licenses for conflicts, compliance risks, and policy violations.
 
@@ -259,7 +365,7 @@ Produce a structured report with these exact sections:
 ```markdown
 ## SBOM Analysis Report
 **Date:** [YYYY-MM-DD]
-**Skill:** sbom-analysis v1.0.0
+**Skill:** sbom-analysis v1.0.1
 **Frameworks:** CycloneDX 1.5, SPDX 2.3, VEX (CSAF), NTIA Minimum Elements
 **Reviewer:** AI-assisted (human review required for license conflicts and risk decisions)
 
@@ -278,6 +384,8 @@ conflicts), and overall classification.]
 | Total Components | [N] (direct: [N], transitive: [N]) |
 | SBOM Author | [Author name] |
 | SBOM Timestamp | [ISO 8601] |
+| Artifact Digest / Release ID | [digest/version/Not Evaluable] |
+| Shipped Artifact Evidence | [container/package/file inventory source] |
 
 ### NTIA Minimum Elements Compliance
 
@@ -296,9 +404,21 @@ conflicts), and overall classification.]
 ### VEX Status Summary
 [If VEX documents are provided]
 
-| CVE ID | Component | VEX Status | Justification | Action |
-|---|---|---|---|---|
-| [CVE-ID] | [component] | [Not Affected/Affected/Fixed/Under Investigation] | [justification if Not Affected] | [action] |
+| CVE ID | Component | VEX Status | Justification | Product/Artifact Binding | Reachability Evidence | Action |
+|---|---|---|---|---|---|---|
+| [CVE-ID] | [component] | [Not Affected/Affected/Fixed/Under Investigation] | [justification if Not Affected] | [bound/mismatch/unknown] | [evidence/none] | [action] |
+
+### Component Identity and purl Normalization
+
+| Component | Raw Identifier | Normalized purl/CPE/SWID | Source/Registry | Advisory Match Basis | Applicability |
+|---|---|---|---|---|---|
+| [component] | [raw SBOM field] | [normalized ID] | [public/private/fork/mirror] | [purl/CPE/name-only/code evidence] | [applies/not applies/not evaluable] |
+
+### Shipped Artifact Coverage
+
+| Artifact Path / Component | Origin | Shipped? | SBOM Entry | Relationship Present | Scan Coverage | Result |
+|---|---|---|---|---|---|---|
+| [path/component] | [source/generator/archive] | [yes/no] | [bom-ref/SPDXID/none] | [yes/no] | [tool/timestamp] | [covered/missing/not evaluable] |
 
 ### Transitive Dependency Risk
 
@@ -336,6 +456,7 @@ conflicts), and overall classification.]
 - NTIA SBOM Minimum Elements: https://www.ntia.gov/sites/default/files/publications/sbom_minimum_elements_report_0.pdf
 - CycloneDX 1.5 Specification: https://cyclonedx.org/docs/1.5/
 - SPDX 2.3 Specification: https://spdx.github.io/spdx-spec/v2.3/
+- Package URL (purl) Specification: https://github.com/package-url/purl-spec
 - VEX (CSAF): https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html
 - Vendor advisory: [URL if applicable]
 ```
@@ -375,11 +496,15 @@ Published by NTIA in July 2021 as part of Executive Order 14028 implementation. 
 
 2. **Ignoring transitive dependencies.** Direct dependencies are typically well-managed, but transitive dependencies (dependencies of dependencies) account for the majority of supply chain vulnerabilities. The xz-utils backdoor (CVE-2024-3094) and Log4Shell (CVE-2021-44228) both demonstrated how deeply nested dependencies create organization-wide exposure. Analyze the full dependency tree, not just the top level.
 
-3. **Treating VEX "Not Affected" as automatic clearance.** A VEX "Not Affected" status is only as trustworthy as its justification. "Component not present" is verifiable against the SBOM; "vulnerable code not in execute path" requires code-level analysis that should be validated independently for critical systems. Always review the justification category and assess its credibility.
+3. **Treating VEX "Not Affected" as automatic clearance.** A VEX "Not Affected" status is only as trustworthy as its justification. "Component not present" is verifiable against the SBOM and shipped artifact; "vulnerable code not in execute path" requires call-graph, runtime, feature-flag, or code-level evidence that should be validated independently for critical systems. Always review the justification category and assess its credibility.
 
 4. **Overlooking license implications in SaaS deployments.** AGPL-3.0 triggers copyleft obligations for network use (SaaS), unlike GPL which only triggers on distribution. Organizations running AGPL-licensed components in SaaS products may have unrecognized compliance obligations. Always flag AGPL components regardless of distribution model.
 
 5. **Failing to track SBOM freshness.** An SBOM is a point-in-time snapshot. Software composition changes with every dependency update, build, or deployment. SBOMs older than the most recent build/release are potentially inaccurate. Check the SBOM timestamp against the software's actual release date and flag stale SBOMs.
+
+6. **Missing vendored and generated shipped code.** SBOMs generated from manifests often miss copied source, generated SDKs, submodules, archives, and compiled dependencies. Compare SBOM entries with artifact contents before declaring coverage complete.
+
+7. **Flattening private forks into public package identity.** A private fork or curated mirror can be affected, fixed, or not equivalent to upstream. Record lineage and patch evidence before applying or dismissing a public advisory.
 
 ---
 
@@ -401,6 +526,7 @@ Published by NTIA in July 2021 as part of Executive Order 14028 implementation. 
 - CycloneDX GitHub: https://github.com/CycloneDX/specification
 - SPDX 2.3 Specification: https://spdx.github.io/spdx-spec/v2.3/
 - SPDX License List: https://spdx.org/licenses/
+- Package URL (purl) Specification: https://github.com/package-url/purl-spec
 - CSAF 2.0 (OASIS): https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html
 - CISA VEX Minimum Requirements: https://www.cisa.gov/sites/default/files/2023-04/minimum-requirements-for-vex-508c.pdf
 - OpenVEX Specification: https://github.com/openvex/spec
@@ -408,3 +534,9 @@ Published by NTIA in July 2021 as part of Executive Order 14028 implementation. 
 - EU Cyber Resilience Act: https://digital-strategy.ec.europa.eu/en/policies/cyber-resilience-act
 - OSV (Open Source Vulnerability Database): https://osv.dev/
 - GitHub Advisory Database: https://github.com/advisories
+
+---
+
+## Changelog
+
+- **1.0.1** -- Adds component identity and purl normalization, shipped artifact/vendored/generated coverage, and VEX reachability evidence gates before accepting advisory applicability or not-affected status.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `sbom-analysis`
**Skill path:** `skills/vuln-management/sbom-analysis/`

### What Was Wrong
Issue #133 notes that SBOM review can over- or under-score risk when component identity, shipped artifact coverage, and VEX evidence are accepted too loosely.

False positive / false negative cases this addresses:
- A public package-name match is applied even though the component purl points to a private fork or curated mirror.
- A scoped/encoded purl such as `pkg:npm/%40scope/lib@1.2.3` is not normalized before advisory matching.
- Generated or vendored code ships in the artifact but is missing from SBOM components and dependency relationships.
- VEX `not_affected` claims are accepted without artifact binding, dependency path, call graph, runtime config, feature flag, or other reachability evidence.

### What This PR Fixes
- Bumps `sbom-analysis` to `1.0.1`.
- Adds artifact identity and shipped artifact evidence to required context.
- Adds a Component Identity and purl Normalization step.
- Adds a Shipped Artifact, Vendored, and Generated Component Coverage step.
- Adds a VEX Reachability and Justification Evidence Gate.
- Extends output with artifact digest/release ID, shipped artifact evidence, richer VEX evidence fields, component identity/purl normalization table, and shipped artifact coverage table.
- Adds common pitfalls for VEX clearance, vendored/generated code, and private fork identity.
- Adds Package URL (purl) reference and changelog entry.

### Validation
- `git diff --check`
- `git diff --cached --check`
- Frontmatter required-field check across 50 skill files
- `index.yaml` path existence check across 50 entries
- Markdown fenced-code balance check for modified Markdown files
- Workflow-equivalent prompt-injection scan
- Targeted marker check for `version: "1.0.1"`, purl normalization, private fork identity, shipped artifact coverage, vendored/generated paths, VEX reachability evidence, artifact digest output, Package URL reference, and changelog

### References
- https://github.com/package-url/purl-spec
- https://cyclonedx.org/docs/1.5/
- https://spdx.github.io/spdx-spec/v2.3/
- https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html
- https://www.cisa.gov/sites/default/files/2023-04/minimum-requirements-for-vex-508c.pdf
- https://github.com/openvex/spec

### Bounty Tier
[x] Moderate ($100)

### Bounty Info
- [x] I am requesting bounty consideration for this skill improvement.
- [x] The PR addresses the issue with evidence-driven workflow changes.
- [x] Validation has been run locally.
- **Preferred payment method:** Payment details can be provided privately after maintainer acceptance.

Fixes #133