### PR TITLE
Add DNS split-horizon and DoH evidence gates

### DIFF
--- a/skills/network/dns-security/SKILL.md
+++ b/skills/network/dns-security/SKILL.md
@@ -13,7 +13,7 @@ phase: [operate]
 frameworks: [NIST-SP-800-81-Rev2, CIS-Controls-v8]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -94,6 +94,20 @@ Categorize discovered configurations:
 
 ---
 
+### Step 1.1: Zone Scope and Bypass Evidence Matrix
+
+Before classifying DNSSEC, DoH, or RPZ findings, build a short evidence matrix that separates public authoritative exposure, private split-horizon scope, client bypass paths, and feed provenance. This prevents private-only internal zones from being scored as Internet-facing DNSSEC gaps while still catching operational bypasses in protective DNS deployments.
+
+| Gate | Evidence fields | Pass condition | Finding trigger |
+|------|-----------------|----------------|-----------------|
+| **Split-Horizon Scope Gate** | `zone_visibility`, `view_scope`, `recursion_policy`, `allow_transfer`, `external_authority`, `dnssec_requirement_rationale` | Private/internal zones document their view boundary, disable recursion on authoritative views, deny zone transfers except approved secondaries, and explain why public DNSSEC expectations do or do not apply. | `DNS-SPLIT-01` when a zone is treated as private without evidence of scope boundaries, or when a public-facing zone is exempted from DNSSEC without rationale. |
+| **DoH Bypass Evidence Gate** | `use-application-dns.net`, `browser_doh_policy`, `enterprise_resolver_enforced`, `public_doh_endpoints`, `egress_policy`, `endpoint_policy_source` | Protective DNS claims are backed by browser/client policy evidence, the canary domain behavior is known, and public DoH endpoints are blocked or explicitly monitored where enterprise DNS filtering is required. | `DNS-DOH-01` when browsers or clients can reach public DoH resolvers and bypass the enterprise resolver path. |
+| **RPZ Feed Provenance Gate** | `rpz_loaded`, `rpz_feed_source`, `feed_update_cadence`, `feed_signature_validation`, `feed_age`, `last_successful_update`, `failure_mode` | RPZ/protective-DNS feeds are loaded from approved sources, update at the documented cadence, validate provider signatures or checksums where available, and fail closed or alert on stale feeds. | `DNS-RPZ-01` when feeds are stale, unauthenticated, manually refreshed without evidence, or silently accepted after failed validation. |
+
+**False-positive guard:** Do not mark an unsigned private-only split-horizon zone as a High public authoritative DNSSEC finding unless external authority, public delegation, recursion exposure, or transfer exposure is proven. If the zone is internal-only but lacks scope evidence, report `DNS-SPLIT-01` as a documentation or scope-validation finding instead of a public DNSSEC failure.
+
+---
+
 ### Step 2: DNSSEC Deployment Review (NIST SP 800-81 Rev 2, Sections 4 and 5)
 
 NIST SP 800-81 Rev 2 Section 4 covers DNSSEC for authoritative servers (zone signing) and Section 5 covers DNSSEC for recursive resolvers (validation).
@@ -102,6 +116,7 @@ NIST SP 800-81 Rev 2 Section 4 covers DNSSEC for authoritative servers (zone sig
 
 For each authoritative zone, verify:
 
+- **Scope and exposure:** Determine whether the zone is public, private-only, or split-horizon. Apply the **Split-Horizon Scope Gate** before assigning public DNSSEC severity.
 - **Zone is signed:** RRSIG, DNSKEY, NSEC/NSEC3 records are present in zone files.
 - **Algorithm strength:** RSA keys must be at least 2048-bit. ECDSA P-256 (Algorithm 13) or Ed25519 (Algorithm 15) are preferred per NIST SP 800-81 Rev 2 Section 4.3.
 - **Key management:**
@@ -126,7 +141,7 @@ auto-dnssec maintain
 inline-signing yes
 ```
 
-**Finding classification:** Unsigned authoritative zones for public-facing domains are **High**. Weak signing algorithms (RSA < 2048-bit, SHA-1) are **High**. Missing DS record in parent (broken chain of trust) is **Critical**.
+**Finding classification:** Unsigned authoritative zones for public-facing domains are **High**. Weak signing algorithms (RSA < 2048-bit, SHA-1) are **High**. Missing DS record in parent (broken chain of trust) is **Critical**. Private split-horizon zones without public delegation should be classified by scope evidence first; missing scope evidence is `DNS-SPLIT-01`, not automatically a public DNSSEC failure.
 
 ---
 
@@ -174,6 +189,7 @@ Evaluate whether DNS queries are protected in transit.
 - **DoH bypass risk:** Browsers (Firefox, Chrome) may use built-in DoH providers, bypassing corporate DNS filtering. Verify that:
   - Canary domain `use-application-dns.net` resolves to NXDOMAIN (signals browsers to disable built-in DoH).
   - Network policy blocks known public DoH endpoints if corporate DNS filtering is required.
+- **DoH Bypass Evidence Gate:** Record `browser_doh_policy`, `enterprise_resolver_enforced`, `public_doh_endpoints`, and `egress_policy` evidence. If `use-application-dns.net` is `not_set` or inconclusive, require endpoint management evidence showing browsers are pinned to the enterprise resolver.
 
 **Patterns to check:**
 
@@ -190,7 +206,7 @@ tls://8.8.8.8
 forwarders { 1.1.1.1; };  # Plaintext -- flag as finding
 ```
 
-**Finding classification:** DNS queries forwarded in plaintext to external resolvers over untrusted networks is **Medium**. No DoH bypass controls when DNS filtering is deployed is **High**.
+**Finding classification:** DNS queries forwarded in plaintext to external resolvers over untrusted networks is **Medium**. No DoH bypass controls when DNS filtering is deployed is **High** (`DNS-DOH-01` when public DoH endpoints remain reachable from managed clients).
 
 ---
 
@@ -221,6 +237,7 @@ rpz:
 - RPZ feeds are sourced from reputable threat intelligence providers.
 - Zone transfers or API-based updates are automated (not manual).
 - Update frequency is at least daily.
+- **RPZ Feed Provenance Gate:** Capture `rpz_feed_source`, `feed_update_cadence`, `feed_signature_validation`, `feed_age`, `last_successful_update`, and `failure_mode`. Weekly or manual updates require an explicit risk acceptance and compensating monitoring; feeds with `feed_signature_validation: false` require provider provenance evidence or should be flagged.
 - Logging of RPZ-blocked queries is enabled for incident detection.
 
 #### 4.2 Protective DNS Service Evaluation
@@ -233,7 +250,7 @@ If a cloud-based protective DNS service is used (Cisco Umbrella, Cloudflare Gate
 - Block pages or NXDOMAIN responses are returned for blocked categories.
 - Logs are forwarded to SIEM.
 
-**Finding classification:** No DNS filtering/RPZ deployed is **High**. RPZ feeds not automatically updated is **Medium**. DNS resolution paths that bypass protective DNS is **High**.
+**Finding classification:** No DNS filtering/RPZ deployed is **High**. RPZ feeds not automatically updated is **Medium**. Stale, unsigned, or unverifiable feeds are `DNS-RPZ-01` findings. DNS resolution paths that bypass protective DNS is **High**.
 
 ---
 
@@ -299,8 +316,8 @@ abcdef0123456789.dnscat.example.com TXT
 | Severity | Definition |
 |----------|-----------|
 | **Critical** | Broken DNSSEC chain of trust (missing DS record in parent); authoritative zones serving invalid signatures. |
-| **High** | DNSSEC validation disabled on resolvers; no DNS filtering/RPZ; unsigned public authoritative zones; DNS bypass paths around protective DNS; no DNS query logging; weak signing algorithms. |
-| **Medium** | Plaintext DNS forwarding over untrusted networks; stale RPZ feeds; undocumented NTAs; no NRD blocking; no exfiltration detection; DoH bypass not controlled. |
+| **High** | DNSSEC validation disabled on resolvers; no DNS filtering/RPZ; unsigned public authoritative zones; DNS bypass paths around protective DNS (`DNS-DOH-01`); no DNS query logging; weak signing algorithms. |
+| **Medium** | Plaintext DNS forwarding over untrusted networks; stale or unauthenticated RPZ feeds (`DNS-RPZ-01`); undocumented NTAs; no NRD blocking; no exfiltration detection; DoH bypass not controlled. |
 | **Low** | Missing documentation of DNS architecture; resolver software not at latest version; cosmetic configuration issues. |
 
 ---
@@ -327,6 +344,14 @@ abcdef0123456789.dnscat.example.com TXT
 | Resolver | DNSSEC Validation | Encrypted Transport | RPZ/Filtering | Query Logging |
 |----------|-------------------|--------------------|--------------|--------------|
 | ns1      | Enabled/Disabled  | DoT/DoH/Plaintext  | Yes/No       | Yes/No       |
+
+### Scope and Bypass Evidence Matrix
+
+| Gate | Target | Evidence | Status | Finding |
+|------|--------|----------|--------|---------|
+| Split-Horizon Scope Gate | <zone/view> | zone_visibility=<public/private/split>, recursion_policy=<value>, allow_transfer=<value>, dnssec_requirement_rationale=<summary> | Pass/Fail | DNS-SPLIT-01 / None |
+| DoH Bypass Evidence Gate | <client group> | use-application-dns.net=<NXDOMAIN/not_set>, public_doh_endpoints=<blocked/reachable>, browser_doh_policy=<source> | Pass/Fail | DNS-DOH-01 / None |
+| RPZ Feed Provenance Gate | <feed/provider> | feed_update_cadence=<daily/weekly/manual>, feed_signature_validation=<true/false>, feed_age=<duration> | Pass/Fail | DNS-RPZ-01 / None |
 
 ### Findings
 
@@ -384,6 +409,10 @@ abcdef0123456789.dnscat.example.com TXT
 
 4. **Ignoring DNS over TCP.** DNS is not UDP-only. DNS over TCP (port 53) supports large responses and is required for zone transfers. Some tunneling tools prefer TCP for reliability. Firewall rules and monitoring must cover both UDP and TCP port 53.
 
+5. **Scoring private split-horizon DNS like public authoritative DNS without exposure evidence.** Private zones still need recursion and transfer controls, but public DNSSEC severity requires public delegation or externally reachable authority evidence.
+
+6. **Trusting RPZ load status without feed provenance.** A resolver can report RPZ loaded while consuming stale weekly feeds or unsigned provider data. Validate update cadence, signatures or checksums, and failure alerts.
+
 ---
 
 ## Prompt Injection Safety Notice
@@ -413,4 +442,5 @@ This skill processes DNS configuration files that may contain user-supplied zone
 
 ## Changelog
 
+- **1.0.1** -- Added split-horizon scope, DoH bypass, and RPZ feed provenance evidence gates to reduce false positives and catch protective-DNS bypass paths.
 - **1.0.0** -- Initial release. Full coverage of NIST SP 800-81 Rev 2 and CIS Controls v8 Control 9.2 for DNS security review.


### PR DESCRIPTION
## Summary
- Closes #120.
- Adds a split-horizon/private-zone scope gate so private internal zones are not scored as public authoritative DNSSEC failures without exposure evidence.
- Adds DoH bypass evidence requirements for browser/client policy, the `use-application-dns.net` canary, and public DoH endpoint reachability.
- Adds RPZ/protective-DNS feed provenance checks for update cadence, signature validation, feed age, and failure handling.

## Validation
- RED: issue #120 marker check failed before the new DNS gates existed.
- GREEN: issue #120 marker check passes after the DNS gates were added.
- `git diff --check`
- frontmatter required-field check for all `SKILL.md` files
- markdown fence balance check for `skills/network/dns-security`
- ASCII-only check for the changed file
- `index.yaml` file-reference existence check
- sensitive added-line scan for payment/wallet/identity patterns

## Bounty
Requesting Improver Moderate ($100) if accepted.
Payment details can be provided privately after maintainer acceptance.