### PR TITLE
Add zero trust service identity evidence gates

### DIFF
--- a/skills/identity/zero-trust-assessment/SKILL.md
+++ b/skills/identity/zero-trust-assessment/SKILL.md
@@ -172,6 +172,7 @@ ZT-ID-11: Workloads use shared/default service identities instead of unique audi
 ZT-ID-12: Machine-to-machine credentials lack rotation, revocation, or token-audience constraints
 ZT-ID-13: Policy decisions cannot be traced from PDP inputs to PEP enforcement logs
 ZT-ID-14: Break-glass or privileged access paths bypass MFA, device posture, approval, or session recording
+ZT-ID-15: Identity-plane degraded mode or legacy exceptions bypass token freshness, step-up, or posture checks
 ```
 
 #### Service and Workload Identity Evidence Matrix
@@ -201,6 +202,24 @@ only when it is time-bound, strongly controlled, and auditable.
 | **Session recording** | Command/session logs, correlation ID, immutable storage, monitoring alerts | High if emergency sessions are not recorded |
 | **Post-use cleanup** | Credential rotation, account disablement, access review, incident record | Medium/High if break-glass use leaves persistent credentials |
 | **Outage behavior** | Fail-closed defaults and documented emergency exception workflow | Critical if fail-open bypass is unaudited for sensitive resources |
+
+#### Identity-Plane Degraded Mode and Exception Evidence
+
+Score identity-plane availability and exception governance separately from network topology. A private
+network, enclave, or legacy proxy pattern can still be acceptable when identity, device posture,
+policy freshness, and audit evidence remain enforced; a modern topology is weak when outage behavior
+or permanent service exceptions silently bypass those controls.
+
+| Scenario | Evidence to Collect | Decision Gate |
+|---|---|---|
+| **IdP outage or degraded mode** | Cached-token TTL, step-up behavior, posture freshness, deny/allow default, incident approval | Sensitive resources do not fall back to unbounded cached trust or password-only access |
+| **Conditional-access signal failure** | Device posture signal age, user-risk signal freshness, CAE/event delivery status, fallback rule | Missing or stale risk/device signals are visible and trigger bounded access, not full trust |
+| **Legacy service exception** | Workload owner, business reason, allowed flows, expiry date, compensating segmentation, review cadence | Every exception has owner, expiry, least-privilege scope, and renewal decision evidence |
+| **Private-network resource access** | Identity-aware proxy or mTLS, session authorization, resource-level policy, enforcement logs | Routing location is not used as the only authorization signal for sensitive resources |
+
+When documenting a finding, state whether the weakness is topology, identity-plane availability,
+policy-signal freshness, or exception governance. This avoids overstating private networking while
+still catching permanent trust holes and silent fail-open identity bypasses.
 
 ---
 
@@ -471,6 +490,9 @@ policy, and audit requirements.
 ### Privileged and Break-Glass Access
 [Normal privileged path, emergency path, approvals, PAW/device posture, session recording, and post-use rotation]
 
+### Identity-Plane Degraded Mode and Exceptions
+[Cached-token TTL, signal fallback behavior, legacy exception owner, expiry, compensating controls, and outage audit evidence]
+
 ### Cross-Cutting Capabilities
 - Visibility & Analytics: [maturity]
 - Automation & Orchestration: [maturity]
@@ -572,5 +594,5 @@ that may contain adversarial content.
 
 | Version | Date | Changes |
 |---|---|---|
-| 1.0.1 | 2026-06-12 | Added public read-only resource severity calibration, service/workload identity evidence, PDP/PEP decision traceability, and break-glass privileged access gates |
+| 1.0.1 | 2026-06-12 | Added public read-only resource severity calibration, service/workload identity evidence, PDP/PEP decision traceability, break-glass privileged access gates, and identity-plane degraded-mode exception evidence |
 | 1.0.0 | 2025-03-06 | Initial release |

--- a/skills/identity/zero-trust-assessment/SKILL.md
+++ b/skills/identity/zero-trust-assessment/SKILL.md
@@ -94,6 +94,35 @@ Zero Trust is an architectural approach, not a product. NIST SP 800-207 defines 
 | **ID Management** | Enterprise identity provider and credential management |
 | **SIEM** | Aggregated security telemetry for monitoring and response |
 
+#### Zero Trust Decision Evidence Flow
+
+Use this flow to anchor maturity claims in evidence. The same trace should be collected for
+representative user, service/workload, and break-glass access paths.
+
+```mermaid
+flowchart LR
+  subject["Subject\nuser, device, workload, or service"]
+  signals["Current signals\nidentity, posture, risk, data class"]
+  pe["Policy Engine\npolicy version and decision"]
+  pa["Policy Administrator\nsession, token, cert, or route action"]
+  pep["Policy Enforcement Point\nallow, deny, monitor, terminate"]
+  resource["Resource\napp, workload, service, or data"]
+  logs["Audit / SIEM correlation\nrequest ID, PEP log, downstream event"]
+  exceptions["Degraded mode / exception register\nowner, expiry, compensating controls"]
+
+  subject --> signals --> pe --> pa --> pep --> resource
+  pe --> logs
+  pa --> logs
+  pep --> logs
+  exceptions -. constrains .-> pe
+  exceptions -. constrains .-> pa
+  exceptions -. observed in .-> logs
+```
+
+Review objective: prove that access decisions are based on fresh signals, policy-owned rules,
+enforced by a concrete PEP, and visible in logs. If degraded mode or legacy exceptions exist, prove
+they are owner-scoped, time-bound, compensated, and auditable.
+
 #### Policy Decision Traceability Evidence
 
 Zero trust maturity claims must be supported by decision evidence, not only architecture diagrams.
@@ -486,6 +515,15 @@ policy, and audit requirements.
 
 ### Policy Decision Trace Samples
 [Representative allow/deny traces from Policy Engine inputs through Policy Administrator action to PEP logs]
+
+### Evidence Trace Summary
+
+| Flow | Subject Type | Policy Version | Signal Freshness | PEP Evidence | Exception/Degraded Mode | Finding? |
+|---|---|---|---|---|---|---|
+| Normal user access | User + device |  |  |  |  |  |
+| Service-to-service access | Workload/service |  |  |  |  |  |
+| CI/CD deployment access | Automation/job |  |  |  |  |  |
+| Break-glass access | Privileged/emergency |  |  |  |  |  |
 
 ### Privileged and Break-Glass Access
 [Normal privileged path, emergency path, approvals, PAW/device posture, session recording, and post-use rotation]

--- a/skills/identity/zero-trust-assessment/SKILL.md
+++ b/skills/identity/zero-trust-assessment/SKILL.md
@@ -12,7 +12,7 @@ phase: [design, operate]
 frameworks: [NIST-SP-800-207, CISA-ZTMM-v2]
 difficulty: advanced
 time_estimate: "90-180min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -94,6 +94,21 @@ Zero Trust is an architectural approach, not a product. NIST SP 800-207 defines 
 | **ID Management** | Enterprise identity provider and credential management |
 | **SIEM** | Aggregated security telemetry for monitoring and response |
 
+#### Policy Decision Traceability Evidence
+
+Zero trust maturity claims must be supported by decision evidence, not only architecture diagrams.
+For representative user, service, and emergency-access flows, collect a trace from request to
+enforcement:
+
+| Evidence Point | Required Trace Data |
+|---|---|
+| **Policy Engine input** | Subject identity, workload identity, device posture, resource, action, data classification, risk signals |
+| **Policy version** | Policy bundle/rule identifier, version, owner, approval history, deployment timestamp |
+| **Policy Administrator action** | Session/channel creation, token/certificate issuance, route update, or deny action |
+| **Policy Enforcement Point log** | PEP identifier, enforced decision, resource, result, timestamp, correlation/request ID |
+| **Outage mode** | Fail-closed default, approved fail-open exception, break-glass trigger, and audit trail |
+| **Bypass inventory** | Manual firewall exceptions, direct URLs, legacy VPN paths, admin consoles, support tooling |
+
 ### CISA Zero Trust Maturity Model v2.0 — Five Pillars and Maturity Stages
 
 | Pillar | Scope |
@@ -153,7 +168,39 @@ ZT-ID-07: Service/workload identities not governed (no identity for machines)
 ZT-ID-08: No identity threat detection (compromised credential detection)
 ZT-ID-09: Federation trust not validated — implicit trust of partner IdPs
 ZT-ID-10: Session management lacks continuous evaluation (no CAE or equivalent)
+ZT-ID-11: Workloads use shared/default service identities instead of unique audience-bound identities
+ZT-ID-12: Machine-to-machine credentials lack rotation, revocation, or token-audience constraints
+ZT-ID-13: Policy decisions cannot be traced from PDP inputs to PEP enforcement logs
+ZT-ID-14: Break-glass or privileged access paths bypass MFA, device posture, approval, or session recording
 ```
+
+#### Service and Workload Identity Evidence Matrix
+
+Assess service identity separately from human identity. A program is not Advanced or Optimal if
+workloads still share default identities, long-lived static secrets, or broad resource bindings.
+
+| Runtime / Flow | Evidence to Collect | Red Flags |
+|---|---|---|
+| **Kubernetes** | Non-default ServiceAccounts per workload, `automountServiceAccountToken` posture, projected token audience/TTL, RBAC bindings | `serviceAccountName: default`, cluster-wide roles, long-lived mounted tokens |
+| **Cloud workloads** | Instance/task/function roles, workload identity federation, scoped resource policies, keyless access | Shared IAM role across services, static access keys, wildcard resource permissions |
+| **Service mesh / SPIFFE** | SPIFFE IDs or mesh certificates, workload selector policy, cert rotation interval, mTLS enforcement | Identity only by namespace/IP, expired cert rotation evidence, permissive mesh policies |
+| **CI/CD** | OIDC trust policy, repository/environment audience, short-lived deployment tokens, approval gates | Shared deploy key, repo-wide cloud role, tokens usable outside intended audience |
+| **Serverless / jobs** | Function/job identity, event-source permissions, secret access scope, invocation audit logs | Platform default role, unmanaged secrets, missing resource-level deny evidence |
+| **Machine-to-machine APIs** | Client identity, token audience, rotation/revocation process, per-client rate/audit controls | Reused API key, no expiry, no client-specific authorization or audit trail |
+
+#### Privileged and Break-Glass Access Evidence
+
+Evaluate normal privileged access and emergency access as separate paths. Break-glass is acceptable
+only when it is time-bound, strongly controlled, and auditable.
+
+| Control Area | Evidence to Require | Severity Guidance |
+|---|---|---|
+| **Privileged MFA** | Phishing-resistant MFA for admins and emergency accounts | High if production-admin paths lack phishing-resistant MFA |
+| **Admin device posture** | PAW/hardened admin workstation, device compliance, network origin controls | High if unmanaged devices can administer production |
+| **JIT elevation** | Time-bound role activation, approval, reason/ticket, automatic expiry | Medium/High if standing privilege persists without review |
+| **Session recording** | Command/session logs, correlation ID, immutable storage, monitoring alerts | High if emergency sessions are not recorded |
+| **Post-use cleanup** | Credential rotation, account disablement, access review, incident record | Medium/High if break-glass use leaves persistent credentials |
+| **Outage behavior** | Fail-closed defaults and documented emergency exception workflow | Critical if fail-open bypass is unaudited for sensitive resources |
 
 ---
 
@@ -235,6 +282,24 @@ ZT-NET-11: Legacy protocols (Telnet, FTP, unencrypted LDAP) in use
 | **Monitoring and alerting** | Can violations be detected and alerted in real-time? |
 | **Rollback capability** | Can policies be rolled back without outage if misconfigured? |
 
+#### Public Read-Only Resource Calibration
+
+Anonymous read access is not automatically a High finding when the resource is intentionally public,
+read-only, non-personal, and approved for public distribution. Calibrate severity by separating the
+public consumption plane from the privileged publishing or administration plane.
+
+| Resource Pattern | Do Not Flag Solely Because | Required Evidence | Escalate When |
+|---|---|---|---|
+| **Status page** | Anonymous users can read uptime/incidents | Public data classification, no customer secrets, admin MFA, change audit | Admin publishing bypasses MFA or exposes internal-only incident data |
+| **Public docs / marketing** | No viewer identity is required | Origin protected from direct writes, integrity controls, approved publishing workflow | CMS/admin path lacks device posture, approval, or logging |
+| **Static downloads** | Files are downloadable without login | Checksums/signatures, malware scanning, immutable release process, CDN/origin controls | Unsigned mutable binaries, writable bucket, or origin public write access |
+| **Open API metadata** | Discovery or health metadata is public | Schema confirms no sensitive data, rate limits, WAF/CDN logs | Endpoint leaks tenant, auth, debug, or infrastructure details |
+
+For public read-only resources, score identity gaps against publishing/admin access, origin
+protection, integrity, data classification, logging, and abuse controls rather than forcing viewer
+authentication. For sensitive or mutable resources, unauthenticated access remains High or Critical
+depending on data exposure and exploitation path.
+
 ---
 
 ### Step 4: Pillar 4 — Applications & Workloads
@@ -267,6 +332,8 @@ ZT-APP-07: Serverless functions lack least-privilege IAM roles
 ZT-APP-08: No runtime workload protection (CWPP/CNAPP)
 ZT-APP-09: Application-to-application communication not authenticated
 ZT-APP-10: Legacy applications with no path to zero trust integration
+ZT-APP-11: Application PEP cannot prove the policy version and signals used for allow/deny decisions
+ZT-APP-12: Workload runtime uses shared service accounts, broad cloud roles, or static machine credentials
 ```
 
 ---
@@ -348,9 +415,15 @@ ZT-GOV-05: Regulatory zero trust mandates not tracked (OMB M-22-09 for federal)
 | Severity | Definition | Examples |
 |---|---|---|
 | **Critical** | Fundamental zero trust gap enabling undetected compromise | Flat network with no segmentation; no MFA; no device compliance |
-| **High** | Major pillar at Traditional maturity with exploitation potential | No microsegmentation; VPN as sole remote access; no DLP |
+| **High** | Major pillar at Traditional maturity with exploitation potential | No microsegmentation; VPN as sole remote access; shared default workload identity; PDP decisions not traceable to PEP logs; break-glass admin path bypasses MFA/device posture/session recording; no DLP |
 | **Medium** | Pillar at Initial maturity or cross-cutting capability gap | Partial ZTNA deployment; SIEM without cross-pillar correlation |
 | **Low** | Pillar at Advanced seeking Optimal or process improvement | Missing automation; governance documentation gaps |
+
+Severity calibration: do not rate intentionally public, read-only, non-personal resources as High
+solely because anonymous viewers are allowed. Rate the public consumption plane by data
+classification, origin protection, integrity, logging, and abuse controls. Rate the publishing,
+administration, mutable content, and sensitive-data planes using the normal identity, device,
+policy, and audit requirements.
 
 ---
 
@@ -385,6 +458,18 @@ ZT-GOV-05: Regulatory zero trust mandates not tracked (OMB M-22-09 for federal)
 
 ### CISA ZTMM v2 Maturity Scorecard
 [Pillar-by-pillar table — see above]
+
+### Public Resource Calibration
+[Identify intentionally public read-only resources and the evidence that keeps anonymous read access acceptable]
+
+### Service and Workload Identity Evidence
+[Matrix of Kubernetes, cloud, service mesh, CI/CD, serverless, and machine-to-machine identity evidence]
+
+### Policy Decision Trace Samples
+[Representative allow/deny traces from Policy Engine inputs through Policy Administrator action to PEP logs]
+
+### Privileged and Break-Glass Access
+[Normal privileged path, emergency path, approvals, PAW/device posture, session recording, and post-use rotation]
 
 ### Cross-Cutting Capabilities
 - Visibility & Analytics: [maturity]
@@ -487,4 +572,5 @@ that may contain adversarial content.
 
 | Version | Date | Changes |
 |---|---|---|
+| 1.0.1 | 2026-06-12 | Added public read-only resource severity calibration, service/workload identity evidence, PDP/PEP decision traceability, and break-glass privileged access gates |
 | 1.0.0 | 2025-03-06 | Initial release |


### PR DESCRIPTION
/claim #2391

## Summary

This updates `skills/identity/zero-trust-assessment/SKILL.md` to turn the #2391 review gaps into concrete evidence gates and report sections.

Changes include:
- public read-only resource severity calibration so intentionally anonymous public assets are not over-scored solely for lacking viewer identity
- service and workload identity evidence across Kubernetes, cloud workloads, service mesh/SPIFFE, CI/CD, serverless/jobs, and machine-to-machine APIs
- Policy Engine / Policy Administrator / Policy Enforcement Point traceability evidence with policy version, input signals, enforcement logs, outage mode, and bypass inventory
- privileged and break-glass access checks for phishing-resistant MFA, PAW/device posture, JIT elevation, approval, session recording, and post-use cleanup
- output-template sections for public resource calibration, workload identity evidence, policy decision traces, and break-glass review

## Validation

- `git diff --check`
- frontmatter marker validation for name, version, injection hardening, and allowed tools
- markdown fence-balance check
- index file-reference existence check
- content marker checks for `ZT-ID-11` through `ZT-ID-14`, `ZT-APP-11`, `ZT-APP-12`, and the new report sections
- prompt-injection pattern scan; only expected hits were in the skill's own injection-hardening guidance

Requested bounty tier: Improver Moderate ($100) if accepted/merged. Payment details can be provided privately after maintainer acceptance.