### PR TITLE
Add SOC 2 deficiency closure evidence gates

### DIFF
--- a/skills/compliance/soc2-gap/SKILL.md
+++ b/skills/compliance/soc2-gap/SKILL.md
@@ -12,7 +12,7 @@ phase: [assess, operate]
 frameworks: [AICPA-TSC, NIST-CSF-2.0]
 difficulty: intermediate
 time_estimate: "60-120min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -99,10 +99,10 @@ Record the final scope determination:
 ```
 SOC 2 Scope:
 - Security (Common Criteria): IN SCOPE [mandatory]
-- Availability:               [IN SCOPE / OUT OF SCOPE] — Justification: ___
-- Confidentiality:             [IN SCOPE / OUT OF SCOPE] — Justification: ___
-- Processing Integrity:        [IN SCOPE / OUT OF SCOPE] — Justification: ___
-- Privacy:                     [IN SCOPE / OUT OF SCOPE] — Justification: ___
+- Availability:               [IN SCOPE / OUT OF SCOPE] â€” Justification: ___
+- Confidentiality:             [IN SCOPE / OUT OF SCOPE] â€” Justification: ___
+- Processing Integrity:        [IN SCOPE / OUT OF SCOPE] â€” Justification: ___
+- Privacy:                     [IN SCOPE / OUT OF SCOPE] â€” Justification: ___
 
 System Description Boundary:
 - Infrastructure: ___
@@ -122,7 +122,7 @@ Walk through each Common Criteria category. For every criterion, assess: (a) whe
 
 The control environment sets the tone for the organization's commitment to integrity, ethical values, and security.
 
-**CC1.1 — COSO Principle 1: The entity demonstrates a commitment to integrity and ethical values.**
+**CC1.1 â€” COSO Principle 1: The entity demonstrates a commitment to integrity and ethical values.**
 - Questions to ask:
   - Is there a Code of Conduct or Ethics policy?
   - Do employees acknowledge the Code of Conduct upon hire and annually?
@@ -136,7 +136,7 @@ The control environment sets the tone for the organization's commitment to integ
   - No anonymous reporting mechanism
   - Policy has not been updated in more than two years
 
-**CC1.2 — COSO Principle 2: The board of directors demonstrates independence from management and exercises oversight.**
+**CC1.2 â€” COSO Principle 2: The board of directors demonstrates independence from management and exercises oversight.**
 - Questions to ask:
   - Is there a board or governance body with oversight of security?
   - Does the board receive regular security briefings?
@@ -150,7 +150,7 @@ The control environment sets the tone for the organization's commitment to integ
   - Security reporting is ad-hoc rather than scheduled
   - No documented governance structure
 
-**CC1.3 — COSO Principle 3: Management establishes structures, reporting lines, and authorities.**
+**CC1.3 â€” COSO Principle 3: Management establishes structures, reporting lines, and authorities.**
 - Questions to ask:
   - Is there an organizational chart showing security responsibilities?
   - Is there a designated security leader (CISO, VP Security, or equivalent)?
@@ -163,7 +163,7 @@ The control environment sets the tone for the organization's commitment to integ
   - Security responsibilities are informal and undocumented
   - No dedicated security role (security is "everyone's job" with no owner)
 
-**CC1.4 — COSO Principle 4: The entity demonstrates a commitment to attract, develop, and retain competent individuals.**
+**CC1.4 â€” COSO Principle 4: The entity demonstrates a commitment to attract, develop, and retain competent individuals.**
 - Questions to ask:
   - Are background checks performed for employees with access to sensitive systems?
   - Is there a security awareness training program?
@@ -177,7 +177,7 @@ The control environment sets the tone for the organization's commitment to integ
   - Security training is one-time at onboarding with no annual refresh
   - No tracking of training completion rates
 
-**CC1.5 — COSO Principle 5: The entity holds individuals accountable for their internal control responsibilities.**
+**CC1.5 â€” COSO Principle 5: The entity holds individuals accountable for their internal control responsibilities.**
 - Questions to ask:
   - Are security responsibilities included in performance evaluations?
   - Is there a disciplinary process for security policy violations?
@@ -194,7 +194,7 @@ The control environment sets the tone for the organization's commitment to integ
 
 #### CC2: Communication and Information
 
-**CC2.1 — COSO Principle 13: The entity obtains or generates and uses relevant, quality information to support internal control.**
+**CC2.1 â€” COSO Principle 13: The entity obtains or generates and uses relevant, quality information to support internal control.**
 - Questions to ask:
   - Are information assets inventoried and classified?
   - Is there a data classification policy?
@@ -208,7 +208,7 @@ The control environment sets the tone for the organization's commitment to integ
   - Data classification policy exists but is not enforced technically
   - Architecture diagrams do not reflect current state
 
-**CC2.2 — COSO Principle 14: The entity internally communicates information necessary to support internal control.**
+**CC2.2 â€” COSO Principle 14: The entity internally communicates information necessary to support internal control.**
 - Questions to ask:
   - Are security policies accessible to all employees?
   - Is there a process for communicating policy changes?
@@ -221,7 +221,7 @@ The control environment sets the tone for the organization's commitment to integ
   - Policies exist but are buried in inaccessible locations
   - No formal change notification process for policy updates
 
-**CC2.3 — COSO Principle 15: The entity communicates with external parties regarding matters affecting internal control.**
+**CC2.3 â€” COSO Principle 15: The entity communicates with external parties regarding matters affecting internal control.**
 - Questions to ask:
   - Is there an external-facing security page or trust center?
   - Are customers notified of security incidents per contractual obligations?
@@ -239,7 +239,7 @@ The control environment sets the tone for the organization's commitment to integ
 
 #### CC3: Risk Assessment
 
-**CC3.1 — COSO Principle 6: The entity specifies objectives with sufficient clarity to enable identification of risks.**
+**CC3.1 â€” COSO Principle 6: The entity specifies objectives with sufficient clarity to enable identification of risks.**
 - Questions to ask:
   - Are security objectives documented and aligned with business objectives?
   - Are security objectives measurable?
@@ -250,7 +250,7 @@ The control environment sets the tone for the organization's commitment to integ
   - Security objectives are implicit rather than documented
   - No alignment between security and business objectives
 
-**CC3.2 — COSO Principle 7: The entity identifies risks to the achievement of its objectives and analyzes risks as a basis for determining how to manage them.**
+**CC3.2 â€” COSO Principle 7: The entity identifies risks to the achievement of its objectives and analyzes risks as a basis for determining how to manage them.**
 - Questions to ask:
   - Is there a formal risk assessment process?
   - How frequently are risk assessments performed?
@@ -264,7 +264,7 @@ The control environment sets the tone for the organization's commitment to integ
   - Risk register exists but is not reviewed or updated regularly
   - Risk assessments do not cover all in-scope systems
 
-**CC3.3 — COSO Principle 8: The entity considers the potential for fraud in assessing risks.**
+**CC3.3 â€” COSO Principle 8: The entity considers the potential for fraud in assessing risks.**
 - Questions to ask:
   - Does the risk assessment process include fraud risk factors?
   - Are insider threat scenarios considered?
@@ -278,7 +278,7 @@ The control environment sets the tone for the organization's commitment to integ
   - No insider threat program or assessment
   - Segregation of duties is not formally evaluated
 
-**CC3.4 — COSO Principle 9: The entity identifies and assesses changes that could significantly impact the system of internal controls.**
+**CC3.4 â€” COSO Principle 9: The entity identifies and assesses changes that could significantly impact the system of internal controls.**
 - Questions to ask:
   - Is there a process for assessing risks associated with significant changes?
   - Are new vendors, technologies, or business processes evaluated for risk before adoption?
@@ -305,13 +305,41 @@ Prioritize remediation by audit readiness impact. Items that would result in exa
 
 | Priority | Criteria | Timeline | Description |
 |----------|----------|----------|-------------|
-| **P0 — Critical** | Score 0-1 on CC6.x, CC7.x, CC8.1 | Days 1-30 | Access controls, monitoring, and change management are the most frequently tested areas. Gaps here almost certainly result in exceptions. |
-| **P1 — High** | Score 0-1 on CC3.x, CC5.x, CC9.2 | Days 1-30 | Risk assessment, control activities, and vendor management are foundational. Auditors expect these to be established. |
-| **P2 — Medium** | Score 0-2 on CC1.x, CC2.x, CC4.x | Days 31-60 | Control environment, communication, and monitoring support the overall program. Gaps here indicate program immaturity. |
-| **P3 — Standard** | Score 0-2 on CC9.1, additional criteria | Days 31-60 | Risk mitigation and optional category criteria. Important for completeness. |
-| **P4 — Enhancement** | Score 3 on any criteria (improving to 4) | Days 61-90 | Polishing controls that are defined but need evidence of sustained operating effectiveness. |
+| **P0 â€” Critical** | Score 0-1 on CC6.x, CC7.x, CC8.1 | Days 1-30 | Access controls, monitoring, and change management are the most frequently tested areas. Gaps here almost certainly result in exceptions. |
+| **P1 â€” High** | Score 0-1 on CC3.x, CC5.x, CC9.2 | Days 1-30 | Risk assessment, control activities, and vendor management are foundational. Auditors expect these to be established. |
+| **P2 â€” Medium** | Score 0-2 on CC1.x, CC2.x, CC4.x | Days 31-60 | Control environment, communication, and monitoring support the overall program. Gaps here indicate program immaturity. |
+| **P3 â€” Standard** | Score 0-2 on CC9.1, additional criteria | Days 31-60 | Risk mitigation and optional category criteria. Important for completeness. |
+| **P4 â€” Enhancement** | Score 3 on any criteria (improving to 4) | Days 61-90 | Polishing controls that are defined but need evidence of sustained operating effectiveness. |
 
-#### 6.2 90-Day Action Plan Template
+#### 6.2 Control Deficiency Closure Gate
+
+Do not score a criterion as audit-ready when known control deficiencies are only tracked as roadmap items. For each open, remediated, or risk-accepted deficiency tied to an in-scope criterion, require a closure record with the following fields:
+
+| Field | Required Evidence |
+|-------|-------------------|
+| Deficiency ID and criterion | Unique ID mapped to the affected TSC criterion, control owner, and source finding. |
+| Severity and impact | Rated impact on design effectiveness, operating effectiveness, or evidence completeness. |
+| Management response | Documented response explaining remediation, risk acceptance, or compensating control strategy. |
+| Owner and due date | Named accountable owner, target date, and overdue status. |
+| Remediation evidence | Policy, configuration, workflow, ticket, training, or control artifact showing the fix was implemented. |
+| Retest evidence | Independent retest result, sampling record, monitoring output, or auditor/readiness reviewer validation. |
+| Closure approval | Closure date, approver, residual risk decision, and link to supporting evidence. |
+
+Apply these score caps before finalizing the gap assessment:
+
+- Open, overdue, or unowned deficiencies cap the affected criterion at **2 - Developing**.
+- Deficiencies marked closed without remediation evidence and retest evidence cap the affected criterion at **2 - Developing**.
+- Risk-accepted deficiencies cannot score above **2 - Developing** unless the acceptance has an authorized approver, compensating controls, expiration or review date, and auditor-facing rationale.
+- Multiple medium or low deficiencies in one category may lower the category readiness narrative even when individual criteria appear documented.
+
+Include a deficiency closure register in the final output:
+
+```
+| Deficiency ID | Criterion | Severity | Owner | Due Date | Status | Remediation Evidence | Retest Evidence | Closure Approval | Score Impact |
+|---------------|-----------|----------|-------|----------|--------|----------------------|-----------------|------------------|--------------|
+```
+
+#### 6.3 90-Day Action Plan Template
 
 **Days 1-30: Foundation and Critical Gaps**
 - [ ] Establish or update access control policy and enforce MFA universally (CC6.1)
@@ -329,7 +357,7 @@ Prioritize remediation by audit readiness impact. Items that would result in exa
 - [ ] Establish risk register and risk treatment plans (CC3.2, CC9.1)
 - [ ] Configure vulnerability scanning on a regular schedule (CC7.1, CC6.8)
 - [ ] Document system description and data flow diagrams (CC2.1)
-- [ ] Establish control monitoring and deficiency tracking (CC4.1, CC4.2)
+- [ ] Establish control monitoring and deficiency tracking with owner, due date, remediation evidence, retest evidence, and closure approval fields (CC4.1, CC4.2)
 - [ ] Implement backup monitoring and conduct restoration test (A1.2, A1.3)
 - [ ] Complete vendor risk assessments for critical vendors (CC9.2)
 
@@ -343,7 +371,7 @@ Prioritize remediation by audit readiness impact. Items that would result in exa
 - [ ] Perform self-assessment using the scoring matrix from Step 4
 - [ ] Engage SOC 2 auditor for readiness assessment (if score >= 3.0)
 
-#### 6.3 Ongoing Activities (Post-90 Days)
+#### 6.4 Ongoing Activities (Post-90 Days)
 
 - Maintain evidence collection continuously throughout the observation period
 - Perform quarterly access reviews and document results
@@ -366,8 +394,9 @@ When performing a SOC 2 gap analysis, produce the following deliverables:
 3. **Category Summary**: Average maturity score per category with narrative assessment.
 4. **Critical Findings**: List of all criteria scored 0 or 1, with specific gap descriptions and remediation recommendations.
 5. **Evidence Checklist**: Customized evidence requirements based on in-scope criteria, marking items as Exists / Partial / Missing.
-6. **90-Day Remediation Roadmap**: Prioritized action items with owners, deadlines, and dependencies.
-7. **Overall Readiness Assessment**: Go/no-go recommendation for engaging a SOC 2 auditor.
+6. **Deficiency Closure Register**: Table of open, remediated, closed, and risk-accepted deficiencies with owners, due dates, management response, remediation evidence, retest evidence, closure approval, residual risk, and score impact.
+7. **90-Day Remediation Roadmap**: Prioritized action items with owners, deadlines, and dependencies.
+8. **Overall Readiness Assessment**: Go/no-go recommendation for engaging a SOC 2 auditor.
 
 ## Prompt Injection Safety Notice
 
@@ -386,6 +415,11 @@ This skill processes user-supplied content including compliance documentation, p
 - **NIST CSF 2.0 Mapping**: CC1-CC2 maps to Govern (GV), CC3 to Identify (ID), CC5-CC6 to Protect (PR), CC7 to Detect (DE) and Respond (RS), CC7.5 to Recover (RC).
 - **ISO 27001:2022**: CC6 maps to Annex A.8 (Technology Controls), CC8 maps to Annex A.8.32 (Change Management), CC9.2 maps to Annex A.5.19-5.22 (Supplier Relationships).
 - **CIS Controls v8**: CC6.1 maps to CIS Control 6 (Access Control Management), CC6.8 maps to CIS Control 10 (Malware Defenses), CC7.1 maps to CIS Control 7 (Continuous Vulnerability Management).
+
+## Version History
+
+- **1.0.1**: Added control deficiency closure and retest evidence gates, score caps for unresolved or unsupported deficiencies, and a deficiency closure register output.
+- **1.0.0**: Initial SOC 2 readiness gap analysis workflow.
 
 ## Limitations
 

--- a/skills/compliance/soc2-gap/tsc-criteria.md
+++ b/skills/compliance/soc2-gap/tsc-criteria.md
@@ -446,6 +446,20 @@ Score each criterion using the following maturity scale:
 | 3 | **Defined** | Controls are implemented and documented. Procedures are standardized. Evidence exists but may not cover the full audit period. |
 | 4 | **Managed** | Controls are fully implemented, documented, monitored, and operating effectively. Evidence covers the full audit period. Ready for SOC 2 Type II examination. |
 
+### Deficiency Closure Score Caps
+
+Before assigning a final score, check whether the criterion has known deficiencies in audit findings, readiness notes, risk registers, exceptions, vulnerability tickets, or control monitoring records. Apply the following caps when deficiency closure evidence is incomplete:
+
+| Deficiency Condition | Score Cap | Evidence Required to Remove Cap |
+|----------------------|-----------|---------------------------------|
+| Open, overdue, or unowned deficiency affects the criterion | 2 - Developing | Named owner, due date, current status, and approved remediation plan. |
+| Deficiency is marked closed without implementation evidence | 2 - Developing | Remediation artifact such as policy update, configuration change, workflow evidence, ticket, or training record. |
+| Deficiency is marked closed without retest evidence | 2 - Developing | Independent retest result, sample validation, monitoring output, or readiness reviewer sign-off. |
+| Deficiency is risk accepted without governance evidence | 2 - Developing | Authorized approver, residual risk rationale, compensating controls, expiration or review date, and auditor-facing explanation. |
+| Repeated medium or low deficiencies exist in one category | Category narrative downgrade | Category-level analysis explaining concentration risk and remediation sequencing. |
+
+Track closure status in a deficiency closure register with deficiency ID, criterion, severity, owner, due date, status, remediation evidence, retest evidence, closure approval, residual risk, and score impact.
+
 ### Scoring Template
 
 Complete the following matrix for all in-scope criteria:


### PR DESCRIPTION
## Summary
- Adds SOC 2 control deficiency closure and retest evidence gates.
- Caps affected criterion scores when deficiencies are open, unowned, overdue, closed without remediation/retest evidence, or risk-accepted without approval/compensating controls.
- Adds a deficiency closure register to output requirements and scoring guidance.

## Validation
- Local marker checks passed for version 1.0.1, closure gate, deficiency closure register, score caps, retest evidence, and version history.
- Markdown fenced code block count remains even.

Closes #2448

Bounty consideration requested if accepted.