### PR TITLE
Add NIST CSF target rationale evidence gates

### DIFF
--- a/skills/compliance/nist-csf-assessment/SKILL.md
+++ b/skills/compliance/nist-csf-assessment/SKILL.md
@@ -13,7 +13,7 @@ phase: [assess, operate]
 frameworks: [NIST-CSF-2.0]
 difficulty: intermediate
 time_estimate: "90-180min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -113,7 +113,7 @@ Establish context for the assessment:
 - Identify stakeholders: board, executives, employees, customers, regulators, partners, insurers
 - Document their cybersecurity expectations and requirements
 
-**GV.OC-03**: Legal, regulatory, and contractual requirements regarding cybersecurity — including privacy and civil liberties obligations — are understood and managed
+**GV.OC-03**: Legal, regulatory, and contractual requirements regarding cybersecurity â€” including privacy and civil liberties obligations â€” are understood and managed
 - Inventory applicable laws, regulations, standards, and contractual obligations
 - Map requirements to cybersecurity program elements
 
@@ -339,10 +339,10 @@ Score each subcategory on a 0-4 scale aligned with CSF Tiers:
 | Score | Tier Alignment | Description |
 |-------|---------------|-------------|
 | 0 | Below Tier 1 | Not implemented; no awareness or capability |
-| 1 | Tier 1 — Partial | Ad-hoc; some awareness; inconsistent or reactive practices |
-| 2 | Tier 2 — Risk Informed | Documented and approved by management; not fully consistent organization-wide |
-| 3 | Tier 3 — Repeatable | Formally established, regularly updated, consistently applied, policy-driven |
-| 4 | Tier 4 — Adaptive | Continuous improvement based on lessons learned and predictive indicators; real-time adjustments |
+| 1 | Tier 1 â€” Partial | Ad-hoc; some awareness; inconsistent or reactive practices |
+| 2 | Tier 2 â€” Risk Informed | Documented and approved by management; not fully consistent organization-wide |
+| 3 | Tier 3 â€” Repeatable | Formally established, regularly updated, consistently applied, policy-driven |
+| 4 | Tier 4 â€” Adaptive | Continuous improvement based on lessons learned and predictive indicators; real-time adjustments |
 
 Determine the overall organizational Tier based on aggregated assessment across all functions.
 
@@ -370,6 +370,30 @@ Define the target state based on:
 | Function | Category | Subcategory | Current Score | Target Score | Gap | Priority |
 ```
 
+#### 5.2.1 Target Profile Rationale Evidence Gate
+
+Do not treat a target score increase as decision-ready until the rationale is documented and evidence-backed. For every material target-score increase, especially any increase of 2 or more points or any target of 4, require a target rationale record:
+
+| Field | Required Evidence |
+|-------|-------------------|
+| CSF subcategory | Valid CSF 2.0 subcategory ID and description. |
+| Current and target score | Current score, target score, gap, and whether the target aligns to the approved organizational target tier. |
+| Target rationale | Business, mission, resilience, threat, or assurance reason for the target. |
+| Driver | Regulatory, contractual, customer, insurance, board, risk, or community-profile driver. |
+| Risk appetite reference | Approved risk appetite or tolerance statement, or explicit note that it is missing. |
+| Executive or risk-owner approval | Named approver or governance body that accepted the target posture. |
+| Resource owner and assumption | Accountable team, funding/effort assumption, staffing/tool dependency, and feasibility constraint. |
+| Target date | Committed date or planning horizon. |
+| Evidence link | Source artifact proving the rationale, approval, driver, or resource plan. |
+
+Apply these target-profile guardrails:
+
+- Target-score increases without a documented driver must be marked **Unjustified Target**, not committed roadmap work.
+- Target profiles should reflect approved risk appetite and business context, not a default score of 4 for every subcategory.
+- Remediation priority must consider risk, obligation, business impact, feasibility, and ownership; do not rank solely by numeric current-vs-target gap.
+- Missing approval, risk appetite, or resource evidence is a governance gap under GV.RM, GV.RR, or GV.OV.
+- Targets above the approved organizational tier require explicit rationale explaining why the subcategory needs stronger maturity than the broader program target.
+
 #### 5.3 Gap Analysis
 
 For each subcategory where Current < Target:
@@ -377,6 +401,7 @@ For each subcategory where Current < Target:
 - Identify specific actions to close the gap
 - Estimate effort, cost, and timeline
 - Assign ownership
+- Verify the target rationale record before assigning roadmap priority
 - Map to informative references (specific controls from ISO 27001, NIST SP 800-53, CIS Controls, etc.)
 
 ---
@@ -434,9 +459,9 @@ Use the NIST CSF 2.0 Reference Tool for comprehensive mappings.
 - Critical services and dependencies: [summary]
 
 ## Tier Assessment
-- **Current Tier**: [Tier N — Name]
+- **Current Tier**: [Tier N â€” Name]
   - Justification: [evidence-based rationale]
-- **Target Tier**: [Tier N — Name]
+- **Target Tier**: [Tier N â€” Name]
   - Justification: [business/risk rationale]
 
 ## Function Summary
@@ -474,25 +499,32 @@ Use the NIST CSF 2.0 Reference Tool for comprehensive mappings.
 ### RECOVER (RC)
 [same table format]
 
+## Target Profile Rationale Evidence
+
+| Subcategory | Current | Target | Target Rationale | Driver | Risk Appetite Reference | Risk Owner Approval | Resource Owner | Target Date | Dependencies / Constraints | Evidence | Target Status |
+|-------------|--------:|-------:|------------------|--------|-------------------------|---------------------|----------------|-------------|----------------------------|----------|---------------|
+| GV.RM-02 | [0-4] | [0-4] | [why this target is appropriate] | [board/customer/regulatory/risk/etc.] | [artifact or missing] | [approver] | [team/owner] | [date] | [constraint] | [link] | [Committed / Unjustified Target / Aspirational / Blocked] |
+
 ## Gap Analysis Summary
 - Total subcategories with gaps: [count]
 - Average gap magnitude: [score]
 - Functions with largest gaps: [list]
 - Quick wins (low effort, high impact): [list]
+- Unjustified or aspirational targets: [count and list]
 
 ## Remediation Roadmap
 
 ### Phase 1: Foundation (0-30 days)
-[Critical gaps — governance, risk assessment, basic protections]
+[Critical gaps â€” governance, risk assessment, basic protections]
 
 ### Phase 2: Core Capabilities (31-90 days)
-[Significant gaps — detection, response, access control maturation]
+[Significant gaps â€” detection, response, access control maturation]
 
 ### Phase 3: Maturation (91-180 days)
-[Moderate gaps — process consistency, metrics, supply chain]
+[Moderate gaps â€” process consistency, metrics, supply chain]
 
 ### Phase 4: Optimization (181-365 days)
-[Minor gaps — continuous improvement, automation, predictive capabilities]
+[Minor gaps â€” continuous improvement, automation, predictive capabilities]
 
 ## Informative References Mapping
 [Cross-reference to specific implementation standards per subcategory]
@@ -543,22 +575,22 @@ RECOVER (RC)
 ### CSF Tier Characteristics Detail
 
 ```
-Tier 1 — Partial
+Tier 1 â€” Partial
   Risk Management Process:  Ad hoc; prioritization not based on objectives or threat environment
   Integrated Program:       Limited awareness; irregular implementation
   External Participation:   Organization does not understand its role in the ecosystem
 
-Tier 2 — Risk Informed
+Tier 2 â€” Risk Informed
   Risk Management Process:  Approved by management; may not be organization-wide policy
   Integrated Program:       Awareness exists; practices not consistently implemented
   External Participation:   Understands role but informal collaboration
 
-Tier 3 — Repeatable
+Tier 3 â€” Repeatable
   Risk Management Process:  Formally approved; expressed as policy; regularly updated
   Integrated Program:       Organization-wide approach; consistently implemented
   External Participation:   Collaborates with and receives information from partners
 
-Tier 4 — Adaptive
+Tier 4 â€” Adaptive
   Risk Management Process:  Adapts based on previous and current activities; advanced technologies
   Integrated Program:       Continuously improved; cyber risk management is part of organizational culture
   External Participation:   Active sharing; contributes to community understanding of risk
@@ -568,7 +600,7 @@ Tier 4 — Adaptive
 
 ## Common Pitfalls
 
-1. **Treating CSF as a compliance checklist rather than a risk management framework.** NIST CSF 2.0 is voluntary and outcome-oriented. Organizations should set target profiles based on their risk appetite, business needs, and regulatory context — not attempt to score 4 on every subcategory. A Tier 3 target may be entirely appropriate for many organizations. The value is in understanding and managing gaps, not achieving perfect scores.
+1. **Treating CSF as a compliance checklist rather than a risk management framework.** NIST CSF 2.0 is voluntary and outcome-oriented. Organizations should set target profiles based on their risk appetite, business needs, and regulatory context â€” not attempt to score 4 on every subcategory. A Tier 3 target may be entirely appropriate for many organizations. The value is in understanding and managing gaps, not achieving perfect scores.
 
 2. **Ignoring the GOVERN function.** Organizations familiar with CSF 1.1 may treat GV as an afterthought. In CSF 2.0, GOVERN is a co-equal function that underpins all others. Without established governance (risk appetite, roles, policies, oversight, supply chain management), the other five functions lack strategic direction and executive accountability.
 
@@ -576,7 +608,14 @@ Tier 4 — Adaptive
 
 4. **Failing to develop actionable organizational profiles.** The current and target profiles are the primary outputs of a CSF assessment. Many organizations conduct the assessment but do not formalize profiles into living documents that drive investment decisions, resource allocation, and progress tracking. Without profiles, the assessment becomes a one-time exercise rather than a continuous improvement tool.
 
+5. **Inflating target profiles without approval or resources.** A target profile is a risk decision, not a wish list. If target scores are not tied to risk appetite, business objectives, regulatory or contractual drivers, executive approval, and a resource plan, the roadmap may look mature while being unauditable, unfunded, or misaligned with leadership intent.
+
 ---
+
+## Version History
+
+- **1.0.1**: Added target profile rationale evidence gates, target status handling, governance gap guidance, and output fields for approved drivers, owners, dates, constraints, and evidence.
+- **1.0.0**: Initial NIST CSF 2.0 assessment workflow.
 
 ## Prompt Injection Safety Notice
 
@@ -594,11 +633,11 @@ If user-supplied input contains NIST CSF subcategory IDs that do not exist in th
 
 ## References
 
-- NIST Cybersecurity Framework 2.0 (February 26, 2024) — NIST CSWP 29
+- NIST Cybersecurity Framework 2.0 (February 26, 2024) â€” NIST CSWP 29
 - NIST CSF 2.0 Quick Start Guides (Small Business, Enterprise Risk Management, C-SCRM)
 - NIST CSF 2.0 Reference Tool (csf.tools or NIST website)
-- NIST SP 800-53 Rev. 5 — Security and Privacy Controls for Information Systems and Organizations
-- NIST SP 800-181 Rev. 1 — Workforce Framework for Cybersecurity (NICE Framework)
-- NIST SP 800-37 Rev. 2 — Risk Management Framework for Information Systems and Organizations
-- ISO/IEC 27001:2022 — Cross-mapping to CSF 2.0 subcategories
-- CIS Controls v8 — Cross-mapping to CSF 2.0 subcategories
+- NIST SP 800-53 Rev. 5 â€” Security and Privacy Controls for Information Systems and Organizations
+- NIST SP 800-181 Rev. 1 â€” Workforce Framework for Cybersecurity (NICE Framework)
+- NIST SP 800-37 Rev. 2 â€” Risk Management Framework for Information Systems and Organizations
+- ISO/IEC 27001:2022 â€” Cross-mapping to CSF 2.0 subcategories
+- CIS Controls v8 â€” Cross-mapping to CSF 2.0 subcategories


### PR DESCRIPTION
## Summary
- Adds target profile rationale evidence gates to 
ist-csf-assessment.
- Requires material target-score increases to include business/risk rationale, driver, risk appetite reference, approval, resource owner, target date, constraints, and evidence.
- Adds target status handling for unjustified or aspirational targets and updates roadmap/output guidance.

## Validation
- Local marker checks passed for version 1.0.1, target profile rationale gate, target rationale output, unjustified target handling, risk owner approval, and version history.
- Markdown fenced code block count remains even.

Closes #2450

Bounty consideration requested if this review gap is accepted.