### PR TITLE
[IMPROVE] api-security GraphQL tenant cache isolation

### DIFF
--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -11,7 +11,7 @@ phase: [design, build, review]
 frameworks: [OWASP-API-Security-2023, OWASP-ASVS]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -184,6 +184,45 @@ Deeply nested or highly complex queries can exhaust server resources (API4:2023)
 ### Field-Level Authorization
 
 Unlike REST, where authorization can be enforced per endpoint, GraphQL requires authorization at the resolver level. Every resolver that returns sensitive data or performs a privileged mutation must independently verify permissions.
+
+### Tenant-Aware DataLoader and Cache Isolation
+
+GraphQL batching and caching layers can bypass otherwise correct resolver authorization if cached objects are reused across tenants, roles, or impersonation scopes. Review DataLoader, persisted query, subscription, CDN, and APQ caches as part of API1/API3 authorization analysis.
+
+Flag GraphQL cache designs when any of these conditions are present:
+
+- A DataLoader or equivalent batch cache is process-wide, singleton-scoped, or shared across requests for tenant-specific data.
+- Cache keys include only object identifiers, operation hashes, or field names without tenant, subject, role, authorization scope, and impersonation context.
+- Persisted query or APQ allowlists validate authorization only at registration time instead of re-checking viewer permissions at execution time.
+- Subscription resolvers authorize the initial connection but do not re-check tenant and resource access for each pushed event.
+- Field masking is applied in a parent resolver while child resolvers can return the same cached object without the same property-level checks.
+
+Treat per-request loaders with tenant-aware cache keys as benign when the loader lifecycle is tied to the request context and the key includes the relevant authorization boundary.
+
+```javascript
+// Benign: per-request loader, tenant-aware cache key, scoped data access
+function buildLoaders(ctx) {
+  return {
+    userById: new DataLoader(
+      ids => loadUsersForTenant(ctx.tenantId, ids),
+      { cacheKeyFn: id => `${ctx.tenantId}:${ctx.subjectId}:${id}` }
+    ),
+  };
+}
+```
+
+```javascript
+// Vulnerable: process-wide loader caches tenant-specific objects by user ID only
+const userById = new DataLoader(ids => loadUsers(ids));
+
+const resolvers = {
+  Query: {
+    user: (_, { id }, ctx) => userById.load(id),
+  },
+};
+```
+
+**Evidence to collect:** loader construction location, request context wiring, cache key function, tenant-aware query predicate, resolver authorization test, APQ/CDN cache key configuration, and subscription event authorization path.
 
 ### Alias-Based Attacks
 

--- a/skills/appsec/api-security/api-top10-checklist.md
+++ b/skills/appsec/api-security/api-top10-checklist.md
@@ -63,6 +63,20 @@ const resolvers = {
 };
 ```
 
+```javascript
+// VULNERABLE: Singleton loader caches tenant data by object ID only
+const userById = new DataLoader(ids => User.find({ id: { $in: ids } }));
+
+const resolvers = {
+  Query: {
+    user: async (_, { id }, context) => {
+      await requireTenantMember(context.user, context.tenantId);
+      return userById.load(id); // Cache can return another tenant's warmed object
+    },
+  },
+};
+```
+
 Remediation:
 
 ```javascript
@@ -78,6 +92,18 @@ const resolvers = {
     },
   },
 };
+```
+
+```javascript
+// SECURE: Loader is created per request and keys include the tenant boundary
+function createLoaders(context) {
+  return {
+    userById: new DataLoader(
+      ids => User.find({ tenantId: context.tenantId, id: { $in: ids } }),
+      { cacheKeyFn: id => `${context.tenantId}:${context.user.id}:${id}` }
+    ),
+  };
+}
 ```
 
 ### BOLA vs BFLA Distinction
@@ -101,6 +127,8 @@ Both can coexist in a single endpoint. An endpoint may lack both a role check (B
 - [ ] Batch/list endpoints filter results by the caller's permissions.
 - [ ] Resource identifiers are UUIDs or non-sequential values to resist enumeration.
 - [ ] GraphQL resolvers enforce authorization on every field that returns sensitive data.
+- [ ] GraphQL DataLoader or batch caches are request-scoped and keyed by tenant, subject, role, and resource scope for sensitive objects.
+- [ ] Persisted query, APQ, CDN, and subscription caches re-check authorization at execution or event delivery time, not only at registration or connection time.
 
 ---
 
@@ -224,6 +252,7 @@ const UserType = new GraphQLObjectType({
 - [ ] Sensitive fields (credentials, PII, internal metadata) are excluded from standard responses.
 - [ ] Update endpoints use an allowlist of modifiable fields; mass assignment is impossible.
 - [ ] GraphQL fields containing sensitive data have resolver-level authorization.
+- [ ] GraphQL child resolvers and DataLoader return paths apply the same field masking and tenant checks as parent resolvers.
 - [ ] API documentation (OpenAPI spec) accurately reflects the actual response schema.
 
 ---

--- a/skills/appsec/api-security/tests/benign/graphql-persisted-query-execution-auth.md
+++ b/skills/appsec/api-security/tests/benign/graphql-persisted-query-execution-auth.md
@@ -1,0 +1,23 @@
+# Benign: persisted query re-checks authorization at execution time
+
+This sample should not be reported for registration-only authorization. The persisted query registry is only an allowlist, while tenant and role checks still run for every execution.
+
+```javascript
+export async function executePersistedQuery(ctx, operationHash, variables) {
+  const operation = await persistedQueries.requireAllowed(operationHash);
+  await requireTenantMember(ctx.user, ctx.tenantId);
+  await requireOperationPermission(ctx.user, operation.requiredPermission);
+
+  return graphql({
+    schema,
+    source: operation.source,
+    variableValues: variables,
+    contextValue: ctx,
+  });
+}
+```
+
+Expected result:
+
+- No finding for APQ or persisted query cache authorization.
+- Reviewer should confirm downstream resolvers keep object and field-level checks.

--- a/skills/appsec/api-security/tests/benign/graphql-request-scoped-dataloader.md
+++ b/skills/appsec/api-security/tests/benign/graphql-request-scoped-dataloader.md
@@ -1,0 +1,26 @@
+# Benign: request-scoped DataLoader with tenant-aware cache key
+
+This sample should not be reported as cross-tenant cache leakage. The loader is constructed for each request, the database query includes `tenantId`, and the cache key includes tenant and subject context.
+
+```javascript
+export function buildContext(req) {
+  const ctx = {
+    tenantId: req.auth.tenantId,
+    subjectId: req.auth.sub,
+  };
+
+  ctx.loaders = {
+    userById: new DataLoader(
+      ids => User.find({ tenantId: ctx.tenantId, id: { $in: ids } }),
+      { cacheKeyFn: id => `${ctx.tenantId}:${ctx.subjectId}:${id}` }
+    ),
+  };
+
+  return ctx;
+}
+```
+
+Expected result:
+
+- No finding for DataLoader cache scope.
+- Reviewer may still inspect field-level authorization for sensitive properties returned by `User`.

--- a/skills/appsec/api-security/tests/vulnerable/graphql-dataloader-process-wide-cache.md
+++ b/skills/appsec/api-security/tests/vulnerable/graphql-dataloader-process-wide-cache.md
@@ -1,0 +1,26 @@
+# Vulnerable: process-wide GraphQL DataLoader cache
+
+This sample should be reported because the loader is module-scoped and caches tenant-specific user records by `id` only. A request from tenant A can warm the cache for `user-123`, and a later request from tenant B can receive the cached object if the same identifier is used or guessed.
+
+```javascript
+import DataLoader from "dataloader";
+
+const userById = new DataLoader(async ids => {
+  return User.find({ id: { $in: ids } });
+});
+
+export const resolvers = {
+  Query: {
+    user: async (_, { id }, ctx) => {
+      await requireTenantMember(ctx.user, ctx.tenantId);
+      return userById.load(id);
+    },
+  },
+};
+```
+
+Expected finding:
+
+- OWASP API Risk: API1:2023 BOLA and API3:2023 object property authorization.
+- Evidence: singleton loader lifecycle and cache key omits tenant, subject, role, and authorization scope.
+- Remediation: create loaders per request and query by tenant plus object ID.

--- a/skills/appsec/api-security/tests/vulnerable/graphql-subscription-event-cache.md
+++ b/skills/appsec/api-security/tests/vulnerable/graphql-subscription-event-cache.md
@@ -1,0 +1,23 @@
+# Vulnerable: subscription event delivery lacks per-event authorization
+
+This sample should be reported because tenant access is checked only when the subscription starts. Later events are delivered from a shared topic without checking whether the viewer still has access to the tenant or resource.
+
+```javascript
+export const resolvers = {
+  Subscription: {
+    ticketUpdated: {
+      subscribe: async (_, { tenantId }, ctx) => {
+        await requireTenantMember(ctx.user, tenantId);
+        return pubsub.asyncIterator(`ticket-updates`);
+      },
+      resolve: event => event.ticket,
+    },
+  },
+};
+```
+
+Expected finding:
+
+- OWASP API Risk: API1:2023 BOLA.
+- Evidence: shared topic and resolver output do not bind each pushed event to tenant and subject authorization.
+- Remediation: use tenant-scoped topics or filter each event with current tenant and resource permissions before returning it.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** api-security
**Skill path:** `skills/appsec/api-security/`

### What Was Wrong
The GraphQL guidance covered resolver authorization, depth, aliases, and field-level checks, but it did not explicitly cover tenant-sensitive batching and cache layers. A benign per-request DataLoader with tenant-aware cache keys can look suspicious, while a process-wide loader keyed only by object ID can leak warmed objects across tenants. Persisted queries, APQ/CDN caches, and subscriptions also need execution-time or event-time authorization checks.

Closes #2489

### What This PR Fixes
- Adds tenant-aware DataLoader and cache isolation guidance to the GraphQL section.
- Extends the API1/API3 checklist with request-scoped loader, cache-key, APQ/CDN, persisted query, subscription, and child-resolver field-masking checks.
- Adds vulnerable examples for process-wide DataLoader cache leakage and subscription event delivery without per-event authorization.
- Adds benign examples for request-scoped tenant-aware DataLoader usage and persisted query execution-time authorization.

### Evidence
Before: the skill could miss architecture-level GraphQL cache issues where resolver auth exists but cached objects are shared across tenants.

After: reviewers are directed to collect loader lifecycle, cache key, tenant query predicate, APQ/CDN keying, persisted-query execution auth, and subscription event authorization evidence.

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing validation still passes

### Local Validation
- `git diff --check` passed
- Frontmatter required fields check passed
- `index.yaml` path check: 50 indexed files are present
- Changed-file prompt-injection keyword scan passed

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** can provide privately if accepted
