### PR TITLE
[IMPROVE] siem-rules suppression expiry and fixtures

### DIFF
--- a/skills/secops/siem-rules/SKILL.md
+++ b/skills/secops/siem-rules/SKILL.md
@@ -12,7 +12,7 @@ phase: [operate]
 frameworks: [MITRE-ATT&CK-v16]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -432,7 +432,37 @@ index=wineventlog sourcetype="WinEventLog:Security" EventCode=4624 LogonType=3
 2. **Statistical analysis:** Calculate mean, median, and standard deviation of the daily/hourly result count.
 3. **Threshold selection:** Set the initial threshold at mean + 2 standard deviations to capture anomalous activity while filtering normal variance.
 4. **Iterative tuning:** After deployment, review alerts weekly for the first month. Adjust the threshold based on TP/FP ratio.
-5. **Exclusion management:** Add exclusions for confirmed legitimate activity. Document each exclusion with a ticket reference and review date.
+5. **Exclusion management:** Add exclusions for confirmed legitimate activity. Document each exclusion with a ticket reference, owner, exact scope, and expiry date.
+
+**Suppression lifecycle gates:**
+
+Treat narrow, temporary suppressions as acceptable tuning only when they have all of the following evidence:
+
+- **Owner and ticket:** named detection owner plus incident/change/tuning ticket.
+- **Exact scope:** bounded to the specific asset, account, process, command line, IP range, parser version, or maintenance window that created the false positive.
+- **Expiry:** explicit date or duration, with production monitoring for expired suppressions that remain active.
+- **Residual detection path:** explanation of what still alerts if the same account, host, or process is abused outside the approved scope.
+- **Regression fixture:** at least one should-alert event and one should-not-alert event proving the suppression does not hide the intended detection.
+
+Flag suppressions as detection blind spots when they are global, permanent, scoped only to a username/shared account, lack an expiry, omit a ticket/owner, or are not covered by regression fixtures.
+
+```kql
+// Benign: scoped to one expected process on one asset and expires automatically.
+DeviceProcessEvents
+| where Timestamp > ago(1h)
+| where FileName =~ "powershell.exe"
+| where not(
+    DeviceName == "build-01"
+    and InitiatingProcessFileName == "signed-builder.exe"
+    and Timestamp < datetime(2026-07-01)
+)
+```
+
+```spl
+`comment("Risky: permanent username-only suppression")`
+index=edr sourcetype=process process_name=powershell.exe
+| search user!="svc-build"
+```
 
 **Threshold tuning parameters:**
 
@@ -444,6 +474,8 @@ index=wineventlog sourcetype="WinEventLog:Security" EventCode=4624 LogonType=3
 | `lookback period` | Historical data to evaluate | `ago(1h)`, `ago(24h)` |
 | `frequency` | How often the rule runs | Every 5m, 15m, 1h |
 | `suppression window` | Cooldown after firing to prevent duplicate alerts | 1h, 4h, 24h |
+| `suppression expiry` | Date or duration when an exclusion must be reviewed or removed | `2026-07-01`, `14d` |
+| `fixture coverage` | Positive and benign events that prove tuning behavior | `should_alert`, `should_not_alert` |
 
 **KQL alert rule scheduling (Sentinel Analytics Rule):**
 
@@ -479,6 +511,8 @@ Entity mapping:      Account -> UserPrincipalName, IP -> IPAddress, Host -> Comp
 | Last triggered date | Within 90 days | > 180 days (rule may be stale or ineffective) |
 | Query execution time | < 30 seconds | > 2 minutes (performance issue) |
 | Exclusion count | < 10 | > 20 (rule may need fundamental redesign) |
+| Expired suppressions | 0 active | Any expired suppression still deployed |
+| Fixture regression coverage | Positive and benign fixtures for each promoted rule | Rule conversion or tuning without fixtures |
 
 **Quarterly review checklist:**
 
@@ -488,6 +522,19 @@ Entity mapping:      Account -> UserPrincipalName, IP -> IPAddress, Host -> Comp
 4. Has the TP/FP ratio changed significantly?
 5. Are there new exclusions needed or obsolete exclusions to remove?
 6. Has the threat landscape changed in ways that require rule logic updates?
+7. Are all active suppressions still scoped, ticketed, owned, and unexpired?
+8. Do regression fixtures prove converted KQL/SPL/Sigma logic still alerts on the same malicious event and stays quiet on approved benign activity?
+
+**Rule conversion regression checks:**
+
+When converting Sigma, KQL, SPL, or vendor content, require fixtures that exercise the old and new field names. Parser and CIM upgrades often rename fields such as `Account` to `TargetUserName`, `DeviceName` to `host`, or `Process` to `process_name`; the converted rule must prove equivalent alert behavior before promotion.
+
+Minimum fixture set:
+
+- One positive event that should alert before and after conversion.
+- One benign event that should not alert.
+- One suppression-scoped benign event proving the exclusion is exact.
+- One out-of-scope event using the same user or host that still alerts.
 
 ---
 
@@ -533,6 +580,7 @@ Produce SIEM rule deliverables in this structure:
 | Time window | [Xm/h] | [Why this window] |
 | Frequency | [Xm/h] | [How often to run] |
 | Suppression | [Xh] | [Cooldown period] |
+| Suppression Expiry | [YYYY-MM-DD or duration] | [Why this is temporary] |
 
 ### Entity Mapping
 | Entity Type | Source Field |
@@ -544,11 +592,25 @@ Produce SIEM rule deliverables in this structure:
 ### Known False Positives
 - [List specific FP sources]
 
+### Suppression Controls
+| Field | Value |
+|-------|-------|
+| Owner | [Detection owner] |
+| Ticket | [Incident/change/tuning ticket] |
+| Scope | [Exact asset/account/process/IP/parser scope] |
+| Expiry | [Date or duration] |
+| Expired Suppression Monitor | [How expired suppressions alert] |
+| Residual Detection | [What still alerts outside the approved scope] |
+
 ### Tuning Guidance
 - [Specific tuning recommendations]
 
 ### Validation
 - [How to test the rule produces a true positive]
+- [Positive fixture event that should alert]
+- [Benign fixture event that should not alert]
+- [Suppression-scoped fixture that should not alert until expiry]
+- [Out-of-scope fixture using the same user/host/process that should alert]
 ```
 
 ---
@@ -631,6 +693,14 @@ Deploying a rule without confirming it fires on known-malicious activity is depl
 ### Pitfall 5: Failing to Suppress Duplicate Alerts
 
 A detection rule that fires every 5 minutes on the same ongoing activity (e.g., a brute force attack lasting 2 hours) floods the alert queue with duplicates. Configure alert suppression or deduplication to prevent the same incident from generating hundreds of identical alerts. Use suppression windows and entity-based grouping to consolidate related alerts.
+
+### Pitfall 6: Letting Tuning Suppressions Become Permanent Blind Spots
+
+Suppressions created for maintenance windows, parser migrations, build hosts, or known business processes must expire. A username-only or process-only exclusion can hide attacker reuse of the same account or binary. Prefer precise scopes that include asset, process, command line, source, and time boundary, then add monitoring for expired suppressions that remain in production.
+
+### Pitfall 7: Promoting Converted Rules Without Regression Fixtures
+
+Sigma-to-KQL, Sigma-to-SPL, and parser-normalization changes can silently break a rule when field names change. Do not promote a converted rule unless positive and benign fixtures prove the old and new logic behave the same. Include a fixture that catches the intended malicious event after conversion and another that proves the approved suppression remains narrow.
 
 ---
 

--- a/skills/secops/siem-rules/tests/benign/conversion-fixture-pair.md
+++ b/skills/secops/siem-rules/tests/benign/conversion-fixture-pair.md
@@ -1,0 +1,29 @@
+# Benign: converted rule includes positive and benign fixtures
+
+This sample should not be reported for missing regression coverage. The conversion notes include a malicious event that should alert, a benign event that should not alert, and the mapped field names used after parser normalization.
+
+```yaml
+rule: suspicious-rundll32-child-process
+source_platform: windows-securityevent
+target_platform: mde-deviceprocessevents
+field_map:
+  Account: InitiatingProcessAccountName
+  Computer: DeviceName
+  Process: FileName
+fixtures:
+  should_alert:
+    FileName: rundll32.exe
+    InitiatingProcessAccountName: alice@example.com
+    DeviceName: workstation-22
+    ProcessCommandLine: rundll32.exe javascript:"\\..\\mshtml,RunHTMLApplication"
+  should_not_alert:
+    FileName: rundll32.exe
+    InitiatingProcessAccountName: patch-admin@example.com
+    DeviceName: patch-host-01
+    ProcessCommandLine: rundll32.exe shell32.dll,Control_RunDLL
+```
+
+Expected result:
+
+- No finding for missing conversion fixtures.
+- Reviewer should still inspect whether the fixture values match the production parser and rule syntax.

--- a/skills/secops/siem-rules/tests/benign/scoped-expiring-suppression.md
+++ b/skills/secops/siem-rules/tests/benign/scoped-expiring-suppression.md
@@ -1,0 +1,23 @@
+# Benign: scoped suppression with owner, ticket, and expiry
+
+This sample should not be reported as a permanent blind spot. The suppression is tied to one build host, one signed process, one ticket, and an expiry date. Events outside that scope still alert.
+
+```kql
+let suppression_ticket = "SEC-1428";
+let suppression_owner = "detection-eng";
+DeviceProcessEvents
+| where Timestamp > ago(1h)
+| where FileName =~ "powershell.exe"
+| where not(
+    DeviceName == "build-01"
+    and InitiatingProcessFileName == "signed-builder.exe"
+    and ProcessCommandLine has "-File build.ps1"
+    and Timestamp < datetime(2026-07-01)
+)
+| project Timestamp, DeviceName, InitiatingProcessFileName, ProcessCommandLine, suppression_ticket, suppression_owner
+```
+
+Expected result:
+
+- No finding for broad or permanent suppression.
+- Reviewer should still confirm an expired-suppression monitor exists for dates after `2026-07-01`.

--- a/skills/secops/siem-rules/tests/vulnerable/conversion-without-fixtures.md
+++ b/skills/secops/siem-rules/tests/vulnerable/conversion-without-fixtures.md
@@ -1,0 +1,22 @@
+# Vulnerable: SIEM conversion lacks regression fixtures
+
+This sample should be reported because the converted rule changes normalized field names but does not include positive or benign fixture events proving equivalent behavior.
+
+```kql
+// Original rule used Account and Computer from Windows SecurityEvent.
+SecurityEvent
+| where EventID == 4688
+| where Process has "rundll32.exe"
+| project TimeGenerated, Account, Computer, Process
+
+// Converted rule uses MDE fields, but no fixture proves this still alerts.
+DeviceProcessEvents
+| where FileName =~ "rundll32.exe"
+| project Timestamp, InitiatingProcessAccountName, DeviceName, ProcessCommandLine
+```
+
+Expected finding:
+
+- Severity: P3 unless the rule covers an active high-priority threat.
+- Evidence: field mapping changed and no should-alert or should-not-alert event is supplied.
+- Remediation: add fixtures for the old and new field names and verify the converted rule alerts on the same malicious event.

--- a/skills/secops/siem-rules/tests/vulnerable/permanent-username-suppression.md
+++ b/skills/secops/siem-rules/tests/vulnerable/permanent-username-suppression.md
@@ -1,0 +1,15 @@
+# Vulnerable: permanent username-only suppression
+
+This sample should be reported because the exclusion is permanent and scoped only to a shared account. If an attacker reuses `svc-build`, the rule no longer alerts even when the host, process, command line, or time window differs from the original false positive.
+
+```spl
+index=edr sourcetype=process process_name=powershell.exe
+| search user!="svc-build"
+| stats count by user, host, process_name, command_line
+```
+
+Expected finding:
+
+- Severity: P2 or P3 depending on the detection objective.
+- Evidence: no owner, ticket, expiry, asset scope, process scope, or residual detection path.
+- Remediation: replace the username-only exclusion with a scoped suppression tied to one host/process/change ticket and an expiry date.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

### Skill Modified
**Skill name:** siem-rules
**Skill path:** `skills/secops/siem-rules/`

### What Was Wrong
The SIEM rule guidance covered threshold tuning, duplicate alert suppression, and rule lifecycle management, but it did not distinguish a narrow temporary suppression from a permanent detection blind spot. It also did not require regression fixtures when SIEM content is converted between Sigma, KQL, SPL, or parser-normalized field names.

Closes #2499

### What This PR Fixes
- Adds suppression lifecycle gates requiring owner, ticket, exact scope, expiry, residual detection, and regression fixture evidence.
- Adds KQL and SPL examples that distinguish scoped expiring suppression from risky permanent username-only suppression.
- Adds health metrics and quarterly review items for expired suppressions and fixture regression coverage.
- Extends the output template with suppression controls and validation fixture requirements.
- Adds vulnerable and benign examples for permanent suppressions, SIEM conversion without fixtures, scoped expiring suppressions, and conversion fixture pairs.

### Evidence
Before: a rule could document a false-positive exclusion without proving it was scoped, temporary, owned, or tested against fixture events.

After: reviewers must verify suppression expiry and regression fixtures, including positive, benign, suppression-scoped, and out-of-scope events.

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing validation still passes

### Local Validation
- `git diff --check` passed
- Frontmatter required fields check passed
- `index.yaml` path check: 50 indexed files are present
- Changed-file prompt-injection keyword scan passed

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the [CONTRIBUTING.md](../../CONTRIBUTING.md) bounty terms
- **Preferred payment method:** can provide privately if accepted
