### PR TITLE
Add Windows HostProcess container gates

### DIFF
--- a/skills/cloud/container-security/SKILL.md
+++ b/skills/cloud/container-security/SKILL.md
@@ -13,7 +13,7 @@ phase: [build, deploy, operate]
 frameworks: [CIS-Docker-v1.6.0, CIS-Kubernetes-v1.9.0, NIST-SP-800-190]
 difficulty: intermediate
 time_estimate: "30-60min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -62,6 +62,7 @@ NIST SP 800-190 identifies five risk categories: image risks, registry risks, or
 - NetworkPolicy definitions
 - Pod Security Standard configurations or OPA/Gatekeeper policies
 - Container registry configurations (if available)
+- Windows workload evidence when present: `spec.os.name`, `windowsOptions`, `nodeSelector`/tolerations/RuntimeClass scheduling, Windows build labels, HostProcess justification, and GMSA credential-spec authorization.
 
 ---
 
@@ -111,6 +112,8 @@ Classify findings by type: Dockerfiles, Kubernetes manifests, Helm charts, Kusto
 
 Evaluate all container and Kubernetes configurations against CIS Docker Benchmark v1.6.0, CIS Kubernetes Benchmark v1.9.0, and NIST SP 800-190 countermeasures. This covers Dockerfile security, Pod Security Standards, RBAC, Network Policies, Secrets Management, Control Plane configuration, and Container Runtime Hardening.
 
+When a workload declares `spec.os.name: windows` or uses a Windows base image, branch the Pod Security Standards review before assigning Linux findings. Do not require Linux-only controls such as Linux capabilities, seccomp, `allowPrivilegeEscalation`, or numeric `runAsUser` on Windows pods. Instead, require Windows-specific evidence for `windowsOptions.runAsUserName`, effective Windows node placement, HostProcess use, Windows Server build compatibility, and GMSA credential-spec authorization.
+
 For detailed CIS benchmark checklist items, NIST SP 800-190 countermeasure tables, and comprehensive security context evaluation criteria, see [cis-benchmarks.md](cis-benchmarks.md) in this skill directory.
 
 ---
@@ -126,8 +129,8 @@ Produce the final report using the structure defined in the Output Format sectio
 
 | Severity | Definition | Examples |
 |----------|-----------|----------|
-| **Critical** | Container escape, cluster compromise, or credential exposure | Privileged containers, Docker socket mounts, cluster-admin bound to application SA, secrets in plaintext manifests, `hostPID`/`hostNetwork` on app pods |
-| **High** | Significant security gap enabling lateral movement or privilege escalation | Running as root, missing network policies, wildcard RBAC, `allowPrivilegeEscalation: true`, host path mounts to sensitive directories |
+| **Critical** | Container escape, cluster compromise, or credential exposure | Privileged containers, Docker socket mounts, cluster-admin bound to application SA, secrets in plaintext manifests, HostProcess workloads running as `NT AUTHORITY\SYSTEM` with broad RBAC |
+| **High** | Significant security gap enabling lateral movement or privilege escalation | Running as root, missing network policies, wildcard RBAC, `allowPrivilegeEscalation: true`, host path mounts to sensitive directories, HostProcess without least-privilege identity or Windows node isolation |
 | **Medium** | Missing hardening that weakens defense-in-depth | No resource limits, mutable image tags, missing seccomp profile, read-write root filesystem, secrets as env vars |
 | **Low** | Best-practice deviation with limited immediate risk | No HEALTHCHECK in Dockerfile, ADD instead of COPY, missing liveness/readiness probes, using default namespace |
 | **Informational** | Observation with no direct security impact | Image size optimization, multi-stage build suggestions, label recommendations |
@@ -184,6 +187,14 @@ Produce the final report using the structure defined in the Output Format sectio
 |----------|-----------|-----------|------------|
 | deploy/app | production | Baseline (not Restricted) | runAsRoot, no seccomp |
 | deploy/worker | production | Privileged | privileged: true |
+
+### Windows Workload Evidence Matrix
+
+| Workload | Namespace | OS | Node placement evidence | HostProcess | Windows identity | GMSA authorization | Windows build compatibility | Status |
+|----------|-----------|----|-------------------------|-------------|------------------|--------------------|-----------------------------|--------|
+| deploy/windows-api | apps | windows | `nodeSelector`, tolerations, or RuntimeClass | No | `ContainerUser` | N/A | `node.kubernetes.io/windows-build` or RuntimeClass | Pass/Fail/Partial |
+
+For Windows workloads, explain which Linux-only Pod Security controls were not evaluated and which Windows-specific controls replaced them.
 
 ### Prioritized Remediation Plan
 
@@ -246,6 +257,8 @@ Produce the final report using the structure defined in the Output Format sectio
 | runAsNonRoot | -- | Must be true |
 | seccompProfile | -- | RuntimeDefault or Localhost |
 
+For `spec.os.name: windows`, do not blindly apply Linux-only rows such as Linux capabilities, seccomp, `allowPrivilegeEscalation`, or numeric `runAsUser`. Evaluate Windows identity, HostProcess, node placement, Windows build compatibility, and GMSA authorization instead.
+
 ---
 
 ## Common Pitfalls
@@ -257,6 +270,7 @@ Produce the final report using the structure defined in the Output Format sectio
 5. **`readOnlyRootFilesystem` breaks many applications.** When recommending this control, also recommend adding writable `emptyDir` volume mounts for directories the application needs to write to (e.g., `/tmp`, `/var/cache`).
 6. **Network policies are additive, not subtractive.** A default-deny policy must be explicitly created. Without it, all pod-to-pod traffic is allowed regardless of other NetworkPolicy resources.
 7. **Distroless images have no shell.** While this is excellent for security, note that debugging requires ephemeral containers (`kubectl debug`). Flag this as a consideration, not a problem.
+8. **Windows pods need an OS-specific branch.** Adding Linux-only fields such as seccomp, Linux capabilities, or numeric `runAsUser` to Windows manifests can break admission instead of improving security. For Windows pods, check `runAsUserName`, effective Windows scheduling, HostProcess identity, and GMSA authorization.
 
 ---
 
@@ -283,6 +297,10 @@ Produce the final report using the structure defined in the Output Format sectio
 - NIST SP 800-190 Application Container Security Guide: https://csrc.nist.gov/publications/detail/sp/800-190/final
 - Kubernetes Pod Security Standards: https://kubernetes.io/docs/concepts/security/pod-security-standards/
 - Kubernetes Pod Security Admission: https://kubernetes.io/docs/concepts/security/pod-security-admission/
+- Kubernetes Windows containers: https://kubernetes.io/docs/concepts/windows/
+- Kubernetes HostProcess pods: https://kubernetes.io/docs/tasks/configure-pod-container/create-hostprocess-pod/
+- Kubernetes RunAsUserName for Windows pods: https://kubernetes.io/docs/tasks/configure-pod-container/configure-runasusername/
+- Kubernetes GMSA for Windows pods: https://kubernetes.io/docs/tasks/configure-pod-container/configure-gmsa/
 - Kubernetes Network Policies: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 - Kubernetes RBAC: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 - Docker Security Best Practices: https://docs.docker.com/develop/security-best-practices/
@@ -294,3 +312,4 @@ Produce the final report using the structure defined in the Output Format sectio
 ## Changelog
 
 - **1.0.0** -- Initial release. Full coverage of CIS Docker Benchmark v1.6.0 Section 4-5, CIS Kubernetes Benchmark v1.9.0 Sections 1-5, and NIST SP 800-190 countermeasures across all five risk categories.
+- **1.0.1** -- Added Windows workload branching, HostProcess identity/scheduling evidence, Windows node placement checks, GMSA authorization review, and Windows-specific output evidence to avoid Linux-only false positives.

--- a/skills/cloud/container-security/cis-benchmarks.md
+++ b/skills/cloud/container-security/cis-benchmarks.md
@@ -264,6 +264,20 @@ Evaluate workload configurations against Kubernetes Pod Security Standards. The 
 | **Baseline** | Minimally restrictive. Prevents known privilege escalations. | Standard workloads |
 | **Restricted** | Heavily restricted. Follows current hardening best practices. | Security-sensitive and untrusted workloads |
 
+#### OS-Specific Pod Security Branch
+
+Before applying Linux Pod Security findings, determine the workload operating system:
+
+| Evidence | Linux workload | Windows workload |
+|----------|----------------|------------------|
+| OS marker | `spec.os.name` absent or `linux` | `spec.os.name: windows` or Windows base image |
+| Identity control | `runAsNonRoot`, numeric `runAsUser` | `windowsOptions.runAsUserName` |
+| Kernel controls | seccomp, Linux capabilities, `allowPrivilegeEscalation` | Not applicable; do not recommend these as Windows fixes |
+| Placement proof | Linux node selector, tolerations, RuntimeClass if needed | Windows node selector/toleration/RuntimeClass required; `spec.os.name` is not scheduling |
+| Privileged equivalent | `privileged`, host namespaces, hostPath | HostProcess plus `hostNetwork`, Windows identity, RBAC, namespace exception |
+
+If the workload is Windows, record which Linux-only controls were skipped and which Windows-specific controls were evaluated instead. This avoids false positives where adding seccomp, Linux capabilities, or numeric `runAsUser` would break admission rather than harden the pod.
+
 #### CIS 5.2.1 -- Ensure that the cluster has at least one active policy control mechanism installed
 
 Check for Pod Security Admission labels on namespaces:
@@ -321,6 +335,8 @@ spec:
 
 #### CIS 5.2.6 -- Minimize the admission of containers with allowPrivilegeEscalation
 
+Linux-only control. For Windows pods, skip this control and evaluate `windowsOptions.runAsUserName`, HostProcess, and GMSA authorization instead.
+
 ```yaml
 # REQUIRED for Restricted profile
 spec:
@@ -334,6 +350,8 @@ spec:
 
 #### CIS 5.2.7 -- Minimize the admission of root containers
 
+For Linux containers, use `runAsNonRoot` and numeric `runAsUser`. For Windows containers, use `windowsOptions.runAsUserName` and verify the account is least-privileged for the workload.
+
 ```yaml
 # REQUIRED for Restricted profile
 spec:
@@ -345,6 +363,8 @@ spec:
 ```
 
 #### CIS 5.2.8 -- Minimize the admission of containers with the NET_RAW capability
+
+Linux-only control. Windows pods do not use Linux capabilities; do not mark a Windows pod non-compliant only because capability fields are absent.
 
 ```yaml
 # GOOD: Drop all capabilities
@@ -358,6 +378,8 @@ spec:
 
 #### CIS 5.2.9 -- Minimize the admission of containers with added capabilities
 
+Linux-only control. For Windows pods, review HostProcess, Windows account identity, and GMSA/domain access instead of capability lists.
+
 ```yaml
 # BAD: Adding dangerous capabilities
 securityContext:
@@ -368,6 +390,8 @@ securityContext:
 ```
 
 #### CIS 5.2.10 -- Minimize the admission of containers with capabilities assigned
+
+Linux-only control. For Windows workloads, record this as not applicable and evaluate Windows-specific privilege evidence.
 
 Verify all containers drop ALL capabilities and only add back what is strictly needed:
 
@@ -381,7 +405,67 @@ securityContext:
 
 #### CIS 5.2.11 -- Minimize the admission of Windows HostProcess containers
 
-Check for `windowsOptions.hostProcess: true`.
+HostProcess containers run directly on the Windows host and should be treated as a privileged host-access path, not as a normal Windows container. Check both pod-level and container-level `windowsOptions`.
+
+**HostProcess evidence matrix:**
+
+| Evidence | What to verify | Risk signal |
+|----------|----------------|-------------|
+| HostProcess location | Pod-level and container-level `windowsOptions.hostProcess` across containers and init containers | Container-level override can hide a privileged path |
+| Required host networking | `hostNetwork: true` for HostProcess pods | Missing host networking can indicate an invalid or misunderstood manifest |
+| Windows identity | `windowsOptions.runAsUserName` such as `ContainerUser`, `LocalService`, `NetworkService`, local group, or `NT AUTHORITY\SYSTEM` | `NT AUTHORITY\SYSTEM` is Critical unless tightly justified |
+| Service account and RBAC | ServiceAccount, Role/ClusterRole, RoleBinding/ClusterRoleBinding permissions | Host access plus broad Kubernetes RBAC compounds impact |
+| Namespace and PSA exception | Dedicated namespace, Pod Security Admission exception, policy approval | HostProcess should not be admitted accidentally in app namespaces |
+| Windows node placement | `nodeSelector`, tolerations, or RuntimeClass scheduling for Windows nodes | `spec.os.name` alone is not scheduling evidence |
+| Windows build compatibility | `node.kubernetes.io/windows-build`, RuntimeClass, or rendered chart values | Build mismatch can force unsafe overrides or runtime failure |
+| Image provenance | Trusted registry, immutable tag/digest, vulnerability scanning | HostProcess image compromise is host compromise |
+
+**Critical pattern:**
+
+```yaml
+apiVersion: apps/v1
+kind: DaemonSet
+spec:
+  template:
+    spec:
+      os:
+        name: windows
+      hostNetwork: true
+      serviceAccountName: windows-node-agent
+      securityContext:
+        windowsOptions:
+          hostProcess: true
+          runAsUserName: "NT AUTHORITY\\SYSTEM"
+```
+
+Flag this as Critical unless there is clear evidence of a system-level purpose, dedicated Windows node placement, least-privilege RBAC, policy exception approval, image provenance, and an operational reason that a lower-privilege identity cannot work.
+
+**Preferred evidence for ordinary Windows workloads:**
+
+```yaml
+spec:
+  os:
+    name: windows
+  nodeSelector:
+    kubernetes.io/os: windows
+  securityContext:
+    windowsOptions:
+      runAsUserName: "ContainerUser"
+```
+
+For non-HostProcess Windows app workloads, do not require Linux-only seccomp or Linux capabilities. Require Windows identity and node placement evidence.
+
+#### Windows gMSA Credential-Spec Authorization
+
+Group Managed Service Accounts add a domain identity path that is separate from normal Kubernetes service account identity. When a Windows workload uses `gmsaCredentialSpecName` or `gmsaCredentialSpec`, verify:
+
+- GMSA CRD and mutating/validating webhooks are installed and scoped as intended.
+- Only approved service accounts can `use` the referenced credential spec through RBAC.
+- The workload's `serviceAccountName` is bound to the expected GMSA credential spec and no wildcard credential-spec use is granted.
+- Domain privileges for the selected account match the application need and are not equivalent to broad domain-admin access.
+- Rendered Helm/Kustomize output preserves the intended `gmsaCredentialSpecName`, `runAsUserName`, and Windows node placement.
+
+**Finding format:** Report HostProcess and GMSA findings with Windows identity, node placement, RBAC scope, namespace/PSA exception, and Windows build compatibility evidence.
 
 #### CIS 5.2.12 -- Minimize the admission of HostPath volumes
 
@@ -610,11 +694,11 @@ Evaluate container runtime configurations against NIST SP 800-190 countermeasure
 
 | Countermeasure | What to Check |
 |---------------|---------------|
-| **CM-11:** Run as non-root | `runAsNonRoot: true`, `runAsUser: >0` |
+| **CM-11:** Run as non-root | Linux: `runAsNonRoot: true`, `runAsUser: >0`; Windows: `windowsOptions.runAsUserName` with least-privilege account |
 | **CM-12:** Use read-only root filesystem | `readOnlyRootFilesystem: true` |
 | **CM-13:** Drop all capabilities | `capabilities.drop: ["ALL"]` |
 | **CM-14:** Set resource limits | CPU and memory limits set on all containers |
-| **CM-15:** Use seccomp profiles | `seccompProfile.type: RuntimeDefault` or custom |
+| **CM-15:** Use seccomp profiles | Linux: `seccompProfile.type: RuntimeDefault` or custom; Windows: not applicable, evaluate HostProcess and Windows identity instead |
 
 **Resource limits check:**
 
@@ -649,6 +733,8 @@ securityContext:
 ## Comprehensive Security Context Evaluation
 
 For each workload (Deployment, StatefulSet, DaemonSet, Job, CronJob), evaluate the complete security context against the Restricted Pod Security Standard.
+
+Apply this Linux Restricted checklist only to Linux workloads. For Windows workloads, use the OS-specific branch in CIS 5.2: `windowsOptions.runAsUserName`, HostProcess evidence, effective Windows scheduling, Windows build compatibility, and GMSA authorization.
 
 **Restricted PSS Requirements Checklist:**
 


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

Closes #2555

### Skill Modified
**Skill name:** container-security  
**Skill path:** skills/cloud/container-security/

### What Was Wrong
The container-security skill applied Linux-centric Pod Security Standards broadly. That can create false positives for Windows pods where Linux-only fields such as seccomp, Linux capabilities, llowPrivilegeEscalation, or numeric unAsUser are not the right controls, while also missing Windows-specific risks around HostProcess identity, Windows node placement, Windows build compatibility, and GMSA credential-spec authorization.

### What This PR Fixes
- Bumps the main skill to v1.0.1.
- Adds Windows workload evidence to the review prerequisites and output format.
- Adds an OS-specific Pod Security branch before Linux Restricted findings are assigned.
- Expands CIS 5.2.11 from a single hostProcess flag check into a HostProcess evidence matrix covering pod/container scope, hostNetwork, Windows identity, service account/RBAC, namespace/PSA exception, Windows scheduling, build compatibility, and image provenance.
- Adds GMSA credential-spec authorization checks for CRD/webhook presence, service-account authorization, wildcard use, domain privilege scope, and rendered Helm/Kustomize evidence.
- Adds severity guidance and common-pitfall text to avoid Linux-only false positives while still escalating host-level Windows workloads.

### Validation
- git diff --check
- Marker check for version, Windows OS branch, windowsOptions.runAsUserName, HostProcess evidence matrix, hostNetwork, 
odeSelector, RuntimeClass, gmsaCredentialSpecName, Windows build compatibility, NT AUTHORITY\\SYSTEM, and Linux-only guidance
- Markdown fence-balance check

Requesting the moderate $100 bounty tier.