### PR TITLE
Improve containment Kubernetes quarantine gates

### DIFF
--- a/skills/incident-response/containment/SKILL.md
+++ b/skills/incident-response/containment/SKILL.md
@@ -12,7 +12,7 @@ phase: [respond]
 frameworks: [NIST-SP-800-61r2, MITRE-ATT&CK]
 difficulty: intermediate
 time_estimate: "15-30min"
-version: "1.0.1"
+version: "1.0.2"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -55,6 +55,7 @@ Before selecting a containment strategy, gather or confirm:
 - [ ] **Attacker access scope** -- What accounts, systems, and network segments has the attacker accessed or potentially compromised?
 - [ ] **Business criticality of affected systems** -- Revenue impact, customer impact, SLA obligations, regulatory implications of downtime.
 - [ ] **Network topology** -- VLANs, subnets, firewall zones, cloud VPCs, segmentation boundaries relevant to the affected systems.
+- [ ] **Kubernetes/container context** -- If the target is containerized, identify namespace, pod, owner controller, image digest, service account, mounted secrets, node, ingress, egress, CNI, service mesh, and Kubernetes audit-log coverage.
 - [ ] **Evidence preservation status** -- Has volatile evidence been captured? (Reference forensics-checklist.) Containment actions may destroy evidence if not collected first.
 - [ ] **Current containment state** -- What actions, if any, have already been taken?
 
@@ -119,8 +120,43 @@ Short-term containment aims to stop the immediate threat with minimal preparatio
 | **API key rotation** | Generate new API keys, revoke old keys | API key exposure or misuse | Specific services |
 | **Certificate revocation** | Revoke and reissue TLS/mTLS certificates | Certificate compromise, CA compromise | Services using the certificate |
 | **Service account reset** | Reset service account passwords and regenerate keys | Lateral movement via service accounts | Downstream services may break |
+| **Kubernetes identity containment** | Rotate projected service account tokens, revoke risky RBAC bindings, rotate image pull secrets, and review workload identity bindings | Compromised pod, kubeconfig, or service account token | Namespace, workload, or cluster identity |
 | **Kerberos ticket reset** | Reset krbtgt account password (twice, per Microsoft guidance) | Golden ticket attack, domain compromise | Domain-wide impact; requires careful planning |
 | **MFA token reset** | Deregister and re-enroll MFA devices | MFA bypass, SIM swap, device compromise | Individual users |
+
+### Step 2b: Kubernetes / Container Containment
+
+Use this step whenever the affected system is a Kubernetes workload, container platform, service mesh member, or cloud workload identity. Kubernetes containment is controller-aware: deleting a pod, cordoning a node, or applying a NetworkPolicy is not sufficient unless the plan accounts for the control plane and credential paths that can recreate or bypass the isolated workload.
+
+**Required Kubernetes evidence before selecting containment scope:**
+
+- Namespace, pod name, labels, node, and workload owner references.
+- Owner controller type and name: Deployment, ReplicaSet, StatefulSet, DaemonSet, Job, CronJob, or operator-managed custom resource.
+- Image reference by digest, rollout status, admission policy, and whether the same image can be rescheduled.
+- Service account, projected token status, RBAC bindings, image pull secrets, mounted secrets, kubeconfig files, and cloud workload identity binding.
+- CNI NetworkPolicy enforcement mode, service mesh policy layer, ingress routes, DNS policy, egress gateway, and cloud load-balancer paths.
+- Kubernetes audit logs, container runtime logs, egress logs, and traffic-test capability for validating containment.
+
+**Kubernetes containment scope matrix:**
+
+| Scope | Use When | Evidence Impact | Validation |
+|---|---|---|---|
+| **Pod quarantine** | One workload instance is suspect and evidence must be preserved | Preserves pod if label-based policy is used; deletion may destroy volatile evidence | Quarantine label applied, CNI policy enforced, no new traffic from suspect pod |
+| **Namespace isolation** | Multiple pods in one namespace or tenant are suspect | Preserves cluster availability while restricting tenant blast radius | Namespace egress/ingress denied except IR tooling, service health exceptions documented |
+| **Controller freeze** | Deployment, ReplicaSet, DaemonSet, Job, CronJob, or operator can recreate the workload | Prevents silent replacement from the same suspect image | Rollout paused or intentionally scaled, suspect image digest blocked or pinned, no new pods from digest |
+| **Node isolation** | Node compromise, kernel/container runtime compromise, or high-confidence host escape | Can disrupt unrelated tenants and evict evidence if drained | Hosted workload inventory reviewed, business owner approval recorded, node traffic and scheduling blocked |
+| **Cluster-level containment** | Control-plane, admission, registry, or shared identity compromise is suspected | High availability impact; preserves security over service continuity | Control-plane API access restricted, cluster-wide RBAC/secret exposure reviewed, audit logs monitored |
+
+**Finding triggers:**
+
+| ID | Flag This Pattern | Required Remediation Gate |
+|---|---|---|
+| **K8S-CONTAIN-01** | Deleting pods, draining nodes, or scaling workloads before identifying the owner controller and image digest | Identify owner controller, pause or intentionally scale rollout, block or pin the suspect image digest, and document the evidence tradeoff before destructive action |
+| **K8S-CONTAIN-02** | Node-level or cluster-level isolation without pod/namespace/node blast-radius comparison | Compare pod, namespace, node, and cluster containment scopes; record unrelated tenant impact, service availability impact, and approval owner |
+| **K8S-CONTAIN-03** | Network-only quarantine while Kubernetes service account tokens, RBAC bindings, image pull secrets, kubeconfigs, or cloud workload identities remain active | Rotate or invalidate tokens and secrets, review RBAC bindings, monitor Kubernetes audit logs, and verify the identity cannot continue API actions from outside the pod |
+| **K8S-CONTAIN-04** | NetworkPolicy-only containment without CNI, service mesh, ingress, egress gateway, DNS, or cloud load-balancer validation | Run traffic tests and log checks for CNI enforcement, mesh AuthorizationPolicy, ingress route removal, egress gateway denial, DNS policy, and Kubernetes audit activity |
+
+**Safe containment pattern:** prefer label-based pod or namespace quarantine plus controller freeze, token/RBAC containment, and explicit traffic validation before pod deletion. Immediate node or cluster isolation remains valid for destructive workload, host escape, or control-plane compromise scenarios, but the plan must record why surgical containment is not enough.
 
 ### Step 3: Long-Term Containment
 
@@ -212,6 +248,9 @@ After implementing containment, verify effectiveness before proceeding to eradic
 | C2 communication blocked | Monitor network traffic for C2 indicators | No outbound connections to known C2 IPs/domains |
 | Lateral movement blocked | Monitor authentication logs and network flows between segments | No unauthorized cross-segment authentication |
 | Compromised credentials revoked | Attempt authentication with known-compromised credentials | Authentication fails |
+| Kubernetes controller/image contained | Review owner references, rollout state, admission policy, and pod creation events | No new pods launch from suspect image digest or unfrozen controller path |
+| Kubernetes identities contained | Review RBAC, service account tokens, image pull secrets, cloud workload identity, and audit logs | Compromised identity cannot continue Kubernetes API actions |
+| Service Mesh / Ingress / Egress Validation | Run traffic tests and inspect mesh policy, ingress controller, egress gateway, DNS, and CNI logs | Quarantined workload cannot bypass containment through mesh, ingress, egress, or DNS paths |
 | Attacker persistence neutralized | Scan for known persistence mechanisms | No active persistence artifacts |
 | Business services operational (if surgical containment) | Verify critical service health checks | Services responding normally |
 | Evidence preserved | Verify forensic images and memory dumps are intact and hashed | Hash verification passes |
@@ -256,7 +295,7 @@ Produce the containment plan with these exact sections:
 ```markdown
 ## Containment Plan: [Incident ID]
 **Date:** [YYYY-MM-DD]
-**Skill:** containment v1.0.0
+**Skill:** containment v1.0.2
 **Frameworks:** NIST SP 800-61 Rev 2, MITRE ATT&CK
 **Incident Commander:** [Name]
 
@@ -288,6 +327,11 @@ threat severity and business criticality, and expected impact on operations.]
 | Service/System | Impact of Containment | Mitigation | Acceptable |
 |---|---|---|---|
 | [Service] | [Description of disruption] | [Workaround if any] | [Yes/No -- requires escalation] |
+
+### Kubernetes Containment Matrix
+| Workload | Namespace | Owner Controller | Image Digest | Service Account | Proposed Containment | Blast Radius | Evidence Impact | Validation |
+|---|---|---|---|---|---|---|---|---|
+| [Workload or N/A] | [Namespace] | [Deployment/ReplicaSet/DaemonSet/StatefulSet/Job/CronJob/Operator] | [sha256 digest] | [Service account] | [Pod/Namespace/Node/Cluster action] | [Affected tenants/services] | [Preserved/Destroyed/Tradeoff] | [CNI/Mesh/Ingress/Egress/Audit checks] |
 
 ### Containment Validation Checklist
 | Check | Result | Timestamp |
@@ -348,6 +392,14 @@ Disconnecting a business-critical production system from the network stops the a
 
 Implementing containment actions without verifying they work is a common failure mode. Firewall rules may not apply to the correct interface or direction. DNS sinkholes may not affect systems using hardcoded DNS servers. Credential resets may not invalidate existing Kerberos tickets. After every containment action, validate effectiveness through monitoring -- confirm that the specific attacker activity the action was intended to block has actually stopped.
 
+### Pitfall 5: Deleting Kubernetes Pods as "Containment"
+
+Deleting a suspect pod can destroy volatile evidence and may trigger its Deployment, ReplicaSet, DaemonSet, Job, CronJob, or operator to recreate the same workload from the same suspect image. Before deleting or draining anything, identify the owner controller, image digest, rollout state, namespace, service account, and evidence-preservation tradeoff. Prefer controller freeze plus label-based quarantine when the incident allows surgical containment.
+
+### Pitfall 6: Treating NetworkPolicy as Complete Kubernetes Containment
+
+A NetworkPolicy can be necessary but incomplete. Service mesh authorization, shared ingress controllers, egress gateways, DNS policy, cloud load balancers, Kubernetes API credentials, and cloud workload identity can all bypass or outlive pod network isolation. Validate CNI enforcement with traffic tests and include service mesh, ingress, egress, and audit-log checks in the containment plan.
+
 ---
 
 ## 8. Prompt Injection Safety Notice
@@ -376,3 +428,7 @@ This skill processes incident data including attacker-controlled indicators (IP 
 10. **MITRE ATT&CK -- Disk Wipe (T1561)** -- https://attack.mitre.org/techniques/T1561/
 11. **CISA Destructive Malware Guidance** -- https://www.cisa.gov/topics/cyber-threats-and-advisories
 12. **KrebsOnSecurity: Iran-backed wiper attack on Stryker medtech (2026)** -- https://krebsonsystems.com/2026/03/iran-backed-hackers-claim-wiper-attack-on-medtech-firm-stryker/
+13. **Kubernetes: Pods and workload resources** -- https://kubernetes.io/docs/concepts/workloads/pods/
+14. **Kubernetes: Network Policies** -- https://kubernetes.io/docs/concepts/services-networking/network-policies/
+15. **Kubernetes: Service Accounts** -- https://kubernetes.io/docs/concepts/security/service-accounts/
+16. **Kubernetes: Auditing** -- https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/

--- a/skills/incident-response/containment/tests/benign/controller-aware-workload-quarantine.yaml
+++ b/skills/incident-response/containment/tests/benign/controller-aware-workload-quarantine.yaml
@@ -1,0 +1,22 @@
+id: controller-aware-workload-quarantine
+kind: benign
+summary: Quarantine plan preserves evidence while containing a compromised Kubernetes workload.
+cluster_context:
+  namespace: prod-payments
+  workload: payments-api
+  owner_controller: Deployment/payments-api
+  image_digest: registry.example.com/payments-api@sha256:known-good
+  service_account: payments-api
+  node: ip-10-0-42-17
+proposed_actions:
+  - label suspect pods with incident.example.com/quarantine=true
+  - apply namespace-scoped NetworkPolicy that denies workload egress except to ir-tools
+  - pause rollout and block the suspect image digest before deleting or replacing pods
+  - rotate projected service account token, image pull secret, and cloud workload identity binding
+  - validate CNI NetworkPolicy, Istio AuthorizationPolicy, ingress route removal, egress gateway logs, and Kubernetes audit logs
+expected_result: should_not_flag_kubernetes_containment
+safe_because:
+  - owner controller and image digest are identified before pod deletion
+  - containment scope is pod and namespace first, not blind node isolation
+  - credential and RBAC containment are included in addition to network controls
+  - CNI, service mesh, ingress, egress, and audit validation are explicit

--- a/skills/incident-response/containment/tests/vulnerable/delete-pod-without-controller-containment.yaml
+++ b/skills/incident-response/containment/tests/vulnerable/delete-pod-without-controller-containment.yaml
@@ -1,0 +1,16 @@
+id: delete-pod-without-controller-containment
+kind: vulnerable
+summary: Deleting a suspect pod without controller or image containment recreates the same compromised workload.
+cluster_context:
+  namespace: prod-payments
+  workload: payments-api
+  owner_controller: Deployment/payments-api
+  image_digest: registry.example.com/payments-api@sha256:suspect
+proposed_actions:
+  - kubectl delete pod payments-api-7f8d9c9d6b-x2k4p -n prod-payments
+expected_result: should_flag_kubernetes_containment
+missing_evidence:
+  - owning controller rollout state was not paused or scaled intentionally
+  - suspect image digest was not blocked or pinned before replacement
+  - volatile pod evidence tradeoff was not approved
+risk: The Deployment or ReplicaSet can immediately create a replacement from the same suspect image.

--- a/skills/incident-response/containment/tests/vulnerable/network-only-with-live-kubernetes-identity.yaml
+++ b/skills/incident-response/containment/tests/vulnerable/network-only-with-live-kubernetes-identity.yaml
@@ -1,0 +1,20 @@
+id: network-only-with-live-kubernetes-identity
+kind: vulnerable
+summary: Network quarantine leaves Kubernetes API credentials and workload identity active.
+cluster_context:
+  namespace: ci
+  workload: build-deployer
+  service_account: build-deployer
+  automount_service_account_token: true
+  mounted_secrets:
+    - registry-pull-secret
+    - deployer-kubeconfig
+proposed_actions:
+  - apply NetworkPolicy deny all ingress and egress to selected pods
+expected_result: should_flag_kubernetes_containment
+missing_evidence:
+  - projected service account token revocation or pod restart boundary
+  - RBAC binding review for compromised service account
+  - image pull secret, kubeconfig, and cloud workload identity rotation
+  - Kubernetes audit-log monitoring for the stolen identity
+risk: A copied token can continue to operate against the Kubernetes API from outside the quarantined pod.

--- a/skills/incident-response/containment/tests/vulnerable/networkpolicy-only-misses-mesh-ingress-egress.yaml
+++ b/skills/incident-response/containment/tests/vulnerable/networkpolicy-only-misses-mesh-ingress-egress.yaml
@@ -1,0 +1,19 @@
+id: networkpolicy-only-misses-mesh-ingress-egress
+kind: vulnerable
+summary: NetworkPolicy-only containment ignores service mesh, shared ingress, and egress gateway paths.
+cluster_context:
+  namespace: prod-payments
+  workload: payments-api
+  cni_network_policy: enabled
+  service_mesh: istio-partial
+  ingress_controller: shared
+  egress_gateway: enabled
+proposed_actions:
+  - apply namespace NetworkPolicy denying all egress from pods labeled quarantine=true
+expected_result: should_flag_kubernetes_containment
+missing_evidence:
+  - CNI egress enforcement was not validated with traffic tests
+  - service mesh AuthorizationPolicy and sidecar routes were not reviewed
+  - ingress routing and egress gateway logs were not included
+  - Kubernetes audit logs were not monitored for continued API-driven movement
+risk: Traffic may still flow through mesh, ingress, or gateway paths even when a NetworkPolicy exists.

--- a/skills/incident-response/containment/tests/vulnerable/node-isolation-without-tenant-blast-radius.yaml
+++ b/skills/incident-response/containment/tests/vulnerable/node-isolation-without-tenant-blast-radius.yaml
@@ -1,0 +1,18 @@
+id: node-isolation-without-tenant-blast-radius
+kind: vulnerable
+summary: Node-level isolation is chosen without namespace, tenant, or evidence impact review.
+cluster_context:
+  node: ip-10-0-42-17
+  hosted_workloads:
+    - prod-payments/payments-api
+    - prod-auth/session-api
+    - observability/otel-collector
+    - ingress/shared-gateway
+proposed_actions:
+  - cloud_security_group: deny all egress for worker node ip-10-0-42-17
+expected_result: should_flag_kubernetes_containment
+missing_evidence:
+  - pod, namespace, node, and cluster containment scopes were not compared
+  - unrelated tenant and ingress impact was not assessed
+  - evidence impact of isolating a shared node was not documented
+risk: The response can disrupt unrelated services while missing the compromised service account or namespace path.


### PR DESCRIPTION
## Skill Improvement ($50-150 Bounty)

/claim #2514

**Competition note:** after opening this PR, I noticed `#2523` was submitted for the same review item while I was working. This PR is not intended to create review noise; its main distinction is the added benign/vulnerable fixture coverage and the red/green evidence for the Kubernetes containment gates. If maintainers prefer the earlier PR, I am comfortable with this being closed as duplicate.

### Skill Modified
**Skill name:** containment
**Skill path:** `skills/incident-response/containment/`

### What Was Wrong
The containment skill covered host, network, DNS, credential, cloud security group, and wiper response patterns, but it did not model Kubernetes controller behavior. That left several important containment misses:

- pod deletion could recreate the same compromised workload through Deployment/ReplicaSet/DaemonSet/Job/CronJob/operator control loops;
- node isolation could disrupt unrelated tenants without comparing pod, namespace, node, and cluster blast radius;
- network-only quarantine could leave Kubernetes service account tokens, RBAC bindings, image pull secrets, kubeconfigs, or cloud workload identities active;
- NetworkPolicy-only plans could miss CNI enforcement gaps, service mesh policy, shared ingress, egress gateways, DNS, and audit-log validation.

### What This PR Fixes
This adds a Kubernetes / Container Containment step to the existing process, including:

- required Kubernetes evidence before selecting a containment scope;
- a pod/namespace/controller/node/cluster scope matrix;
- four explicit finding triggers: `K8S-CONTAIN-01` through `K8S-CONTAIN-04`;
- validation checks for controller/image containment, Kubernetes identity containment, and service mesh / ingress / egress paths;
- a `Kubernetes Containment Matrix` in the output template;
- pitfalls for deleting pods as containment and treating NetworkPolicy as complete containment;
- Kubernetes primary references.

### Evidence
**Before (skill misses this / false positive on this):**

The red check failed on the existing skill because it did not include these required gates:

```text
missing: K8S-CONTAIN-01
missing: K8S-CONTAIN-02
missing: K8S-CONTAIN-03
missing: K8S-CONTAIN-04
missing: Kubernetes Containment Matrix
missing: Owner Controller
missing: Service Mesh / Ingress / Egress Validation
```

**After (now correctly handled):**

The same marker/fixture check passes after the update, and the new test fixtures cover:

- benign controller-aware workload quarantine;
- vulnerable pod deletion without controller/image containment;
- vulnerable node isolation without tenant blast-radius review;
- vulnerable network-only containment with live Kubernetes identity;
- vulnerable NetworkPolicy-only containment that misses service mesh, ingress, and egress paths.

### Test Cases Added/Updated
- [x] Added vulnerable test cases (`tests/vulnerable/`)
- [x] Added benign test cases (`tests/benign/`)
- [x] Existing skill structure still validates

### Pull Request Checklist
- [x] Skill follows the format specification in `CONTRIBUTING.md`
- [x] At least one real framework is cited with correct control IDs where applicable
- [x] Framework references verified against primary sources already used by the skill (NIST SP 800-61 Rev 2, MITRE ATT&CK) plus Kubernetes primary docs
- [x] Prompt Injection Safety Notice section included
- [x] `injection-hardened: true` set in frontmatter
- [x] `allowed-tools` scoped to minimum necessary permissions
- [x] Tested with at least one AI coding agent: Codex (GPT-5)
- [x] No prohibited patterns per `SECURITY.md` in changed files
- [x] `index.yaml` update not applicable because this improves an existing skill

### Framework References
- NIST SP 800-61 Rev 2, Section 3.3: containment criteria and evidence-preservation tradeoffs
- MITRE ATT&CK Enterprise Matrix: lateral movement, command and control, persistence, and destructive-impact containment mapping
- Kubernetes primary documentation: pods/workloads, NetworkPolicies, service accounts, and auditing

### Testing
- Red/green marker check: required Kubernetes gates failed before the update and passed after the update
- `ruby -ryaml` parsed all five YAML fixtures
- Ruby frontmatter parse confirmed `version: 1.0.2` and required metadata keys
- `git diff --check HEAD~1 HEAD`
- Prohibited injection-pattern scan against changed files using the `SECURITY.md` patterns
- Added-line sensitive content scan found no credentials or private keys
- Initial preflight before implementation: issue `#2514` was open, unassigned, zero-comment, and PR searches for `2514` and the Kubernetes containment topic returned no open competing PR. A later same-scope PR (`#2523`) appeared during the implementation/publish window; see note above.

### Bounty Tier
- [ ] **Minor** ($50) - Doc update, small logic tweak, typo fix
- [x] **Moderate** ($100) - New edge case coverage, FP reduction with evidence
- [ ] **Substantial** ($150) - Rewritten detection logic, major coverage expansion

### Bounty Info
- [x] I have read and agree to the `CONTRIBUTING.md` bounty terms
- **Preferred payment method:** Can provide privately after maintainer acceptance