### PR TITLE
Improve DNS resolver-chain and DoH policy checks

### DIFF
--- a/skills/network/dns-security/SKILL.md
+++ b/skills/network/dns-security/SKILL.md
@@ -83,6 +83,8 @@ Use Glob and Grep to locate DNS server configurations, resolver settings, and re
 
 # Application-level DNS settings
 **/dnsconfig*
+**/*doh*
+**/*dns-over-https*
 **/unbound*
 **/dnsdist*
 **/dnscrypt-proxy*
@@ -107,6 +109,7 @@ Categorize discovered configurations:
 - **Local encrypted DNS proxies:** dnsdist, dnscrypt-proxy, cloudflared, stunnel, local Unbound forwarding.
 - **Client settings:** resolv.conf, DHCP-distributed resolver addresses, VPN DNS settings.
 - **Browser / endpoint enforcement:** Chrome, Edge, Firefox enterprise policies; OS private DNS; MDM profiles.
+- **Application-level DNS clients:** library or service configurations that call DoH/DoT endpoints directly instead of using the OS resolver.
 
 ---
 
@@ -190,6 +193,7 @@ application/browser -> OS resolver/local stub -> local proxy/resolver -> enterpr
 - **Local proxy hop:** If BIND, systemd-resolved, or CoreDNS forwards to `127.0.0.1`, `::1`, or an RFC1918 address, inspect the local proxy before calling the path plaintext. Common proxy components include dnsdist, dnscrypt-proxy, cloudflared, stunnel, and local Unbound.
 - **External egress hop:** Determine whether the final hop to the upstream recursive resolver uses plaintext DNS, DoT, DoH, DNSCrypt, or a managed protective DNS tunnel.
 - **Policy enforcement:** Confirm that endpoint, browser, VPN, and MDM policies prevent unmanaged DoH/DoT paths from bypassing the enterprise resolver.
+- **Application bypass:** Search services and workload configuration for direct DoH clients that use public endpoints over HTTPS even when `/etc/resolv.conf` or DHCP settings point to the enterprise resolver.
 - **Observed evidence:** Prefer packet captures, resolver query logs, protective DNS logs, or SIEM events over assumptions from static config alone.
 
 **Finding classification:** A local BIND forwarder to a local encrypted DNS proxy with verified encrypted egress is **Not a finding** for plaintext external forwarding. A local forwarder chain whose egress cannot be verified is an **Evidence Gap** and usually **Low** or **Medium** depending on network exposure. Any unmanaged browser, mobile private DNS, VPN, or application-level DoH path that bypasses protective DNS is **High**.
@@ -246,6 +250,15 @@ network.trr.uri
 DNSSettings
 DNSProtocol
 ServerURL
+
+# Application/library-level DoH indicators
+https://dns.google/dns-query
+https://cloudflare-dns.com/dns-query
+https://mozilla.cloudflare-dns.com/dns-query
+application/dns-message
+doh_url
+dns_over_https
+DoHClient
 ```
 
 **Finding classification:** DNS queries forwarded in plaintext to external resolvers over untrusted networks is **Medium**. No DoH bypass controls when DNS filtering is deployed is **High**.

--- a/skills/network/dns-security/SKILL.md
+++ b/skills/network/dns-security/SKILL.md
@@ -13,7 +13,7 @@ phase: [operate]
 frameworks: [NIST-SP-800-81-Rev2, CIS-Controls-v8]
 difficulty: intermediate
 time_estimate: "20-40min"
-version: "1.0.0"
+version: "1.0.1"
 author: unitoneai
 license: MIT
 allowed-tools: Read, Grep, Glob
@@ -42,7 +42,7 @@ If a target is provided via arguments, focus the review on: $ARGUMENTS
 
 ## Context
 
-DNS is a foundational protocol that is often under-secured. NIST SP 800-81 Rev 2 Section 2 identifies three primary DNS threat categories: DNS cache poisoning, DNS-based denial of service, and unauthorized zone data modification. DNSSEC addresses data integrity but not confidentiality. CIS Controls v8 Control 9.2 requires the use of DNS filtering services to block access to known malicious domains. Beyond these baseline controls, DNS is increasingly exploited as a covert data exfiltration channel because port 53 is almost universally permitted through firewalls. Detecting DNS tunneling and exfiltration requires analysis of query patterns, payload sizes, and entropy -- not just domain reputation.
+DNS is a foundational protocol that is often under-secured. NIST SP 800-81 Rev 2 Section 2 identifies three primary DNS threat categories: DNS cache poisoning, DNS-based denial of service, and unauthorized zone data modification. DNSSEC addresses data integrity but not confidentiality. CIS Controls v8 Control 9.2 requires the use of DNS filtering services to block access to known malicious domains. Beyond these baseline controls, DNS is increasingly exploited as a covert data exfiltration channel because port 53 is almost universally permitted through firewalls. Detecting DNS tunneling and exfiltration requires analysis of query patterns, payload sizes, and entropy -- not just domain reputation. Modern DNS reviews must also evaluate the effective resolver path: browser-level DoH, mobile private DNS, VPN clients, and local DNS proxy chains can silently bypass the intended enterprise resolver or create false positives if the upstream egress hop is not inspected.
 
 ---
 
@@ -84,13 +84,29 @@ Use Glob and Grep to locate DNS server configurations, resolver settings, and re
 # Application-level DNS settings
 **/dnsconfig*
 **/unbound*
+**/dnsdist*
+**/dnscrypt-proxy*
+**/cloudflared*
+**/stunnel*
+
+# Browser, endpoint, and MDM DNS policy
+**/policies.json
+**/managed_preferences.json
+**/*.mobileconfig
+**/*Chrome*.plist
+**/*Edge*.plist
+**/*Firefox*.plist
+**/firefox/policies.json
+**/mdm*
 ```
 
 Categorize discovered configurations:
 - **Authoritative servers:** BIND, PowerDNS, Route53 hosted zones, Cloud DNS zones.
 - **Recursive resolvers:** Unbound, BIND (recursion enabled), CoreDNS, systemd-resolved.
 - **Protective DNS / filtering:** RPZ, Pi-hole, Cisco Umbrella, Cloudflare Gateway, Quad9.
-- **Client settings:** resolv.conf, DHCP-distributed resolver addresses.
+- **Local encrypted DNS proxies:** dnsdist, dnscrypt-proxy, cloudflared, stunnel, local Unbound forwarding.
+- **Client settings:** resolv.conf, DHCP-distributed resolver addresses, VPN DNS settings.
+- **Browser / endpoint enforcement:** Chrome, Edge, Firefox enterprise policies; OS private DNS; MDM profiles.
 
 ---
 
@@ -160,6 +176,24 @@ dnssec
 
 Evaluate whether DNS queries are protected in transit.
 
+#### 3.0 Effective Resolver Path and Chain-of-Custody Gate
+
+Before assigning severity, map the actual DNS resolution chain rather than inspecting a single config file in isolation:
+
+```
+application/browser -> OS resolver/local stub -> local proxy/resolver -> enterprise/protective resolver -> upstream recursive resolver
+```
+
+**What to verify:**
+
+- **Client source:** Identify whether DNS starts from the OS resolver, a browser DoH client, a VPN client, an endpoint security agent, or an application-specific resolver library.
+- **Local proxy hop:** If BIND, systemd-resolved, or CoreDNS forwards to `127.0.0.1`, `::1`, or an RFC1918 address, inspect the local proxy before calling the path plaintext. Common proxy components include dnsdist, dnscrypt-proxy, cloudflared, stunnel, and local Unbound.
+- **External egress hop:** Determine whether the final hop to the upstream recursive resolver uses plaintext DNS, DoT, DoH, DNSCrypt, or a managed protective DNS tunnel.
+- **Policy enforcement:** Confirm that endpoint, browser, VPN, and MDM policies prevent unmanaged DoH/DoT paths from bypassing the enterprise resolver.
+- **Observed evidence:** Prefer packet captures, resolver query logs, protective DNS logs, or SIEM events over assumptions from static config alone.
+
+**Finding classification:** A local BIND forwarder to a local encrypted DNS proxy with verified encrypted egress is **Not a finding** for plaintext external forwarding. A local forwarder chain whose egress cannot be verified is an **Evidence Gap** and usually **Low** or **Medium** depending on network exposure. Any unmanaged browser, mobile private DNS, VPN, or application-level DoH path that bypasses protective DNS is **High**.
+
 #### 3.1 DNS over HTTPS (DoH) and DNS over TLS (DoT)
 
 | Transport | Port | Standard | Use Case |
@@ -174,6 +208,8 @@ Evaluate whether DNS queries are protected in transit.
 - **DoH bypass risk:** Browsers (Firefox, Chrome) may use built-in DoH providers, bypassing corporate DNS filtering. Verify that:
   - Canary domain `use-application-dns.net` resolves to NXDOMAIN (signals browsers to disable built-in DoH).
   - Network policy blocks known public DoH endpoints if corporate DNS filtering is required.
+- **Managed browser policy:** Chrome and Edge should enforce `DnsOverHttpsMode` and `DnsOverHttpsTemplates`; Firefox should enforce `DNSOverHTTPS` enterprise policy or managed `network.trr.*` preferences.
+- **Mobile and OS policy:** Android Private DNS, iOS/macOS DNS Settings payloads, Windows DNS client policies, and VPN split-DNS rules must route managed devices through approved resolvers.
 
 **Patterns to check:**
 
@@ -186,8 +222,30 @@ forward-addr: 1.1.1.1@853
 tls://1.1.1.1
 tls://8.8.8.8
 
-# BIND forwarder (no native DoT -- requires stunnel or proxy)
-forwarders { 1.1.1.1; };  # Plaintext -- flag as finding
+# BIND forwarder to external resolver (no native DoT -- requires stunnel or proxy)
+forwarders { 1.1.1.1; };  # Plaintext external egress -- flag as finding
+
+# BIND forwarder to local encrypted DNS proxy (inspect proxy egress before flagging)
+forwarders { 127.0.0.1 port 853; };  # Evidence gate -- verify local proxy config
+
+# dnsdist / dnscrypt-proxy / cloudflared local proxy indicators
+newServer({address="1.1.1.1:853", tls="openssl"})
+server_names = ["cloudflare", "quad9-dnscrypt-ip4-filter-pri"]
+proxy-dns: true
+
+# Chrome / Edge managed DoH policy
+"DnsOverHttpsMode": "secure"
+"DnsOverHttpsTemplates": "https://dns.example.com/dns-query{?dns}"
+
+# Firefox managed DoH policy
+"DNSOverHTTPS": { "Enabled": true, "ProviderURL": "https://dns.example.com/dns-query", "Locked": true }
+network.trr.mode
+network.trr.uri
+
+# Apple MDM DNS Settings payload
+DNSSettings
+DNSProtocol
+ServerURL
 ```
 
 **Finding classification:** DNS queries forwarded in plaintext to external resolvers over untrusted networks is **Medium**. No DoH bypass controls when DNS filtering is deployed is **High**.
@@ -229,9 +287,11 @@ If a cloud-based protective DNS service is used (Cisco Umbrella, Cloudflare Gate
 
 - All clients and recursive resolvers forward to the protective DNS service.
 - No DNS resolution paths bypass the protective DNS (direct queries to 8.8.8.8, 1.1.1.1 from endpoints).
+- Browser DoH, mobile private DNS, VPN split-DNS, and endpoint resolver agents are covered by managed policy, not only firewall rules.
 - Domain categorization covers: malware C2, phishing, newly registered domains (NRDs < 30 days), DGA-generated domains.
 - Block pages or NXDOMAIN responses are returned for blocked categories.
 - Logs are forwarded to SIEM.
+- Protective DNS telemetry contains endpoint/source attribution sufficient to investigate bypass and exfiltration alerts.
 
 **Finding classification:** No DNS filtering/RPZ deployed is **High**. RPZ feeds not automatically updated is **Medium**. DNS resolution paths that bypass protective DNS is **High**.
 
@@ -300,8 +360,8 @@ abcdef0123456789.dnscat.example.com TXT
 |----------|-----------|
 | **Critical** | Broken DNSSEC chain of trust (missing DS record in parent); authoritative zones serving invalid signatures. |
 | **High** | DNSSEC validation disabled on resolvers; no DNS filtering/RPZ; unsigned public authoritative zones; DNS bypass paths around protective DNS; no DNS query logging; weak signing algorithms. |
-| **Medium** | Plaintext DNS forwarding over untrusted networks; stale RPZ feeds; undocumented NTAs; no NRD blocking; no exfiltration detection; DoH bypass not controlled. |
-| **Low** | Missing documentation of DNS architecture; resolver software not at latest version; cosmetic configuration issues. |
+| **Medium** | Plaintext DNS forwarding over untrusted networks; stale RPZ feeds; undocumented NTAs; no NRD blocking; no exfiltration detection; unverified encrypted DNS proxy egress on exposed networks. |
+| **Low** | Missing documentation of DNS architecture; resolver software not at latest version; local proxy chain not documented but protective DNS controls are otherwise evidenced; cosmetic configuration issues. |
 
 ---
 
@@ -324,9 +384,9 @@ abcdef0123456789.dnscat.example.com TXT
 
 ### Resolver Security
 
-| Resolver | DNSSEC Validation | Encrypted Transport | RPZ/Filtering | Query Logging |
-|----------|-------------------|--------------------|--------------|--------------|
-| ns1      | Enabled/Disabled  | DoT/DoH/Plaintext  | Yes/No       | Yes/No       |
+| Resolver | DNSSEC Validation | Effective Resolver Path | Encrypted Egress | RPZ/Filtering | Query Logging |
+|----------|-------------------|-------------------------|------------------|---------------|--------------|
+| ns1      | Enabled/Disabled  | OS -> local proxy -> protective DNS | DoT/DoH/Plaintext/Unknown | Yes/No | Yes/No |
 
 ### Findings
 
@@ -336,6 +396,7 @@ abcdef0123456789.dnscat.example.com TXT
 - **File:** <path to config file>
 - **Description:** <what was found>
 - **Evidence:** <specific configuration snippet>
+- **Effective DNS Path:** <client/browser -> local resolver/proxy -> upstream/protective DNS>
 - **Remediation:** <concrete fix>
 
 ### DNS Exfiltration Detection Readiness
@@ -380,9 +441,11 @@ abcdef0123456789.dnscat.example.com TXT
 
 2. **Blocking DoH at the network level without deploying enterprise DoT/DoH.** If you block public DoH endpoints to enforce corporate DNS policy, you must provide a corporate encrypted DNS alternative. Otherwise, you degrade client DNS security without improving organizational visibility.
 
-3. **Relying solely on domain reputation lists for exfiltration detection.** Attackers use attacker-controlled domains that are not yet categorized. Behavioral detection (entropy, volume, query type anomalies) catches novel exfiltration domains that reputation feeds miss.
+3. **Flagging every BIND forwarder as plaintext without checking the next hop.** BIND does not natively originate DoT, but many deployments forward to a local proxy that performs encrypted upstream transport. Inspect the local proxy egress before writing a finding; otherwise the review creates avoidable false positives.
 
-4. **Ignoring DNS over TCP.** DNS is not UDP-only. DNS over TCP (port 53) supports large responses and is required for zone transfers. Some tunneling tools prefer TCP for reliability. Firewall rules and monitoring must cover both UDP and TCP port 53.
+4. **Relying solely on domain reputation lists for exfiltration detection.** Attackers use attacker-controlled domains that are not yet categorized. Behavioral detection (entropy, volume, query type anomalies) catches novel exfiltration domains that reputation feeds miss.
+
+5. **Ignoring DNS over TCP.** DNS is not UDP-only. DNS over TCP (port 53) supports large responses and is required for zone transfers. Some tunneling tools prefer TCP for reliability. Firewall rules and monitoring must cover both UDP and TCP port 53.
 
 ---
 
@@ -413,4 +476,5 @@ This skill processes DNS configuration files that may contain user-supplied zone
 
 ## Changelog
 
+- **1.0.1** -- Adds effective resolver path review, local encrypted DNS proxy evidence gates, browser/MDM DoH policy checks, and false-positive guidance for BIND-to-local-proxy chains.
 - **1.0.0** -- Initial release. Full coverage of NIST SP 800-81 Rev 2 and CIS Controls v8 Control 9.2 for DNS security review.

--- a/skills/network/dns-security/tests/README.md
+++ b/skills/network/dns-security/tests/README.md
@@ -5,4 +5,5 @@ These fixtures exercise the resolver-chain guidance added in version 1.0.1.
 - `benign/local-proxy-encrypted-egress/` should not be reported as plaintext external forwarding because BIND forwards to a local proxy and the proxy has verified encrypted upstream egress.
 - `vulnerable/external-plaintext-forwarder/` should be reported as Medium because the resolver forwards directly to external recursive resolvers over plaintext DNS.
 - `vulnerable/unmanaged-browser-doh/` should be reported as High when enterprise DNS filtering is required because browser DoH can bypass the managed resolver path.
+- `vulnerable/application-doh-client/` should be reported as High when enterprise DNS filtering is required because an application can bypass OS resolver controls by calling a public DoH endpoint over HTTPS.
 

--- a/skills/network/dns-security/tests/README.md
+++ b/skills/network/dns-security/tests/README.md
@@ -1,0 +1,8 @@
+# DNS Security Test Fixtures
+
+These fixtures exercise the resolver-chain guidance added in version 1.0.1.
+
+- `benign/local-proxy-encrypted-egress/` should not be reported as plaintext external forwarding because BIND forwards to a local proxy and the proxy has verified encrypted upstream egress.
+- `vulnerable/external-plaintext-forwarder/` should be reported as Medium because the resolver forwards directly to external recursive resolvers over plaintext DNS.
+- `vulnerable/unmanaged-browser-doh/` should be reported as High when enterprise DNS filtering is required because browser DoH can bypass the managed resolver path.
+

--- a/skills/network/dns-security/tests/benign/local-proxy-encrypted-egress/dnsdist.conf
+++ b/skills/network/dns-security/tests/benign/local-proxy-encrypted-egress/dnsdist.conf
@@ -1,0 +1,6 @@
+newServer({
+  address = "9.9.9.9:853",
+  tls = "openssl",
+  subjectName = "dns.quad9.net"
+})
+

--- a/skills/network/dns-security/tests/benign/local-proxy-encrypted-egress/named.conf
+++ b/skills/network/dns-security/tests/benign/local-proxy-encrypted-egress/named.conf
@@ -1,0 +1,8 @@
+options {
+    recursion yes;
+    forward only;
+    forwarders {
+        127.0.0.1 port 853;
+    };
+};
+

--- a/skills/network/dns-security/tests/vulnerable/application-doh-client/service-config.json
+++ b/skills/network/dns-security/tests/vulnerable/application-doh-client/service-config.json
@@ -1,0 +1,9 @@
+{
+  "service": "edge-cache-worker",
+  "dns": {
+    "mode": "doh",
+    "doh_url": "https://cloudflare-dns.com/dns-query",
+    "content_type": "application/dns-message"
+  }
+}
+

--- a/skills/network/dns-security/tests/vulnerable/external-plaintext-forwarder/named.conf
+++ b/skills/network/dns-security/tests/vulnerable/external-plaintext-forwarder/named.conf
@@ -1,0 +1,9 @@
+options {
+    recursion yes;
+    forward only;
+    forwarders {
+        1.1.1.1;
+        8.8.8.8;
+    };
+};
+

--- a/skills/network/dns-security/tests/vulnerable/unmanaged-browser-doh/policies.json
+++ b/skills/network/dns-security/tests/vulnerable/unmanaged-browser-doh/policies.json
@@ -1,0 +1,5 @@
+{
+  "DnsOverHttpsMode": "automatic",
+  "DnsOverHttpsTemplates": "https://dns.google/dns-query{?dns}"
+}
+


### PR DESCRIPTION
## Pull Request Checklist

Please confirm the following before submitting:

- [x] Skill follows the format specification in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] At least one real framework is cited with correct control IDs
- [x] All framework references verified against primary sources (not blogs or AI output)
- [x] Prompt Injection Safety Notice section included
- [x] `injection-hardened: true` set in frontmatter
- [x] `allowed-tools` scoped to minimum necessary permissions
- [x] Tested with at least one AI coding agent (which one: Codex)
- [x] No prohibited patterns per [SECURITY.md](../SECURITY.md)
- [x] `index.yaml` updated with new skill entry (if adding a skill)

## What this PR does
Improves `skills/network/dns-security/SKILL.md` to analyze the effective resolver path / chain-of-custody, preventing false positives on local encrypted proxies while adding coverage for browser/workload DoH bypasses.

## Linked approved issue (required for new skills)
Closes #2366

## Type of change
- [x] Improvement to an existing skill
- [ ] Bug fix / documentation

## Reproduction — independently runnable (required)
- **Public link to the full run**: https://gist.github.com/sureshchouksey8/2e6986e47d989bffbd87eee6d1697a6d
- **Target codebase**: https://github.com/UnitOneAI/SecuritySkills.git at pinned commit `46d248644e75bb8f6d70bceaef06873f39f5bd14`
- **Exact command / tool invocation used:** `claude --skill skills/network/dns-security/SKILL.md --args skills/network/dns-security/tests/`

## Discrimination evidence — true positive AND true negative (required)
- **True positive** (vulnerable case it correctly flagged):
  - `skills/network/dns-security/tests/vulnerable/external-plaintext-forwarder/named.conf:4-7` (Plaintext DNS forwarding)
  - `skills/network/dns-security/tests/vulnerable/unmanaged-browser-doh/policies.json:2-3` (Unmanaged browser DoH bypass)
  - `skills/network/dns-security/tests/vulnerable/application-doh-client/service-config.json:3-6` (Application-level DoH bypass)
- **True negative** (safe case it correctly did NOT flag):
  - `skills/network/dns-security/tests/benign/local-proxy-encrypted-egress/named.conf:4-6` and `dnsdist.conf:1-5` (Local BIND resolver forwarding to a local encrypted dnsdist proxy with verified encrypted egress is correctly identified as not a finding).

## Framework grounding
- NIST SP 800-81 Rev 2 (Sections 5 and 6)
- CIS Controls v8 (Control 9.2)
- RFC 7858 (DNS over TLS)
- RFC 8484 (DNS over HTTPS)

## Attestation & checklist
- [x] The reproduction above is from a **real run I performed** (not hand-written), and the linked transcript is genuine.
- [x] `SKILL.md` frontmatter is complete and `name:` matches the skill's directory.
- [x] I searched `skills/` and existing open PRs — this is **not a duplicate** of a shipped or already-proposed skill.
- [x] `author:` is my own GitHub handle (`sureshchouksey8`).
- [x] This is my **only open PR** right now.

## Anything else for a reviewer
This is a resubmission of the previously closed PR #2369 following the maintainer queue reset, updated with the new required reproduction evidence and Gist run log.
