### PR TITLE
feat: add fixer review and rollback guidance

### DIFF
--- a/SKILL_TEMPLATE.md
+++ b/SKILL_TEMPLATE.md
@@ -68,7 +68,9 @@ reference/script file (§7), not inline. Every fix recommendation must include
 remediation guidance, confidence, blast radius, behavior-change risk, and a
 test strategy that names what proves the issue is fixed. If this skill can
 modify code or configuration, classify each remediation path using the repo-level
-`docs/fixer-policy.md` before applying changes.
+`docs/fixer-policy.md` before applying changes, isolate the patch to the finding,
+request approval when the policy requires it, and include review evidence plus
+rollback guidance in the handoff.
 
 **Before (vulnerable):**
 ```
@@ -160,6 +162,7 @@ skills/<domain>/<skill-name>/
 - [ ] Before/after remediation example present
 - [ ] Every fix recommendation includes `guidance`, `confidence`, `blast_radius`, `behavior_change_risk`, and `test_strategy`
 - [ ] Every `test_strategy` includes a summary plus recommended tests, generated tests, or both
+- [ ] Fixer-capable workflows reference `docs/fixer-policy.md` and include review and rollback gates
 - [ ] Falsifiable verification test defined (binary pass/fail)
 - [ ] Gotchas: ≥2 false positives + ≥1 precision trap
 - [ ] `SKILL.md` stays lean; long detail moved to reference files

--- a/docs/fixer-policy.md
+++ b/docs/fixer-policy.md
@@ -95,6 +95,17 @@ Any of these conditions forces `human-review-required`:
 - Unclear ownership, missing tests for a high-impact path, conflicting framework guidance, or evidence that the finding may be a false positive.
 - Any remediation that would weaken an existing security control to make a tool pass.
 
+## Fixer Workflow Review Gates
+
+Fixer-capable workflows must pass these gates before any applied patch is considered ready for handoff:
+
+1. **Scope gate:** State the files, settings, and behaviors that are in scope; avoid unrelated refactors, formatting churn, dependency updates, or opportunistic cleanup.
+2. **Approval gate:** Request explicit approval before assisted-fix or human-review-required work proceeds, and before any change that affects hard-gated areas even when a patch can be drafted.
+3. **Review gate:** Provide reviewer evidence that includes the finding, policy category, changed files, behavior-change risk, verification performed or still required, and any assumptions the reviewer must confirm.
+4. **Rollback gate:** Provide rollback guidance for every proposed or applied change, including the exact revert path when local patches are used or the operational rollback owner when the change cannot be reverted locally.
+
+Applied fixes must be isolated to the smallest viable patch. If the agent discovers unrelated defects while fixing, it should report them separately instead of expanding the patch. If rollback is unclear, expensive, or depends on production state, classify the remediation as `human-review-required`.
+
 ## Skill Usage
 
-Fixer-capable skills must reference this policy when producing remediation guidance or patches. The policy classifies the remediation path only; it does not change finding schemas or require new output fields.
+Fixer-capable skills must reference this policy when producing remediation guidance or patches. Their workflows must include the review gates above and must not apply changes until the selected category allows it. The policy classifies the remediation path only; it does not change finding schemas or require new output fields.

--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -53,7 +53,7 @@ For detailed checklist items with vulnerable code patterns, remediation examples
 
 ## Findings Classification
 
-Before applying or proposing patches, classify each remediation path using [Security Fixer Policy](../../../docs/fixer-policy.md).
+Before applying or proposing patches, classify each remediation path using [Security Fixer Policy](../../../docs/fixer-policy.md). Include the policy review gate, reviewer evidence, and rollback guidance in the remediation plan.
 
 Each finding produced by this review must include the following fields:
 

--- a/skills/appsec/dependency-scanning/SKILL.md
+++ b/skills/appsec/dependency-scanning/SKILL.md
@@ -183,7 +183,7 @@ Typosquatting (also called dependency confusion or combosquatting) is a supply c
 
 ## Assessment Output Template
 
-Before applying or proposing dependency changes, classify each remediation path using [Security Fixer Policy](../../../docs/fixer-policy.md).
+Before applying or proposing dependency changes, classify each remediation path using [Security Fixer Policy](../../../docs/fixer-policy.md). Include the policy review gate, reviewer evidence, and rollback guidance in the remediation plan.
 
 When performing a dependency scan, produce findings in the following structure:
 

--- a/skills/appsec/secure-code-review/SKILL.md
+++ b/skills/appsec/secure-code-review/SKILL.md
@@ -408,7 +408,7 @@ Remediation: Validate the URL scheme (allow only `https`), resolve the hostname 
 
 ## Findings Classification
 
-Before applying or proposing patches, classify each remediation path using [Security Fixer Policy](../../../docs/fixer-policy.md).
+Before applying or proposing patches, classify each remediation path using [Security Fixer Policy](../../../docs/fixer-policy.md). Include the policy review gate, reviewer evidence, and rollback guidance in the remediation plan.
 
 Each finding produced by this review must include the following fields:
 

--- a/skills/cloud/container-security/SKILL.md
+++ b/skills/cloud/container-security/SKILL.md
@@ -124,7 +124,7 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Findings Classification
 
-Before applying or proposing container or Kubernetes changes, classify each remediation path using [Security Fixer Policy](../../../docs/fixer-policy.md).
+Before applying or proposing container or Kubernetes changes, classify each remediation path using [Security Fixer Policy](../../../docs/fixer-policy.md). Include the policy review gate, reviewer evidence, and rollback guidance in the remediation plan.
 
 | Severity | Definition | Examples |
 |----------|-----------|----------|

--- a/skills/cloud/iac-security/SKILL.md
+++ b/skills/cloud/iac-security/SKILL.md
@@ -109,7 +109,7 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ## Findings Classification
 
-Before applying or proposing infrastructure changes, classify each remediation path using [Security Fixer Policy](../../../docs/fixer-policy.md).
+Before applying or proposing infrastructure changes, classify each remediation path using [Security Fixer Policy](../../../docs/fixer-policy.md). Include the policy review gate, reviewer evidence, and rollback guidance in the remediation plan.
 
 | Severity | Definition | Examples |
 |----------|-----------|----------|

--- a/skills/devsecops/dast-config/SKILL.md
+++ b/skills/devsecops/dast-config/SKILL.md
@@ -479,7 +479,7 @@ DAST tools report findings per-URL, producing hundreds of duplicate alerts for t
 
 ## Findings Classification
 
-Before applying or proposing configuration changes, classify each remediation path using [Security Fixer Policy](../../../docs/fixer-policy.md).
+Before applying or proposing configuration changes, classify each remediation path using [Security Fixer Policy](../../../docs/fixer-policy.md). Include the policy review gate, reviewer evidence, and rollback guidance in the remediation plan.
 
 | Severity | Definition |
 |----------|-----------|

--- a/skills/devsecops/pipeline-security/SKILL.md
+++ b/skills/devsecops/pipeline-security/SKILL.md
@@ -492,7 +492,7 @@ Produce the final report using the following structure:
 
 ### Prioritized Remediation Plan
 
-Before applying or proposing pipeline changes, classify each remediation path using [Security Fixer Policy](../../../docs/fixer-policy.md).
+Before applying or proposing pipeline changes, classify each remediation path using [Security Fixer Policy](../../../docs/fixer-policy.md). Include the policy review gate, reviewer evidence, and rollback guidance in the remediation plan.
 
 1. **[Critical]** <CICD-SEC-X> -- <action item>
 2. **[High]** <CICD-SEC-X> -- <action item>

--- a/skills/devsecops/sast-config/SKILL.md
+++ b/skills/devsecops/sast-config/SKILL.md
@@ -437,7 +437,7 @@ jobs:
 
 ## Findings Classification
 
-Before applying or proposing configuration changes, classify each remediation path using [Security Fixer Policy](../../../docs/fixer-policy.md).
+Before applying or proposing configuration changes, classify each remediation path using [Security Fixer Policy](../../../docs/fixer-policy.md). Include the policy review gate, reviewer evidence, and rollback guidance in the remediation plan.
 
 | Severity | Definition |
 |----------|-----------|

--- a/skills/devsecops/secrets-management/SKILL.md
+++ b/skills/devsecops/secrets-management/SKILL.md
@@ -354,7 +354,7 @@ spec:
 
 ## Findings Classification
 
-Before applying or proposing fixes, classify each remediation path using [Security Fixer Policy](../../../docs/fixer-policy.md).
+Before applying or proposing fixes, classify each remediation path using [Security Fixer Policy](../../../docs/fixer-policy.md). Include the policy review gate, reviewer evidence, and rollback guidance in the remediation plan.
 
 | Severity | Definition |
 |----------|-----------|


### PR DESCRIPTION
## Summary
- Add fixer workflow review gates for change isolation, approval, reviewer evidence, and rollback guidance.
- Update the skill template to require review/rollback gates for fixer-capable workflows.
- Update fixer-capable AppSec, Cloud, and DevSecOps skills to include policy review gates, reviewer evidence, and rollback guidance.

## Verification
- ruby scripts/validate_skill_schema.rb
- ruby scripts/validate_index.rb
- ruby scripts/test_skill_fixtures.rb
- git diff --check

Linear: UNI-16