### PR TITLE
feat: add SARIF output support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,10 @@ top-level envelope and field semantics are documented in
 human-readable report sections may remain, but machine-readable finding output
 must use the normalized contract.
 
+When SARIF output is requested, map the normalized findings to SARIF
+2.1.0-compatible JSON using [docs/sarif-output.md](docs/sarif-output.md).
+SARIF is an export view; it must not replace the normalized JSON contract.
+
 ---
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ against [`schemas/finding.schema.json`](schemas/finding.schema.json). The
 top-level envelope, required run/skill metadata, finding fields, evidence,
 framework/CWE references, remediation fields, and test strategy requirements are
 documented in [`docs/normalized-json-output.md`](docs/normalized-json-output.md).
+When SARIF is requested, skills should map those normalized findings to
+SARIF 2.1.0-compatible JSON using [`docs/sarif-output.md`](docs/sarif-output.md).
 
 ### Progressive disclosure (keep `SKILL.md` lean)
 

--- a/SKILL_TEMPLATE.md
+++ b/SKILL_TEMPLATE.md
@@ -76,7 +76,10 @@ When machine-readable output is requested, findings MUST be available as JSON
 that validates against the repo-level normalized contract:
 [`schemas/finding.schema.json`](schemas/finding.schema.json). See
 [`docs/normalized-json-output.md`](docs/normalized-json-output.md) for
-the top-level envelope and required fields.
+the top-level envelope and required fields. When SARIF is requested, map the
+normalized findings to SARIF 2.1.0-compatible JSON using
+[`docs/sarif-output.md`](docs/sarif-output.md); do not replace or bypass the
+normalized contract.
 
 **Before (vulnerable):**
 ```
@@ -165,6 +168,7 @@ skills/<domain>/<skill-name>/
 - [ ] Every framework ID is real and resolves (no invented control numbers)
 - [ ] At least one machine-matchable detection signal (regex / structural)
 - [ ] Findings can be emitted as normalized JSON per `schemas/finding.schema.json`
+- [ ] Findings can be emitted as SARIF-compatible JSON per `docs/sarif-output.md` when requested
 - [ ] Rules are hard constraints (no "consider"/"may")
 - [ ] Before/after remediation example present
 - [ ] Every fix recommendation includes `guidance`, `confidence`, `blast_radius`, `behavior_change_risk`, and `test_strategy`

--- a/docs/normalized-json-output.md
+++ b/docs/normalized-json-output.md
@@ -5,6 +5,8 @@ that validates against [`schemas/finding.schema.json`](../schemas/finding.schema
 This contract is independent of SARIF. Downstream systems may map it to SARIF,
 ticketing systems, GRC platforms, dashboards, or vulnerability stores without
 changing individual skill output rules.
+See [`docs/sarif-output.md`](sarif-output.md) for the repo-level SARIF 2.1.0
+export mapping.
 
 ## Envelope
 

--- a/docs/sarif-output.md
+++ b/docs/sarif-output.md
@@ -1,0 +1,229 @@
+# SARIF Output Mapping
+
+SecuritySkills may emit SARIF-compatible JSON for tools that ingest Static
+Analysis Results Interchange Format (SARIF) 2.1.0. SARIF output is an export
+view of the normalized finding envelope documented in
+[`docs/normalized-json-output.md`](normalized-json-output.md); it does not
+replace the normalized JSON contract or change the required finding fields.
+
+## Top-Level Shape
+
+Use SARIF version `2.1.0` with the standard schema URI:
+
+```json
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "SecuritySkills",
+          "semanticVersion": "1.0.0",
+          "rules": []
+        }
+      },
+      "results": []
+    }
+  ]
+}
+```
+
+Use one `run` per normalized envelope. `run.tool.driver.name` should identify
+SecuritySkills or the executing agent. `run.tool.driver.semanticVersion` should
+use the skill version when a single skill produced the run.
+
+## Mapping
+
+Map normalized fields to SARIF as follows:
+
+| Normalized field | SARIF field |
+|---|---|
+| `run.id`, `run.timestamp`, `run.target`, `run.source_ref` | `runs[].properties.securityskills.run` |
+| `skill.name`, `skill.version`, `skill.path`, `skill.frameworks` | `runs[].tool.driver.name`, `runs[].tool.driver.semanticVersion`, `runs[].properties.securityskills.skill` |
+| `finding.id` | `results[].ruleId` and `results[].properties.securityskills.finding_id` |
+| `finding.fingerprint` | `results[].partialFingerprints.securityskillsFingerprint` |
+| `finding.title` | `tool.driver.rules[].shortDescription.text` |
+| `finding.description` | `tool.driver.rules[].fullDescription.text` and `results[].message.text` |
+| `finding.severity` | `results[].level` |
+| `finding.status` | `results[].properties.securityskills.status` |
+| `finding.cwe` | `tool.driver.rules[].relationships` when supported, and `properties.securityskills.cwe` |
+| `finding.framework_refs` | `tool.driver.rules[].properties.securityskills.framework_refs` |
+| `finding.evidence` | `results[].locations` plus `properties.securityskills.evidence` |
+| `finding.references` | `tool.driver.rules[].helpUri` or `tool.driver.rules[].properties.securityskills.references` |
+| `finding.remediations` | `tool.driver.rules[].help.text` and `properties.securityskills.remediations`, including each remediation's `test_strategy` |
+
+## Severity
+
+SARIF `level` has fewer values than the normalized contract. Use this mapping:
+
+| Normalized severity | SARIF level |
+|---|---|
+| `critical` | `error` |
+| `high` | `error` |
+| `medium` | `warning` |
+| `low` | `note` |
+| `info` | `note` |
+
+Keep the original severity in
+`results[].properties.securityskills.severity` so downstream systems can
+preserve the distinction between `critical` and `high`.
+
+## Locations
+
+For source, configuration, policy, or scan-result evidence with file locations,
+populate `results[].locations[].physicalLocation`:
+
+```json
+{
+  "physicalLocation": {
+    "artifactLocation": {
+      "uri": "routes/users.js"
+    },
+    "region": {
+      "startLine": 42
+    }
+  },
+  "message": {
+    "text": "DELETE /users/:id checks authentication but not administrator role."
+  }
+}
+```
+
+If the normalized evidence location does not contain a parseable file path and
+line number, still emit a SARIF result and store the original location under
+`properties.securityskills.evidence`. For cloud resources, identities, network
+assets, logs, or documents, use the best stable asset identifier as
+`artifactLocation.uri` only when it is meaningful to the SARIF consumer.
+
+## Rules
+
+Create one `tool.driver.rules[]` entry per distinct `ruleId`. A rule should
+include:
+
+- `id`: the normalized `finding.id`, or a stable detector ID when multiple
+  findings share the same detection rule.
+- `shortDescription.text`: the finding title or detector title.
+- `fullDescription.text`: the finding description.
+- `help.text`: remediation guidance and test strategy summary.
+- `properties.securityskills`: CWE IDs, framework references, normalized
+  severity, and any remediation metadata that does not fit native SARIF fields.
+
+Do not invent CWE, framework, or control identifiers for SARIF. Reuse only the
+values already present in the normalized finding.
+
+## Minimal Example
+
+```json
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "api-security",
+          "semanticVersion": "1.0.0",
+          "rules": [
+            {
+              "id": "API-SEC-001",
+              "shortDescription": {
+                "text": "Administrative endpoint lacks authorization check"
+              },
+              "fullDescription": {
+                "text": "The delete-user route accepts authenticated requests without verifying administrative privileges."
+              },
+              "help": {
+                "text": "Require an administrator role check before invoking deleteUser. Validate with integration tests for non-admin and admin delete flows."
+              },
+              "properties": {
+                "securityskills": {
+                  "severity": "high",
+                  "cwe": ["CWE-862"],
+                  "framework_refs": [
+                    {
+                      "framework": "OWASP-API-Top-10-2023",
+                      "control": "API5:2023",
+                      "name": "Broken Function Level Authorization"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "API-SEC-001",
+          "level": "error",
+          "message": {
+            "text": "Administrative endpoint lacks authorization check"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "routes/users.js"
+                },
+                "region": {
+                  "startLine": 42
+                }
+              },
+              "message": {
+                "text": "DELETE /users/:id checks authentication but not administrator role."
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "securityskillsFingerprint": "api-security:users-delete:missing-admin-auth"
+          },
+          "properties": {
+            "securityskills": {
+              "finding_id": "API-SEC-001",
+              "severity": "high",
+              "status": "open",
+              "remediations": [
+                {
+                  "guidance": "Require an administrator role check before invoking deleteUser.",
+                  "confidence": "high",
+                  "blast_radius": "User administration routes only.",
+                  "behavior_change_risk": "medium",
+                  "test_strategy": {
+                    "summary": "Proves non-admin users cannot delete accounts while admins still can.",
+                    "recommended_tests": [
+                      {
+                        "name": "Reject non-admin delete",
+                        "type": "integration",
+                        "purpose": "Confirms the authorization bypass no longer succeeds.",
+                        "command": "npm test -- users-authz.test.js",
+                        "expected_result": "Non-admin DELETE returns 403 and admin DELETE succeeds."
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "properties": {
+        "securityskills": {
+          "run": {
+            "id": "run-001",
+            "timestamp": "2026-06-16T12:00:00Z",
+            "target": "payments-api",
+            "source_ref": "abc1234"
+          },
+          "skill": {
+            "name": "api-security",
+            "version": "1.0.0",
+            "path": "skills/appsec/api-security/SKILL.md",
+            "frameworks": ["OWASP-API-Top-10-2023", "CWE"]
+          }
+        }
+      }
+    }
+  ]
+}
+```

--- a/skills/appsec/api-security/SKILL.md
+++ b/skills/appsec/api-security/SKILL.md
@@ -225,6 +225,7 @@ Unlike REST, where authorization can be enforced per endpoint, GraphQL requires 
 - **False-positive risks:** Treat findings as hypotheses until validated against asset criticality, compensating controls, environment intent, and recent authorized changes.
 - **Required evidence:** Support each finding with concrete artifacts such as file paths and line numbers, policy snippets, scanner output, logs, screenshots, control records, or reproducible steps.
 - **Normalized JSON:** When machine-readable output is requested, findings MUST be available as JSON that validates against [`schemas/finding.schema.json`](../../../schemas/finding.schema.json).
+- **SARIF JSON:** When SARIF output is requested, map normalized findings to SARIF 2.1.0-compatible JSON using [`docs/sarif-output.md`](../../../docs/sarif-output.md).
 - **Escalation rules:** Escalate immediately for suspected active compromise, exposed secrets, regulated-data exposure, critical exploitable vulnerabilities, privileged-access abuse, or when evidence is insufficient to safely disposition a high-impact risk.
 
 ---

--- a/skills/appsec/dependency-scanning/SKILL.md
+++ b/skills/appsec/dependency-scanning/SKILL.md
@@ -237,6 +237,7 @@ When performing a dependency scan, produce findings in the following structure:
 - **False-positive risks:** Treat findings as hypotheses until validated against asset criticality, compensating controls, environment intent, and recent authorized changes.
 - **Required evidence:** Support each finding with concrete artifacts such as file paths and line numbers, policy snippets, scanner output, logs, screenshots, control records, or reproducible steps.
 - **Normalized JSON:** When machine-readable output is requested, findings MUST be available as JSON that validates against [`schemas/finding.schema.json`](../../../schemas/finding.schema.json).
+- **SARIF JSON:** When SARIF output is requested, map normalized findings to SARIF 2.1.0-compatible JSON using [`docs/sarif-output.md`](../../../docs/sarif-output.md).
 - **Escalation rules:** Escalate immediately for suspected active compromise, exposed secrets, regulated-data exposure, critical exploitable vulnerabilities, privileged-access abuse, or when evidence is insufficient to safely disposition a high-impact risk.
 
 ---

--- a/skills/appsec/owasp-top-10-web/SKILL.md
+++ b/skills/appsec/owasp-top-10-web/SKILL.md
@@ -693,6 +693,7 @@ Present findings in this structure:
 - **False-positive risks:** Treat findings as hypotheses until validated against asset criticality, compensating controls, environment intent, and recent authorized changes.
 - **Required evidence:** Support each finding with concrete artifacts such as file paths and line numbers, policy snippets, scanner output, logs, screenshots, control records, or reproducible steps.
 - **Normalized JSON:** When machine-readable output is requested, findings MUST be available as JSON that validates against [`schemas/finding.schema.json`](../../../schemas/finding.schema.json).
+- **SARIF JSON:** When SARIF output is requested, map normalized findings to SARIF 2.1.0-compatible JSON using [`docs/sarif-output.md`](../../../docs/sarif-output.md).
 - **Escalation rules:** Escalate immediately for suspected active compromise, exposed secrets, regulated-data exposure, critical exploitable vulnerabilities, privileged-access abuse, or when evidence is insufficient to safely disposition a high-impact risk.
 
 ---

--- a/skills/appsec/secure-code-review/SKILL.md
+++ b/skills/appsec/secure-code-review/SKILL.md
@@ -551,6 +551,7 @@ The final review output must be structured as follows:
 - **False-positive risks:** Treat findings as hypotheses until validated against asset criticality, compensating controls, environment intent, and recent authorized changes.
 - **Required evidence:** Support each finding with concrete artifacts such as file paths and line numbers, policy snippets, scanner output, logs, screenshots, control records, or reproducible steps.
 - **Normalized JSON:** When machine-readable output is requested, findings MUST be available as JSON that validates against [`schemas/finding.schema.json`](../../../schemas/finding.schema.json).
+- **SARIF JSON:** When SARIF output is requested, map normalized findings to SARIF 2.1.0-compatible JSON using [`docs/sarif-output.md`](../../../docs/sarif-output.md).
 - **Escalation rules:** Escalate immediately for suspected active compromise, exposed secrets, regulated-data exposure, critical exploitable vulnerabilities, privileged-access abuse, or when evidence is insufficient to safely disposition a high-impact risk.
 
 ---

--- a/skills/appsec/threat-modeling/SKILL.md
+++ b/skills/appsec/threat-modeling/SKILL.md
@@ -473,6 +473,7 @@ A threat register full of identified threats but no prioritized, assignable miti
 - **False-positive risks:** Treat findings as hypotheses until validated against asset criticality, compensating controls, environment intent, and recent authorized changes.
 - **Required evidence:** Support each finding with concrete artifacts such as file paths and line numbers, policy snippets, scanner output, logs, screenshots, control records, or reproducible steps.
 - **Normalized JSON:** When machine-readable output is requested, findings MUST be available as JSON that validates against [`schemas/finding.schema.json`](../../../schemas/finding.schema.json).
+- **SARIF JSON:** When SARIF output is requested, map normalized findings to SARIF 2.1.0-compatible JSON using [`docs/sarif-output.md`](../../../docs/sarif-output.md).
 - **Escalation rules:** Escalate immediately for suspected active compromise, exposed secrets, regulated-data exposure, critical exploitable vulnerabilities, privileged-access abuse, or when evidence is insufficient to safely disposition a high-impact risk.
 
 ---

--- a/skills/devsecops/dast-config/SKILL.md
+++ b/skills/devsecops/dast-config/SKILL.md
@@ -594,6 +594,7 @@ Before applying or proposing configuration changes, classify each remediation pa
 - **False-positive risks:** Treat findings as hypotheses until validated against asset criticality, compensating controls, environment intent, and recent authorized changes.
 - **Required evidence:** Support each finding with concrete artifacts such as file paths and line numbers, policy snippets, scanner output, logs, screenshots, control records, or reproducible steps.
 - **Normalized JSON:** When machine-readable output is requested, findings MUST be available as JSON that validates against [`schemas/finding.schema.json`](../../../schemas/finding.schema.json).
+- **SARIF JSON:** When SARIF output is requested, map normalized findings to SARIF 2.1.0-compatible JSON using [`docs/sarif-output.md`](../../../docs/sarif-output.md).
 - **Escalation rules:** Escalate immediately for suspected active compromise, exposed secrets, regulated-data exposure, critical exploitable vulnerabilities, privileged-access abuse, or when evidence is insufficient to safely disposition a high-impact risk.
 
 ---

--- a/skills/devsecops/pipeline-security/SKILL.md
+++ b/skills/devsecops/pipeline-security/SKILL.md
@@ -540,6 +540,7 @@ The final deliverable is a structured assessment report as shown in Step 4 above
 - **False-positive risks:** Treat findings as hypotheses until validated against asset criticality, compensating controls, environment intent, and recent authorized changes.
 - **Required evidence:** Support each finding with concrete artifacts such as file paths and line numbers, policy snippets, scanner output, logs, screenshots, control records, or reproducible steps.
 - **Normalized JSON:** When machine-readable output is requested, findings MUST be available as JSON that validates against [`schemas/finding.schema.json`](../../../schemas/finding.schema.json).
+- **SARIF JSON:** When SARIF output is requested, map normalized findings to SARIF 2.1.0-compatible JSON using [`docs/sarif-output.md`](../../../docs/sarif-output.md).
 - **Escalation rules:** Escalate immediately for suspected active compromise, exposed secrets, regulated-data exposure, critical exploitable vulnerabilities, privileged-access abuse, or when evidence is insufficient to safely disposition a high-impact risk.
 
 ---

--- a/skills/devsecops/sast-config/SKILL.md
+++ b/skills/devsecops/sast-config/SKILL.md
@@ -546,6 +546,7 @@ Before applying or proposing configuration changes, classify each remediation pa
 - **False-positive risks:** Treat findings as hypotheses until validated against asset criticality, compensating controls, environment intent, and recent authorized changes.
 - **Required evidence:** Support each finding with concrete artifacts such as file paths and line numbers, policy snippets, scanner output, logs, screenshots, control records, or reproducible steps.
 - **Normalized JSON:** When machine-readable output is requested, findings MUST be available as JSON that validates against [`schemas/finding.schema.json`](../../../schemas/finding.schema.json).
+- **SARIF JSON:** When SARIF output is requested, map normalized findings to SARIF 2.1.0-compatible JSON using [`docs/sarif-output.md`](../../../docs/sarif-output.md).
 - **Escalation rules:** Escalate immediately for suspected active compromise, exposed secrets, regulated-data exposure, critical exploitable vulnerabilities, privileged-access abuse, or when evidence is insufficient to safely disposition a high-impact risk.
 
 ---

--- a/skills/devsecops/secrets-management/SKILL.md
+++ b/skills/devsecops/secrets-management/SKILL.md
@@ -452,6 +452,7 @@ Before applying or proposing fixes, classify each remediation path using [Securi
 - **False-positive risks:** Treat findings as hypotheses until validated against asset criticality, compensating controls, environment intent, and recent authorized changes.
 - **Required evidence:** Support each finding with concrete artifacts such as file paths and line numbers, policy snippets, scanner output, logs, screenshots, control records, or reproducible steps.
 - **Normalized JSON:** When machine-readable output is requested, findings MUST be available as JSON that validates against [`schemas/finding.schema.json`](../../../schemas/finding.schema.json).
+- **SARIF JSON:** When SARIF output is requested, map normalized findings to SARIF 2.1.0-compatible JSON using [`docs/sarif-output.md`](../../../docs/sarif-output.md).
 - **Escalation rules:** Escalate immediately for suspected active compromise, exposed secrets, regulated-data exposure, critical exploitable vulnerabilities, privileged-access abuse, or when evidence is insufficient to safely disposition a high-impact risk.
 
 ---


### PR DESCRIPTION
## Summary
- Add SARIF 2.1.0 output mapping from the normalized finding envelope.
- Document mappings for findings, severity, CWE/framework refs, locations/evidence, and remediations including test_strategy.
- Mark all AppSec and DevSecOps skills as able to emit SARIF-compatible JSON when requested.

## Verification
- ruby -rjson -e 'JSON.parse(File.read("schemas/finding.schema.json")); puts "OK: schemas/finding.schema.json parses"'
- ruby scripts/validate_skill_schema.rb
- ruby scripts/validate_index.rb
- ruby scripts/test_skill_fixtures.rb
- git diff --check

Linear: UNI-17