### PR TITLE
feat: add CI/CD examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,6 +158,13 @@ If your contribution includes skill test fixtures, also run:
 ruby scripts/test_skill_fixtures.rb
 ```
 
+If your contribution changes CI/CD examples, update
+[docs/ci-cd-examples.md](docs/ci-cd-examples.md) and run:
+
+```bash
+ruby scripts/validate_ci_cd_examples.rb
+```
+
 ### Normalized JSON output
 
 Every skill must be able to emit findings as normalized JSON that validates

--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ Validate skill fixture manifests and expected evidence strings with:
 ruby scripts/test_skill_fixtures.rb
 ```
 
+CI/CD examples for GitHub Actions, GitLab CI, Azure DevOps, Jenkins,
+pre-commit, and local agent usage are available in
+[`docs/ci-cd-examples.md`](docs/ci-cd-examples.md). Validate those examples
+locally with:
+
+```bash
+ruby scripts/validate_ci_cd_examples.rb
+```
+
 ### Normalized finding JSON
 
 Every skill must be able to emit findings as normalized JSON that validates

--- a/docs/ci-cd-examples.md
+++ b/docs/ci-cd-examples.md
@@ -1,0 +1,107 @@
+# CI/CD Examples
+
+These examples wire SecuritySkills repository validation into common CI/CD
+systems. They are intentionally small so maintainers can copy them into a
+consumer repository and then add an agent-specific review step when needed.
+
+Every hosted CI example runs:
+
+```bash
+ruby scripts/validate_skill_schema.rb
+ruby scripts/validate_index.rb
+ruby scripts/test_skill_fixtures.rb
+```
+
+Those checks validate skill frontmatter, role bundles, `index.yaml`, fixture
+manifests, and expected evidence strings. Each pipeline also prepares
+`artifacts/securityskills/` as the conventional location for normalized finding
+JSON and SARIF output from an agent review step. Use
+[`docs/normalized-json-output.md`](normalized-json-output.md) for the normalized
+JSON envelope and [`docs/sarif-output.md`](sarif-output.md) for SARIF 2.1.0
+mapping.
+
+## GitHub Actions
+
+Copy [`examples/ci/github-actions.yml`](../examples/ci/github-actions.yml) to
+`.github/workflows/securityskills.yml`.
+
+The workflow uses `ruby/setup-ruby`, validates the repository on pull requests
+and pushes to `main`, and uploads any `artifacts/securityskills/*.json` or
+`*.sarif` files that an added review step produces.
+
+## GitLab CI
+
+Copy [`examples/ci/gitlab-ci.yml`](../examples/ci/gitlab-ci.yml) to
+`.gitlab-ci.yml`.
+
+The job runs in the `ruby:3.2` container image, validates the repository, and
+keeps optional normalized JSON and SARIF artifacts for 14 days.
+
+## Azure DevOps
+
+Copy [`examples/ci/azure-pipelines.yml`](../examples/ci/azure-pipelines.yml) to
+`azure-pipelines.yml`.
+
+The pipeline runs on `ubuntu-latest`, executes the repository validators, and
+publishes `artifacts/securityskills/` as a build artifact even when validation
+fails.
+
+## Jenkins
+
+Copy [`examples/ci/Jenkinsfile`](../examples/ci/Jenkinsfile) to `Jenkinsfile`.
+
+The pipeline assumes Ruby is already installed on the Jenkins agent. If your
+agent image does not include Ruby, add the installation step that matches your
+Jenkins environment before the validation commands.
+
+## pre-commit
+
+Copy
+[`examples/ci/pre-commit-config.yaml`](../examples/ci/pre-commit-config.yaml)
+to `.pre-commit-config.yaml`, or merge the local hooks into an existing config.
+
+Run the hooks locally with:
+
+```bash
+pre-commit run --all-files
+```
+
+The hooks use `language: system`, so Ruby must be available in the developer
+environment.
+
+## Local Agent Usage
+
+Run [`examples/ci/local-agent.sh`](../examples/ci/local-agent.sh) from a clone
+of this repository:
+
+```bash
+examples/ci/local-agent.sh path/to/target
+```
+
+The script validates the repository, creates `artifacts/securityskills/`, and
+writes an agent prompt that asks for both:
+
+- `artifacts/securityskills/securityskills-findings.json`
+- `artifacts/securityskills/securityskills-findings.sarif`
+
+Set `SKILL_PATH` to review with a specific skill:
+
+```bash
+SKILL_PATH=skills/devsecops/pipeline-security/SKILL.md examples/ci/local-agent.sh .
+```
+
+The script does not invoke a hosted model or require credentials. It prints a
+copy-paste Codex command so teams can adapt it to Codex CLI, Claude Code,
+Gemini CLI, Cursor, Kiro, or another local agent.
+
+## Validating These Examples
+
+Run the example validator after changing any files in `examples/ci/`:
+
+```bash
+ruby scripts/validate_ci_cd_examples.rb
+```
+
+The validator parses the YAML examples, checks that each platform includes the
+three repository validation commands, confirms Jenkins archives optional
+artifacts, and syntax-checks the local agent shell script.

--- a/examples/ci/Jenkinsfile
+++ b/examples/ci/Jenkinsfile
@@ -1,0 +1,23 @@
+pipeline {
+  agent any
+
+  stages {
+    stage('Validate SecuritySkills') {
+      steps {
+        sh '''
+          ruby --version
+          ruby scripts/validate_skill_schema.rb
+          ruby scripts/validate_index.rb
+          ruby scripts/test_skill_fixtures.rb
+          mkdir -p artifacts/securityskills
+        '''
+      }
+    }
+  }
+
+  post {
+    always {
+      archiveArtifacts artifacts: 'artifacts/securityskills/**/*', allowEmptyArchive: true
+    }
+  }
+}

--- a/examples/ci/azure-pipelines.yml
+++ b/examples/ci/azure-pipelines.yml
@@ -1,0 +1,29 @@
+trigger:
+  branches:
+    include:
+      - main
+
+pr:
+  branches:
+    include:
+      - main
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+  - script: |
+      ruby --version
+      ruby scripts/validate_skill_schema.rb
+      ruby scripts/validate_index.rb
+      ruby scripts/test_skill_fixtures.rb
+      mkdir -p artifacts/securityskills
+    displayName: Validate SecuritySkills repository
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish normalized JSON and SARIF artifacts
+    condition: always()
+    inputs:
+      PathtoPublish: artifacts/securityskills
+      ArtifactName: securityskills-artifacts
+      publishLocation: Container

--- a/examples/ci/github-actions.yml
+++ b/examples/ci/github-actions.yml
@@ -1,0 +1,40 @@
+name: SecuritySkills validation
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  validate:
+    name: Validate skills, index, and fixtures
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+
+      - name: Run SecuritySkills validation
+        run: |
+          ruby scripts/validate_skill_schema.rb
+          ruby scripts/validate_index.rb
+          ruby scripts/test_skill_fixtures.rb
+
+      - name: Prepare optional SecuritySkills artifacts
+        if: always()
+        run: mkdir -p artifacts/securityskills
+
+      - name: Upload normalized JSON and SARIF artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: securityskills-artifacts
+          path: |
+            artifacts/securityskills/*.json
+            artifacts/securityskills/*.sarif
+          if-no-files-found: ignore

--- a/examples/ci/gitlab-ci.yml
+++ b/examples/ci/gitlab-ci.yml
@@ -1,0 +1,17 @@
+stages:
+  - validate
+
+securityskills:validate:
+  stage: validate
+  image: ruby:3.2
+  script:
+    - ruby scripts/validate_skill_schema.rb
+    - ruby scripts/validate_index.rb
+    - ruby scripts/test_skill_fixtures.rb
+    - mkdir -p artifacts/securityskills
+  artifacts:
+    when: always
+    expire_in: 14 days
+    paths:
+      - artifacts/securityskills/*.json
+      - artifacts/securityskills/*.sarif

--- a/examples/ci/local-agent.sh
+++ b/examples/ci/local-agent.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TARGET="${1:-.}"
+SKILL_PATH="${SKILL_PATH:-skills/appsec/secure-code-review/SKILL.md}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-artifacts/securityskills}"
+PROMPT_FILE="$ARTIFACT_DIR/local-agent-prompt.md"
+
+cd "$ROOT_DIR"
+
+ruby scripts/validate_skill_schema.rb
+ruby scripts/validate_index.rb
+ruby scripts/test_skill_fixtures.rb
+
+mkdir -p "$ARTIFACT_DIR"
+
+cat > "$PROMPT_FILE" <<PROMPT
+Use SecuritySkills skill: $SKILL_PATH
+Target: $TARGET
+
+Run a security review against the target and emit:
+- Normalized finding JSON at $ARTIFACT_DIR/securityskills-findings.json
+- SARIF 2.1.0 export at $ARTIFACT_DIR/securityskills-findings.sarif
+
+Follow docs/normalized-json-output.md for the normalized envelope.
+Follow docs/sarif-output.md for the SARIF mapping.
+Do not invent framework or CWE identifiers.
+PROMPT
+
+echo "Validation passed."
+echo "Agent prompt written to $PROMPT_FILE"
+echo "Example Codex command:"
+echo "  codex --context \"$SKILL_PATH\" \"$(tr '\n' ' ' < "$PROMPT_FILE")\""

--- a/examples/ci/pre-commit-config.yaml
+++ b/examples/ci/pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: local
+    hooks:
+      - id: securityskills-schema
+        name: Validate SecuritySkills schema
+        entry: ruby scripts/validate_skill_schema.rb
+        language: system
+        pass_filenames: false
+
+      - id: securityskills-index
+        name: Validate SecuritySkills index
+        entry: ruby scripts/validate_index.rb
+        language: system
+        pass_filenames: false
+
+      - id: securityskills-fixtures
+        name: Validate SecuritySkills fixtures
+        entry: ruby scripts/test_skill_fixtures.rb
+        language: system
+        pass_filenames: false

--- a/scripts/validate_ci_cd_examples.rb
+++ b/scripts/validate_ci_cd_examples.rb
@@ -1,0 +1,76 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "yaml"
+require "English"
+
+ROOT = File.expand_path("..", __dir__)
+EXAMPLE_DIR = File.join(ROOT, "examples", "ci")
+YAML_EXAMPLES = %w[
+  github-actions.yml
+  gitlab-ci.yml
+  azure-pipelines.yml
+  pre-commit-config.yaml
+].freeze
+REQUIRED_COMMANDS = %w[
+  ruby\ scripts/validate_skill_schema.rb
+  ruby\ scripts/validate_index.rb
+  ruby\ scripts/test_skill_fixtures.rb
+].freeze
+
+def rel(path)
+  path.delete_prefix("#{ROOT}#{File::SEPARATOR}")
+end
+
+def validate_yaml(path, errors)
+  document = YAML.safe_load(File.read(path), permitted_classes: [], aliases: false)
+  errors << "#{rel(path)}: YAML document must be a mapping" unless document.is_a?(Hash)
+rescue Psych::SyntaxError => e
+  errors << "#{rel(path)}: invalid YAML: #{e.message}"
+end
+
+def validate_required_commands(path, errors)
+  text = File.read(path)
+  REQUIRED_COMMANDS.each do |command|
+    errors << "#{rel(path)}: missing #{command}" unless text.include?(command.tr("\\", ""))
+  end
+end
+
+errors = []
+
+YAML_EXAMPLES.each do |filename|
+  path = File.join(EXAMPLE_DIR, filename)
+  if File.file?(path)
+    validate_yaml(path, errors)
+    validate_required_commands(path, errors)
+  else
+    errors << "#{rel(path)}: missing CI example"
+  end
+end
+
+jenkinsfile = File.join(EXAMPLE_DIR, "Jenkinsfile")
+if File.file?(jenkinsfile)
+  validate_required_commands(jenkinsfile, errors)
+  text = File.read(jenkinsfile)
+  errors << "#{rel(jenkinsfile)}: missing archiveArtifacts step" unless text.include?("archiveArtifacts")
+else
+  errors << "#{rel(jenkinsfile)}: missing CI example"
+end
+
+local_agent = File.join(EXAMPLE_DIR, "local-agent.sh")
+if File.file?(local_agent)
+  validate_required_commands(local_agent, errors)
+  system("bash", "-n", local_agent)
+  errors << "#{rel(local_agent)}: bash syntax check failed" unless $CHILD_STATUS.success?
+else
+  errors << "#{rel(local_agent)}: missing local agent example"
+end
+
+if errors.empty?
+  puts "OK: validated CI/CD examples."
+else
+  puts "FAIL: CI/CD example validation failed."
+  errors.each { |error| puts "  - #{error}" }
+end
+
+exit(errors.empty? ? 0 : 1)


### PR DESCRIPTION
## Summary
- Add copy-paste CI/CD examples for GitHub Actions, GitLab CI, Azure DevOps, Jenkins, pre-commit, and local agent usage.
- Document how examples validate SecuritySkills and reserve normalized JSON/SARIF artifact output paths.
- Add scripts/validate_ci_cd_examples.rb to parse YAML examples, verify required commands, check Jenkins artifacts, and syntax-check the local agent script.

## Verification
- ruby scripts/validate_skill_schema.rb
- ruby scripts/validate_index.rb
- ruby scripts/test_skill_fixtures.rb
- ruby scripts/validate_ci_cd_examples.rb
- git diff --check

Linear: UNI-19