### PR TITLE
feat: add tracker handoff format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,6 +178,13 @@ When SARIF output is requested, map the normalized findings to SARIF
 2.1.0-compatible JSON using [docs/sarif-output.md](docs/sarif-output.md).
 SARIF is an export view; it must not replace the normalized JSON contract.
 
+When tracker handoff output is requested, map normalized findings to
+tracker-ready work items using
+[docs/tracker-handoff.md](docs/tracker-handoff.md). Tracker handoff is an export
+view for systems such as DefectDojo, Jira, and Linear; it must include title,
+severity, evidence, owner, SLA, and remediation, and must not require a live
+tracker integration.
+
 ---
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ framework/CWE references, remediation fields, and test strategy requirements are
 documented in [`docs/normalized-json-output.md`](docs/normalized-json-output.md).
 When SARIF is requested, skills should map those normalized findings to
 SARIF 2.1.0-compatible JSON using [`docs/sarif-output.md`](docs/sarif-output.md).
+When tracker handoff is requested, skills should map normalized findings to
+tracker-ready work items using
+[`docs/tracker-handoff.md`](docs/tracker-handoff.md) and
+[`schemas/tracker-handoff.schema.json`](schemas/tracker-handoff.schema.json).
 
 ### Progressive disclosure (keep `SKILL.md` lean)
 

--- a/SKILL_TEMPLATE.md
+++ b/SKILL_TEMPLATE.md
@@ -79,7 +79,11 @@ that validates against the repo-level normalized contract:
 the top-level envelope and required fields. When SARIF is requested, map the
 normalized findings to SARIF 2.1.0-compatible JSON using
 [`docs/sarif-output.md`](docs/sarif-output.md); do not replace or bypass the
-normalized contract.
+normalized contract. When tracker handoff is requested, map normalized findings
+to tracker-ready work items using
+[`docs/tracker-handoff.md`](docs/tracker-handoff.md); include title, severity,
+evidence, owner, SLA, and remediation without performing live tracker
+integration.
 
 **Before (vulnerable):**
 ```
@@ -169,6 +173,7 @@ skills/<domain>/<skill-name>/
 - [ ] At least one machine-matchable detection signal (regex / structural)
 - [ ] Findings can be emitted as normalized JSON per `schemas/finding.schema.json`
 - [ ] Findings can be emitted as SARIF-compatible JSON per `docs/sarif-output.md` when requested
+- [ ] Findings can be emitted as tracker handoff JSON per `docs/tracker-handoff.md` when requested
 - [ ] Rules are hard constraints (no "consider"/"may")
 - [ ] Before/after remediation example present
 - [ ] Every fix recommendation includes `guidance`, `confidence`, `blast_radius`, `behavior_change_risk`, and `test_strategy`

--- a/docs/tracker-handoff.md
+++ b/docs/tracker-handoff.md
@@ -1,0 +1,249 @@
+# Tracker Handoff Format
+
+SecuritySkills can emit tracker-ready work items for DefectDojo, Jira, Linear,
+or equivalent issue trackers. The handoff format is an export view of the
+normalized finding envelope documented in
+[`docs/normalized-json-output.md`](normalized-json-output.md). It does not
+replace normalized findings, perform live API calls, or require credentials.
+
+The JSON shape validates against
+[`schemas/tracker-handoff.schema.json`](../schemas/tracker-handoff.schema.json).
+
+## Envelope
+
+Every tracker handoff uses this top-level shape:
+
+```json
+{
+  "schema_version": "1.0.0",
+  "source": {
+    "normalized_schema_version": "1.0.0",
+    "run_id": "run-001",
+    "generated_at": "2026-06-16T12:00:00Z",
+    "target": "payments-api",
+    "source_ref": "abc1234",
+    "skill_name": "api-security",
+    "skill_version": "1.0.0"
+  },
+  "work_items": []
+}
+```
+
+- `schema_version` is fixed at `1.0.0` until a breaking handoff change is
+  required.
+- `source` identifies the normalized finding run that produced the handoff.
+- `work_items` contains one tracker-ready item per normalized finding, unless a
+  downstream workflow intentionally groups findings before export.
+
+## Required Work Item Fields
+
+Each work item must include:
+
+- `title`: concise issue title suitable for a tracker summary.
+- `severity`: one of `info`, `low`, `medium`, `high`, or `critical`.
+- `evidence`: one or more concrete evidence entries with `location` and
+  `summary`.
+- `owner`: responsible person, team, service, or queue.
+- `sla`: due date or timestamp plus the SLA policy or rationale.
+- `remediation`: concrete guidance and validation summary.
+- `tracker_fields`: explicit DefectDojo, Jira, and Linear import hints.
+
+The handoff should preserve `source_finding_id` and, when available,
+`source_finding_fingerprint` so importers can deduplicate work items without
+depending on mutable titles.
+
+## Mapping From Normalized Findings
+
+| Normalized field | Tracker handoff field |
+|---|---|
+| `run.id`, `run.target`, `run.source_ref` | `source.run_id`, `source.target`, `source.source_ref` |
+| `skill.name`, `skill.version` | `source.skill_name`, `source.skill_version` |
+| `finding.id` | `work_items[].source_finding_id` |
+| `finding.fingerprint` | `work_items[].source_finding_fingerprint` and `tracker_fields.defectdojo.unique_id_from_tool` |
+| `finding.title` | `work_items[].title` |
+| `finding.description` | `work_items[].description` and tracker description bodies |
+| `finding.severity` | `work_items[].severity` and tracker priority/severity fields |
+| `finding.evidence` | `work_items[].evidence` and tracker description bodies |
+| `finding.references`, `finding.cwe`, `finding.framework_refs` | `work_items[].references`, labels, and tracker description bodies |
+| `finding.remediations[0].guidance` | `work_items[].remediation.guidance` |
+| `finding.remediations[0].test_strategy.summary` | `work_items[].remediation.validation` |
+
+Owner and SLA are not present in the normalized finding contract. A handoff
+producer must add them from routing rules, service ownership metadata, severity
+policy, or an orchestrator-supplied assignment map before a work item is
+considered tracker-ready.
+
+## Severity And Priority
+
+Use the normalized `severity` value as the canonical severity. Tracker-specific
+fields may require translation:
+
+| Normalized severity | DefectDojo severity | Jira priority | Linear priority |
+|---|---|---|---|
+| `critical` | `Critical` | `Highest` | `1` |
+| `high` | `High` | `High` | `2` |
+| `medium` | `Medium` | `Medium` | `3` |
+| `low` | `Low` | `Low` | `4` |
+| `info` | `Info` | `Lowest` | `0` |
+
+Keep the original normalized severity in `work_items[].severity` even when a
+tracker has fewer or differently named priority levels.
+
+## Tracker Field Mappings
+
+### DefectDojo
+
+Map a work item to DefectDojo finding import fields:
+
+| Handoff field | DefectDojo field |
+|---|---|
+| `title` | `title` |
+| `severity` | `severity` |
+| `description` plus evidence | `description` |
+| `remediation.guidance` | `mitigation` |
+| `source_finding_fingerprint` or `source_finding_id` | `unique_id_from_tool` |
+| `source.target` or affected asset | `component_name` |
+| CWE reference, when present | `cwe` |
+| `references` | `references` |
+| `labels` | `tags` |
+| `sla.due_at` | `due_date` |
+
+### Jira
+
+Map a work item to Jira issue import fields:
+
+| Handoff field | Jira field |
+|---|---|
+| `title` | `summary` |
+| `description`, evidence, remediation, validation | `description` |
+| Handoff policy | `issue_type`, usually `Bug`, `Task`, or `Security Finding` |
+| `severity` | `priority` |
+| `owner.id` | `assignee` |
+| `sla.due_at` | `due_date` |
+| `labels` | `labels` |
+| Security classification policy | `security_level` |
+
+### Linear
+
+Map a work item to Linear issue fields:
+
+| Handoff field | Linear field |
+|---|---|
+| `title` | `title` |
+| `description`, evidence, remediation, validation | `description` |
+| `severity` | `priority` |
+| `owner.id` | `assignee_id` |
+| Owner routing | `team_key` |
+| `sla.due_at` | `due_date` |
+| `labels` | `label_names` |
+| Handoff workflow policy | `state_name` |
+
+## Description Body
+
+Tracker descriptions should be complete enough for an assignee to act without
+opening the raw scanner output. Include:
+
+- finding context and severity;
+- concrete evidence locations and redacted snippets;
+- remediation guidance;
+- validation or test strategy;
+- SLA due date and owner;
+- CWE, framework, and external references when available.
+
+Do not include secrets, tokens, personal data, or unredacted internal-only
+values. Preserve `redacted: true` when evidence was sanitized.
+
+## Minimal Example
+
+```json
+{
+  "schema_version": "1.0.0",
+  "source": {
+    "normalized_schema_version": "1.0.0",
+    "run_id": "run-001",
+    "generated_at": "2026-06-16T12:00:00Z",
+    "target": "payments-api",
+    "source_ref": "abc1234",
+    "skill_name": "api-security",
+    "skill_version": "1.0.0"
+  },
+  "work_items": [
+    {
+      "id": "TRACKER-001",
+      "source_finding_id": "API-SEC-001",
+      "source_finding_fingerprint": "api-security:users-delete:missing-admin-auth",
+      "title": "Administrative endpoint lacks authorization check",
+      "severity": "high",
+      "status": "ready",
+      "description": "The delete-user route accepts authenticated requests without verifying administrative privileges.",
+      "evidence": [
+        {
+          "location": "routes/users.js:42",
+          "artifact_type": "source",
+          "summary": "DELETE /users/:id checks authentication but not administrator role.",
+          "snippet": "router.delete('/users/:id', requireAuth, deleteUser)",
+          "redacted": false
+        }
+      ],
+      "owner": {
+        "type": "team",
+        "id": "payments-platform",
+        "display_name": "Payments Platform"
+      },
+      "sla": {
+        "due_at": "2026-06-30",
+        "policy": "High severity application security findings remediate within 14 days."
+      },
+      "remediation": {
+        "guidance": "Require an administrator role check before invoking deleteUser.",
+        "validation": "Run integration tests proving non-admin delete requests return 403 and admin delete requests still succeed.",
+        "confidence": "high",
+        "blast_radius": "User administration routes only.",
+        "behavior_change_risk": "medium"
+      },
+      "labels": ["security", "api-security", "CWE-862"],
+      "references": [
+        {
+          "type": "cwe",
+          "id": "CWE-862",
+          "url": "https://cwe.mitre.org/data/definitions/862.html"
+        }
+      ],
+      "tracker_fields": {
+        "defectdojo": {
+          "title": "Administrative endpoint lacks authorization check",
+          "severity": "High",
+          "description": "The delete-user route accepts authenticated requests without verifying administrative privileges. Evidence: routes/users.js:42.",
+          "mitigation": "Require an administrator role check before invoking deleteUser.",
+          "unique_id_from_tool": "api-security:users-delete:missing-admin-auth",
+          "component_name": "payments-api",
+          "cwe": "CWE-862",
+          "references": "https://cwe.mitre.org/data/definitions/862.html",
+          "tags": ["security", "api-security", "CWE-862"],
+          "due_date": "2026-06-30"
+        },
+        "jira": {
+          "summary": "Administrative endpoint lacks authorization check",
+          "description": "Severity: high\n\nEvidence:\n- routes/users.js:42: DELETE /users/:id checks authentication but not administrator role.\n\nRemediation: Require an administrator role check before invoking deleteUser.\n\nValidation: Run integration tests proving non-admin delete requests return 403 and admin delete requests still succeed.",
+          "issue_type": "Security Finding",
+          "priority": "High",
+          "assignee": "payments-platform",
+          "due_date": "2026-06-30",
+          "labels": ["security", "api-security", "CWE-862"],
+          "security_level": "Security"
+        },
+        "linear": {
+          "title": "Administrative endpoint lacks authorization check",
+          "description": "Severity: high\n\nEvidence:\n- routes/users.js:42: DELETE /users/:id checks authentication but not administrator role.\n\nRemediation: Require an administrator role check before invoking deleteUser.\n\nValidation: Run integration tests proving non-admin delete requests return 403 and admin delete requests still succeed.",
+          "priority": 2,
+          "assignee_id": "payments-platform",
+          "team_key": "PAY",
+          "due_date": "2026-06-30",
+          "label_names": ["security", "api-security", "CWE-862"],
+          "state_name": "Todo"
+        }
+      }
+    }
+  ]
+}
+```

--- a/schemas/tracker-handoff.schema.json
+++ b/schemas/tracker-handoff.schema.json
@@ -1,0 +1,381 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/UnitOneAI/SecuritySkills/schemas/tracker-handoff.schema.json",
+  "title": "SecuritySkills Tracker Handoff Output",
+  "description": "Machine-readable tracker-ready work item envelope derived from normalized SecuritySkills findings for DefectDojo, Jira, Linear, or equivalent issue trackers. This schema describes export data only and does not perform live integration.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "source", "work_items"],
+  "properties": {
+    "schema_version": {
+      "const": "1.0.0",
+      "description": "Version of this tracker handoff envelope."
+    },
+    "source": {
+      "$ref": "#/$defs/source",
+      "description": "Metadata from the normalized finding envelope that produced this handoff."
+    },
+    "work_items": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/workItem"
+      },
+      "description": "Tracker-ready work items derived from normalized findings."
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["info", "low", "medium", "high", "critical"]
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["normalized_schema_version", "run_id", "generated_at"],
+      "properties": {
+        "normalized_schema_version": {
+          "const": "1.0.0",
+          "description": "Version of schemas/finding.schema.json used as the source contract."
+        },
+        "run_id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "generated_at": {
+          "$ref": "#/$defs/nonEmptyString",
+          "description": "ISO 8601 timestamp for when this handoff was generated."
+        },
+        "target": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "source_ref": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "skill_name": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "skill_version": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "workItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "source_finding_id",
+        "title",
+        "severity",
+        "evidence",
+        "owner",
+        "sla",
+        "remediation",
+        "tracker_fields"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/nonEmptyString",
+          "description": "Stable handoff item identifier within this export."
+        },
+        "source_finding_id": {
+          "$ref": "#/$defs/nonEmptyString",
+          "description": "Normalized finding id that produced this work item."
+        },
+        "source_finding_fingerprint": {
+          "$ref": "#/$defs/nonEmptyString",
+          "description": "Normalized finding fingerprint used for tracker deduplication when available."
+        },
+        "title": {
+          "$ref": "#/$defs/nonEmptyString",
+          "description": "Concise tracker issue title."
+        },
+        "severity": {
+          "$ref": "#/$defs/severity"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["ready", "blocked", "deferred"],
+          "description": "Handoff readiness status, not the target tracker status."
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyString",
+          "description": "Issue context suitable for a tracker description body."
+        },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/evidence"
+          },
+          "description": "Concrete evidence copied or summarized from the normalized finding."
+        },
+        "owner": {
+          "$ref": "#/$defs/owner",
+          "description": "Responsible person, team, service, or resolver queue for the work item."
+        },
+        "sla": {
+          "$ref": "#/$defs/sla",
+          "description": "Expected remediation target for the work item."
+        },
+        "remediation": {
+          "$ref": "#/$defs/remediation",
+          "description": "Remediation guidance and validation requirements copied from the normalized finding."
+        },
+        "labels": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          },
+          "description": "Tracker labels or tags to apply during import."
+        },
+        "references": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/reference"
+          },
+          "description": "External standards, advisories, or knowledge-base links useful to the assignee."
+        },
+        "tracker_fields": {
+          "$ref": "#/$defs/trackerFields",
+          "description": "Tracker-specific field mappings. Values are import hints, not API calls."
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["location", "summary"],
+      "properties": {
+        "location": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "summary": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "artifact_type": {
+          "type": "string",
+          "enum": ["source", "config", "policy", "log", "scan_result", "cloud_resource", "identity", "network", "document", "other"]
+        },
+        "snippet": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "redacted": {
+          "type": "boolean"
+        }
+      }
+    },
+    "owner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "id"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["person", "team", "service", "queue"]
+        },
+        "id": {
+          "$ref": "#/$defs/nonEmptyString",
+          "description": "Tracker account ID, team key, service ID, group alias, or queue name."
+        },
+        "display_name": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "sla": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["due_at", "policy"],
+      "properties": {
+        "due_at": {
+          "$ref": "#/$defs/nonEmptyString",
+          "description": "ISO 8601 date or timestamp when remediation is due."
+        },
+        "policy": {
+          "$ref": "#/$defs/nonEmptyString",
+          "description": "SLA policy name or rationale, such as severity-based remediation standard."
+        }
+      }
+    },
+    "remediation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["guidance", "validation"],
+      "properties": {
+        "guidance": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "validation": {
+          "$ref": "#/$defs/nonEmptyString",
+          "description": "Test strategy summary or command set that proves remediation is complete."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": ["low", "medium", "high"]
+        },
+        "blast_radius": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "behavior_change_risk": {
+          "type": "string",
+          "enum": ["low", "medium", "high"]
+        }
+      }
+    },
+    "reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "id"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["cve", "cwe", "framework", "advisory", "vendor", "documentation", "other"]
+        },
+        "id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "trackerFields": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["defectdojo", "jira", "linear"],
+      "properties": {
+        "defectdojo": {
+          "$ref": "#/$defs/defectDojoFields"
+        },
+        "jira": {
+          "$ref": "#/$defs/jiraFields"
+        },
+        "linear": {
+          "$ref": "#/$defs/linearFields"
+        }
+      }
+    },
+    "defectDojoFields": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "severity", "description", "mitigation", "unique_id_from_tool"],
+      "properties": {
+        "title": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["Info", "Low", "Medium", "High", "Critical"]
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "mitigation": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "unique_id_from_tool": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "component_name": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "cwe": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "references": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "tags": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        },
+        "due_date": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "jiraFields": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["summary", "description", "issue_type", "priority", "assignee", "due_date"],
+      "properties": {
+        "summary": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "issue_type": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "priority": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "assignee": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "due_date": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "labels": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        },
+        "security_level": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "linearFields": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "description", "priority", "assignee_id", "team_key", "due_date"],
+      "properties": {
+        "title": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "priority": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 4
+        },
+        "assignee_id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "team_key": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "due_date": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "label_names": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        },
+        "state_name": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a strict tracker handoff schema for DefectDojo, Jira, Linear, and equivalent issue trackers.
- Document required tracker-ready fields: title, severity, evidence, owner, SLA, and remediation.
- Add normalized finding mappings plus DefectDojo/Jira/Linear field mappings.
- Link the handoff contract from README, CONTRIBUTING, and the skill template.

## Verification
- Parsed schemas/tracker-handoff.schema.json as JSON.
- Parsed embedded JSON examples in docs/tracker-handoff.md.
- ruby scripts/validate_skill_schema.rb
- ruby scripts/validate_index.rb
- ruby scripts/test_skill_fixtures.rb
- git diff --check

Linear: UNI-20