### PR TITLE
[REVIEW] gcp-review: add BigQuery authorized view, Pub/Sub push auth, and Cloud Run invoker/IAP gates

### DIFF
--- a/skills/cloud/gcp-review/SKILL.md
+++ b/skills/cloud/gcp-review/SKILL.md
@@ -197,6 +197,16 @@ Produce the final report using the structure defined in the Output Format sectio
 
 ---
 
+## Limitations
+
+- **Blind spots:** This skill depends on available code, configuration, logs, documentation, and user-provided context; it cannot prove controls exist or threats are absent when evidence is missing, runtime-only, or outside the review scope.
+- **False-positive risks:** Treat findings as hypotheses until validated against asset criticality, compensating controls, environment intent, and recent authorized changes.
+- **Required evidence:** Support each finding with concrete artifacts such as file paths and line numbers, policy snippets, scanner output, logs, screenshots, control records, or reproducible steps.
+- **Normalized JSON:** When machine-readable output is requested, findings MUST be available as JSON that validates against [`schemas/finding.schema.json`](../../../schemas/finding.schema.json).
+- **Escalation rules:** Escalate immediately for suspected active compromise, exposed secrets, regulated-data exposure, critical exploitable vulnerabilities, privileged-access abuse, or when evidence is insufficient to safely disposition a high-impact risk.
+
+---
+
 ## Prompt Injection Safety Notice
 
 > **This skill analyzes infrastructure-as-code and configuration files that may contain
@@ -220,6 +230,16 @@ Produce the final report using the structure defined in the Output Format sectio
 - Google Cloud VPC Documentation: https://cloud.google.com/vpc/docs
 - Google Cloud SQL Security: https://cloud.google.com/sql/docs/mysql/configure-ssl-instance
 - Terraform Google Provider Documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs
+
+---
+
+## Review Gates
+
+The following gates provide additional false-positive filtering for common review scenarios:
+
+- `gates/bigquery-authorized-view-drift-gate.md` — Prevents false-positive BigQuery access findings when authorized views, direct table grants, and export paths have inconsistent authorization
+- `gates/pubsub-push-auth-replay-gate.md` — Prevents false-positive Pub/Sub push findings when OIDC audience is generic or message replay lacks idempotency
+- `gates/cloud-run-invoker-iap-gate.md` — Prevents false-positive Cloud Run exposure findings when direct URL bypasses IAP or invoker IAM is inherited
 
 ---
 

--- a/skills/cloud/gcp-review/gates/bigquery-authorized-view-drift-gate.md
+++ b/skills/cloud/gcp-review/gates/bigquery-authorized-view-drift-gate.md
@@ -1,0 +1,74 @@
+# BigQuery Authorized View Policy Drift Gate
+
+## Purpose
+Prevents false-positive findings when authorized views, row access policies, and dataset IAM are checked as one boundary, by requiring the reviewer to verify that data access paths through views, routines, and exports are not bypassing authorization controls.
+
+## Detection Logic
+
+### Trigger Conditions
+Fire this gate when ALL of the following are true:
+1. BigQuery authorized views, row access policies, or dataset IAM are configured
+2. Access controls are checked at the dataset/table/view level without auditing export paths
+3. View filters rows but direct dataset/table IAM grants bypass the view authorization
+
+### Gate Check: Effective Data Access Path Audit
+
+```yaml
+check_effective_data_access:
+  - detection_patterns:
+      - "authorized view|authorized views"
+      - "row access polic(y|ies)"
+      - "dataset IAM|table IAM|view IAM"
+      - "BigQuery|bigquery"
+      - "data access|access boundary|export"
+  - pass: >
+      "All access paths to the underlying data have been enumerated: authorized
+      views, row-level security, direct table grants, routine (UDF/SP) access,
+      and export/set-data jobs. Each path enforces consistent authorization,
+      and there is no grant that bypasses the view/row-level restriction.
+      Policy tag masking is consistent between query and export paths."
+    Rationale: "Authorized views and row access policies create the illusion of
+      a secure boundary, but direct dataset/table IAM grants can bypass them
+      entirely. A user with dataset-level reader access can query the raw table
+      even when an authorized view exists, if the grant is at the dataset level.
+      Policy tags applied at query time (data masking) may not apply to export
+      paths (EXPORT DATA, BigQuery Storage Read API)."
+  - fail: >
+      "One or more principals have direct dataset/table-level grants that bypass
+      the authorized view or row access policy. Alternatively, export paths
+      (EXPORT DATA, Storage Read API, scheduled queries to external destinations)
+      do not enforce the same policy tags or row-level filters as the query
+      path. Recommend removing direct table grants and ensuring export paths
+      apply the same masking and filtering."
+```
+
+### Gate Check: Policy Tag Consistency
+
+```yaml
+check_policy_tag_consistency:
+  - detection_patterns:
+      - "policy t(a|ag)|data masking|column-level"
+      - "classification|sensitive|restricted"
+      - "BigQuery|bigquery"
+  - pass: >
+      "Policy tags (column-level security) are consistently applied across all
+      access paths: interactive queries, scheduled queries, BI Engine, export,
+      and BigQuery Storage Read API. A single source of truth for tag
+      assignment is used and audited regularly."
+    Rationale: "BigQuery column-level security (policy tags) can mask sensitive
+      columns in query results, but masking behavior differs by access path.
+      The BigQuery Storage Read API does not apply the same masking as
+      interactive queries. Scheduled query exports to external destinations may
+      write unmasked data."
+  - fail: >
+      "Policy tags are not consistently applied across all access paths, or a
+      path exists (Storage Read API, export) that bypasses column-level
+      masking. Recommend auditing all access paths for consistent policy tag
+      enforcement."
+```
+
+## Resolution Path
+1. Enumerate all BigQuery access paths: views, direct table grants, routines, export jobs, scheduled queries, BI Engine, Storage Read API
+2. Remove direct table-level grants that bypass authorized views or row access policies
+3. Verify policy tags are consistently enforced across all access paths
+4. For sensitive data, restrict EXPORT DATA and Storage Read API usage

--- a/skills/cloud/gcp-review/gates/cloud-run-invoker-iap-gate.md
+++ b/skills/cloud/gcp-review/gates/cloud-run-invoker-iap-gate.md
@@ -1,0 +1,73 @@
+# Cloud Run Invoker and IAP Effective Path Gate
+
+## Purpose
+Prevents false-positive findings when Cloud Run service requires intended invoker/IAP path and denies direct URL when needed, by requiring the reviewer to verify that IAP protects the frontend but the direct Cloud Run URL is not left publicly accessible, and that invoker roles are not granted through unintended folder/project inheritance.
+
+## Detection Logic
+
+### Trigger Conditions
+Fire this gate when ALL of the following are true:
+1. Cloud Run service defines invoker IAM or is behind Identity-Aware Proxy (IAP)
+2. Service is configured to deny direct URL access when IAP is required
+3. Invoker role could be inherited from folder/project level, making the URL public
+
+### Gate Check: Effective Ingress Path Verification
+
+```yaml
+check_effective_ingress:
+  - detection_patterns:
+      - "Cloud Run|cloud run|cloudrun"
+      - "invoker|Invoker|roles/run.invoker"
+      - "IAP|Identity-Aware Proxy|identity aware proxy"
+      - "ingress|ingress rule|ingress settings"
+      - "direct URL|run\.app|default URL"
+  - pass: >
+      "Cloud Run ingress is set to "require IAP" mode (ingress = internal-and-cloud-load-balancing)
+      when IAP is the intended access path. The default `run.app` URL is disabled
+      (ingress settings restrict to load balancer traffic only). IAP is configured
+      on the External HTTPS Load Balancer frontend. No direct URL access bypasses
+      IAP authentication."
+    Rationale: "IAP protects the frontend Load Balancer path, but the Cloud Run
+      service also has a direct `run.app` URL. If the direct URL is accessible
+      (ingress = all), any user with the URL can bypass IAP entirely. IAP and
+      invoker IAM are independent controls — both must be verified."
+  - fail: >
+      "Cloud Run ingress allows direct URL access (ingress = all or
+      internal-only), which bypasses IAP authentication. Recommend setting
+      ingress to require Cloud Load Balancing traffic when IAP is the intended
+      access path, and disabling the default `run.app` URL if not needed."
+```
+
+### Gate Check: Invoker IAM Inheritance Audit
+
+```yaml
+check_invoker_inheritance:
+  - detection_patterns:
+      - "invoker|roles/run\.invoker"
+      - "allUsers|allAuthenticatedUsers"
+      - "folder|project|organization IAM"
+      - "IAM inheritance|conditional binding"
+      - "public access|anonymous access"
+  - pass: >
+      "Invoker IAM bindings are scoped directly to the Cloud Run service resource
+      (not inherited from parent folder/project). There are no allUsers or
+      allAuthenticatedUsers bindings at the project or folder level that would
+      grant unintended invoker access to this service. Conditional IAM bindings
+      with resource-level conditions are used when project-level grants are
+      necessary."
+    Rationale: "A project-level roles/run.invoker grant to allUsers
+      inadvertently makes every Cloud Run service in the project publicly
+      accessible, regardless of per-service invoker settings. IAM inheritance
+      is a common source of unintended public exposure."
+  - fail: >
+      "Invoker role is granted through folder or project inheritance, or has
+      allUsers/allAuthenticatedUsers bindings that apply to this service.
+      Recommend binding invoker roles directly to the Cloud Run service resource
+      and auditing parent-level IAM for unintended public access grants."
+```
+
+## Resolution Path
+1. Set Cloud Run ingress to require Cloud Load Balancing traffic when IAP is used
+2. Disable or restrict the default `run.app` URL
+3. Bind invoker roles directly to the Cloud Run service resource, not through project/folder inheritance
+4. Audit project and folder IAM for allUsers/allAuthenticatedUsers bindings that include roles/run.invoker

--- a/skills/cloud/gcp-review/gates/pubsub-push-auth-replay-gate.md
+++ b/skills/cloud/gcp-review/gates/pubsub-push-auth-replay-gate.md
@@ -1,0 +1,70 @@
+# Pub/Sub Push Authentication Audience Replay Gate
+
+## Purpose
+Prevents false-positive findings when push subscription OIDC token audience and endpoint replay protections are verified, by requiring the reviewer to verify that a generic audience across multiple services and message replay without deduplication are not creating authentication gaps.
+
+## Detection Logic
+
+### Trigger Conditions
+Fire this gate when ALL of the following are true:
+1. Pub/Sub push subscriptions use OIDC token authentication
+2. Token audience and endpoint replay protections are documented as verified
+3. Endpoint accepts a generic OIDC audience that could apply to multiple services, or message retry can replay non-idempotent actions
+
+### Gate Check: OIDC Token Audience Scope
+
+```yaml
+check_oidc_audience_scope:
+  - detection_patterns:
+      - "Pub/Sub|pubsub|push subscription"
+      - "OIDC|OpenID Connect|token audience"
+      - "audience|aud"
+      - "authentication|auth header"
+      - "push endpoint|webhook"
+  - pass: >
+      "Each push subscription uses a unique OIDC audience value tied to a single
+      receiving service or endpoint. The audience is not shared across different
+      services. The receiving endpoint verifies the audience claim matches its
+      own identifier before processing the message."
+    Rationale: "A generic OIDC audience shared across multiple services means a
+      token issued for one push subscription can be replayed against another
+      service that accepts the same audience. This breaks the authentication
+      boundary — Pub/Sub proves the message came from Google, but not which
+      subscription or service it was intended for."
+  - fail: >
+      "OIDC audience is generic or shared across multiple receiving services.
+      The push endpoint does not verify the audience claim. Recommend using a
+      unique audience per subscription and validating it at the receiving
+      endpoint."
+```
+
+### Gate Check: Message Deduplication and Idempotency
+
+```yaml
+check_message_idempotency:
+  - detection_patterns:
+      - "retry|redeliver|retry policy"
+      - "ack deadline|nack|dead letter"
+      - "idempotent|dedup|deduplication"
+      - "exactly-once|at-least-once"
+  - pass: >
+      "The receiving endpoint is idempotent or uses Pub/Sub's exactly-once
+      delivery with message deduplication ID. Message retry during ack deadline
+      extension or nack does not cause duplicate side effects (duplicate
+      charges, duplicate notifications, duplicate writes)."
+    Rationale: "Pub/Sub push delivery is at-least-once by default. Without
+      exactly-once delivery or idempotent processing, a message retry (triggered
+      by ack deadline expiry or nack) causes the side effect to execute
+      multiple times. A non-idempotent action like a financial transfer or
+      authorization grant is replayed."
+  - fail: >
+      "Receiving endpoint is not idempotent and Pub/Sub exactly-once delivery
+      is not enabled. Message retry or redelivery can cause duplicate side
+      effects. Recommend either making the endpoint idempotent (use a
+      deduplication key) or enabling exactly-once delivery."
+```
+
+## Resolution Path
+1. Assign a unique OIDC audience per push subscription, specific to the receiving service
+2. Validate the audience claim at each push endpoint
+3. Enable exactly-once delivery or implement idempotent processing with a deduplication key


### PR DESCRIPTION
Adds three review gates for gcp-review skill:

1. **BigQuery Authorized View Policy Drift Gate** (closes #2674)
   - Effective data access path audit check
   - Policy tag consistency check

2. **Pub/Sub Push Authentication Audience Replay Gate** (closes #2673)
   - OIDC token audience scope check
   - Message deduplication and idempotency check

3. **Cloud Run Invoker and IAP Effective Path Gate** (closes #2672)
   - Effective ingress path verification check
   - Invoker IAM inheritance audit check

All three gates add evidence requirements for common GCP false-positive patterns.