### PR TITLE
Add container sidecar bypass evidence gates

### DIFF
--- a/skills/cloud/container-security/SKILL.md
+++ b/skills/cloud/container-security/SKILL.md
@@ -113,6 +113,22 @@ Evaluate all container and Kubernetes configurations against CIS Docker Benchmar
 
 For detailed CIS benchmark checklist items, NIST SP 800-190 countermeasure tables, and comprehensive security context evaluation criteria, see [cis-benchmarks.md](cis-benchmarks.md) in this skill directory.
 
+#### Service Mesh Sidecar Bypass Evidence Gate
+
+When reviewing Istio, Linkerd, Consul, Envoy-based, or other service mesh controls, do not treat mesh policy as equivalent to network segmentation until the effective traffic path is proven. Mesh authorization, mTLS, and egress policy findings require evidence for both the intended mesh boundary and any route that can avoid the sidecar or mesh dataplane.
+
+Before filing a sidecar bypass finding, collect concrete evidence for at least one attacker-controlled bypass path:
+
+- Workloads using `hostNetwork`, host ports, host namespace sharing, privileged networking capabilities, or direct node networking that can avoid sidecar interception.
+- Init, sidecar, or ephemeral containers that are not covered by injection, policy, or egress controls for the pod.
+- Pod, namespace, Helm, or mesh annotations that disable injection, exclude inbound or outbound ports, exclude IP ranges, or opt the workload out of mesh policy.
+- AuthorizationPolicy, PeerAuthentication, destination, egress, or namespace scoping that protects only in-mesh traffic while allowing direct pod IP, service CIDR, node-local, or external egress paths.
+- Missing or ineffective Kubernetes NetworkPolicy default-deny controls that leave a non-mesh route open even though the mesh policy looks restrictive.
+
+Benign exception pattern: do not flag a workload solely because it uses mesh policy if the reviewed artifacts show both mesh policy and Kubernetes NetworkPolicy deny direct pod bypass paths for the relevant namespace, workload selectors, ports, and egress destinations. In that case, record the evidence as a pass or informational note unless another concrete bypass path is present.
+
+For remediation, require a verification step that proves the effective boundary after the fix: cite the updated workload, namespace, mesh policy, and NetworkPolicy artifacts, then confirm the previously identified non-mesh path is blocked or forced through the intended sidecar/dataplane. Include rollback guidance for policy changes that could interrupt service-to-service traffic.
+
 ---
 
 ### Step 7: Compile Assessment Report
@@ -259,6 +275,7 @@ Before applying or proposing container or Kubernetes changes, classify each reme
 5. **`readOnlyRootFilesystem` breaks many applications.** When recommending this control, also recommend adding writable `emptyDir` volume mounts for directories the application needs to write to (e.g., `/tmp`, `/var/cache`).
 6. **Network policies are additive, not subtractive.** A default-deny policy must be explicitly created. Without it, all pod-to-pod traffic is allowed regardless of other NetworkPolicy resources.
 7. **Distroless images have no shell.** While this is excellent for security, note that debugging requires ephemeral containers (`kubectl debug`). Flag this as a consideration, not a problem.
+8. **Service mesh policy can be bypassed outside the sidecar path.** Check host networking, injection exclusions, direct pod IP or service CIDR routes, egress exceptions, and namespace scoping before classifying mesh controls as effective segmentation.
 
 ---
 

--- a/skills/cloud/container-security/cis-benchmarks.md
+++ b/skills/cloud/container-security/cis-benchmarks.md
@@ -431,6 +431,37 @@ spec:
 
 **Critical check:** A default-deny NetworkPolicy should exist in every namespace.
 
+#### Service Mesh Sidecar and mTLS Boundary Checks
+
+When service mesh resources are present, validate that mesh policy and Kubernetes network controls enforce the same boundary. Mesh policy alone is not sufficient evidence of segmentation because workloads may still reach peers through paths that avoid the sidecar or mesh dataplane.
+
+Before reporting a service mesh bypass, require evidence of all three conditions:
+
+- **Source:** an attacker-controlled or compromised workload, init container, ephemeral container, or sidecar in scope.
+- **Path:** a reachable direct pod IP, service CIDR, node-local, host-network, excluded-port, excluded-IP-range, or external egress route that avoids the intended sidecar or mTLS enforcement.
+- **Impact:** access crosses a tenant, namespace, service, privilege, or data boundary that the mesh policy was expected to protect.
+
+Flag as High or Critical when reviewed artifacts show any of these bypass paths:
+
+```yaml
+# host networking can avoid sidecar interception for application workloads
+spec:
+  hostNetwork: true
+
+# injection or traffic interception exclusions can leave direct paths open
+metadata:
+  annotations:
+    sidecar.istio.io/inject: "false"
+    traffic.sidecar.istio.io/excludeOutboundPorts: "5432"
+    traffic.sidecar.istio.io/excludeOutboundIPRanges: "10.0.0.0/8"
+```
+
+Also check for namespace-scoped mTLS, authorization, or egress policies that apply only to injected mesh traffic while NetworkPolicy still allows direct pod-to-pod or unrestricted egress traffic.
+
+**Benign exception:** Do not report a finding when mesh policy and Kubernetes NetworkPolicy both deny the direct pod path for the same namespace, workload selectors, ports, and egress destinations, and no attacker-controlled route is evidenced. Record the artifacts as a pass or informational note.
+
+**Remediation verification:** The fix must prove that the same source workload cannot reach the protected destination except through the intended sidecar or mTLS path, and that NetworkPolicy or equivalent CNI policy denies direct pod-to-pod and egress routes.
+
 ### CIS 5.4 -- Secrets Management
 
 #### CIS 5.4.1 -- Prefer using Secrets as files over Secrets as environment variables

--- a/tests/fixtures/container-security/mesh-sidecar-bypass-benign/manifest.yaml
+++ b/tests/fixtures/container-security/mesh-sidecar-bypass-benign/manifest.yaml
@@ -1,0 +1,5 @@
+skill: container-security
+case_id: mesh-sidecar-bypass-benign
+kind: benign
+target: workload.yaml
+expected_findings: []

--- a/tests/fixtures/container-security/mesh-sidecar-bypass-benign/workload.yaml
+++ b/tests/fixtures/container-security/mesh-sidecar-bypass-benign/workload.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payments-api
+  namespace: payments
+spec:
+  selector:
+    matchLabels:
+      app: payments-api
+  template:
+    metadata:
+      labels:
+        app: payments-api
+      annotations:
+        sidecar.istio.io/inject: "true"
+    spec:
+      containers:
+        - name: app
+          image: registry.example.com/payments-api:1.2.3
+          ports:
+            - containerPort: 8080
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: payments-strict-mtls
+  namespace: payments
+spec:
+  mtls:
+    mode: STRICT
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-direct-pod-traffic
+  namespace: payments
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress

--- a/tests/fixtures/container-security/mesh-sidecar-bypass-vulnerable/manifest.yaml
+++ b/tests/fixtures/container-security/mesh-sidecar-bypass-vulnerable/manifest.yaml
@@ -1,0 +1,9 @@
+skill: container-security
+case_id: mesh-sidecar-bypass-vulnerable
+kind: vulnerable
+target: workload.yaml
+expected_findings:
+  - id: service-mesh-sidecar-bypass
+    severity: high
+    framework: NIST SP 800-190 CM-8
+    evidence_contains: 'hostNetwork: true'

--- a/tests/fixtures/container-security/mesh-sidecar-bypass-vulnerable/workload.yaml
+++ b/tests/fixtures/container-security/mesh-sidecar-bypass-vulnerable/workload.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payments-api
+  namespace: payments
+spec:
+  selector:
+    matchLabels:
+      app: payments-api
+  template:
+    metadata:
+      labels:
+        app: payments-api
+      annotations:
+        sidecar.istio.io/inject: "false"
+        traffic.sidecar.istio.io/excludeOutboundIPRanges: "10.0.0.0/8"
+    spec:
+      hostNetwork: true
+      containers:
+        - name: app
+          image: registry.example.com/payments-api:1.2.3
+          ports:
+            - containerPort: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-mesh-only
+  namespace: payments
+spec:
+  podSelector:
+    matchLabels:
+      app: payments-api
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              istio-injection: enabled


### PR DESCRIPTION
﻿## What this PR does

Adds service mesh sidecar bypass evidence gates to `container-security`, with CIS/NIST guidance for direct pod routes, injection exclusions, host networking, namespace-scoped mTLS, and benign mesh-plus-NetworkPolicy denial cases.

Closes #2669.

## Type of change

- [ ] New skill
- [x] Improvement to an existing skill
- [x] Bug fix / documentation

## Reproduction - independently runnable

- Public reproducer: this PR adds fixture cases under `tests/fixtures/container-security/mesh-sidecar-bypass-*`.
- Base target: `UnitOneAI/SecuritySkills@553177e4156c0c163232e25656be282deaa40bb7`.
- PR head: `Desalzes:codex/container-sidecar-bypass-gates@84b703cb3cd1c68f11f20b3bded60bc38b36742b`.
- CI commands expected for maintainers:
  - `ruby scripts/test_skill_fixtures.rb`
  - `ruby scripts/validate_skill_schema.rb`
  - `ruby scripts/validate_index.rb`

## Discrimination evidence

- True positive fixture: `tests/fixtures/container-security/mesh-sidecar-bypass-vulnerable/workload.yaml` contains `hostNetwork: true`, disabled sidecar injection, and an excluded outbound IP range.
- True negative fixture: `tests/fixtures/container-security/mesh-sidecar-bypass-benign/workload.yaml` combines sidecar injection, STRICT mTLS, and a default-deny NetworkPolicy, so it expects no findings.

## Framework grounding

- CIS Kubernetes Benchmark v1.9.0 5.3.1 and 5.3.2 for NetworkPolicy segmentation.
- CIS Kubernetes Benchmark v1.9.0 5.2.5 for host networking exposure.
- NIST SP 800-190 CM-8 for container network segmentation.

## Attestation & checklist

- [x] I searched existing open PRs for `2669`, `sidecar`, and `service-mesh`; no duplicate open PR was found.
- [x] This is an existing-skill improvement; `author:` remains the original project owner.
- [x] This is my only open PR for this repository right now.
- [x] I ran `git diff --check` and `git diff --cached --check`.
- [x] I ran structural fixture validation for the added manifest/target pairs.
- [x] I ran targeted injection-pattern and secret-pattern scans over changed files.

## Local validation note

Ruby is not installed in this Windows environment, so I could not run the exact Ruby validators locally. The added fixtures follow `scripts/test_skill_fixtures.rb` shape and should be exercised by GitHub CI.
