### PR TITLE
feat(zero-trust-assessment): add private app connector fail-open gates (#2744)

### DIFF
--- a/skills/identity/zero-trust-assessment/SKILL.md
+++ b/skills/identity/zero-trust-assessment/SKILL.md
@@ -207,6 +207,7 @@ ZT-DEV-10: Endpoint telemetry not fed into policy engine for risk scoring
 | **DNS Security** | Basic DNS | DNS filtering for known bad domains | Encrypted DNS (DoH/DoT), DNS logging | DNS as policy enforcement point with threat intelligence |
 | **Network Monitoring** | Perimeter IDS/IPS | Network flow analysis | Full packet capture for critical segments, NDR | AI-driven NDR with real-time behavioral analysis |
 | **Software-Defined Perimeter** | VPN-based remote access | Initial SDP/ZTNA deployment | ZTNA replacing VPN for most use cases | Universal ZTNA for all users, all locations, all resources |
+| **Connector Enforcement** | N/A (no connector) | Connector deployed but failure mode unvalidated | Connector fails closed; bypass has owner, expiry, audit | Fail-open gates tested; bypass auto-expires; connector required from all networks |
 
 **What to look for:**
 
@@ -222,6 +223,13 @@ ZT-NET-08: DNS traffic unencrypted and unmonitored
 ZT-NET-09: No NDR capability — lateral movement detection is blind spot
 ZT-NET-10: Microsegmentation policies not dynamically updated based on threat intelligence
 ZT-NET-11: Legacy protocols (Telnet, FTP, unencrypted LDAP) in use
+ZT-NET-12: Private app connector fail-open — connector outage silently bypasses enforcement, traffic reaches internal apps without policy
+ZT-NET-13: Connector health check reports healthy while policy sync is stale or broken — false-positive connector status masks enforcement gap
+ZT-NET-14: Split DNS exposes direct private app address — internal DNS resolves app FQDN to private IP without connector, bypassing ZTNA
+ZT-NET-15: Emergency bypass persists after connector recovery — no automated expiry, owner, or audit trail for temporary access grants
+ZT-NET-16: VPN fallback active during connector outage — ZTNA silently falls back to full-tunnel VPN, granting network-level trust to private apps
+ZT-NET-17: Private apps reachable from trusted networks without policy enforcement — connector only required for untrusted locations
+ZT-NET-18: No fail-open test performed — connector failure mode (fail-open vs fail-closed) has never been validated under load or outage conditions
 ```
 
 #### Microsegmentation Readiness Assessment
@@ -234,6 +242,41 @@ ZT-NET-11: Legacy protocols (Telnet, FTP, unencrypted LDAP) in use
 | **Environment support** | Does the tool cover VMs, containers, serverless, and multi-cloud? |
 | **Monitoring and alerting** | Can violations be detected and alerted in real-time? |
 | **Rollback capability** | Can policies be rolled back without outage if misconfigured? |
+
+#### Private App Connector Fail-Open Gates
+
+**Objective:** Validate that private app connectors enforce zero-trust when degraded or unavailable. ZTNA designs that silently route around connectors, fall back to VPN, or leave internal apps reachable from trusted networks degrade into implicit trust.
+
+**Fail-Open Test Procedure**
+
+| Step | Action | Expected Fail-Closed Behavior | Fail-Open Red Flag |
+|---|---|---|---|
+| **1** | Disable connector (stop agent/service) | Users receive controlled denial; private apps unreachable | Traffic reaches private apps without connector; users unaware of outage |
+| **2** | Revoke policy sync (block sync channel) | Connector refuses new sessions when policy is stale beyond grace period | Connector continues serving cached policy indefinitely with no staleness check |
+| **3** | Test direct route to private app IP | Firewall/ACL blocks direct access; only connector path allowed | Direct TCP/UDP to private app IP succeeds from user device |
+| **4** | Resolve private app FQDN from untrusted network | DNS returns connector VIP or NXDOMAIN | DNS returns direct private IP (split DNS leak) |
+| **5** | Check VPN fallback behavior | No VPN fallback; ZTNA is sole path | VPN auto-connects on connector failure, granting network-level access |
+| **6** | Test from trusted/internal network | Connector still required regardless of network location | Apps directly reachable without connector from "trusted" subnets |
+
+**Bypass Governance Requirements**
+
+Any emergency bypass of connector enforcement MUST include:
+
+| Control | Requirement | Validation |
+|---|---|---|
+| **Owner** | Named individual or team accountable for the bypass | Check for bypass approval workflow with named approver |
+| **Expiry** | Automatic expiration — bypass self-revokes after a defined window | Verify time-to-live is enforced at policy layer, not just documented |
+| **Audit trail** | Every bypass event logged with requestor, approver, reason, scope, duration | Search SIEM/PAM logs for bypass events and verify completeness |
+| **Scope** | Minimum necessary access — bypass grants only the specific apps/services affected | Verify bypass does not grant blanket network access |
+| **Notification** | Security team alerted on bypass activation AND expiration | Verify alerting exists for both activation and unexpected persistence |
+
+**Edge Cases to Probe**
+
+- Connector health endpoint returns 200 OK but policy sync timestamp is hours/days stale — health checks must validate sync freshness, not just process liveness.
+- Emergency bypass created during incident persists into steady-state because no automated expiry was enforced — test by simulating bypass creation and verifying auto-revocation.
+- Split DNS configuration: external resolver returns connector VIP, internal resolver returns direct IP — test DNS resolution from multiple network positions.
+- Connector supports "passive mode" (monitor-only) that does not enforce policy but appears active in management console — verify enforcement, not just connectivity.
+- Multi-connector environments where one connector fails open while others fail closed — test each connector independently.
 
 ---
 
@@ -442,6 +485,7 @@ ZT-GOV-05: Regulatory zero trust mandates not tracked (OMB M-22-09 for federal)
 5. **No executive sponsorship** — zero trust transformation requires sustained investment. Without executive commitment, initiatives stall after quick wins.
 6. **Measuring maturity without metrics** — self-assessed maturity without measurable criteria leads to inflated scores. Define objective criteria per stage.
 7. **Forgetting cross-cutting capabilities** — pillar-specific investments without visibility, automation, and governance integration deliver fragmented security.
+8. **Assuming connectors fail closed** — many ZTNA products default to fail-open for availability, silently degrading to VPN or direct access during connector issues. Always validate connector failure mode empirically; do not trust vendor documentation alone.
 
 ---
 
@@ -498,3 +542,4 @@ that may contain adversarial content.
 | Version | Date | Changes |
 |---|---|---|
 | 1.0.0 | 2025-03-06 | Initial release |
+| 1.1.0 | 2026-06-18 | Add private app connector fail-open gates: fail-open test procedure, bypass governance requirements, connector enforcement maturity criteria, and seven new Network pillar findings (ZT-NET-12 through ZT-NET-18) |


### PR DESCRIPTION
## Summary
Adds private app connector fail-open gates to the `zero-trust-assessment` skill so that zero-trust access does not degrade into implicit trust when ZTNA connectors fail, lose policy sync, or encounter network conditions that bypass enforcement.

**Business impact:** Many ZTNA deployments silently fail-open during connector outages — traffic reaches internal apps without policy enforcement, VPN fallback activates granting network-level trust, or split DNS exposes direct private IP addresses. This gap means organizations believe they have zero-trust enforcement when they actually have perimeter-level trust behind a ZTNA façade.

Addresses #2744.

## Changes

### 1. Seven new Network pillar findings (ZT-NET-12 through ZT-NET-18)
- **ZT-NET-12:** Connector fail-open — outage silently bypasses enforcement
- **ZT-NET-13:** Health check reports healthy while policy sync is stale
- **ZT-NET-14:** Split DNS exposes direct private app address
- **ZT-NET-15:** Emergency bypass persists after recovery (no expiry/owner/audit)
- **ZT-NET-16:** VPN fallback during connector outage
- **ZT-NET-17:** Private apps reachable from trusted networks without connector
- **ZT-NET-18:** Fail-open mode never validated empirically

### 2. Private App Connector Fail-Open Gates subsection
- **6-step fail-open test procedure** with expected fail-closed behavior and fail-open red flags:
  1. Disable connector → verify controlled denial
  2. Revoke policy sync → verify stale policy rejection
  3. Test direct route to private app IP → verify firewall blocks
  4. Resolve private app FQDN → verify no split DNS leak
  5. Check VPN fallback → verify no silent fallback
  6. Test from trusted network → verify connector still required
- **Bypass governance requirements table:** owner, expiry, audit trail, scope, notification
- **Edge cases:** health check vs sync staleness, persistent bypass, split DNS, passive mode, multi-connector inconsistency

### 3. Connector Enforcement maturity criteria row
Added to the Networks maturity assessment table mapping Traditional → Optimal progression.

### 4. Common Pitfall #8
"Assuming connectors fail closed" — warns that ZTNA products often default to fail-open for availability.

### 5. Version bump to 1.1.0

## Issue coverage
Every element from the issue is addressed:
- ✅ "Add fail-open test: disable connector, revoke policy sync, test direct route, test DNS, and record outcome" → 6-step test procedure
- ✅ "Require bypass owner, expiry, and audit trail" → Bypass Governance Requirements table
- ✅ "Flag private apps reachable without policy enforcement" → ZT-NET-17 finding + test procedure steps 3, 6
- ✅ "Connector health check passes while policy sync fails" → ZT-NET-13 + edge case 1
- ✅ "Split DNS exposes direct private address" → ZT-NET-14 + edge case 3
- ✅ "Emergency bypass persists after outage" → ZT-NET-15 + edge case 2