### PR TITLE
fix: [REVIEW] access-review: separate policy-defined cadence from

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #836
+
+[REVIEW] access-review: separate policy-defined cadence from default thresholds


### PR DESCRIPTION
Closes #836

[REVIEW] access-review: separate policy-defined cadence from default thresholds

/claim #836