### PR TITLE
fix: [REVIEW] vciso: refresh OWASP Agentic Applications source

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #802
+
+[REVIEW] vciso: refresh OWASP Agentic Applications source


### PR DESCRIPTION
Closes #802

[REVIEW] vciso: refresh OWASP Agentic Applications source

/claim #802