### PR TITLE
fix: [REVIEW] owasp-top-10-web: make CSRF and SameSite checks cre

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #843
+
+[REVIEW] owasp-top-10-web: make CSRF and SameSite checks credential-aware


### PR DESCRIPTION
Closes #843

[REVIEW] owasp-top-10-web: make CSRF and SameSite checks credential-aware

/claim #843